### PR TITLE
fix: restore benchmarks by increasing node sync timeout

### DIFF
--- a/.buildkite/restoration-benchmarks.yml
+++ b/.buildkite/restoration-benchmarks.yml
@@ -17,7 +17,7 @@ steps:
       - select: "Node Sync Timeout"
         hint: "Possible timeout in hours until node is synced"
         key: "to-tip-timeout"
-        default: "4"
+        default: "infinite"
         options:
         - label: "Infinite"
           value: "infinite"
@@ -50,42 +50,3 @@ steps:
       queue: adrestia-bench
     concurrency: 1
     concurrency_group: 'restoration-benchmarks-1'
-
-  - label: Restore benchmark seq0 (linux)
-    command: |
-      nix develop path:./scripts/buildkite/main --command bash -c \
-        "./scripts/buildkite/main/bench-restore.sh mainnet seq0 $HOME/databases/node/mainnet-2"
-    depends_on:
-      - restoration-parameters
-    timeout_in_minutes: 1380
-    agents:
-      system: ${linux}
-      queue: adrestia-bench
-    concurrency: 1
-    concurrency_group: 'restoration-benchmarks-2'
-
-  - label: Restore benchmark seq1 (linux)
-    command: |
-      nix develop path:./scripts/buildkite/main --command bash -c \
-        "./scripts/buildkite/main/bench-restore.sh mainnet seq1 $HOME/databases/node/mainnet-3"
-    depends_on:
-      - restoration-parameters
-    timeout_in_minutes: 1380
-    agents:
-      system: ${linux}
-      queue: adrestia-bench
-    concurrency: 1
-    concurrency_group: 'restoration-benchmarks-3'
-
-  - label: Restore benchmark rnd5 (linux)
-    command: |
-      nix develop path:./scripts/buildkite/main --command bash -c \
-        "./scripts/buildkite/main/bench-restore.sh mainnet rnd5 $HOME/databases/node/mainnet-4"
-    depends_on:
-      - restoration-parameters
-    timeout_in_minutes: 1380
-    agents:
-      system: ${linux}
-      queue: adrestia-bench
-    concurrency: 1
-    concurrency_group: 'restoration-benchmarks-4'

--- a/.buildkite/restoration-benchmarks.yml
+++ b/.buildkite/restoration-benchmarks.yml
@@ -50,3 +50,42 @@ steps:
       queue: adrestia-bench
     concurrency: 1
     concurrency_group: 'restoration-benchmarks-1'
+
+  - label: Restore benchmark seq0 (linux)
+    command: |
+      nix develop path:./scripts/buildkite/main --command bash -c \
+        "./scripts/buildkite/main/bench-restore.sh mainnet seq0 $HOME/databases/node/mainnet-2"
+    depends_on:
+      - restoration-parameters
+    timeout_in_minutes: 1380
+    agents:
+      system: ${linux}
+      queue: adrestia-bench
+    concurrency: 1
+    concurrency_group: 'restoration-benchmarks-2'
+
+  - label: Restore benchmark seq1 (linux)
+    command: |
+      nix develop path:./scripts/buildkite/main --command bash -c \
+        "./scripts/buildkite/main/bench-restore.sh mainnet seq1 $HOME/databases/node/mainnet-3"
+    depends_on:
+      - restoration-parameters
+    timeout_in_minutes: 1380
+    agents:
+      system: ${linux}
+      queue: adrestia-bench
+    concurrency: 1
+    concurrency_group: 'restoration-benchmarks-3'
+
+  - label: Restore benchmark rnd5 (linux)
+    command: |
+      nix develop path:./scripts/buildkite/main --command bash -c \
+        "./scripts/buildkite/main/bench-restore.sh mainnet rnd5 $HOME/databases/node/mainnet-4"
+    depends_on:
+      - restoration-parameters
+    timeout_in_minutes: 1380
+    agents:
+      system: ${linux}
+      queue: adrestia-bench
+    concurrency: 1
+    concurrency_group: 'restoration-benchmarks-4'

--- a/scripts/buildkite/main/bench-restore.sh
+++ b/scripts/buildkite/main/bench-restore.sh
@@ -27,7 +27,7 @@ echo "--- Run benchmarks - $network"
 CARDANO_NODE_CONFIGS=$(pwd)/configs/cardano
 
 if [ -n "${BUILDKITE:-}" ]; then
-    TO_TIP_TIMEOUT=$(buildkite-agent meta-data get to-tip-timeout --default '4')
+    TO_TIP_TIMEOUT=$(buildkite-agent meta-data get to-tip-timeout --default 'infinite')
 else
     TO_TIP_TIMEOUT=4
 fi


### PR DESCRIPTION
## Summary
- Change default node sync timeout from 4h to infinite for restoration benchmarks
- All 4 node DBs (mainnet-1 through mainnet-4) have been replayed with fresh ledger snapshots

Restoration benchmarks have been failing since build 59 (Dec 21, 2025) due to
the cardano-node upgrade from 10.2.1 to 10.5.3 invalidating ledger snapshots.
The 4h timeout killed the ~8h genesis replay mid-way, creating a vicious cycle.