### PR TITLE
ci: add macOS CI workflows for GitHub Actions

### DIFF
--- a/.github/workflows/macos-artifacts.yml
+++ b/.github/workflows/macos-artifacts.yml
@@ -1,9 +1,7 @@
 name: macOS Artifacts
 
+# Disabled until macOS self-hosted runners are configured
 on:
-  push:
-    branches: [master]
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-artifacts.yml
+++ b/.github/workflows/macos-artifacts.yml
@@ -1,0 +1,60 @@
+name: macOS Artifacts
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-integration:
+    name: "Build Integration Tests (macOS, arm64)"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build integration test executable
+        run: nix build -L .#packages.aarch64-darwin.integration-exe
+
+  package-intel:
+    name: "Build Package (macOS, x86_64)"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build macOS Intel package
+        run: nix build -L -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-intel-package
+          path: result/macos-intel/
+
+  package-silicon:
+    name: "Build Package (macOS, arm64)"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build macOS Silicon package
+        run: nix build -L -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-silicon-package
+          path: result/macos-silicon/

--- a/.github/workflows/macos-artifacts.yml
+++ b/.github/workflows/macos-artifacts.yml
@@ -1,7 +1,7 @@
 name: macOS Artifacts
 
-# Disabled until macOS self-hosted runners are configured
 on:
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-e2e.yml
+++ b/.github/workflows/macos-e2e.yml
@@ -1,0 +1,34 @@
+name: macOS E2E Tests
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Build E2E dependencies"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build derivations
+        run: nix build -L .#cardano-node .#cardano-wallet .#e2e
+
+  e2e:
+    name: "Run E2E Tests (macOS, arm64)"
+    needs: build
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run E2E tests
+        run: nix shell 'nixpkgs#just' -c just e2e

--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -1,0 +1,50 @@
+name: macOS Integration Tests
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Build integration test dependencies"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build derivations
+        run: nix build -L .#cardano-wallet .#local-cluster .#integration-exe .#cardano-node .#cardano-cli
+
+  conway-integration:
+    name: "Conway Integration Tests (macOS)"
+    needs: build
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    timeout-minutes: 120
+    env:
+      LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
+      LOCAL_CLUSTER_ERA: conway
+      CARDANO_WALLET_TEST_DATA: lib/integration/test/data
+      TESTS_RETRY_FAILED: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run integration tests
+        run: |
+          mkdir -p integration-test-dir/cluster.logs
+          export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
+          export INTEGRATION_TEST_DIR=integration-test-dir
+          nix shell 'nixpkgs#just' -c just conway-integration-tests 2
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-integration-test-logs
+          path: integration-test-dir/

--- a/.github/workflows/macos-nix-check.yml
+++ b/.github/workflows/macos-nix-check.yml
@@ -1,7 +1,7 @@
 name: macOS Nix Check
 
-# Disabled until macOS self-hosted runners are configured
 on:
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-nix-check.yml
+++ b/.github/workflows/macos-nix-check.yml
@@ -1,0 +1,43 @@
+name: macOS Nix Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-nix:
+    name: "Check Nix (macOS)"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check nix version
+        run: nix --version
+
+      - name: Check flake info
+        run: nix flake info
+
+  attic-cache:
+    name: "Dev Shell Attic Cache (macOS)"
+    needs: check-nix
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push dev shell to Attic
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          system: aarch64-darwin
+        run: nix develop path:./scripts/buildkite/main -c ./scripts/buildkite/main/attic-cache.sh

--- a/.github/workflows/macos-nix-check.yml
+++ b/.github/workflows/macos-nix-check.yml
@@ -1,9 +1,8 @@
 name: macOS Nix Check
 
+# Disabled until macOS self-hosted runners are configured
 on:
-  push:
-    branches: [master]
-  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,7 +1,7 @@
 name: macOS Unit Tests
 
-# Disabled until macOS self-hosted runners are configured
 on:
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,0 +1,191 @@
+name: macOS Unit Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Build test executables"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build all unit test derivations
+        run: >-
+          nix build -L
+          .#unit-cardano-wallet-unit
+          .#unit-cardano-numeric
+          .#unit-cardano-balance-tx
+          .#unit-cardano-wallet-primitive
+          .#unit-cardano-wallet-secrets
+          .#unit-cardano-wallet-test-utils
+          .#unit-cardano-wallet-launcher
+          .#unit-cardano-wallet-network-layer
+          .#unit-cardano-wallet-application-tls
+          .#unit-cardano-wallet-blackbox-benchmarks
+          .#unit-delta-chain
+          .#unit-delta-store
+          .#unit-delta-table
+          .#unit-delta-types
+          .#unit-std-gen-seed
+          .#unit-wai-middleware-logging
+          .#cardano-cli
+
+  unit-tests:
+    name: ${{ matrix.name }}
+    needs: build
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # -- Standalone package tests (nix run) --
+          - name: "cardano-wallet-application-tls"
+            working-directory: lib/application-tls
+            command: nix run ../../.#unit-cardano-wallet-application-tls -- +RTS -M2G -s -RTS
+
+          - name: "cardano-balance-tx"
+            working-directory: lib/balance-tx
+            command: nix run ../../.#unit-cardano-balance-tx -- +RTS -M2G -s -RTS
+
+          - name: "cardano-numeric"
+            command: nix run .#unit-cardano-numeric -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-blackbox-benchmarks"
+            command: nix run .#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-launcher"
+            command: nix run .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-network-layer"
+            command: nix run .#unit-cardano-wallet-network-layer -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-primitive"
+            working-directory: lib/primitive
+            command: nix run ../../.#unit-cardano-wallet-primitive -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-secrets"
+            command: nix run .#unit-cardano-wallet-secrets -- +RTS -M2G -s -RTS
+
+          - name: "cardano-wallet-test-utils"
+            command: nix run .#unit-cardano-wallet-test-utils -- +RTS -M2G -s -RTS
+
+          - name: "delta-chain"
+            command: nix run .#unit-delta-chain -- +RTS -M2G -s -RTS
+
+          - name: "delta-store"
+            command: nix run .#unit-delta-store -- +RTS -M2G -s -RTS
+
+          - name: "delta-table"
+            command: nix run .#unit-delta-table -- +RTS -M2G -s -RTS
+
+          - name: "delta-types"
+            command: nix run .#unit-delta-types -- +RTS -M2G -s -RTS
+
+          - name: "std-gen-seed"
+            command: nix run .#unit-std-gen-seed -- +RTS -M2G -s -RTS
+
+          - name: "wai-middleware-logging"
+            command: nix run .#unit-wai-middleware-logging -- +RTS -M2G -s -RTS
+
+          # -- wallet-unit splits (nix run with cardano-cli) --
+          - name: "wallet-unit / Byron + CLI"
+            working-directory: lib/unit
+            command: >-
+              nix shell ../../.#cardano-cli -c
+              nix run ../../.#unit-cardano-wallet-unit --
+              --match "/Cardano.Byron./"
+              --match "/Cardano.CLI/"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / DB.Sqlite + Pool"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.DB./"
+              --match "/Cardano.Pool./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Address"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.Address./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Api"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.Api./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Balance"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.Balance./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / DB"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.DB./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Primitive"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.Primitive./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Shelley"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet.Shelley./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Other Wallet"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Cardano.Wallet./"
+              --skip "/Cardano.Wallet.Address./"
+              --skip "/Cardano.Wallet.Api./"
+              --skip "/Cardano.Wallet.Balance./"
+              --skip "/Cardano.Wallet.DB./"
+              --skip "/Cardano.Wallet.Primitive./"
+              --skip "/Cardano.Wallet.Shelley./"
+              -j1 +RTS -M2G -s -RTS
+
+          - name: "wallet-unit / Control + Data"
+            command: >-
+              nix shell .#cardano-cli -c
+              nix run .#unit-cardano-wallet-unit --
+              --match "/Control./"
+              --match "/Data./"
+              -j1 +RTS -M2G -s -RTS
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        working-directory: ${{ matrix.working-directory || '.' }}
+        run: ${{ matrix.command }}

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,9 +1,7 @@
 name: macOS Unit Tests
 
+# Disabled until macOS self-hosted runners are configured
 on:
-  push:
-    branches: [master]
-  pull_request:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add macOS equivalents of all Linux GHA workflows
- Nix check + Attic cache, artifacts (intel + silicon), unit tests (26 suites), integration, E2E
- Requires macOS self-hosted runners with label `[self-hosted, macOS, ARM64, cardano-wallet]`
- Integration and E2E are manual dispatch (matching Buildkite block pattern)

## Test plan
- [ ] Configure macOS ARM64 self-hosted runners
- [ ] Verify nix-check workflow passes
- [ ] Verify artifacts build for both intel and silicon
- [ ] Run unit test matrix
- [ ] Trigger integration tests manually
- [ ] Trigger E2E tests manually