### PR TITLE
fix: enable LMDB ledger backend for Mithril snapshots

### DIFF
--- a/configs/cardano/mainnet/config.json
+++ b/configs/cardano/mainnet/config.json
@@ -106,5 +106,8 @@
       "scName": "stdout",
       "scRotation": null
     }
-  ]
+  ],
+  "LedgerDB": {
+    "Backend": "V1LMDB"
+  }
 }

--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -149,6 +149,14 @@ case "$1" in
                 sleep 1
             fi
         done
+        # Dump container logs before cleanup for debugging
+        if [[ "$result" != "success" ]]; then
+            echo "=== cardano-node logs ==="
+            docker compose -p "$COMPOSE_PROJECT_NAME" logs cardano-node 2>&1 | tail -200
+            echo "=== cardano-wallet logs ==="
+            docker compose -p "$COMPOSE_PROJECT_NAME" logs cardano-wallet 2>&1 | tail -200
+        fi
+
         cleanup
 
         # Stop the service after syncing

--- a/run/mainnet/docker/docker-compose.yml
+++ b/run/mainnet/docker/docker-compose.yml
@@ -2,6 +2,7 @@ name: mainnet
 services:
   cardano-node:
     image: cardanofoundation/cardano-wallet:${WALLET_TAG}
+    working_dir: /data
     environment:
       CARDANO_NODE_SOCKET_PATH: /ipc/${NODE_SOCKET_NAME}
     volumes:


### PR DESCRIPTION
## Summary
- Adds `LedgerDB.Backend: V1LMDB` to mainnet node config
- Fixes Docker boot sync by setting `working_dir: /data` for the node container
- Adds container log dumping on Docker boot sync failure for debugging

## Context
V1LMDB is the recommended backend for edge nodes (wallets, explorers) — uses ~8GB RAM vs ~24GB for V2InMemory. Required for Mithril snapshot ledger states which use LMDB format.

The Docker boot sync was failing because V1LMDB creates its database directory (`mainnet/db/lmdb/tables`) relative to CWD, which in the container pointed to a read-only path. Setting `working_dir: /data` ensures LMDB writes to the mounted data volume.

## CI
All checks pass: https://github.com/cardano-foundation/cardano-wallet/actions/runs/21954112236