### PR TITLE
ci: migrate release pipeline to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,287 @@
-name: release
+name: Release
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        default: 'nightly'
+        type: choice
+        options:
+          - nightly
+          - release
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  RELEASE_SCRIPTS_DIR: ./scripts/buildkite/release
 
 jobs:
-  release:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release/v') }}
-    runs-on: ubuntu-20.04
+  prepare:
+    name: "Prepare Release Candidate"
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    outputs:
+      release-version: ${{ steps.rc.outputs.release-version }}
+      release-candidate-commit: ${{ steps.rc.outputs.release-candidate-commit }}
+      release-candidate-branch: ${{ steps.rc.outputs.release-candidate-branch }}
+      release-cabal-version: ${{ steps.rc.outputs.release-cabal-version }}
+      test-rc: ${{ steps.rc.outputs.test-rc }}
+      node-tag: ${{ steps.rc.outputs.node-tag }}
+      last-release-date: ${{ steps.rc.outputs.last-release-date }}
     steps:
-      # This should create an empty release draft
-      # TODO: get artifacts from Buildkite to be attached to the draft
-      # Task: https://cardanofoundation.atlassian.net/browse/ADP-2502
-      - name: '🚀 Release'
-        uses: softprops/action-gh-release@v1
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          draft: true
-          # fail_on_unmatched_files: true
-          # files: |
-          #   *.tar.gz
-          #   *.zip
+          fetch-depth: 0
+
+      - name: Create release candidate
+        id: rc
+        run: $RELEASE_SCRIPTS_DIR/release-candidate.sh
+
+  build-artifacts:
+    name: "Build ${{ matrix.name }}"
+    needs: prepare
+    runs-on: ${{ fromJson(matrix.runner) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
+            output: ci.artifacts.linux64.release
+            artifact-name: linux-release
+          - name: Windows
+            runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
+            output: ci.artifacts.win64.release
+            artifact-name: windows-release
+          - name: macOS Silicon
+            runner: '["self-hosted", "macOS", "ARM64", "cardano-wallet"]'
+            output: packages.aarch64-darwin.ci.artifacts.macos-silicon.release
+            artifact-name: macos-silicon-release
+          - name: Docker Image
+            runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
+            output: ci.artifacts.dockerImage
+            artifact-name: docker-image
+    steps:
+      - name: Checkout release candidate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release-candidate-branch }}
+          fetch-depth: 0
+
+      - name: Build
+        run: nix build -L -o result .#${{ matrix.output }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: result/
+
+  changelog:
+    name: "Generate Changelog & API Diff"
+    needs: prepare
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release-candidate-branch }}
+          fetch-depth: 0
+
+      - name: Generate changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LAST_RELEASE_DATE: ${{ needs.prepare.outputs.last-release-date }}
+        run: nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/make_changelog.sh
 
+      - name: Generate API diff
+        run: nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/openapi-diff.sh
+
+      - name: Upload changelog artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: artifacts/
+
+  create-release:
+    name: "Create ${{ inputs.release_type || 'nightly' }} Release"
+    needs: [prepare, build-artifacts, changelog]
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    environment: ${{ (inputs.release_type == 'release' && github.ref == 'refs/heads/master') && 'release' || '' }}
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
+      RELEASE_CANDIDATE_COMMIT: ${{ needs.prepare.outputs.release-candidate-commit }}
+      RELEASE_CABAL_VERSION: ${{ needs.prepare.outputs.release-cabal-version }}
+      TEST_RC: ${{ needs.prepare.outputs.test-rc }}
+      NODE_TAG: ${{ needs.prepare.outputs.node-tag }}
+      IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release-candidate-branch }}
+          fetch-depth: 0
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "$IS_RELEASE" == "true" ]; then
+            echo "tag=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+            echo "title=Release $RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          elif [ "$TEST_RC" == "TRUE" ]; then
+            echo "tag=test" >> "$GITHUB_OUTPUT"
+            echo "title=Test $RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=nightly" >> "$GITHUB_OUTPUT"
+            echo "title=Nightly $RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push tag
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          git tag -l | xargs git tag -d
+          git fetch --tags
+          if [ "$IS_RELEASE" == "true" ]; then
+            exists=$(git tag -l "$TAG")
+            if [ -n "$exists" ]; then
+              echo "Tag $TAG already exists. Remove it before proceeding."
+              exit 1
+            fi
+          else
+            git tag -d "$TAG" 2>/dev/null || true
+          fi
+          git tag -m "$TAG" "$TAG" "$RELEASE_CANDIDATE_COMMIT"
+          git push origin -f "$TAG"
+
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+          path: artifacts/
+
+      - name: Prepare release body
+        run: |
+          export CHANGES=$(cat artifacts/changes.md)
+          export API_CHANGES=$(cat artifacts/api-diff.md)
+          export DOCKER_SHA=xxx
+          envsubst < "$RELEASE_SCRIPTS_DIR/release-template.md" > release-body.md
+
+      - name: Delete existing release (nightly/test)
+        if: env.IS_RELEASE == 'false'
+        run: gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
+
+      - name: Create GitHub release
+        run: |
+          gh release create \
+            -d \
+            -F release-body.md \
+            -t "${{ steps.tag.outputs.title }}" \
+            "${{ steps.tag.outputs.tag }}"
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts/
+
+      - name: Upload release artifacts
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          cd build-artifacts
+
+          for dir_name in linux-release windows-release macos-silicon-release docker-image; do
+            [ -d "$dir_name" ] || continue
+            case "$dir_name" in
+              linux-release)
+                file=$(find "$dir_name" -name "*.tar.gz" | head -1)
+                [ -n "$file" ] && gh release upload "$TAG" "$file#cardano-wallet-$TAG-linux64.tar.gz"
+                ;;
+              windows-release)
+                file=$(find "$dir_name" -name "*.zip" | head -1)
+                [ -n "$file" ] && gh release upload "$TAG" "$file#cardano-wallet.exe-$TAG-win64.zip"
+                ;;
+              macos-silicon-release)
+                file=$(find "$dir_name" -name "*.tar.gz" | head -1)
+                [ -n "$file" ] && gh release upload "$TAG" "$file#cardano-wallet-$TAG-macos-silicon.tar.gz"
+                ;;
+              docker-image)
+                file=$(find "$dir_name" -name "*.tgz" -o -name "*.tar.gz" | head -1)
+                [ -n "$file" ] && gh release upload "$TAG" "$file#cardano-wallet-$TAG-docker-image.tgz"
+                ;;
+            esac
+          done
+
+  push-docker:
+    name: "Push Docker Image"
+    needs: [prepare, create-release]
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
+      RELEASE_CABAL_VERSION: ${{ needs.prepare.outputs.release-cabal-version }}
+      TEST_RC: ${{ needs.prepare.outputs.test-rc }}
+      IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image
+          path: docker-image/
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "$IS_RELEASE" == "true" ]; then
+            echo "tag=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          elif [ "$TEST_RC" == "TRUE" ]; then
+            echo "tag=test" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=nightly" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Login to Docker Hub
+        run: docker login -u cfhal -p "${{ secrets.DOCKER_HUB_TOKEN }}"
+
+      - name: Load and push Docker image
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          REPO="cardanofoundation/cardano-wallet"
+
+          image_file=$(find docker-image -name "*.tgz" -o -name "*.tar.gz" | head -1)
+          docker load -i "$image_file"
+
+          LOADED_IMAGE="$REPO:$RELEASE_CABAL_VERSION"
+          docker tag "$LOADED_IMAGE" "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
+          if [ "$IS_RELEASE" == "true" ]; then
+            docker tag "$REPO:$TAG" "$REPO:latest"
+            docker push "$REPO:latest"
+          fi
+
+  update-docs:
+    name: "Update Documentation Links"
+    if: inputs.release_type == 'release'
+    needs: [prepare, create-release]
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Update redirects
+        run: |
+          cd releases
+          ./make_redirects.sh "${{ needs.prepare.outputs.release-version }}"
+
+      - name: Push updates
+        run: git push origin gh-pages

--- a/scripts/buildkite/release/make_changelog.sh
+++ b/scripts/buildkite/release/make_changelog.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-if [ -n "${BUILDKITE:-}" ]; then
+if [ -n "${LAST_RELEASE_DATE:-}" ]; then
+    since_date="$LAST_RELEASE_DATE"
+elif [ -n "${BUILDKITE:-}" ]; then
     since_date="$(buildkite-agent meta-data get last-release-date)"
 fi
 

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -101,3 +101,15 @@ if [ -n "${BUILDKITE:-}" ]; then
     buildkite-agent meta-data set "node-tag" "$CARDANO_NODE_TAG"
     buildkite-agent meta-data set "last-release-date" "$LAST_RELEASE_DATE"
 fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "release-version=$NEW_GIT_TAG"
+        echo "release-candidate-commit=$RELEASE_COMMIT"
+        echo "release-candidate-branch=$RELEASE_CANDIDATE_BRANCH"
+        echo "release-cabal-version=$NEW_CABAL_VERSION"
+        echo "test-rc=$TEST_RC"
+        echo "node-tag=$CARDANO_NODE_TAG"
+        echo "last-release-date=$LAST_RELEASE_DATE"
+    } >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
## Summary
- Replaces Buildkite release pipeline (`release.yml`) with GitHub Actions
- Nightly releases via cron schedule (3 AM UTC) or manual `workflow_dispatch`
- Production releases via dispatch with `release` environment approval gate
- Builds all platform artifacts in parallel (Linux, Windows cross-compile, macOS Silicon, Docker)
- Generates changelog and API diff using existing scripts (adapted for GHA outputs)
- Pushes Docker image to Docker Hub, updates gh-pages documentation links

## Script Changes
- `release-candidate.sh`: writes to `$GITHUB_OUTPUT` when running in GHA
- `make_changelog.sh`: accepts `LAST_RELEASE_DATE` env var as fallback

## Secrets Required
- `GITHUB_TOKEN` (automatic)
- `DOCKER_HUB_TOKEN` (for Docker Hub push)
- `release` environment with required reviewers (for production releases)

## Test plan
- [x] Trigger nightly release via `workflow_dispatch` on this branch
- [x] Verify RC branch creation and version bumps
- [x] Verify all 4 platform artifacts build
- [x] Verify changelog and API diff generation
- [x] Verify GitHub release creation with artifacts
- [x] Verify Docker Hub push