### PR TITLE
autoformatter for nix files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1609,7 +1609,8 @@
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-unstable": "nixpkgs-unstable_3"
+        "nixpkgs-unstable": "nixpkgs-unstable_3",
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "secp256k1": {
@@ -1755,6 +1756,26 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "761ae7aff00907b607125b2f57338b74177697ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769353635,
+        "narHash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "f46bb205f239b415309f58166f8df6919fa88377",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -443,6 +443,7 @@
               tests = lib.collect lib.isDerivation windowsPackages.tests;
               benchmarks = lib.collect lib.isDerivation windowsPackages.benchmarks;
             };
+            inherit windowsPackages;
           };
         }
         # macos is never cross-compiled
@@ -505,6 +506,7 @@
             inherit pkgs;
             project = walletProject;
           };
+          musl64Packages = mkPackages walletProject.projectCross.musl64;
         })
         // {
           # Continuous integration builds

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
   #     - cardano-wallet.unit
   #     - etc
   #   - benchmarks - attret of benchmark executables
+  #     -
   #     - cardano-wallet.db
   #     - cardano-wallet.latency
   #     - etc
@@ -34,8 +35,8 @@
   # This flake contains a few outputs useful for continous integration.
   # These outputs come in two flavors:
   #
-  #   outputs.packages."<system>".ci.*  - build a test, benchmark, …
-  #   outputs.apps."<system>".ci.*      - run a test, benchmark, …
+  #   outputs.packages."<system>".ci.* - build a test, benchmark, …
+  #   outputs.apps."<system>".ci.* - run a test, benchmark, …
   #
   # For building, say all tests, use `nix build`:
   #
@@ -46,6 +47,7 @@
   #   nix run .#ci.tests.unit
   #
   # (Running an item will typically also build it if it has not been built
+  #
   #  in the nix store already.)
   #
   # 2024-12-18
@@ -63,6 +65,7 @@
   #       - all             - build all benchmarks
   #       - restore         - build individual benchmark
   #       - …
+
   #     - artifacts         - artifacts by platform
   #       - linux64.release
   #       - win64
@@ -70,6 +73,7 @@
   #         - tests         - bundle of executables for testing on Windows
   #       - macos-intel.release
   #       - macos-silicon.release
+
   #       - dockerImage
   #  - outputs.apps."<system>".ci.
   #     - tests
@@ -84,7 +88,8 @@
   # TODO Continuous Integration (CI)
   #
   # Make the flake.nix file *itself* part of continuous integration,
-  # i.e. check that `devShells`, `scripts` or `nixosTests` evalute and build
+  # i.e. check that `devShells`, `scripts` or `nixosTests` evalute and
+  # build
   # correctly.
   ############################################################################
 
@@ -119,429 +124,436 @@
     mithril = {
       url = "github:input-output-hk/mithril?ref=2543.1-hotfix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
-      };
+    };
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      nixpkgs-unstable,
-      hostNixpkgs,
-      flake-utils,
-      haskellNix,
-      iohkNix,
-      CHaP,
-      customConfig,
-      cardano-node-runtime,
-      mithril,
-      ...
-    }:
-    let
-      # Import libraries
-      lib = import ./nix/lib.nix nixpkgs.lib;
-      config = import ./nix/config.nix nixpkgs.lib customConfig;
-      inherit (flake-utils.lib) eachSystem mkApp flattenTree;
-      inherit (iohkNix.lib) evalService;
-
-      # Definitions
-      supportedSystems = import ./nix/supported-systems.nix;
-      fix-crypton-x509 =
-        final: prev:
-        let
-          old = prev.haskell-nix;
-          fix =
-            {
-              pkgs,
-              buildModules,
-              config,
-              lib,
-              ...
-            }:
-            {
-              packages =
-                { }
-                // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc) {
-                  # Workaround for broken nixpkgs darwin.security_tool in
-                  # Mojave. This mirrors the workaround in nixpkgs
-                  # haskellPackages.
-                  #
-                  # ref:
-                  # https://github.com/NixOS/nixpkgs/pull/47676
-                  # https://github.com/NixOS/nixpkgs/issues/45042
-                  crypton-x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
-                };
-            };
-        in
-        {
-          haskell-nix = old // {
-            defaultModules = old.defaultModules ++ [ fix ];
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-unstable,
+    hostNixpkgs,
+    flake-utils,
+    haskellNix,
+    iohkNix,
+    CHaP,
+    customConfig,
+    cardano-node-runtime,
+    mithril,
+    treefmt-nix,
+    ...
+  }: let
+    # Import libraries
+    lib = import ./nix/lib.nix nixpkgs.lib;
+    config = import ./nix/config.nix nixpkgs.lib customConfig;
+    inherit (flake-utils.lib) eachSystem mkApp flattenTree;
+    inherit (iohkNix.lib) evalService;
+    # Definitions
+    supportedSystems = import ./nix/supported-systems.nix;
+    fix-crypton-x509 = final: prev: let
+      old = prev.haskell-nix;
+      fix = {
+        pkgs,
+        buildModules,
+        config,
+        lib,
+        ...
+      }: {
+        packages =
+          {}
+          // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc) {
+            # Workaround for broken nixpkgs
+            # darwin.security_tool in
+            # Mojave.
+            # This mirrors the workaround in nixpkgs
+            # haskellPackages.
+            # #
+            # ref:
+            # https://github.com/NixOS/nixpkgs/pull/47676
+            # https://github.com/NixOS/nixpkgs/issues/45042
+            crypton-x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
           };
+      };
+    in {
+      haskell-nix =
+        old
+        // {
+          defaultModules = old.defaultModules ++ [fix];
         };
-      overlay = final: prev: {
-        cardanoWalletHaskellProject = self.legacyPackages.${final.system};
-        inherit (final.cardanoWalletHaskellProject.hsPkgs.cardano-wallet-application.components.exes)
-          cardano-wallet
-          ;
+    };
+    overlay = final: prev: {
+      cardanoWalletHaskellProject = self.legacyPackages.${final.system};
+      inherit
+        (final.cardanoWalletHaskellProject.hsPkgs.cardano-wallet-application.components.exes)
+        cardano-wallet
+        ;
+    };
+
+    nixosModule = {
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [./nix/nixos/cardano-wallet-service.nix];
+      services.cardano-node.package = lib.mkDefault self.packages.${pkgs.system}.cardano-node;
+    };
+    nixosModules.cardano-wallet = nixosModule;
+
+    # Define flake outputs for a particular system.
+    mkOutputs = system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        inherit (haskellNix) config;
+        overlays = [
+          # Same overlay sequence as used by cardano-node
+          iohkNix.overlays.crypto
+          haskellNix.overlay
+          iohkNix.overlays.haskell-nix-extra
+          iohkNix.overlays.haskell-nix-crypto
+          iohkNix.overlays.cardano-lib
+          # Cardano deployments
+          (import ./nix/overlays/cardano-deployments.nix)
+
+          # Our own utils (cardanoWalletLib)
+          (import ./nix/overlays/common-lib.nix)
+          (import ./nix/overlays/basement.nix)
+          fix-crypton-x509
+          overlay
+        ];
       };
 
-      nixosModule =
-        { pkgs, lib, ... }:
-        {
-          imports = [ ./nix/nixos/cardano-wallet-service.nix ];
-          services.cardano-node.package = lib.mkDefault self.packages.${pkgs.system}.cardano-node;
-        };
-      nixosModules.cardano-wallet = nixosModule;
+      # treefmt-nix evaluation
+      treefmtEval = treefmt-nix.lib.evalModule pkgs {
+        projectRootFile = "flake.nix";
+        programs.alejandra.enable = true;
+        settings.global.excludes = [
+          "*.lock"
+          "*.patch"
+          "package-lock.json"
+          "go.mod"
+          "go.sum"
+          ".gitattributes"
+          ".gitignore"
+          ".gitmodules"
+          "LICENSE"
+        ];
+        settings.formatter.alejandra.includes = ["**/*.nix"];
+      };
 
-      # Define flake outputs for a particular system.
-      mkOutputs =
-        system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            inherit (haskellNix) config;
-            overlays = [
-              # Same overlay sequence as used by cardano-node
-              iohkNix.overlays.crypto
-              haskellNix.overlay
-              iohkNix.overlays.haskell-nix-extra
-              iohkNix.overlays.haskell-nix-crypto
-              iohkNix.overlays.cardano-lib
-              # Cardano deployments
-              (import ./nix/overlays/cardano-deployments.nix)
-              # Our own utils (cardanoWalletLib)
-              (import ./nix/overlays/common-lib.nix)
-              (import ./nix/overlays/basement.nix)
-              fix-crypton-x509
-              overlay
-            ];
+      inherit (pkgs.stdenv) buildPlatform;
+
+      inherit
+        (pkgs.haskell-nix.haskellLib)
+        isProjectPackage
+        collectComponents
+        collectChecks
+        check
+        ;
+      mithrilPackages = mithril.packages.${system};
+      nodePackages = cardano-node-runtime.packages.${system};
+      nodeProject = cardano-node-runtime.project.${system};
+      nodeConfigs = lib.fileset.toSource {
+        root = ./configs;
+        fileset = ./configs;
+      };
+      set-git-rev = import ./nix/set-git-rev/set-git-rev.nix {
+        inherit system;
+        inherit nixpkgs flake-utils haskellNix;
+      };
+
+      walletProject =
+        (
+          import ./nix/haskell.nix CHaP pkgs.haskell-nix nixpkgs-unstable.legacyPackages.${system}
+          nodePackages
+          mithrilPackages
+          set-git-rev.packages.default
+          rewrite-libs.packages.default
+        )
+        .appendModule
+        [
+          {
+            gitrev =
+              if config.gitrev != null
+              then config.gitrev
+              else self.rev or "0000000000000000000000000000000000000000";
+          }
+          config.haskellNix
+        ];
+      mkPackages = project: let
+        coveredProject = project.appendModule {coverage = true;};
+        self = {
+          # Cardano wallet
+          cardano-wallet = import ./nix/release-build.nix {
+            inherit pkgs;
+            exe = project.hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
+            backend = self.cardano-node;
           };
-
-          inherit (pkgs.stdenv) buildPlatform;
-
-          inherit (pkgs.haskell-nix.haskellLib)
-            isProjectPackage
-            collectComponents
-            collectChecks
-            check
-            ;
-
-          mithrilPackages = mithril.packages.${system};
-          nodePackages = cardano-node-runtime.packages.${system};
-          nodeProject = cardano-node-runtime.project.${system};
-          nodeConfigs = lib.fileset.toSource {
-            root = ./configs;
-            fileset = ./configs;
-          };
-          set-git-rev = import ./nix/set-git-rev/set-git-rev.nix {
-            inherit system;
-            inherit nixpkgs flake-utils haskellNix;
-          };
-
-          walletProject =
-            (import ./nix/haskell.nix CHaP pkgs.haskell-nix nixpkgs-unstable.legacyPackages.${system}
-              nodePackages
-              mithrilPackages
-              set-git-rev.packages.default
-              rewrite-libs.packages.default
-            ).appendModule
-              [
-                {
-                  gitrev =
-                    if config.gitrev != null then
-                      config.gitrev
-                    else
-                      self.rev or "0000000000000000000000000000000000000000";
-                }
-                config.haskellNix
-              ];
-
-          mkPackages =
-            project:
-            let
-              coveredProject = project.appendModule { coverage = true; };
-              self = {
-                # Cardano wallet
-                cardano-wallet = import ./nix/release-build.nix {
-                  inherit pkgs;
-                  exe = project.hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
-                  backend = self.cardano-node;
-                };
-                # Local test cluster and mock metadata server
-                inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server;
-                inherit (project.hsPkgs.cardano-wallet-benchmarks.components.exes) benchmark-history;
-                inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
-                integration-exe = project.hsPkgs.cardano-wallet-integration.components.exes.integration-exe;
-                e2e = project.hsPkgs.cardano-wallet-integration.components.tests.e2e;
-                inherit (project.hsPkgs.local-cluster.components.exes) test-local-cluster-exe;
-
-                # Adrestia tool belt
-                inherit (project.hsPkgs.bech32.components.exes) bech32;
-                inherit (project.hsPkgs.cardano-addresses-cli.components.exes) cardano-address;
-
-                # Cardano
-                cardano-cli = nodeProject.hsPkgs.cardano-cli.components.exes.cardano-cli;
-                cardano-node = nodeProject.hsPkgs.cardano-node.components.exes.cardano-node // {
-                  deployments = pkgs.cardano-node-deployments;
-                };
-
-                # Provide db-converter, so daedalus can ship it without needing to
-                # pin an ouroborus-network rev.
-                inherit (project.hsPkgs.ouroboros-consensus-byron.components.exes) db-converter;
-
-                # Combined project coverage report
-                testCoverageReport = coveredProject.projectCoverageReport;
-                # `tests` are the test suites which have been built.
-                tests = lib.removeRecurse (collectComponents "tests" isProjectPackage coveredProject.hsPkgs);
-                # `checks` are the result of executing the tests.
-                checks = lib.removeRecurse (collectChecks isProjectPackage coveredProject.hsPkgs);
-                # `benchmarks` are only built, not run.
-                benchmarks = lib.removeRecurse (collectComponents "benchmarks" isProjectPackage project.hsPkgs);
-              };
-            in
-            self;
-
-          # nix run .#<network>/wallet
-          mkScripts =
-            project:
-            flattenTree (
-              import ./nix/scripts.nix {
-                inherit project evalService;
-                customConfigs = [ config ];
-              }
-            );
-
-          # See the imported file for how to use the docker build.
-          mkDockerImage =
-            isRelease: packages:
-            let
-              version = (builtins.head exes).version;
-              revision = "c-" + self.shortRev;
-              exes = with packages; [
-                cardano-wallet
-                local-cluster
-              ];
-            in
-
-            pkgs.callPackage ./nix/docker.nix {
-              inherit exes;
-              base = with packages; [
-                bech32
-                cardano-address
-                cardano-cli
-                cardano-node
-                (pkgs.linkFarm "docker-config-layer" [
-                  {
-                    name = "config";
-                    path = pkgs.cardano-node-deployments;
-                  }
-                ])
-              ];
-              tag = if isRelease then version else revision;
-            };
-
-          mkDevShells = project: rec {
-            default = project.shell;
-            profiled = (project.appendModule { profiling = true; }).shell;
-
-            docs = pkgs.mkShell {
-              name = "cardano-wallet-docs";
-              nativeBuildInputs = [
-                pkgs.mdbook
-                pkgs.mdbook-mermaid
-                pkgs.mdbook-admonish
-              ];
-              # allow building the shell so that it can be cached
-              phases = [ "installPhase" ];
-              installPhase = "echo $nativeBuildInputs > $out";
-            };
-          };
-          rewrite-libs = import ./nix/rewrite-libs/rewrite-libs.nix {
-            inherit system;
-            inherit nixpkgs flake-utils haskellNix;
-          };
-          # One ${system} can cross-compile artifacts for other platforms.
-          mkReleaseArtifacts =
-            project:
-            let # compiling with musl gives us a statically linked executable
-              linuxPackages = mkPackages project.projectCross.musl64;
-              linuxReleaseExes = [
-                linuxPackages.cardano-wallet
-                linuxPackages.bech32
-                linuxPackages.cardano-address
-                cardano-node-runtime.hydraJobs.x86_64-linux.musl.cardano-cli
-                cardano-node-runtime.hydraJobs.x86_64-linux.musl.cardano-node
-              ];
-              # Which exes should be put in the release archives.
-              checkReleaseContents =
-                jobs:
-                map (exe: jobs.${exe}) [
-                  "cardano-wallet"
-                  "bech32"
-                  "cardano-address"
-                  "cardano-cli"
-                  "cardano-node"
-                ];
-            in
-            lib.optionalAttrs buildPlatform.isLinux {
-              linux64.release = import ./nix/release-package.nix {
-                inherit pkgs nodeConfigs;
-                walletLib = lib;
-                exes = linuxReleaseExes;
-                platform = "linux64";
-                format = "tar.gz";
-              };
-              win64 =
-                let
-                  # windows is cross-compiled from linux
-                  windowsPackages = mkPackages project.projectCross.ucrt64 // {
-                    cardano-cli = cardano-node-runtime.hydraJobs.x86_64-linux.windows.cardano-cli;
-                    cardano-node = cardano-node-runtime.hydraJobs.x86_64-linux.windows.cardano-node;
-                  };
-                in
-                {
-                  release = import ./nix/release-package.nix {
-                    inherit pkgs nodeConfigs;
-                    walletLib = lib;
-                    exes = [
-                      windowsPackages.cardano-wallet
-                      windowsPackages.bech32
-                      windowsPackages.cardano-address
-                      windowsPackages.cardano-cli
-                      windowsPackages.cardano-node
-                    ];
-                    platform = "win64";
-                    format = "zip";
-                  };
-                  # Testing on Windows is done using a collection of executables.
-                  tests = import ./nix/windows-testing-bundle.nix {
-                    inherit pkgs;
-                    cardano-wallet = windowsPackages.cardano-wallet;
-                    cardano-cli = windowsPackages.cardano-cli;
-                    cardano-node = windowsPackages.cardano-node;
-                    tests = lib.collect lib.isDerivation windowsPackages.tests;
-                    benchmarks = lib.collect lib.isDerivation windowsPackages.benchmarks;
-                  };
-                };
-            }
-            # macos is never cross-compiled
-            // lib.optionalAttrs buildPlatform.isMacOS {
-              macos-intel = lib.optionalAttrs buildPlatform.isx86_64 {
-                release = import ./nix/release-package.nix {
-                  inherit pkgs nodeConfigs;
-                  walletLib = lib;
-                  exes =
-                    let
-                      macOsPkgs = mkPackages project;
-                    in
-                    [
-                      macOsPkgs.cardano-wallet
-                      macOsPkgs.bech32
-                      macOsPkgs.cardano-address
-                      nodePackages.cardano-cli
-                      nodePackages.cardano-node
-                    ];
-                  platform = "macos-intel";
-                  format = "tar.gz";
-                  rewrite-libs = rewrite-libs.packages.default;
-                };
-              };
-              macos-silicon = lib.optionalAttrs buildPlatform.isAarch64 {
-                release = import ./nix/release-package.nix {
-                  inherit pkgs nodeConfigs;
-                  walletLib = lib;
-                  exes =
-                    let
-                      macOsPkgs = mkPackages project;
-                    in
-                    [
-                      macOsPkgs.cardano-wallet
-                      macOsPkgs.bech32
-                      macOsPkgs.cardano-address
-                      nodePackages.cardano-cli
-                      nodePackages.cardano-node
-                    ];
-                  platform = "macos-silicon";
-                  format = "tar.gz";
-                  rewrite-libs = rewrite-libs.packages.default;
-                };
-              };
-            };
-          imagePackages = mkPackages walletProject.projectCross.musl64;
-        in
-        rec {
-
-          legacyPackages = walletProject;
-
-          # Built by `nix build .`
-          defaultPackage = packages.cardano-wallet;
-
-          # Run by `nix run .`
-          defaultApp = apps.cardano-wallet;
-
-          packages =
-            mkPackages walletProject
-            // mkScripts walletProject
-            // rec {
-              dockerImage = mkDockerImage true imagePackages;
-              dockerTestImage = mkDockerImage false imagePackages;
-            }
-            //
-
-              (lib.optionalAttrs buildPlatform.isLinux {
-                nixosTests = import ./nix/nixos/tests {
-                  inherit pkgs;
-                  project = walletProject;
-                };
-              })
+          # Local test cluster and mock metadata server
+          inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server;
+          inherit (project.hsPkgs.cardano-wallet-benchmarks.components.exes) benchmark-history;
+          inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
+          integration-exe = project.hsPkgs.cardano-wallet-integration.components.exes.integration-exe;
+          e2e = project.hsPkgs.cardano-wallet-integration.components.tests.e2e;
+          inherit (project.hsPkgs.local-cluster.components.exes) test-local-cluster-exe;
+          # Adrestia tool belt
+          inherit (project.hsPkgs.bech32.components.exes) bech32;
+          inherit (project.hsPkgs.cardano-addresses-cli.components.exes) cardano-address;
+          # Cardano
+          cardano-cli = nodeProject.hsPkgs.cardano-cli.components.exes.cardano-cli;
+          cardano-node =
+            nodeProject.hsPkgs.cardano-node.components.exes.cardano-node
             // {
-              # Continuous integration builds
-              ci.tests.all = pkgs.releaseTools.aggregate {
-                name = "cardano-wallet-tests";
-                meta.description = "Build (all) tests";
-                constituents = lib.collect lib.isDerivation packages.tests;
-              };
-
-              ci.benchmarks =
-                let
-                  collectedBenchmarks = lib.concatMapAttrs (_n: v: v) packages.benchmarks;
-                in
-                collectedBenchmarks
-                // {
-                  all = pkgs.releaseTools.aggregate {
-                    name = "cardano-wallet-benchmarks";
-                    meta.description = "Build all benchmarks";
-                    constituents = lib.collect lib.isDerivation collectedBenchmarks;
-                  };
-                };
-              ci.artifacts = mkReleaseArtifacts walletProject // {
-                dockerImage = packages.dockerImage;
-              };
+              deployments = pkgs.cardano-node-deployments;
             };
 
-          # Heinrich: I don't quite understand the 'checks' attribute. See also
-          # https://www.reddit.com/r/NixOS/comments/x5cjmz/comment/in0qqm6/?utm_source=share&utm_medium=web2x&context=3
-          checks = packages.checks;
+          # Provide db-converter, so daedalus can ship it without needing to
+          # pin an ouroborus-network rev.
+          inherit (project.hsPkgs.ouroboros-consensus-byron.components.exes) db-converter;
 
-          mkApp = name: pkg: {
-            type = "app";
-            program = pkg.exePath or "${pkg}/bin/${pkg.name or name}";
-          };
-          apps = lib.mapAttrs mkApp packages;
+          # Combined project coverage report
+          testCoverageReport = coveredProject.projectCoverageReport;
+          # `tests` are the test suites which have been built.
+          tests = lib.removeRecurse (collectComponents "tests" isProjectPackage coveredProject.hsPkgs);
+          # `checks` are the result of executing the tests.
+          checks = lib.removeRecurse (collectChecks isProjectPackage coveredProject.hsPkgs);
+          # `benchmarks` are only built, not run.
+          benchmarks = lib.removeRecurse (collectComponents "benchmarks" isProjectPackage project.hsPkgs);
+        };
+      in
+        self;
 
-          devShells = mkDevShells walletProject;
+      # nix run .#<network>/wallet
+      mkScripts = project:
+        flattenTree (
+          import ./nix/scripts.nix {
+            inherit project evalService;
+            customConfigs = [config];
+          }
+        );
+      # See the imported file for how to use the docker build.
+      mkDockerImage = isRelease: packages: let
+        version = (builtins.head exes).version;
+        revision = "c-" + self.shortRev;
+        exes = with packages; [
+          cardano-wallet
+          local-cluster
+        ];
+      in
+        pkgs.callPackage ./nix/docker.nix {
+          inherit exes;
+          base = with packages; [
+            bech32
+            cardano-address
+            cardano-cli
+            cardano-node
+            (pkgs.linkFarm "docker-config-layer" [
+              {
+                name = "config";
 
-          ci.tests.run.unit = pkgs.releaseTools.aggregate {
-            name = "tests.run.unit";
-            meta.description = "Run unit tests";
-            constituents = lib.collect lib.isDerivation (lib.keepUnitChecks packages.checks);
-          };
+                path = pkgs.cardano-node-deployments;
+              }
+            ])
+          ];
+          tag =
+            if isRelease
+            then version
+            else revision;
         };
 
-      systems = eachSystem supportedSystems mkOutputs;
-      rev = self.rev or null;
-    in
-    lib.recursiveUpdate systems { inherit overlay nixosModule nixosModules; }
+      mkDevShells = project: rec {
+        default = project.shell.overrideAttrs (old: {
+          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [treefmtEval.config.build.wrapper];
+        });
+        profiled = (project.appendModule {profiling = true;}).shell;
+
+        docs = pkgs.mkShell {
+          name = "cardano-wallet-docs";
+          nativeBuildInputs = [
+            pkgs.mdbook
+            pkgs.mdbook-mermaid
+            pkgs.mdbook-admonish
+          ];
+          # allow building the shell so that it can be cached
+          phases = ["installPhase"];
+          installPhase = "echo $nativeBuildInputs > $out";
+        };
+      };
+      rewrite-libs = import ./nix/rewrite-libs/rewrite-libs.nix {
+        inherit system;
+        inherit nixpkgs flake-utils haskellNix;
+      };
+      # One ${system} can cross-compile artifacts for other platforms.
+      mkReleaseArtifacts = project: let
+        # compiling with musl gives us a statically linked executable
+        linuxPackages = mkPackages project.projectCross.musl64;
+        linuxReleaseExes = [
+          linuxPackages.cardano-wallet
+          linuxPackages.bech32
+          linuxPackages.cardano-address
+          cardano-node-runtime.hydraJobs.x86_64-linux.musl.cardano-cli
+          cardano-node-runtime.hydraJobs.x86_64-linux.musl.cardano-node
+        ];
+        # Which exes should be put in the release archives.
+        checkReleaseContents = jobs:
+          map (exe: jobs.${exe}) [
+            "cardano-wallet"
+            "bech32"
+            "cardano-address"
+            "cardano-cli"
+            "cardano-node"
+          ];
+      in
+        lib.optionalAttrs buildPlatform.isLinux {
+          linux64.release = import ./nix/release-package.nix {
+            inherit pkgs nodeConfigs;
+            walletLib = lib;
+            exes = linuxReleaseExes;
+            platform = "linux64";
+            format = "tar.gz";
+          };
+          win64 = let
+            # windows is cross-compiled from linux
+            windowsPackages =
+              mkPackages project.projectCross.ucrt64
+              // {
+                cardano-cli = cardano-node-runtime.hydraJobs.x86_64-linux.windows.cardano-cli;
+                cardano-node = cardano-node-runtime.hydraJobs.x86_64-linux.windows.cardano-node;
+              };
+          in {
+            release = import ./nix/release-package.nix {
+              inherit pkgs nodeConfigs;
+              walletLib = lib;
+              exes = [
+                windowsPackages.cardano-wallet
+                windowsPackages.bech32
+                windowsPackages.cardano-address
+                windowsPackages.cardano-cli
+                windowsPackages.cardano-node
+              ];
+              platform = "win64";
+              format = "zip";
+            };
+            # Testing on Windows is done using a collection of executables.
+            tests = import ./nix/windows-testing-bundle.nix {
+              inherit pkgs;
+              cardano-wallet = windowsPackages.cardano-wallet;
+              cardano-cli = windowsPackages.cardano-cli;
+              cardano-node = windowsPackages.cardano-node;
+              tests = lib.collect lib.isDerivation windowsPackages.tests;
+              benchmarks = lib.collect lib.isDerivation windowsPackages.benchmarks;
+            };
+          };
+        }
+        # macos is never cross-compiled
+        // lib.optionalAttrs buildPlatform.isMacOS {
+          macos-intel = lib.optionalAttrs buildPlatform.isx86_64 {
+            release = import ./nix/release-package.nix {
+              inherit pkgs nodeConfigs;
+              walletLib = lib;
+              exes = let
+                macOsPkgs = mkPackages project;
+              in [
+                macOsPkgs.cardano-wallet
+                macOsPkgs.bech32
+                macOsPkgs.cardano-address
+                nodePackages.cardano-cli
+                nodePackages.cardano-node
+              ];
+              platform = "macos-intel";
+              format = "tar.gz";
+              rewrite-libs = rewrite-libs.packages.default;
+            };
+          };
+          macos-silicon = lib.optionalAttrs buildPlatform.isAarch64 {
+            release = import ./nix/release-package.nix {
+              inherit pkgs nodeConfigs;
+              walletLib = lib;
+              exes = let
+                macOsPkgs = mkPackages project;
+              in [
+                macOsPkgs.cardano-wallet
+                macOsPkgs.bech32
+                macOsPkgs.cardano-address
+                nodePackages.cardano-cli
+                nodePackages.cardano-node
+              ];
+              platform = "macos-silicon";
+              format = "tar.gz";
+              rewrite-libs = rewrite-libs.packages.default;
+            };
+          };
+        };
+      imagePackages = mkPackages walletProject.projectCross.musl64;
+    in rec {
+      legacyPackages = walletProject;
+      # Built by `nix build .`
+      defaultPackage = packages.cardano-wallet;
+      # Run by `nix run .`
+      defaultApp = apps.cardano-wallet;
+      # This makes 'nix fmt' work automatically
+      formatter = treefmtEval.config.build.wrapper;
+      packages =
+        mkPackages walletProject
+        // mkScripts walletProject
+        // rec {
+          dockerImage = mkDockerImage true imagePackages;
+          dockerTestImage = mkDockerImage false imagePackages;
+        }
+        // (lib.optionalAttrs buildPlatform.isLinux {
+          nixosTests = import ./nix/nixos/tests {
+            inherit pkgs;
+            project = walletProject;
+          };
+        })
+        // {
+          # Continuous integration builds
+
+          ci.tests.all = pkgs.releaseTools.aggregate {
+            name = "cardano-wallet-tests";
+            meta.description = "Build (all) tests";
+            constituents = lib.collect lib.isDerivation packages.tests;
+          };
+          ci.benchmarks = let
+            collectedBenchmarks = lib.concatMapAttrs (_n: v: v) packages.benchmarks;
+          in
+            collectedBenchmarks
+            // {
+              all = pkgs.releaseTools.aggregate {
+                name = "cardano-wallet-benchmarks";
+                meta.description = "Build all benchmarks";
+                constituents = lib.collect lib.isDerivation collectedBenchmarks;
+              };
+            };
+          ci.artifacts =
+            mkReleaseArtifacts walletProject
+            // {
+              dockerImage = packages.dockerImage;
+            };
+        };
+
+      # Heinrich: I don't quite understand the 'checks' attribute.
+      # See also
+      # https://www.reddit.com/r/NixOS/comments/x5cjmz/comment/in0qqm6/?utm_source=share&utm_medium=web2x&context=3
+      checks = packages.checks;
+      mkApp = name: pkg: {
+        type = "app";
+        program = pkg.exePath or "${pkg}/bin/${pkg.name or name}";
+      };
+      apps = lib.mapAttrs mkApp packages;
+
+      devShells = mkDevShells walletProject;
+      ci.tests.run.unit = pkgs.releaseTools.aggregate {
+        name = "tests.run.unit";
+        meta.description = "Run unit tests";
+        constituents = lib.collect lib.isDerivation (lib.keepUnitChecks packages.checks);
+      };
+    };
+
+    systems = eachSystem supportedSystems mkOutputs;
+    rev = self.rev or null;
+  in
+    lib.recursiveUpdate systems {inherit overlay nixosModule nixosModules;}
     // {
       revision = rev;
     };

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,28 +1,27 @@
-lib: customConfig: let config =
- lib.recursiveUpdate {
-  platform = "all";
-  # The systems that the jobset will be built for.
-  supportedSystems = import ./nix/supported-systems.nix;
+lib: customConfig: let
+  config = lib.recursiveUpdate {
+    platform = "all";
+    # The systems that the jobset will be built for.
+    supportedSystems = import ./nix/supported-systems.nix;
 
-  # Enable debug tracing
-  debug = false;
+    # Enable debug tracing
+    debug = false;
 
-  # Use this git revision for stamping executables
-  gitrev = null;
+    # Use this git revision for stamping executables
+    gitrev = null;
 
-  # Enable building the cabal-cache util - only needed under CI
-  withCabalCache = false;
+    # Enable building the cabal-cache util - only needed under CI
+    withCabalCache = false;
 
-  # optional extra haskell.nix module
-  haskellNix = {};
+    # optional extra haskell.nix module
+    haskellNix = {};
 
-  # optional string argument to override compiler, in cabal shell.
-  ghcVersion = null;
+    # optional string argument to override compiler, in cabal shell.
+    ghcVersion = null;
 
-  dockerHubRepoName = null;
-
-} customConfig;
+    dockerHubRepoName = null;
+  }
+  customConfig;
 in
   assert lib.asserts.assertOneOf "platform" config.platform
-    ["all" "linux" "macos" "windows"];
-  config
+  ["all" "linux" "macos" "windows"]; config

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,27 +1,28 @@
 lib: customConfig: let
-  config = lib.recursiveUpdate {
-    platform = "all";
-    # The systems that the jobset will be built for.
-    supportedSystems = import ./nix/supported-systems.nix;
+  config =
+    lib.recursiveUpdate {
+      platform = "all";
+      # The systems that the jobset will be built for.
+      supportedSystems = import ./nix/supported-systems.nix;
 
-    # Enable debug tracing
-    debug = false;
+      # Enable debug tracing
+      debug = false;
 
-    # Use this git revision for stamping executables
-    gitrev = null;
+      # Use this git revision for stamping executables
+      gitrev = null;
 
-    # Enable building the cabal-cache util - only needed under CI
-    withCabalCache = false;
+      # Enable building the cabal-cache util - only needed under CI
+      withCabalCache = false;
 
-    # optional extra haskell.nix module
-    haskellNix = {};
+      # optional extra haskell.nix module
+      haskellNix = {};
 
-    # optional string argument to override compiler, in cabal shell.
-    ghcVersion = null;
+      # optional string argument to override compiler, in cabal shell.
+      ghcVersion = null;
 
-    dockerHubRepoName = null;
-  }
-  customConfig;
+      dockerHubRepoName = null;
+    }
+    customConfig;
 in
   assert lib.asserts.assertOneOf "platform" config.platform
   ["all" "linux" "macos" "windows"]; config

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,3 +1,3 @@
-{ ... }@args:
+{...} @ args:
 with (import ./flake-compat.nix args);
-defaultNix.legacyPackages.${builtins.currentSystem}.pkgs
+  defaultNix.legacyPackages.${builtins.currentSystem}.pkgs

--- a/nix/flake-compat.nix
+++ b/nix/flake-compat.nix
@@ -1,5 +1,4 @@
-{...}@args:
-let
+{...} @ args: let
   src = args.src or ../.;
   lock = builtins.fromJSON (builtins.readFile (src + "/flake.lock"));
   flake-compate-input = lock.nodes.root.inputs.flake-compat;
@@ -8,16 +7,17 @@ let
     url = "https://api.github.com/repos/input-output-hk/flake-compat/tarball/${lock.nodes.${flake-compate-input}.locked.rev}";
     sha256 = lock.nodes.${flake-compate-input}.locked.narHash;
   });
-  pkgs = import
+  pkgs =
+    import
     (builtins.fetchTarball {
       url = "https://api.github.com/repos/NixOS/nixpkgs/tarball/${lock.nodes.${nixpkgs-input}.locked.rev}";
       sha256 = lock.nodes.${nixpkgs-input}.locked.narHash;
     })
-    { };
+    {};
 in
-flake-compat {
-  inherit src pkgs;
-  override-inputs = {
-    customConfig = args;
-  };
-}
+  flake-compat {
+    inherit src pkgs;
+    override-inputs = {
+      customConfig = args;
+    };
+  }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,8 +1,14 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-libs: haskell-nix.cabalProject' [
-  ({ lib, pkgs, buildProject, ... }: {
+CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-libs:
+haskell-nix.cabalProject' [
+  ({
+    lib,
+    pkgs,
+    buildProject,
+    ...
+  }: {
     options = {
       gitrev = lib.mkOption {
         type = lib.types.str;
@@ -23,114 +29,113 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
         description = ''If false, prevent check results from being cached on `nix build`'';
         default = true;
       };
-
     };
   })
-  ({ pkgs
-   , lib
-   , config
-   , buildProject
-   , ...
-   }:
+  ({
+    pkgs,
+    lib,
+    config,
+    buildProject,
+    ...
+  }: let
+    inherit (pkgs) stdenv;
+    inherit (haskell-nix) haskellLib;
 
-    let
-      inherit (pkgs) stdenv;
-      inherit (haskell-nix) haskellLib;
+    # Add this string to a tests preCheck to prevent test results from
+    # being cached.
+    #
+    # It is useful to have when your tests are flaky and fail a lot --
+    # we don't want to cache false failures.
+    noCacheCookie = ''
+      # Causes tests to be re-run whenever the git revision
+      # changes, even if everything else is identical.
+      echo "Git revision is ${toString config.gitrev}"
+    '';
 
-      # Add this string to a tests preCheck to prevent test results from
-      # being cached.
-      #
-      # It is useful to have when your tests are flaky and fail a lot --
-      # we don't want to cache false failures.
-      noCacheCookie = ''
-        # Causes tests to be re-run whenever the git revision
-        # changes, even if everything else is identical.
-        echo "Git revision is ${toString config.gitrev}"
-      '';
+    noCacheTestFailuresCookie = lib.optionalString (!config.cacheTestFailures) noCacheCookie;
 
-      noCacheTestFailuresCookie = lib.optionalString (!config.cacheTestFailures) noCacheCookie;
+    # setGitRev is a postInstall script to stamp executables with
+    # version info. It uses the "gitrev" option.
+    setGitRevPostInstall = ''
+      ${set-git-rev}/bin/set-git-rev "${config.gitrev}" $out/bin/*
+    '';
 
-      # setGitRev is a postInstall script to stamp executables with
-      # version info. It uses the "gitrev" option.
-      setGitRevPostInstall = ''
-         ${set-git-rev}/bin/set-git-rev "${config.gitrev}" $out/bin/*
-        '';
+    rewriteLibsPostInstall = lib.optionalString (pkgs.stdenv.hostPlatform.isDarwin) ''
+      export PATH=$PATH:${lib.makeBinPath (with pkgs.buildPackages; [binutils nix])}
+      ${rewrite-libs}/bin/rewrite-libs $out/bin $out/bin/*
+    '';
 
-      rewriteLibsPostInstall = lib.optionalString (pkgs.stdenv.hostPlatform.isDarwin) ''
-        export PATH=$PATH:${lib.makeBinPath (with pkgs.buildPackages; [ binutils nix ])}
-        ${rewrite-libs}/bin/rewrite-libs $out/bin $out/bin/*
-      '';
+    stripBinariesPostInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+      ${pkgs.buildPackages.binutils-unwrapped}/bin/*strip $out/bin/*
+    '';
 
-      stripBinariesPostInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-        ${pkgs.buildPackages.binutils-unwrapped}/bin/*strip $out/bin/*
-      '';
+    # This exe component postInstall script adds shell completion
+    # scripts. These completion
+    # scripts will be picked up automatically if the resulting
+    # derivation is installed, e.g. by `nix-env -i`.
+    optparseCompletionPostInstall = lib.optionalString stdenv.hostPlatform.isUnix ''
+      exeName=$(ls -1 $out/bin | head -n1)  # FIXME add $exeName to Haskell.nix
+      bashCompDir="$out/share/bash-completion/completions"
+      zshCompDir="$out/share/zsh/vendor-completions"
+      fishCompDir="$out/share/fish/vendor_completions.d"
+      mkdir -p "$bashCompDir" "$zshCompDir" "$fishCompDir"
+      "$out/bin/$exeName" --bash-completion-script "$exeName" >"$bashCompDir/$exeName"
+      "$out/bin/$exeName" --zsh-completion-script "$exeName" >"$zshCompDir/_$exeName"
+      "$out/bin/$exeName" --fish-completion-script "$exeName" >"$fishCompDir/$exeName.fish"
+    '';
 
-      # This exe component postInstall script adds shell completion
-      # scripts. These completion
-      # scripts will be picked up automatically if the resulting
-      # derivation is installed, e.g. by `nix-env -i`.
-      optparseCompletionPostInstall = lib.optionalString stdenv.hostPlatform.isUnix ''
-        exeName=$(ls -1 $out/bin | head -n1)  # FIXME add $exeName to Haskell.nix
-        bashCompDir="$out/share/bash-completion/completions"
-        zshCompDir="$out/share/zsh/vendor-completions"
-        fishCompDir="$out/share/fish/vendor_completions.d"
-        mkdir -p "$bashCompDir" "$zshCompDir" "$fishCompDir"
-        "$out/bin/$exeName" --bash-completion-script "$exeName" >"$bashCompDir/$exeName"
-        "$out/bin/$exeName" --zsh-completion-script "$exeName" >"$zshCompDir/_$exeName"
-        "$out/bin/$exeName" --fish-completion-script "$exeName" >"$fishCompDir/$exeName.fish"
-      '';
+    # The list of project packages is not automatically discovered yet,
+    # instead it is generated by ./nix/regenerate.sh
+    projectPackages = import ./project-package-list.nix;
 
-      # The list of project packages is not automatically discovered yet,
-      # instead it is generated by ./nix/regenerate.sh
-      projectPackages = import ./project-package-list.nix;
+    srcAll = lib.cleanSourceWith {
+      name = "cardano-wallet-src-all";
+      src = ../.;
+      filter = lib.cleanSourceFilter;
+    };
 
-      srcAll = lib.cleanSourceWith {
-        name = "cardano-wallet-src-all";
-        src = ../.;
-        filter = lib.cleanSourceFilter;
-      };
+    # this is a local variable, it controls only the index-state of the
+    # tools
+    indexState = "2025-01-01T23:24:19Z";
 
-      # this is a local variable, it controls only the index-state of the
-      # tools
-      indexState = "2025-01-01T23:24:19Z";
+    localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;
+  in {
+    name = "cardano-wallet";
+    compiler-nix-name = "ghc966";
 
-      localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;
+    src = haskellLib.cleanSourceWith {
+      name = "cardano-wallet-src";
+      src = srcAll;
+      filter = haskell-nix.haskellSourceFilter;
+    };
 
-    in {
-      name = "cardano-wallet";
-      compiler-nix-name = "ghc966";
-
-      src = haskellLib.cleanSourceWith {
-        name = "cardano-wallet-src";
-        src = srcAll;
-        filter = haskell-nix.haskellSourceFilter;
-      };
-
-      shell = {
-        name = "cardano-wallet-shell${lib.optionalString config.profiling "-profiled"}";
-        packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
-        tools = {
-          cabal = { index-state = indexState; };
-          cabal-fmt = { index-state = indexState; };
-          haskell-language-server = {
-            index-state = indexState;
-            version = "latest";
-          };
-          hoogle = {
-            index-state = indexState;
-            version = "latest";
-          };
+    shell = {
+      name = "cardano-wallet-shell${lib.optionalString config.profiling "-profiled"}";
+      packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
+      tools = {
+        cabal = {index-state = indexState;};
+        cabal-fmt = {index-state = indexState;};
+        haskell-language-server = {
+          index-state = indexState;
+          version = "latest";
         };
-        nativeBuildInputs = (with buildProject.hsPkgs; [
+        hoogle = {
+          index-state = indexState;
+          version = "latest";
+        };
+      };
+      nativeBuildInputs =
+        (with buildProject.hsPkgs; [
           nodePkgs.cardano-cli
           nodePkgs.cardano-node
           cardano-addresses-cli.components.exes.cardano-address
           bech32.components.exes.bech32
-        ]) ++ (with pkgs.buildPackages.buildPackages; [
+        ])
+        ++ (with pkgs.buildPackages.buildPackages; [
           just
           pkg-config
           nixpkgs-recent.python3Packages.openapi-spec-validator
-          (ruby_3_1.withPackages (ps: [ ps.rake ps.thor ]))
+          (ruby_3_1.withPackages (ps: [ps.rake ps.thor]))
           rubyPackages_3_1.rubocop
           sqlite-interactive
           curlFull
@@ -147,166 +152,169 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           haskellPackages.weeder
           haskellPackages.stylish-haskell
           mithrilPkgs.mithril-client-cli
-
         ]);
-        shellHook = "export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}";
-      };
+      shellHook = "export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}";
+    };
 
-      inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
+    inputMap = {"https://chap.intersectmbo.org/" = CHaP;};
 
-      modules =
-        let inherit (config) src coverage profiling;
-        in
-        [
-          {
-            packages = lib.genAttrs projectPackages (name: {
-              # Enable release flag (optimization and -Werror)
-              flags.release = true;
+    modules = let
+      inherit (config) src coverage profiling;
+    in [
+      {
+        packages = lib.genAttrs projectPackages (name: {
+          # Enable release flag (optimization and -Werror)
+          flags.release = true;
 
-              # Enable Haskell Program Coverage for all local libraries
-              # and test suites.
-              doCoverage = coverage;
-            });
-          }
+          # Enable Haskell Program Coverage for all local libraries
+          # and test suites.
+          doCoverage = coverage;
+        });
+      }
 
-          # Provide configuration and dependencies to cardano-wallet components
-          ({ config, pkgs, ... }:
-            let
-              cardanoNodeExes = [ nodePkgs.cardano-cli nodePkgs.cardano-node ];
-            in
-            {
-              reinstallableLibGhc = true;
+      # Provide configuration and dependencies to cardano-wallet components
+      ({
+        config,
+        pkgs,
+        ...
+      }: let
+        cardanoNodeExes = [nodePkgs.cardano-cli nodePkgs.cardano-node];
+      in {
+        reinstallableLibGhc = true;
 
-              packages.cardano-wallet-unit.components.tests = {
-                unit.build-tools = cardanoNodeExes;
-                unit.preCheck = noCacheTestFailuresCookie + ''
-                    export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}
-                  '' + lib.optionalString stdenv.isDarwin ''
-                    # cardano-node socket path becomes too long otherwise
-                    export TMPDIR=/tmp
-                  '';
-                  };
-
-              packages.cardano-wallet-integration.components.tests = {
-                # NOTE:
-                # We are concerned with building integration test executables here,
-                # but we are no longer concerned with *running* the integration
-                # tests as part of building a nix derivation.
-                #
-                # provide cardano-node & cardano-cli to tests
-                integration.build-tools = cardanoNodeExes;
-              };
-
-              # Add node backend to the PATH of the latency benchmarks, and
-              # set the source tree as its working directory.
-              packages.cardano-wallet-benchmarks.components.benchmarks.latency =
-                lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/* \
-                      --run "cd ${srcAll}/lib/wallet" \
-                      --add-flags --cluster-configs="${localClusterConfigs}" \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
-
-              # Add cardano-node to the PATH of the byroon restore benchmark.
-              # cardano-node will want to write logs to a subdirectory of the working directory.
-              # We don't `cd $src` because of that.
-              packages.cardano-wallet-benchmarks.components.benchmarks.restore =
-                lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/restore \
-                      --set CARDANO_NODE_CONFIGS ${pkgs.cardano-node-deployments} \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
-
-              packages.cardano-wallet.components.exes.local-cluster = {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/* \
-                      --add-flags --cluster-configs="${localClusterConfigs}" \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
-
-              # Add shell completions for main executables.
-              packages.cardano-wallet-application.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + setGitRevPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
-              packages.cardano-wallet.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + setGitRevPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
-            })
-
-          # Provide the swagger file in an environment variable for
-          # tests because it is located outside of the Cabal package
-          # source tree.
-          {
-            packages.cardano-wallet-unit.components.tests.unit.preBuild = ''
-              export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}
+        packages.cardano-wallet-unit.components.tests = {
+          unit.build-tools = cardanoNodeExes;
+          unit.preCheck =
+            noCacheTestFailuresCookie
+            + ''
+              export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}
+            ''
+            + lib.optionalString stdenv.isDarwin ''
+              # cardano-node socket path becomes too long otherwise
+              export TMPDIR=/tmp
             '';
-          }
+        };
 
-          ({ lib, pkgs, ... }: {
-            # Use our forked libsodium from iohk-nix crypto overlay.
-            packages.plutus-tx.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.byron-spec-ledger.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ] ];
-          })
+        packages.cardano-wallet-integration.components.tests = {
+          # NOTE:
+          # We are concerned with building integration test executables here,
+          # but we are no longer concerned with *running* the integration
+          # tests as part of building a nix derivation.
+          #
+          # provide cardano-node & cardano-cli to tests
+          integration.build-tools = cardanoNodeExes;
+        };
 
-          # Build fixes for library dependencies
-          {
-            # Packages we wish to ignore version bounds of.
-            # This is similar to jailbreakCabal, however it
-            # does not require any messing with cabal files.
-            packages.katip.doExactConfig = true;
+        # Add node backend to the PATH of the latency benchmarks, and
+        # set the source tree as its working directory.
+        packages.cardano-wallet-benchmarks.components.benchmarks.latency = lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
+          build-tools = [pkgs.buildPackages.makeWrapper];
+          postInstall = ''
+            wrapProgram $out/bin/* \
+              --run "cd ${srcAll}/lib/wallet" \
+              --add-flags --cluster-configs="${localClusterConfigs}" \
+              --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+          '';
+        };
 
-            # Lets us put the pretty-simple tool in shell.nix.
-            packages.pretty-simple.flags.buildexe = true;
-          }
+        # Add cardano-node to the PATH of the byroon restore benchmark.
+        # cardano-node will want to write logs to a subdirectory of the working directory.
+        # We don't `cd $src` because of that.
+        packages.cardano-wallet-benchmarks.components.benchmarks.restore = lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
+          build-tools = [pkgs.buildPackages.makeWrapper];
+          postInstall = ''
+            wrapProgram $out/bin/restore \
+              --set CARDANO_NODE_CONFIGS ${pkgs.cardano-node-deployments} \
+              --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+          '';
+        };
 
-          # Enable profiling on executables if the profiling argument is set.
-          (lib.optionalAttrs profiling {
-            enableLibraryProfiling = true;
-            packages.cardano-wallet-application.components.exes.cardano-wallet.enableProfiling = true;
-            packages.cardano-wallet-benchmarks.components.benchmarks.restore.enableProfiling = true;
-            packages.plutus-core.ghcOptions = [ "-fexternal-interpreter" ];
-          })
+        packages.cardano-wallet.components.exes.local-cluster = {
+          build-tools = [pkgs.buildPackages.makeWrapper];
+          postInstall = ''
+            wrapProgram $out/bin/* \
+              --add-flags --cluster-configs="${localClusterConfigs}" \
+              --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+          '';
+        };
 
-          # Musl libc fully static build
-          (lib.optionalAttrs stdenv.hostPlatform.isMusl (
-            let
-              staticLibs = with pkgs; [ zlib openssl libffi gmp6 pkgs.secp256k1 ];
+        # Add shell completions for main executables.
+        packages.cardano-wallet-application.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + setGitRevPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
+        packages.cardano-wallet.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + setGitRevPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
+      })
 
-              # Module options which add GHC flags and libraries for a fully static build
-              fullyStaticOptions = {
-                enableShared = false;
-                enableStatic = true;
-                configureFlags = map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs;
-              };
-            in
-            {
-              # Apply fully static options to our Haskell executables
-              packages.cardano-wallet-benchmarks.components.benchmarks.restore = fullyStaticOptions;
-              packages.cardano-wallet-application.components.exes.cardano-wallet = fullyStaticOptions;
-              packages.cardano-wallet-integration.components.tests.integration = fullyStaticOptions;
-              packages.cardano-wallet-unit.components.tests.unit = fullyStaticOptions;
-              packages.cardano-wallet-benchmarks.components.benchmarks.db = fullyStaticOptions;
-              packages.cardano-wallet-launcher.components.tests.unit = fullyStaticOptions;
-              packages.cardano-wallet-application-tls.components.tests.unit = fullyStaticOptions;
+      # Provide the swagger file in an environment variable for
+      # tests because it is located outside of the Cabal package
+      # source tree.
+      {
+        packages.cardano-wallet-unit.components.tests.unit.preBuild = ''
+          export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}
+        '';
+      }
 
-              # Haddock not working for cross builds and is not needed anyway
-              doHaddock = false;
-            }
-          ))
+      ({
+        lib,
+        pkgs,
+        ...
+      }: {
+        # Use our forked libsodium from iohk-nix crypto overlay.
+        packages.plutus-tx.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf pkgs.secp256k1]];
+        packages.byron-spec-ledger.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf pkgs.secp256k1]];
+        packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf pkgs.secp256k1]];
+        packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [[pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst]];
+      })
 
-          # Silence some warnings about "cleaning component source not
-          # supported for hpack package" which appear in nix-shell
-          {
-            packages.cardano-addresses.cabal-generator = lib.mkForce null;
-            packages.cardano-addresses-cli.cabal-generator = lib.mkForce null;
-          }
+      # Build fixes for library dependencies
+      {
+        # Packages we wish to ignore version bounds of.
+        # This is similar to jailbreakCabal, however it
+        # does not require any messing with cabal files.
+        packages.katip.doExactConfig = true;
 
-        ];
-    })
+        # Lets us put the pretty-simple tool in shell.nix.
+        packages.pretty-simple.flags.buildexe = true;
+      }
+
+      # Enable profiling on executables if the profiling argument is set.
+      (lib.optionalAttrs profiling {
+        enableLibraryProfiling = true;
+        packages.cardano-wallet-application.components.exes.cardano-wallet.enableProfiling = true;
+        packages.cardano-wallet-benchmarks.components.benchmarks.restore.enableProfiling = true;
+        packages.plutus-core.ghcOptions = ["-fexternal-interpreter"];
+      })
+
+      # Musl libc fully static build
+      (lib.optionalAttrs stdenv.hostPlatform.isMusl (
+        let
+          staticLibs = with pkgs; [zlib openssl libffi gmp6 pkgs.secp256k1];
+
+          # Module options which add GHC flags and libraries for a fully static build
+          fullyStaticOptions = {
+            enableShared = false;
+            enableStatic = true;
+            configureFlags = map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs;
+          };
+        in {
+          # Apply fully static options to our Haskell executables
+          packages.cardano-wallet-benchmarks.components.benchmarks.restore = fullyStaticOptions;
+          packages.cardano-wallet-application.components.exes.cardano-wallet = fullyStaticOptions;
+          packages.cardano-wallet-integration.components.tests.integration = fullyStaticOptions;
+          packages.cardano-wallet-unit.components.tests.unit = fullyStaticOptions;
+          packages.cardano-wallet-benchmarks.components.benchmarks.db = fullyStaticOptions;
+          packages.cardano-wallet-launcher.components.tests.unit = fullyStaticOptions;
+          packages.cardano-wallet-application-tls.components.tests.unit = fullyStaticOptions;
+
+          # Haddock not working for cross builds and is not needed anyway
+          doHaddock = false;
+        }
+      ))
+
+      # Silence some warnings about "cleaning component source not
+      # supported for hpack package" which appear in nix-shell
+      {
+        packages.cardano-addresses.cabal-generator = lib.mkForce null;
+        packages.cardano-addresses-cli.cabal-generator = lib.mkForce null;
+      }
+    ];
+  })
 ]

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,74 +1,90 @@
 # Library of Nix functions used for cardano-wallet
-
 # nixpkgs.lib  library to import from.
 lib
-:
-
-rec {
+: rec {
   # Imports from nixpkgs.lib
-  inherit (lib) filterAttrsRecursive recursiveUpdate collect 
-                optionalAttrs mapAttrs isDerivation fileset
-                concatMapAttrs;
+  inherit
+    (lib)
+    filterAttrsRecursive
+    recursiveUpdate
+    collect
+    optionalAttrs
+    mapAttrs
+    isDerivation
+    fileset
+    concatMapAttrs
+    ;
 
-  /* Convert versions string from Cabal (YYYY.M.D)
-     to git tag format (vYYYY-MM-DD).
+  /*
+  Convert versions string from Cabal (YYYY.M.D)
+  to git tag format (vYYYY-MM-DD).
   */
   gitTagFromCabalVersion =
     # Version number in cabal format as string (YYYY.M.D)
-    cabalName :
-    let
-      versionRegExp =
-        "(^.*)([[:digit:]]{4})\.([[:digit:]]{1,2})\.([[:digit:]]{1,2})(.*$)";
+    cabalName: let
+      versionRegExp = "(^.*)([[:digit:]]{4})\.([[:digit:]]{1,2})\.([[:digit:]]{1,2})(.*$)";
       parts = builtins.match versionRegExp cabalName;
       name = lib.head parts;
       cabalVer = lib.take 3 (lib.drop 1 parts);
       rest = lib.drop 4 parts;
-      leading0 = str: if lib.stringLength str == 1 then "0" + str else str;
+      leading0 = str:
+        if lib.stringLength str == 1
+        then "0" + str
+        else str;
       tag = "v" + lib.concatMapStringsSep "-" leading0 cabalVer;
     in
       assert lib.assertMsg (parts != null)
-          "gitTagFromCabalVersion: \"${cabalName}\" does not have a version in YYYY.M.D format";
-      (name + tag + lib.concatStrings rest);
+      "gitTagFromCabalVersion: \"${cabalName}\" does not have a version in YYYY.M.D format"; (name + tag + lib.concatStrings rest);
 
-  /* Recursively set all attributes whose path satisfies
-     a given condition to the empty set {}.
+  /*
+  Recursively set all attributes whose path satisfies
+  a given condition to the empty set {}.
   */
   setEmptyAttrsWithCondition =
     # cond :: [string] -> bool
     cond:
-    lib.mapAttrsRecursiveCond
+      lib.mapAttrsRecursiveCond
       (value: !(lib.isDerivation value)) # do not modify attributes of derivations
-      (path: value: if cond path then {} else value);
+      
+      (path: value:
+        if cond path
+        then {}
+        else value);
 
-  /* Keep all attributes whose path contains a name starting
-     with "integration".
+  /*
+  Keep all attributes whose path contains a name starting
+  with "integration".
   */
   keepIntegrationChecks =
     setEmptyAttrsWithCondition
-      (path: !lib.any (lib.hasPrefix "integration") path);
+    (path: !lib.any (lib.hasPrefix "integration") path);
 
-  /* Keep all attributes whose path contain a name that is "unit" or "test".
+  /*
+  Keep all attributes whose path contain a name that is "unit" or "test".
   */
   keepUnitChecks =
     setEmptyAttrsWithCondition
-      (path: !lib.any (name: name == "unit" || name == "test" || name == "scenario") path);
+    (path: !lib.any (name: name == "unit" || name == "test" || name == "scenario") path);
 
-  /* Recursively remove all attributes named `recurseForDerivations`.
+  /*
+  Recursively remove all attributes named `recurseForDerivations`.
   */
   removeRecurse =
     lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
 
-  /* Recursively traces an attrset as it's evaluated.
-     This is helpful for debugging large attribute sets.
+  /*
+  Recursively traces an attrset as it's evaluated.
+  This is helpful for debugging large attribute sets.
   */
-  traceNames =
-    let
-      go = prefix: builtins.mapAttrs (n: v:
+  traceNames = let
+    go = prefix:
+      builtins.mapAttrs (n: v:
         if builtins.isAttrs v
-          then if v ? type && v.type == "derivation"
-            then __trace (prefix + n) v
-            else go (prefix + n + ".") v
-          else v);
-    in
-      go;
+        then
+          if v ? type && v.type == "derivation"
+          then __trace (prefix + n) v
+          else go (prefix + n + ".") v
+        else v);
+  in
+    go;
 }

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -23,57 +23,77 @@
 #   exec migration-test -- step2 launch --state-dir=./debug ...
 #
 ############################################################################
-
-{ system ? builtins.currentSystem
-, crossSystem ? null
-, config ? {}
-, pkgs ? import ./default.nix {}
+{
+  system ? builtins.currentSystem,
+  crossSystem ? null,
+  config ? {},
+  pkgs ? import ./default.nix {},
 }:
-
-with pkgs.lib;
-
-let
-
+with pkgs.lib; let
   # List of git revisions to test against.
   # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.4.8:
   # nix-prefetch-url --unpack https://github.com/cardano-foundation/cardano-wallet/archive/v2021-11-11.zip
   releases = [
-    { rev = "v2021-02-15";
-      sha256 = "1mg8n58j2mjqhhzjb4p5yp8z06b9arh40pagi9rddil2f3vxzihm"; }
-    { rev = "v2021-03-04";
-      sha256 = "07awzp8ifgkh966qirlmr8igbx8hx5nlaw3zgflnic3lqc8672sc"; }
-    { rev = "v2021-04-08";
-      sha256 = "06agcxjp3wzb76iiy79yap4qjn37mka0c2ccybnqswm3wr4ngkz2"; }
-    { rev = "v2021-04-28";
-      sha256 = "1ng0y6jmcgb3agpqwais1mfx0yh9bqxza3xxkggdzgic89pg6pg1"; }
-    { rev = "v2021-05-26";
-      sha256 = "0ladc7bpy6fwvlsp2zjw3h8rm384w3qf93gvb1s6nn2n912sp7ck"; }
-    { rev = "v2021-06-11";
-      sha256 = "0civfzjhcglc7r1382r55gwnk0rn2f9nsnqpyscs049jwsw5r7sq"; }
-    { rev = "v2021-08-27";
-      sha256 = "113d5h5b84bdgc9iclk22a02272xr9pja7n48wfdqrciqzy3ng30"; }
-    { rev = "v2021-09-09";
-      sha256 = "14l6fyjp7pxpjc7ga33bakg19fqy8dna6hmmrzp2f73hw27xg4dj"; }
-    { rev = "v2021-09-29";
-      sha256 = "0n1vgbz3m73v33462ifg3qas9djwlpcvi1m0qxc7j15l3w5qhlw5"; }
-    { rev = "v2021-11-11";
-      sha256 = "012lnp5rah4qyl8r0v04d0rz28b1rdaz6flhjrahf45b9gx7mny1"; }
+    {
+      rev = "v2021-02-15";
+      sha256 = "1mg8n58j2mjqhhzjb4p5yp8z06b9arh40pagi9rddil2f3vxzihm";
+    }
+    {
+      rev = "v2021-03-04";
+      sha256 = "07awzp8ifgkh966qirlmr8igbx8hx5nlaw3zgflnic3lqc8672sc";
+    }
+    {
+      rev = "v2021-04-08";
+      sha256 = "06agcxjp3wzb76iiy79yap4qjn37mka0c2ccybnqswm3wr4ngkz2";
+    }
+    {
+      rev = "v2021-04-28";
+      sha256 = "1ng0y6jmcgb3agpqwais1mfx0yh9bqxza3xxkggdzgic89pg6pg1";
+    }
+    {
+      rev = "v2021-05-26";
+      sha256 = "0ladc7bpy6fwvlsp2zjw3h8rm384w3qf93gvb1s6nn2n912sp7ck";
+    }
+    {
+      rev = "v2021-06-11";
+      sha256 = "0civfzjhcglc7r1382r55gwnk0rn2f9nsnqpyscs049jwsw5r7sq";
+    }
+    {
+      rev = "v2021-08-27";
+      sha256 = "113d5h5b84bdgc9iclk22a02272xr9pja7n48wfdqrciqzy3ng30";
+    }
+    {
+      rev = "v2021-09-09";
+      sha256 = "14l6fyjp7pxpjc7ga33bakg19fqy8dna6hmmrzp2f73hw27xg4dj";
+    }
+    {
+      rev = "v2021-09-29";
+      sha256 = "0n1vgbz3m73v33462ifg3qas9djwlpcvi1m0qxc7j15l3w5qhlw5";
+    }
+    {
+      rev = "v2021-11-11";
+      sha256 = "012lnp5rah4qyl8r0v04d0rz28b1rdaz6flhjrahf45b9gx7mny1";
+    }
   ];
 
   # Download the sources for a release.
-  fetchRelease = rel: pkgs.fetchFromGitHub {
-    owner = "input-output-hk";
-    repo = "cardano-wallet";
-    inherit (rel) rev sha256;
-    name = "cardano-wallet-src-${rel.rev}";
-  };
+  fetchRelease = rel:
+    pkgs.fetchFromGitHub {
+      owner = "input-output-hk";
+      repo = "cardano-wallet";
+      inherit (rel) rev sha256;
+      name = "cardano-wallet-src-${rel.rev}";
+    };
 
   # Gets a package set for a specific release. If the argument is null
   # it returns the current working tree version.
   importRelease = rel:
     if rel == null
-      then import ../default.nix { inherit system crossSystem config; }
-      else let src = fetchRelease rel; in import src {
+    then import ../default.nix {inherit system crossSystem config;}
+    else let
+      src = fetchRelease rel;
+    in
+      import src {
         inherit system crossSystem config;
         gitrev = src.rev;
       };
@@ -82,7 +102,8 @@ let
   migrationTest = (importRelease null).haskellPackages.cardano-wallet.components.exes.migration-test;
 
   # Generate attribute name/filename for a release.
-  releaseName = rel: if rel == null
+  releaseName = rel:
+    if rel == null
     then "head"
     else builtins.replaceStrings ["."] ["-"] rel.rev;
 
@@ -94,13 +115,14 @@ let
     # Create a script that runs the migration test against the server of
     # a certain release.
     testRelease = rel: let
-        targetRelease = importRelease rel;
-        # Use the genesis block from the latest release only.
-        # Having different genesis block (hash) across releases will basically
-        # make all wallets incompatible with each others. Prior to v2020-01-20,
-        # workers would simply loop ad-infinitum trying to rollback to (0, 0).
-        latestRelease = importRelease null;
-      in pkgs.writeScript "launch-migration-test-${releaseName rel}.sh" ''
+      targetRelease = importRelease rel;
+      # Use the genesis block from the latest release only.
+      # Having different genesis block (hash) across releases will basically
+      # make all wallets incompatible with each others. Prior to v2020-01-20,
+      # workers would simply loop ad-infinitum trying to rollback to (0, 0).
+      latestRelease = importRelease null;
+    in
+      pkgs.writeScript "launch-migration-test-${releaseName rel}.sh" ''
         #!${pkgs.runtimeShell}
 
         export PATH=${makeBinPath [
@@ -116,7 +138,8 @@ let
         export configFile=${targetRelease.src}/lib/jormungandr/test/data/jormungandr/config.yaml
 
         exec ${./launch-migration-test.sh} "$@"
-      '' // { inherit (latestRelease) cardano-wallet; };
+      ''
+      // {inherit (latestRelease) cardano-wallet;};
 
     # Create a test runner script for the given release.
     # The test scenario is quite simple at present.
@@ -142,28 +165,30 @@ let
           " || echo 'This test is allowed to fail.'"}
       '';
     };
-
   in
     # Create a directory with migration test scripts for each release version.
     # At the top level is a script that runs all tests.
     rels: let
       tests = map mkTestRunner rels;
-    in pkgs.runCommand "migration-tests" {
-      # provide individual tests as attributes of this derivation
-      passthru = listToAttrs (map (test: nameValuePair test.name test.runner) tests);
-    } (''
-      mkdir -p $out
-      echo "#!${pkgs.runtimeShell}" >> $out/runall.sh
-      echo "set -euo pipefail" >> $out/runall.sh
-      chmod 755 $out/runall.sh
-    '' + concatMapStringsSep "\n" (test: ''
-        mkdir -p $out/${test.name}
-        ln -s ${test.test} $out/${test.name}/migration-test
-        ln -s ${test.test.cardano-wallet}/bin/* $out/${test.name}
-        ln -s ${test.runner} $out/${test.name}/${test.runner.name}
-        echo 'printf "\n\n *** Migrating from ${test.name} ***\n\n"' >> $out/runall.sh
-        echo "$out/${test.name}/${test.runner.name}" >> $out/runall.sh
-      '') tests);
+    in
+      pkgs.runCommand "migration-tests" {
+        # provide individual tests as attributes of this derivation
+        passthru = listToAttrs (map (test: nameValuePair test.name test.runner) tests);
+      } (''
+          mkdir -p $out
+          echo "#!${pkgs.runtimeShell}" >> $out/runall.sh
+          echo "set -euo pipefail" >> $out/runall.sh
+          chmod 755 $out/runall.sh
+        ''
+        + concatMapStringsSep "\n" (test: ''
+          mkdir -p $out/${test.name}
+          ln -s ${test.test} $out/${test.name}/migration-test
+          ln -s ${test.test.cardano-wallet}/bin/* $out/${test.name}
+          ln -s ${test.runner} $out/${test.name}/${test.runner.name}
+          echo 'printf "\n\n *** Migrating from ${test.name} ***\n\n"' >> $out/runall.sh
+          echo "$out/${test.name}/${test.runner.name}" >> $out/runall.sh
+        '')
+        tests);
 
   ############################################################################
   # Generate a folder of wallet versions under test, with batch files
@@ -182,48 +207,57 @@ let
       runner = let
         stateDir = "state-migration-test-${name}";
         args = "launch --state-dir ${stateDir} --genesis-block ${name}/data/block0.bin -- --secret ${name}/data/secret.yaml --config ${name}/data/config.yaml";
-      in pkgs.writeScript "run.bat" ''
-        SETLOCAL
+      in
+        pkgs.writeScript "run.bat" ''
+          SETLOCAL
 
-        SET PATH=%~dp0;%PATH%
+          SET PATH=%~dp0;%PATH%
 
-        rmdir /s /q ${stateDir}
+          rmdir /s /q ${stateDir}
 
-        migration-test.exe step1 ${args}
-        if %errorlevel% neq 0 exit /b %errorlevel%
+          migration-test.exe step1 ${args}
+          if %errorlevel% neq 0 exit /b %errorlevel%
 
-        migration-test.exe step2 ${args}
-        if %errorlevel% neq 0 ${if allowFail then ''
-          echo This test is allowed to fail.
-        '' else ''
-          exit /b %errorlevel%
-        ''}
-      '';
+          migration-test.exe step2 ${args}
+          if %errorlevel% neq 0 ${
+            if allowFail
+            then ''
+              echo This test is allowed to fail.
+            ''
+            else ''
+              exit /b %errorlevel%
+            ''
+          }
+        '';
     };
     latest = importRelease null;
   in
     # Create a directory with migration test scripts for each release version.
     # At the top level is a script that runs all tests.
-    rels: pkgs.runCommand "migration-tests" {} (''
-      mkdir $out
-      cp ${migrationTest}/bin/* $out
-    '' + concatMapStringsSep "\n" (test: ''
-      mkdir -p $out/${test.name}/data
-      cp ${test.cardano-wallet}/bin/* $out/${test.name}
-      cp ${test.runner} $out/${test.name}/${test.runner.name}
-      # fixme: ADP-549 port to shelley
-      cp ${latest.src}/lib/jormungandr/test/data/jormungandr/{block0.bin,config.yaml,secret.yaml} $out/${test.name}/data
+    rels:
+      pkgs.runCommand "migration-tests" {} (''
+          mkdir $out
+          cp ${migrationTest}/bin/* $out
+        ''
+        + concatMapStringsSep "\n" (test: ''
+          mkdir -p $out/${test.name}/data
+          cp ${test.cardano-wallet}/bin/* $out/${test.name}
+          cp ${test.runner} $out/${test.name}/${test.runner.name}
+          # fixme: ADP-549 port to shelley
+          cp ${latest.src}/lib/jormungandr/test/data/jormungandr/{block0.bin,config.yaml,secret.yaml} $out/${test.name}/data
 
-      # append test to the run all script
-      echo "${test.name}\${test.runner.name}" >> $out/runall.bat
-      echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> $out/runall.bat
-    '') (map mkTestRunner rels));
+          # append test to the run all script
+          echo "${test.name}\${test.runner.name}" >> $out/runall.bat
+          echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> $out/runall.bat
+        '') (map mkTestRunner rels));
 
   ############################################################################
 
-  mkTests = if pkgs.stdenv.hostPlatform.isWindows then mkTestsWindows else mkTestsBash;
-
+  mkTests =
+    if pkgs.stdenv.hostPlatform.isWindows
+    then mkTestsWindows
+    else mkTestsBash;
 in
   if pkgs.stdenv.hostPlatform.isMusl
-    then pkgs.runCommand "migration-tests-disabled" {} "touch $out"
-    else mkTests releases
+  then pkgs.runCommand "migration-tests-disabled" {} "touch $out"
+  else mkTests releases

--- a/nix/nixos/default.nix
+++ b/nix/nixos/default.nix
@@ -1,1 +1,1 @@
-{ imports = import ./module-list.nix; }
+{imports = import ./module-list.nix;}

--- a/nix/nixos/tests/default.nix
+++ b/nix/nixos/tests/default.nix
@@ -1,18 +1,17 @@
-{ pkgs
-, project
-}:
-let
-  importTest = fn: args:
-    let
-      imported = import fn;
-      test = import (pkgs.path + "/nixos/tests/make-test-python.nix") imported;
-    in
-    test ({
-      inherit pkgs project;
-      inherit (pkgs) system config;
-    } // args);
-in
 {
+  pkgs,
+  project,
+}: let
+  importTest = fn: args: let
+    imported = import fn;
+    test = import (pkgs.path + "/nixos/tests/make-test-python.nix") imported;
+  in
+    test ({
+        inherit pkgs project;
+        inherit (pkgs) system config;
+      }
+      // args);
+in {
   # TODO: @jbgi Python dependencies of NixOS tests are broken
   # basicTest = importTest ./service-basic-test.nix { };
 }

--- a/nix/nixos/tests/service-basic-test.nix
+++ b/nix/nixos/tests/service-basic-test.nix
@@ -1,12 +1,16 @@
-{ pkgs, project, lib, ... }: with pkgs;
-let
+{
+  pkgs,
+  project,
+  lib,
+  ...
+}:
+with pkgs; let
   inherit (project.hsPkgs.cardano-wallet.components.exes) cardano-wallet;
   inherit (pkgs) cardanoLib;
-in
-{
+in {
   name = "wallet-nixos-test";
   nodes = {
-    machine = { config, ... }: {
+    machine = {config, ...}: {
       nixpkgs.pkgs = pkgs;
       imports = [
         ../.
@@ -26,18 +30,18 @@ in
       services.cardano-node = {
         enable = true;
         environment = "mainnet";
-        environments = { mainnet = { }; };
+        environments = {mainnet = {};};
         package = project.hsPkgs.cardano-node.components.exes.cardano-node;
         inherit (cardanoLib.environments.mainnet) nodeConfig;
         topology = cardanoLib.mkEdgeTopology {
           port = 3001;
-          edgeNodes = [ "127.0.0.1" ];
+          edgeNodes = ["127.0.0.1"];
         };
         systemdSocketActivation = true;
       };
       systemd.services.cardano-node.serviceConfig.Restart = lib.mkForce "no";
       systemd.services.cardano-wallet = {
-        after = [ "cardano-node.service" ];
+        after = ["cardano-node.service"];
         serviceConfig = {
           Restart = "no";
           SupplementaryGroups = "cardano-node";
@@ -55,5 +59,4 @@ in
         "${cardano-wallet}/bin/cardano-wallet network information"
     )
   '';
-
 }

--- a/nix/overlays/basement.nix
+++ b/nix/overlays/basement.nix
@@ -1,10 +1,15 @@
-final: prev:
-    let
-      old = prev.haskell-nix;
-      fix = { pkgs, buildModules, config, lib, ... }: prev.haskell-nix.haskellLib.addPackageKeys {
-            packages.basement.components.library.configureFlags = [ "--hsc2hs-option=--cflag=-Wno-int-conversion" ];
-      };
-    in {
-      haskell-nix = old // { defaultModules = old.defaultModules ++ [ fix ]; };
-    }
-
+final: prev: let
+  old = prev.haskell-nix;
+  fix = {
+    pkgs,
+    buildModules,
+    config,
+    lib,
+    ...
+  }:
+    prev.haskell-nix.haskellLib.addPackageKeys {
+      packages.basement.components.library.configureFlags = ["--hsc2hs-option=--cflag=-Wno-int-conversion"];
+    };
+in {
+  haskell-nix = old // {defaultModules = old.defaultModules ++ [fix];};
+}

--- a/nix/overlays/cardano-deployments.nix
+++ b/nix/overlays/cardano-deployments.nix
@@ -3,40 +3,56 @@ pkgs: _: {
   # https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/index.html
   cardano-node-deployments = let
     environments = {
-      inherit (pkgs.cardanoLib.environments)
+      inherit
+        (pkgs.cardanoLib.environments)
         mainnet
         preview
         preprod
         ;
     };
-    updateConfig = env: env.nodeConfig // {
-      minSeverity = "Notice";
-    } // (if (env.consensusProtocol == "Cardano") then {
-      ByronGenesisFile = "genesis-byron.json";
-      ShelleyGenesisFile = "genesis-shelley.json";
-      AlonzoGenesisFile = "genesis-alonzo.json";
-    } else {
-      GenesisFile = "genesis.json";
-    });
-    mkTopology = env: pkgs.cardanoLib.mkEdgeTopology {
-      edgeNodes = [ env.relaysNew ];
-      valency = 2;
-    };
+    updateConfig = env:
+      env.nodeConfig
+      // {
+        minSeverity = "Notice";
+      }
+      // (
+        if (env.consensusProtocol == "Cardano")
+        then {
+          ByronGenesisFile = "genesis-byron.json";
+          ShelleyGenesisFile = "genesis-shelley.json";
+          AlonzoGenesisFile = "genesis-alonzo.json";
+        }
+        else {
+          GenesisFile = "genesis.json";
+        }
+      );
+    mkTopology = env:
+      pkgs.cardanoLib.mkEdgeTopology {
+        edgeNodes = [env.relaysNew];
+        valency = 2;
+      };
     mapAttrsToString = f: attrs:
       pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList f attrs);
   in
     pkgs.runCommand "cardano-node-deployments" {
-      nativeBuildInputs = [ pkgs.buildPackages.jq ];
-    } (mapAttrsToString (name: env: ''
-      cfg=$out/${name}
-      mkdir -p $cfg
-      jq . < ${mkTopology env} > $cfg/topology.json
-      jq . < ${__toFile "${name}-config.json" (__toJSON (updateConfig env))} > $cfg/configuration.json
-    '' + (if env.consensusProtocol == "Cardano" then ''
-      jq . < ${env.nodeConfig.ByronGenesisFile} > $cfg/genesis-byron.json
-      cp ${env.nodeConfig.ShelleyGenesisFile} $cfg/genesis-shelley.json
-      cp ${env.nodeConfig.AlonzoGenesisFile} $cfg/genesis-alonzo.json
-    '' else ''
-      jq . < ${env.genesisFile} > $cfg/genesis.json
-    '')) environments);
+      nativeBuildInputs = [pkgs.buildPackages.jq];
+    } (mapAttrsToString (name: env:
+      ''
+        cfg=$out/${name}
+        mkdir -p $cfg
+        jq . < ${mkTopology env} > $cfg/topology.json
+        jq . < ${__toFile "${name}-config.json" (__toJSON (updateConfig env))} > $cfg/configuration.json
+      ''
+      + (
+        if env.consensusProtocol == "Cardano"
+        then ''
+          jq . < ${env.nodeConfig.ByronGenesisFile} > $cfg/genesis-byron.json
+          cp ${env.nodeConfig.ShelleyGenesisFile} $cfg/genesis-shelley.json
+          cp ${env.nodeConfig.AlonzoGenesisFile} $cfg/genesis-alonzo.json
+        ''
+        else ''
+          jq . < ${env.genesisFile} > $cfg/genesis.json
+        ''
+      ))
+    environments);
 }

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -3,15 +3,12 @@ self: super: let
   inherit (self.haskell-nix) haskellLib;
 in {
   cardanoWalletLib = {
-
     # Retrieve the list of local project packages by
     # using the haskell.nix selectProjectPackages function.
-    projectPackageList =
-      let
-        project = haskellLib.selectProjectPackages cardanoWalletHaskellProject.hsPkgs;
-        names = map (key: (builtins.getAttr key project).identifier.name) (builtins.attrNames project);
-      in
-        lib.lists.unique names;
-
+    projectPackageList = let
+      project = haskellLib.selectProjectPackages cardanoWalletHaskellProject.hsPkgs;
+      names = map (key: (builtins.getAttr key project).identifier.name) (builtins.attrNames project);
+    in
+      lib.lists.unique names;
   };
 }

--- a/nix/release-build.nix
+++ b/nix/release-build.nix
@@ -2,27 +2,30 @@
 # Release build for cardano-wallet
 #
 ############################################################################
-
-{ pkgs
-, exe  # executable component for the program, from Haskell.nix
-, backend ? null  # node backend
+{
+  pkgs,
+  exe, # executable component for the program, from Haskell.nix
+  backend ? null, # node backend
 }:
-
-with pkgs.lib;
-
-let drv = pkgs.stdenv.mkDerivation rec {
-  name = "${exe.exeName}-${version}";
-  version = exe.identifier.version;
-  phases = [ "installPhase" ];
-  installPhase = ''
-    cp -R ${exe} $out
-  '' + (optionalString (pkgs.stdenv.hostPlatform.isWindows && backend != null) ''
-    # fixme: remove this
-    cp -Rv ${backend.deployments} $out/deployments
-  '');
-  meta.platforms = platforms.all;
-  passthru = {
-    exePath = drv + "/bin/cardano-wallet";
-  } // (optionalAttrs (backend != null) { inherit backend; });
-};
-in drv
+with pkgs.lib; let
+  drv = pkgs.stdenv.mkDerivation rec {
+    name = "${exe.exeName}-${version}";
+    version = exe.identifier.version;
+    phases = ["installPhase"];
+    installPhase =
+      ''
+        cp -R ${exe} $out
+      ''
+      + (optionalString (pkgs.stdenv.hostPlatform.isWindows && backend != null) ''
+        # fixme: remove this
+        cp -Rv ${backend.deployments} $out/deployments
+      '');
+    meta.platforms = platforms.all;
+    passthru =
+      {
+        exePath = drv + "/bin/cardano-wallet";
+      }
+      // (optionalAttrs (backend != null) {inherit backend;});
+  };
+in
+  drv

--- a/nix/rewrite-libs/flake.nix
+++ b/nix/rewrite-libs/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    haskellNix = { url = "github:input-output-hk/haskell.nix"; };
+    haskellNix = {url = "github:input-output-hk/haskell.nix";};
     nixpkgs = {
       url = "github:NixOS/nixpkgs";
       follows = "haskellNix/nixpkgs-unstable";
@@ -9,14 +9,13 @@
       url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     };
   };
-  outputs = inputs@{ flake-utils, ... }:
-    let
-      supportedSystems =
-        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
-      perSystem = system:
-        import ./rewrite-libs.nix {
-          inherit system;
-          inherit (inputs) nixpkgs haskellNix flake-utils;
-        };
-    in flake-utils.lib.eachSystem supportedSystems perSystem;
+  outputs = inputs @ {flake-utils, ...}: let
+    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+    perSystem = system:
+      import ./rewrite-libs.nix {
+        inherit system;
+        inherit (inputs) nixpkgs haskellNix flake-utils;
+      };
+  in
+    flake-utils.lib.eachSystem supportedSystems perSystem;
 }

--- a/nix/rewrite-libs/nix/project.nix
+++ b/nix/rewrite-libs/nix/project.nix
@@ -1,11 +1,15 @@
-{ indexState, src, haskell-nix, ... }:
-let
-  shell = { pkgs, ... }: {
+{
+  indexState,
+  src,
+  haskell-nix,
+  ...
+}: let
+  shell = {pkgs, ...}: {
     tools = {
-      cabal = { index-state = indexState; };
-      cabal-fmt = { index-state = indexState; };
-      haskell-language-server = { index-state = indexState; };
-      hoogle = { index-state = indexState; };
+      cabal = {index-state = indexState;};
+      cabal-fmt = {index-state = indexState;};
+      haskell-language-server = {index-state = indexState;};
+      hoogle = {index-state = indexState;};
     };
     withHoogle = true;
     buildInputs = [
@@ -21,12 +25,16 @@ let
     '';
   };
 
-  mkProject = ctx@{ lib, pkgs, ... }: {
+  mkProject = ctx @ {
+    lib,
+    pkgs,
+    ...
+  }: {
     name = "cardano-deposit-wallet";
     compiler-nix-name = "ghc966";
     inherit src;
-    shell = shell { inherit pkgs; };
-    modules = [ ];
+    shell = shell {inherit pkgs;};
+    modules = [];
   };
   project = haskell-nix.cabalProject' mkProject;
   packages = {

--- a/nix/rewrite-libs/rewrite-libs.nix
+++ b/nix/rewrite-libs/rewrite-libs.nix
@@ -1,15 +1,21 @@
-{ system, nixpkgs, haskellNix, flake-utils, ... }:
-let
+{
+  system,
+  nixpkgs,
+  haskellNix,
+  flake-utils,
+  ...
+}: let
   src = ./.;
   indexState = "2024-08-20T21:35:22Z";
   pkgs = import nixpkgs {
-    overlays = [ haskellNix.overlay ];
+    overlays = [haskellNix.overlay];
     inherit system;
   };
-in import ./nix/project.nix {
-  inherit system;
-  inherit indexState;
-  inherit src;
-  inherit (pkgs) haskell-nix;
-  inherit pkgs;
-}
+in
+  import ./nix/project.nix {
+    inherit system;
+    inherit indexState;
+    inherit src;
+    inherit (pkgs) haskell-nix;
+    inherit pkgs;
+  }

--- a/nix/set-git-rev/flake.nix
+++ b/nix/set-git-rev/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    haskellNix = { url = "github:input-output-hk/haskell.nix"; };
+    haskellNix = {url = "github:input-output-hk/haskell.nix";};
     nixpkgs = {
       url = "github:NixOS/nixpkgs";
       follows = "haskellNix/nixpkgs-unstable";
@@ -9,14 +9,13 @@
       url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     };
   };
-  outputs = inputs@{ flake-utils, ... }:
-    let
-      supportedSystems =
-        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
-      perSystem = system:
-        import ./set-git-rev.nix {
-          inherit system;
-          inherit (inputs) nixpkgs haskellNix flake-utils;
-        };
-    in flake-utils.lib.eachSystem supportedSystems perSystem;
+  outputs = inputs @ {flake-utils, ...}: let
+    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
+    perSystem = system:
+      import ./set-git-rev.nix {
+        inherit system;
+        inherit (inputs) nixpkgs haskellNix flake-utils;
+      };
+  in
+    flake-utils.lib.eachSystem supportedSystems perSystem;
 }

--- a/nix/set-git-rev/nix/project.nix
+++ b/nix/set-git-rev/nix/project.nix
@@ -1,11 +1,15 @@
-{ indexState, src, haskell-nix, ... }:
-let
-  shell = { pkgs, ... }: {
+{
+  indexState,
+  src,
+  haskell-nix,
+  ...
+}: let
+  shell = {pkgs, ...}: {
     tools = {
-      cabal = { index-state = indexState; };
-      cabal-fmt = { index-state = indexState; };
-      haskell-language-server = { index-state = indexState; };
-      hoogle = { index-state = indexState; };
+      cabal = {index-state = indexState;};
+      cabal-fmt = {index-state = indexState;};
+      haskell-language-server = {index-state = indexState;};
+      hoogle = {index-state = indexState;};
     };
     withHoogle = true;
     buildInputs = [
@@ -21,12 +25,16 @@ let
     '';
   };
 
-  mkProject = ctx@{ lib, pkgs, ... }: {
+  mkProject = ctx @ {
+    lib,
+    pkgs,
+    ...
+  }: {
     name = "cardano-deposit-wallet";
     compiler-nix-name = "ghc966";
     inherit src;
-    shell = shell { inherit pkgs; };
-    modules = [ ];
+    shell = shell {inherit pkgs;};
+    modules = [];
   };
   project = haskell-nix.cabalProject' mkProject;
   packages = {

--- a/nix/set-git-rev/set-git-rev.nix
+++ b/nix/set-git-rev/set-git-rev.nix
@@ -1,15 +1,21 @@
-{ system, nixpkgs, haskellNix, flake-utils, ... }:
-let
+{
+  system,
+  nixpkgs,
+  haskellNix,
+  flake-utils,
+  ...
+}: let
   src = ./.;
   indexState = "2024-08-20T21:35:22Z";
   pkgs = import nixpkgs {
-    overlays = [ haskellNix.overlay ];
+    overlays = [haskellNix.overlay];
     inherit system;
   };
-in import ./nix/project.nix {
-  inherit system;
-  inherit indexState;
-  inherit src;
-  inherit (pkgs) haskell-nix;
-  inherit pkgs;
-}
+in
+  import ./nix/project.nix {
+    inherit system;
+    inherit indexState;
+    inherit src;
+    inherit (pkgs) haskell-nix;
+    inherit pkgs;
+  }

--- a/nix/windows-migration-tests-bundle.nix
+++ b/nix/windows-migration-tests-bundle.nix
@@ -11,23 +11,21 @@
 #        nix/windows-migration-tests-bundle.nix
 #
 ############################################################################
-
-{ system ? builtins.currentSystem
-, crossSystem ? null
-, config ? {}
-, project ? import ../default.nix { inherit system crossSystem config; }
-, pkgs ? project.pkgs
-}:
-
-let
+{
+  system ? builtins.currentSystem,
+  crossSystem ? null,
+  config ? {},
+  project ? import ../default.nix {inherit system crossSystem config;},
+  pkgs ? project.pkgs,
+}: let
   name = "cardano-wallet-${project.version}-migration-tests-win64";
-  migration-tests = import ./migration-tests.nix { inherit system crossSystem config pkgs; };
-
-in pkgs.buildPackages.runCommand name {
-  nativeBuildInputs = [ pkgs.buildPackages.zip ];
-} ''
-  mkdir -p $out/nix-support
-  cd ${migration-tests}
-  zip -r $out/${name}.zip .
-  echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
-''
+  migration-tests = import ./migration-tests.nix {inherit system crossSystem config pkgs;};
+in
+  pkgs.buildPackages.runCommand name {
+    nativeBuildInputs = [pkgs.buildPackages.zip];
+  } ''
+    mkdir -p $out/nix-support
+    cd ${migration-tests}
+    zip -r $out/${name}.zip .
+    echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
+  ''

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -6,59 +6,59 @@
 # and sets up the Hydra build artifact.
 #
 ############################################################################
-
-{ pkgs
-, cardano-wallet
-, cardano-node
-, cardano-cli
-, tests ? []
-, benchmarks ? []
-}:
-
-let
+{
+  pkgs,
+  cardano-wallet,
+  cardano-node,
+  cardano-cli,
+  tests ? [],
+  benchmarks ? [],
+}: let
   testData = {
     wallet = ../lib/unit/test/data;
     local-cluster = ../lib/local-cluster/test/data;
   };
 
   name = "cardano-wallet-${cardano-wallet.version}-tests-win64";
+in
+  pkgs.runCommand name {
+    nativeBuildInputs = [pkgs.zip pkgs.gnused];
+    passthru = {inherit tests benchmarks;};
+  } ''
+    mkdir -pv bundle/test/data $out/nix-support
+    cd bundle
 
-in pkgs.runCommand name {
-  nativeBuildInputs = [ pkgs.zip pkgs.gnused ];
-  passthru = { inherit tests benchmarks; };
-} ''
-  mkdir -pv bundle/test/data $out/nix-support
-  cd bundle
+    # Copy in wallet and node EXEs and DLLs.
+    for pkg in ${cardano-wallet} ${cardano-node} ${cardano-cli}; do
+      cp -vf $pkg/bin/* .
+    done
 
-  # Copy in wallet and node EXEs and DLLs.
-  for pkg in ${cardano-wallet} ${cardano-node} ${cardano-cli}; do
-    cp -vf $pkg/bin/* .
-  done
+    # Copy test data to location expected by test suites.
+    ${pkgs.lib.concatMapStringsSep "\n" (dir: ''
+      cp -Rv --no-preserve=mode ${dir}/* test/data
+    '') (pkgs.lib.attrValues testData)}
 
-  # Copy test data to location expected by test suites.
-  ${pkgs.lib.concatMapStringsSep "\n" (dir: ''
-  cp -Rv --no-preserve=mode ${dir}/* test/data
-  '') (pkgs.lib.attrValues testData)}
+    # Copy in test executables and rename.
+    # Add each one to tests.bat.
+    ${pkgs.lib.concatMapStringsSep "\n" (test: ''
+        exe=`cd ${test}/bin; ls -1 *.exe`
+        name=${test.passthru.identifier.name}-test-$exe
+        cp ${test}/bin/$exe $name
+        echo $name >> tests.bat
+        echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
+      '')
+      tests}
 
-  # Copy in test executables and rename.
-  # Add each one to tests.bat.
-  ${pkgs.lib.concatMapStringsSep "\n" (test: ''
-    exe=`cd ${test}/bin; ls -1 *.exe`
-    name=${test.passthru.identifier.name}-test-$exe
-    cp ${test}/bin/$exe $name
-    echo $name >> tests.bat
-    echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
-  '') tests}
+    # Copy in benchmark executables and rename.
+    ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
+        exe=`cd ${bench}/bin; ls -1 *.exe`
+        name=${bench.passthru.identifier.name}-bench-$exe
+        cp ${bench}/bin/$exe $name
+      '')
+      benchmarks}
 
-  # Copy in benchmark executables and rename.
-  ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
-    exe=`cd ${bench}/bin; ls -1 *.exe`
-    name=${bench.passthru.identifier.name}-bench-$exe
-    cp ${bench}/bin/$exe $name
-  '') benchmarks}
+    chmod -R +w .
 
-  chmod -R +w .
-
-  zip -r $out/${name}.zip .
-  echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
-''
+    zip -r $out/${name}.zip .
+    echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
+  ''

--- a/scripts/buildkite/admin/flake.nix
+++ b/scripts/buildkite/admin/flake.nix
@@ -8,20 +8,20 @@
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
   };
 
-  outputs = inputs:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-       ]; in
-    inputs.flake-utils.lib.eachSystem supportedSystems (system:
-      let
+  outputs = inputs: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  in
+    inputs.flake-utils.lib.eachSystem supportedSystems (
+      system: let
         # Imports
         pkgs = inputs.nixpkgs.legacyPackages.${system};
       in {
-        packages = { };
+        packages = {};
 
         devShells.default = pkgs.mkShell {
           buildInputs = [

--- a/scripts/buildkite/main/flake.nix
+++ b/scripts/buildkite/main/flake.nix
@@ -11,21 +11,21 @@
     attic.url = "github:zhaofengli/attic";
   };
 
-  outputs = inputs:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-       ]; in
-    inputs.flake-utils.lib.eachSystem supportedSystems (system:
-      let
+  outputs = inputs: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  in
+    inputs.flake-utils.lib.eachSystem supportedSystems (
+      system: let
         # Imports
         pkgs = inputs.nixpkgs.legacyPackages.${system};
         attic = inputs.attic.packages.${system}.default;
       in {
-        packages = { };
+        packages = {};
 
         devShells.default = pkgs.mkShell {
           buildInputs = [

--- a/scripts/buildkite/release/flake.nix
+++ b/scripts/buildkite/release/flake.nix
@@ -9,20 +9,20 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-       ]; in
-    inputs.flake-utils.lib.eachSystem supportedSystems (system:
-      let
+  outputs = inputs: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  in
+    inputs.flake-utils.lib.eachSystem supportedSystems (
+      system: let
         # Imports
         pkgs = inputs.nixpkgs.legacyPackages.${system};
       in {
-        packages = { };
+        packages = {};
 
         devShells.default = pkgs.mkShell {
           buildInputs = [


### PR DESCRIPTION
Reading and editing the nix code in this repository is very painful because it doesn't conform to any sort of standard structure. This uses the default treefmt-nix structure.

I've manually run treefmt once to reformat all nix files.

## CI Check

To verify formatting is correct, run:

```bash
nix fmt -- --fail-on-change
```

This will fail if any nix files need reformatting.

---
Original PR: #5084 by @disassembler