### PR TITLE
ci: add ci:bench PR label to trigger benchmarks

### DIFF
--- a/.github/runners/README.md
+++ b/.github/runners/README.md
@@ -109,6 +109,7 @@ To trigger cross-platform CI on a PR, add one of these labels:
 |---|---|
 | `ci:macos` | Run macOS unit tests, nix check, and artifacts |
 | `ci:windows` | Run Windows unit tests and text-class tests |
+| `ci:bench` | Run Linux benchmarks (API, latency, DB, read-blocks, memory) |
 
 Labels can be added at any time — the workflow triggers on the `labeled` event, so no new push is needed.
 

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -1,11 +1,20 @@
 name: Linux Benchmarks
 
 on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: "Build benchmarks"
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:bench')
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Benchmarks now run on push to master and via `ci:bench` PR label
- Skipped on PRs without the label
- Added concurrency control

## Test plan

- [x] Label `ci:bench` created on the repo
- [ ] Add label to a PR and verify benchmarks trigger