### PR TITLE
ci: suspend macOS Attic cache job (stale pallas ref #5120)

### DIFF
--- a/.github/workflows/macos-nix-check.yml
+++ b/.github/workflows/macos-nix-check.yml
@@ -32,7 +32,8 @@ jobs:
     name: "Dev Shell Attic Cache (macOS)"
     needs: check-nix
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # Suspended: stale pallas fetchGit reference breaks aarch64-darwin eval (#5120)
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Suspend macOS dev shell Attic cache push — broken by stale `pallas` fetchGit reference upstream
- See #5120 for details

## Test plan

- [x] No functional impact — only affects cache warming on master pushes