### PR TITLE
feat: sequential integration test executable

### DIFF
--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -145,6 +145,7 @@ import Test.Hspec
     ( SpecWith
     , describe
     , pendingWith
+    , sequential
     )
 import Test.Hspec.Expectations.Lifted
     ( expectationFailure
@@ -1660,7 +1661,9 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             let epochs = poolGarbageCollectionEpochNo <$> events
             (reverse epochs `zip` [1 ..]) `shouldSatisfy` all (uncurry (==))
 
-    it "STAKE_POOLS_SMASH_01 - fetching metadata from SMASH works with delisted pools"
+    -- Flaky under parallel execution (see #5108)
+    sequential
+        $ it "STAKE_POOLS_SMASH_01 - fetching metadata from SMASH works with delisted pools"
         $ \ctx -> runResourceT $ bracketSettings ctx $ do
             updateMetadataSource ctx (_smashUrl ctx)
             -- This can be slow; let's retry less frequently and with a longer


### PR DESCRIPTION
## Summary
- Add `integration-exe-sequential` that runs all integration tests one at a time
- Parameterize `Run.mainWith` to accept `parallel` or `sequential` strategy
- Add Buildkite CI step running SMASH tests sequentially with `concurrency: 1`

Closes #5108

## Test plan
- [x] `cabal build integration-exe-sequential` succeeds
- [ ] `just conway-integration-tests-sequential "STAKE_POOLS_SMASH"` passes on CI