### PR TITLE
Bump GHC to version 9.10.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -128,11 +128,12 @@ allow-newer:
   , strict-stm:io-classes
   , cardano-cli:cardano-api
   , si-timers:io-classes
+  , hkd:base
 constraints:
     base >= 4.18.2.0 && < 5
   , openapi3 >= 3.2.0
   , persistent ^>= 2.14.6.0
-  , text ^>= 2.0
+  , text >= 2.0 && < 2.2
   -- bytesmith 0.3.14.0 uses text API incompatible with text-2.x
   , bytesmith < 0.3.14
 

--- a/flake.nix
+++ b/flake.nix
@@ -219,6 +219,7 @@
               # Our own utils (cardanoWalletLib)
               (import ./nix/overlays/common-lib.nix)
               (import ./nix/overlays/basement.nix)
+              (import ./nix/overlays/ghc-lib-parser.nix)
               fix-crypton-x509
               overlay
             ];

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery.hs
@@ -205,7 +205,10 @@ emptyPendingIxs = PendingIxs mempty
 -- | Construct a 'PendingIxs' from a list, ensuring that it is a set of indexes
 -- in descending order.
 pendingIxsFromList :: [Index 'Soft k] -> PendingIxs k
-pendingIxsFromList = PendingIxs . reverse . map head . L.group . L.sort
+pendingIxsFromList = PendingIxs . reverse . map groupHead . L.group . L.sort
+  where
+    groupHead (x:_) = x
+    groupHead [] = error "impossible: L.group returns non-empty lists"
 
 -- | Get the next change index; If every available indexes have already been
 -- taken, we'll rotate the pending set and re-use already provided indexes.

--- a/lib/api/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Client.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -223,8 +223,7 @@ import Cardano.Wallet.Address.Derivation
     , stakeDerivationPath
     )
 import Cardano.Wallet.Address.Derivation.Byron
-    ( ByronKey
-    , mkByronKeyFromMasterKey
+    ( mkByronKeyFromMasterKey
     )
 import Cardano.Wallet.Address.Derivation.Icarus
     ( IcarusKey
@@ -1549,10 +1548,9 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
         W.withRootKey @s db wid mempty Prelude.id (\_ _ -> pure ())
 
 postRandomWallet
-    :: forall ctx s k n.
+    :: forall ctx s n.
         ( ctx ~ ApiLayer s
         , s ~ RndState n
-        , k ~ ByronKey
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]

--- a/lib/application/cardano-wallet-application.cabal
+++ b/lib/application/cardano-wallet-application.cabal
@@ -44,7 +44,7 @@ executable cardano-wallet
   import:           language, opts-exe
   main-is:          cardano-wallet.hs
   hs-source-dirs:   app/shelley
-  build-depends:    base ^>=4.18.2.0
+  build-depends:    base >=4.18.2.0 && <4.21
   default-language: Haskell2010
   build-depends:
     , base

--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 -- |
 -- Copyright: © 2023-2024 Cardano Foundation
 -- License: Apache-2.0

--- a/lib/benchmarks/exe/db-bench.hs
+++ b/lib/benchmarks/exe/db-bench.hs
@@ -611,8 +611,8 @@ bgroupWriteTxHistory tr = bgroup "TxHistory (Write)"
             $ benchPutTxHistory n i o a r
       where
         lbl = n|+" w/ "+|i|+"i + "+|o|+"o ["+|inf|+".."+|sup|+"]"
-        inf = head r
-        sup = last r
+        inf = case r of (x:_) -> x; [] -> error "benchmark range cannot be empty"
+        sup = case reverse r of (x:_) -> x; [] -> error "benchmark range cannot be empty"
 
 bgroupReadTxHistory :: Tracer IO WalletDBLog -> Benchmark
 bgroupReadTxHistory tr = bgroup "TxHistory (Read)"
@@ -639,7 +639,9 @@ bgroupReadTxHistory tr = bgroup "TxHistory (Read)"
             $ benchReadTxHistory o s st Nothing
       where
         lbl = unwords [show n, show a, range, ord, mstatus, search]
-        range = let inf = head r in let sup = last r in "["+|inf|+".."+|sup|+"]"
+        range = case (r, reverse r) of
+            ((inf:_), (sup:_)) -> "["+|inf|+".."+|sup|+"]"
+            _ -> "[]"
         ord = case o of Descending -> "DESC"; Ascending -> "ASC"
         mstatus = maybe "-" pretty st
         search = case s of

--- a/lib/benchmarks/exe/db-bench.hs
+++ b/lib/benchmarks/exe/db-bench.hs
@@ -264,9 +264,6 @@ import Data.Functor
 import Data.Functor.Identity
     ( Identity (..)
     )
-import Data.List
-    ( foldl'
-    )
 import Data.Maybe
     ( fromMaybe
     )

--- a/lib/benchmarks/exe/db-bench.hs
+++ b/lib/benchmarks/exe/db-bench.hs
@@ -641,7 +641,7 @@ bgroupReadTxHistory tr = bgroup "TxHistory (Read)"
         lbl = unwords [show n, show a, range, ord, mstatus, search]
         range = case (r, reverse r) of
             ((inf:_), (sup:_)) -> "["+|inf|+".."+|sup|+"]"
-            _ -> "[]"
+            _ -> error "benchmark range cannot be empty"
         ord = case o of Descending -> "DESC"; Ascending -> "ASC"
         mstatus = maybe "-" pretty st
         search = case s of

--- a/lib/benchmarks/exe/restore-bench.hs
+++ b/lib/benchmarks/exe/restore-bench.hs
@@ -22,8 +22,6 @@
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# HLINT ignore "Avoid NonEmpty.unzip" #-}
-
 {- HLINT ignore "Redundant pure" -}
 
 -- | Benchmark measuring how long restoration takes for different wallets.
@@ -895,10 +893,12 @@ bench_baseline_restoration
                                 $ writeTVar
                                     chainPointT
                                     [Read.chainPointFromChainTip nodeTip]
-                            let (ntxs, hss) =
-                                    NE.unzip
-                                        $ numberOfTransactionsInBlock <$> blocks
-                                (heights, slots) = NE.unzip hss
+                            let pairs =
+                                    numberOfTransactionsInBlock <$> blocks
+                                ntxs = fst <$> pairs
+                                hss = snd <$> pairs
+                                heights = fst <$> hss
+                                slots = snd <$> hss
                                 tip = NE.last heights
                             traceWith progressTrace $ Just tip
                             seq (sum ntxs)

--- a/lib/benchmarks/exe/restore-bench.hs
+++ b/lib/benchmarks/exe/restore-bench.hs
@@ -275,9 +275,6 @@ import Data.Functor
 import Data.Functor.Contravariant
     ( contramap
     )
-import Data.List
-    ( foldl'
-    )
 import Data.Percentage
     ( Percentage
     )

--- a/lib/benchmarks/test/unit/Cardano/Wallet/Benchmarks/HistorySpec.hs
+++ b/lib/benchmarks/test/unit/Cardano/Wallet/Benchmarks/HistorySpec.hs
@@ -51,11 +51,11 @@ spec = do
         it "parses benchmark CSV into indexed results"
             $ case parseResults sampleCsv of
                 Left e -> fail e
-                Right rs -> do
+                Right rs@((ix0, r0) : _) -> do
                     length rs `shouldBe` 2
-                    let (ix0, r0) = head rs
                     index ix0 `shouldBe` 0
                     resultValue r0 `shouldBe` 3.5
+                Right [] -> fail "expected non-empty results"
 
         it "rejects malformed CSV" $ do
             let bad = "not,a,valid,csv\nfoo"

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Chain.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Chain.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 {- |
 Copyright: © 2024 Cardano Foundation
 License: Apache-2.0

--- a/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
+++ b/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
@@ -91,7 +91,9 @@ genValue :: Gen Value
 genValue = injectCoin . CoinC . getPositive <$> arbitrary
 
 genNonByronEra :: Gen (EraValue Era)
-genNonByronEra = elements (drop 1 knownEras)
+genNonByronEra = case knownEras of
+    (_:rest) -> elements rest
+    [] -> error "genNonByronEra: knownEras is empty"
 
 genTxOut :: Gen TxOut
 genTxOut = do

--- a/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
+++ b/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
@@ -91,7 +91,7 @@ genValue :: Gen Value
 genValue = injectCoin . CoinC . getPositive <$> arbitrary
 
 genNonByronEra :: Gen (EraValue Era)
-genNonByronEra = elements (tail knownEras)
+genNonByronEra = elements (drop 1 knownEras)
 
 genTxOut :: Gen TxOut
 genTxOut = do

--- a/lib/delta-store/src/Test/Store.hs
+++ b/lib/delta-store/src/Test/Store.hs
@@ -107,7 +107,7 @@ genChain gen0 more = do
 shrinkChain :: Chain da -> [Chain da]
 shrinkChain (Chain [] _) = []
 shrinkChain (Chain das a0) =
-    [ Chain [] a0, Chain [last das] a0, Chain (tail das) a0 ]
+    [ Chain [] a0, Chain [last das] a0, Chain (drop 1 das) a0 ]
 
 -- | Test whether the law on 'updateS' is satisfied.
 --
@@ -129,6 +129,9 @@ prop_StoreUpdate toIO mkStore gen0 more =
         let Chain adas a0 = chain
             as = map fst adas ++ [a0]
             das = map snd adas
+            expected = case as of
+                (x:_) -> x
+                [] -> error "impossible: as is always non-empty"
         in  counterexample ("\nUpdates applied:\n" <> pretty (listF das))
             $ monadicIO $ do
                 ea <- run . toIO $ do
@@ -142,10 +145,10 @@ prop_StoreUpdate toIO mkStore gen0 more =
                     Left err -> run $ throwIO err
                     Right a -> do
                         monitor $ counterexample
-                            $ "\nExpected:\n" <> show (head as)
+                            $ "\nExpected:\n" <> show expected
                         monitor $ counterexample
                             $ "\nGot:\n" <> show a
-                        assert $ a == head as
+                        assert $ a == expected
 
 {-----------------------------------------------------------------------------
     DSL for developing

--- a/lib/delta-store/src/Test/Store.hs
+++ b/lib/delta-store/src/Test/Store.hs
@@ -107,7 +107,12 @@ genChain gen0 more = do
 shrinkChain :: Chain da -> [Chain da]
 shrinkChain (Chain [] _) = []
 shrinkChain (Chain das a0) =
-    [ Chain [] a0, Chain [last das] a0, Chain (drop 1 das) a0 ]
+    [ Chain [] a0
+    , Chain [last das] a0
+    , case das of
+        (_:rest) -> Chain rest a0
+        [] -> error "shrinkChain: impossible empty das"
+    ]
 
 -- | Test whether the law on 'updateS' is satisfied.
 --

--- a/lib/delta-store/src/Test/Store.hs
+++ b/lib/delta-store/src/Test/Store.hs
@@ -106,12 +106,10 @@ genChain gen0 more = do
 -- | Shrink a chain of deltas.
 shrinkChain :: Chain da -> [Chain da]
 shrinkChain (Chain [] _) = []
-shrinkChain (Chain das a0) =
+shrinkChain (Chain (d:rest) a0) =
     [ Chain [] a0
-    , Chain [last das] a0
-    , case das of
-        (_:rest) -> Chain rest a0
-        [] -> error "shrinkChain: impossible empty das"
+    , Chain [last (d:rest)] a0
+    , Chain rest a0
     ]
 
 -- | Test whether the law on 'updateS' is satisfied.

--- a/lib/delta-types/delta-types.cabal
+++ b/lib/delta-types/delta-types.cabal
@@ -21,7 +21,7 @@ maintainer:      hal@cardanofoundation.org
 copyright:       2021-2023 IOHK, 2024-2025 Cardano Foundation
 category:        Data Structures
 build-type:      Simple
-tested-with:     GHC ==9.6.6
+tested-with:     GHC ==9.10.1
 extra-doc-files:
   CHANGELOG.md
   README.md

--- a/lib/integration/framework/Test/Integration/Framework/DSL/Wallet.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL/Wallet.hs
@@ -228,7 +228,7 @@ fundWallet amt = do
         faucetWalletId <- aFaucetWallet
         Partial addrs <- request $ C.listAddresses w Nothing
         over faucetWalletId $ do
-            let destination = head addrs ^. #id
+            let destination = case addrs of (a:_) -> a ^. #id; [] -> error "expected addresses"
                 addressAmount =
                     AddressAmount
                         { address = destination

--- a/lib/integration/framework/Test/Integration/Framework/Preprod.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Preprod.hs
@@ -200,10 +200,12 @@ setupPreprodWallets tr mnemonics ctx = do
             | w ^. #balance . #total . #toNatural > 5_000_000
                 = pure Nothing
             | otherwise = do
-                addr <- view #id . head . getResponse
+                resp <- getResponse
                     <$> request @[ApiAddressWithPath ('Testnet 1)] ctx -- hardcoded to preprod
                             (Link.listAddresses @'Shelley w) Default Empty
-                pure $ Just $ toStringViaJson addr
+                case resp of
+                    (a:_) -> pure $ Just $ toStringViaJson (view #id a)
+                    [] -> error "expected addresses in wallet"
 
         toStringViaJson :: ToJSON a => a -> String
         toStringViaJson x =

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -511,14 +511,18 @@ spec = describe "BYRON_MIGRATIONS" $ do
                 let addrShelley = (addrs !! 1) ^. #id
 
                 -- Create an Icarus address:
-                addrIcarus <-
-                    encodeAddress (sNetworkId @n) . head . icarusAddresses @n
-                        <$> Mnemonics.generateSome Mnemonics.M15
+                addrIcarus <- do
+                    icarusAddrs <- icarusAddresses @n <$> Mnemonics.generateSome Mnemonics.M15
+                    case icarusAddrs of
+                        (a:_) -> pure $ encodeAddress (sNetworkId @n) a
+                        [] -> error "icarusAddresses returned empty list"
 
                 -- Create a Byron address:
-                addrByron <-
-                    encodeAddress (sNetworkId @n) . head . randomAddresses @n
-                        <$> Mnemonics.generateSome Mnemonics.M12
+                addrByron <- do
+                    byronAddrs <- randomAddresses @n <$> Mnemonics.generateSome Mnemonics.M12
+                    case byronAddrs of
+                        (a:_) -> pure $ encodeAddress (sNetworkId @n) a
+                        [] -> error "randomAddresses returned empty list"
 
                 -- Create a source wallet:
                 sourceWallet <- destWallet ctx

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -1211,7 +1211,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
             (Link.listAddresses @'Shared walDest) Default Empty
         expectResponseCode HTTP.status200 rAddr
         let addrs = getResponse rAddr
-        let destAddr1 = (head addrs) ^. #id
+        let destAddr1 = case addrs of (a:_) -> a ^. #id; [] -> error "expected addresses"
         let destAddr2 = (addrs !! 1) ^. #id
         let payload destination amt = Json [json|{
                 "payments": [{
@@ -2657,7 +2657,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         expectResponseCode HTTP.status200 rAddr
         let addrs = getResponse rAddr
 
-        let addr0 = (head addrs) ^. #id
+        let addr0 = case addrs of (a:_) -> a ^. #id; [] -> error "expected addresses"
         let linkList0 = listTransactionsFilteredByAddress wDest (Just (apiAddress addr0))
         rl0 <- request @([ApiTransaction n]) ctx linkList0 Default Empty
         verify rl0 [expectListSize 2]

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -970,7 +970,7 @@ spec = describe "SHARED_WALLETS" $ do
         --send funds to one change address wallet
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
         addrs1 <- listAddresses walOneAddr
-        let destOneChange = (head addrs1) ^. #id
+        let destOneChange = case addrs1 of (a:_) -> a ^. #id; [] -> error "expected addresses"
         let payloadTx amt destination = Json [json|{
                 "payments": [{
                     "address": #{destination},
@@ -1018,7 +1018,7 @@ spec = describe "SHARED_WALLETS" $ do
             >>= verifyAddrs (initialTotal1+1) (initialUsed1+1)
 
         addrs2 <- listAddresses wFixture
-        let destFixture = (head addrs2) ^. #id
+        let destFixture = case addrs2 of (a:_) -> a ^. #id; [] -> error "expected addresses"
         forM_ [1,1,1,1,1] $ \num -> realizeTx walOneAddr wFixture (num * minUTxOValue') destFixture
 
         -- the fixture wallet has still 20 unused external addresses, 2 used external addresses (first and second),

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -325,7 +326,9 @@ spec = describe "SHELLEY_ADDRESSES" $ do
             >>= verifyAddrs initialTotalB initialUsedB
 
         -- 2. Send a transaction from A -> B
-        destination <- view #id . head <$> listAddresses @n ctx wB
+        destination <- listAddresses @n ctx wB >>= \case
+            (a:_) -> pure $ view #id a
+            [] -> error "expected addresses"
         let amount = 10 * minUTxOValue (_mainEra ctx)
         let payload = Json [json|{
                 "payments": [{

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -1837,8 +1837,10 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         otherWallet <- emptyWallet ctx
 
         -- We send funds to one of our addresses but with a modified stake key.
-        foreignAddr <- head . map (view #id) <$> listAddresses @n ctx otherWallet
-        ourAddr <- head . map (view #id) <$> listAddresses @n ctx w
+        foreignAddr <- listAddresses @n ctx otherWallet >>= \case
+            (a:_) -> pure $ view #id a; [] -> error "expected addresses"
+        ourAddr <- listAddresses @n ctx w >>= \case
+            (a:_) -> pure $ view #id a; [] -> error "expected addresses"
         let ourAddr' = replaceStakeKey ourAddr foreignAddr
         let payload =
                 [json|

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1074,7 +1074,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                         (take 2 srcAddrs)
                 return (wSrc, nAssetsPerAddr)
             wDest <- emptyWallet ctx
-            destAddr <- head . map (view #id) <$> listAddresses @n ctx wDest
+            destAddr <- listAddresses @n ctx wDest >>= \case
+                (a:_) -> pure $ view #id a; [] -> error "expected addresses"
             waitForTxImmutability ctx
 
             -- 2. Try spending from each wallet, and record the response.
@@ -2867,7 +2868,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
     it "SHELLEY_TX_REDEEM_06 - Can't redeem rewards using byron wallet"
         $ \ctx -> runResourceT $ do
             (wSelf, addrs) <- fixtureIcarusWalletAddrs @n ctx
-            let addr = encodeAddress (sNetworkId @n) (head addrs)
+            addr <- case addrs of
+                (a:_) -> pure $ encodeAddress (sNetworkId @n) a
+                [] -> error "expected addresses"
 
             let payload =
                     Json

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -638,7 +638,7 @@ spec = describe "SHELLEY_WALLETS" $ do
         --send funds to one change address wallet
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
         addrs1 <- listAddresses @n ctx wOneChangeAddr
-        let destOneChange = (head addrs1) ^. #id
+        let destOneChange = case addrs1 of (a:_) -> a ^. #id; [] -> error "expected addresses"
         let payloadTx amt destination = Json [json|{
                 "payments": [{
                     "address": #{destination},
@@ -676,7 +676,7 @@ spec = describe "SHELLEY_WALLETS" $ do
             >>= verifyAddrs (initialTotal1+1) (initialUsed1+1)
 
         addrs2 <- listAddresses @n ctx wFixture
-        let destFixture = (head addrs2) ^. #id
+        let destFixture = case addrs2 of (a:_) -> a ^. #id; [] -> error "expected addresses"
         forM_ [1,1,1,1,1] $ \num -> realizeTx wOneChangeAddr (num * minUTxOValue') destFixture
 
         -- the fixture wallet has still 20 unused external addresses, 10 used external addresses,

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -194,11 +194,15 @@ httpApiPortParser = do
                 ++ ".."
                 ++ show maxPort
         pure p
-    minPort = 1024 :: PortNumber
-    maxPort = 65535 :: PortNumber
+
+minPort :: PortNumber
+minPort = 1024
+
+maxPort :: PortNumber
+maxPort = 65535
 
 validPorts :: [PortNumber]
-validPorts = [1024 .. 65535]
+validPorts = [minPort .. maxPort]
 
 nodeToClientSocketParser
     :: Absolutizer

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -190,10 +190,12 @@ httpApiPortParser = do
         unless (p `elem` validPorts)
             $ fail
             $ "Invalid port number. Must be inside: "
-                ++ show (head validPorts)
+                ++ show minPort
                 ++ ".."
-                ++ show (last validPorts)
+                ++ show maxPort
         pure p
+    minPort = 1024 :: PortNumber
+    maxPort = 65535 :: PortNumber
 
 validPorts :: [PortNumber]
 validPorts = [1024 .. 65535]

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Faucet/SendFaucetAssets.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Faucet/SendFaucetAssets.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}

--- a/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
@@ -123,7 +123,7 @@ secondLatest []  = Read.GenesisPoint
 secondLatest [_] = Read.GenesisPoint
 secondLatest xs  = case sortBy (flip compareSlot) xs of
     (_:y:_) -> y
-    _ -> Read.GenesisPoint
+    _ -> error "secondLatest: sort of 2+ elements returned fewer than 2"
 
 -- | Compare the slot numbers of two 'Read.ChainPoint's,
 -- but where the 'Read.GenesisPoint' comes before all other slot numbers.

--- a/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
@@ -121,7 +121,9 @@ latest xs = maximumBy compareSlot xs
 secondLatest :: [Read.ChainPoint] -> Read.ChainPoint
 secondLatest []  = Read.GenesisPoint
 secondLatest [_] = Read.GenesisPoint
-secondLatest xs  = head . tail $ sortBy (flip compareSlot) xs
+secondLatest xs  = case sortBy (flip compareSlot) xs of
+    (_:y:_) -> y
+    _ -> Read.GenesisPoint
 
 -- | Compare the slot numbers of two 'Read.ChainPoint's,
 -- but where the 'Read.GenesisPoint' comes before all other slot numbers.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -37,7 +37,7 @@ shrinkAddress a
     | a == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head addresses
+    simplest = case addresses of (x:_) -> x; [] -> error "impossible"
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
@@ -40,7 +40,7 @@ shrinkAssetName i
     | i == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head testAssetNames
+    simplest = case testAssetNames of (x:_) -> x; [] -> error "impossible"
 
 --------------------------------------------------------------------------------
 -- Asset names chosen from a large range (to minimize the risk of collisions)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
@@ -33,7 +33,7 @@ shrinkRewardAccount a
     | a == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head addresses
+    simplest = case addresses of (x:_) -> x; [] -> error "impossible"
 
 addresses :: [RewardAccount]
 addresses = mkRewardAccount <$> ['0' ..]

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId/Gen.hs
@@ -50,7 +50,7 @@ shrinkTokenPolicyId i
     | i == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head testTokenPolicyIds
+    simplest = case testTokenPolicyIds of (x:_) -> x; [] -> error "impossible"
 
 --------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a large range (to minimize the risk of

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -185,7 +185,7 @@ data TxChange derivationPath = TxChange
     , amount :: Coin
     , assets :: TokenMap
     , derivationPath :: derivationPath
-    } deriving (Show, Generic, Eq, Ord)
+    } deriving (Show, Generic, Eq)
 
 {-------------------------------------------------------------------------------
                           Conversions (Unsafe)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
@@ -61,7 +61,9 @@ shrinkTxHash x
     | x == simplest = []
     | otherwise = [simplest]
   where
-    simplest = case txHashes of (h:_) -> h; [] -> error "impossible"
+    simplest = case txHashes of
+        (h:_) -> h
+        [] -> error "shrinkTxHash: txHashes is empty"
 
 txHashes :: [Hash "Tx"]
 txHashes = mkTxHash <$> ['0' .. '9'] <> ['A' .. 'F']

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
@@ -61,7 +61,7 @@ shrinkTxHash x
     | x == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head txHashes
+    simplest = case txHashes of (h:_) -> h; [] -> error "impossible"
 
 txHashes :: [Hash "Tx"]
 txHashes = mkTxHash <$> ['0' .. '9'] <> ['A' .. 'F']

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -109,6 +109,7 @@ import Ouroboros.Consensus.Config.SecurityParam
 import Test.Hspec
     ( Spec
     , describe
+    , expectationFailure
     , it
     , runIO
     , shouldBe
@@ -222,10 +223,10 @@ spec = do
                     runExceptT $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isLeft
-                logs `shouldSatisfy` (\case
-                    [MsgInterpreterPastHorizon Nothing _ _] -> True
-                    _ -> False)
-                getSeverityAnnotation (head logs) `shouldBe` Notice
+                case logs of
+                    [log1@(MsgInterpreterPastHorizon Nothing _ _)] -> do
+                        getSeverityAnnotation log1 `shouldBe` Notice
+                    _ -> expectationFailure "Expected single MsgInterpreterPastHorizon log"
 
             it "(neverFails \"because\" ti) logs failures as Error" $ do
                 (logs, res) <- captureLogging $ \tr -> do
@@ -235,10 +236,10 @@ spec = do
                     try @IO @PastHorizonException $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isLeft
-                logs `shouldSatisfy` (\case
-                    [MsgInterpreterPastHorizon (Just "because") _ _] -> True
-                    _ -> False)
-                getSeverityAnnotation (head logs) `shouldBe` Error
+                case logs of
+                    [log1@(MsgInterpreterPastHorizon (Just "because") _ _)] -> do
+                        getSeverityAnnotation log1 `shouldBe` Error
+                    _ -> expectationFailure "Expected single MsgInterpreterPastHorizon log"
 
             it "(unsafeExtendSafeZone ti) doesn't fail nor log" $ do
                 (logs, res) <- captureLogging $ \tr -> do
@@ -258,10 +259,10 @@ spec = do
                     try @IO @PastHorizonException $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isLeft
-                logs `shouldSatisfy` (\case
-                    [MsgInterpreterPastHorizon Nothing _ _] -> True
-                    _ -> False)
-                getSeverityAnnotation (head logs) `shouldBe` Notice
+                case logs of
+                    [log1@(MsgInterpreterPastHorizon Nothing _ _)] -> do
+                        getSeverityAnnotation log1 `shouldBe` Notice
+                    _ -> expectationFailure "Expected single MsgInterpreterPastHorizon log"
   where
     forkInterpreter =
         let

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
@@ -19,7 +19,9 @@ import Cardano.Wallet.Primitive.Types.Range
     , isSubrangeOf
     )
 import Data.Maybe
-    ( mapMaybe
+    ( fromJust
+    , listToMaybe
+    , mapMaybe
     )
 import Test.Hspec
     ( Spec
@@ -223,7 +225,8 @@ instance (Arbitrary a, Ord a) => Arbitrary (NonSingletonRange a) where
     arbitrary = do
         -- Iterate through the infinite list of arbitrary ranges and return
         -- the first range that is not a singleton range:
-        head . mapMaybe (makeNonSingletonRangeValid . NonSingletonRange)
+        fromJust . listToMaybe
+            . mapMaybe (makeNonSingletonRangeValid . NonSingletonRange)
             <$> infiniteList
     shrink (NonSingletonRange r) = mapMaybe
         (makeNonSingletonRangeValid . NonSingletonRange) (shrink r)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
@@ -19,9 +19,7 @@ import Cardano.Wallet.Primitive.Types.Range
     , isSubrangeOf
     )
 import Data.Maybe
-    ( fromJust
-    , listToMaybe
-    , mapMaybe
+    ( mapMaybe
     )
 import Test.Hspec
     ( Spec
@@ -225,8 +223,11 @@ instance (Arbitrary a, Ord a) => Arbitrary (NonSingletonRange a) where
     arbitrary = do
         -- Iterate through the infinite list of arbitrary ranges and return
         -- the first range that is not a singleton range:
-        fromJust . listToMaybe
+        firstValid
             . mapMaybe (makeNonSingletonRangeValid . NonSingletonRange)
             <$> infiniteList
+      where
+        firstValid (x:_) = x
+        firstValid [] = error "no valid NonSingletonRange found"
     shrink (NonSingletonRange r) = mapMaybe
         (makeNonSingletonRangeValid . NonSingletonRange) (shrink r)

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -30,6 +30,7 @@ import Data.List
     )
 import Data.Maybe
     ( fromMaybe
+    , listToMaybe
     )
 import Fmt
     ( (+|)
@@ -345,7 +346,7 @@ instance Arbitrary HspecArgs where
                ]
         num = show @Int . getPositive <$> arbitrary
 
-        nubArgs = nubBy ((==) `on` head)
+        nubArgs = nubBy ((==) `on` listToMaybe)
 
         genOpt :: String -> Gen String
         genOpt name = elements $ map ("--" ++) [name, "no-" ++ name]

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
@@ -470,7 +470,9 @@ prop_oursUnexpectedPrefix
 prop_oursUnexpectedPrefix s prefix =
     case knownAddresses s of
         ((Address addr, _, _):_) ->
-            let addr' = BS.cons (unWord8 prefix) (BS.drop 1 addr)
+            let addr' = case BS.uncons addr of
+                    Just (_, rest) -> BS.cons (unWord8 prefix) rest
+                    Nothing -> error "prop_oursUnexpectedPrefix: address is empty"
             in first isJust (isOurs (Address addr') s) === (False, s)
         [] -> error "expected known addresses"
 

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
@@ -302,7 +302,7 @@ prop_addressDiscoveryDoesNotChangeGapInvariance (CatalystSharedState accXPub' ac
     addr = AddressPool.addressFromIx (getAddrPool sharedState) keyIx
     (_, sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
     mapOfConsecutiveUnused
-        = L.tail
+        = drop 1
         . L.dropWhile (== Unused)
         . L.map snd
         . L.sortOn fst
@@ -339,11 +339,11 @@ prop_oursUnexpectedPrefix
     -> UnexpectedPrefix
     -> Property
 prop_oursUnexpectedPrefix s prefix =
-    let
-        (Address addr, _, _) = head $ knownAddresses s
-        addr' = BS.cons (unWord8 prefix) (BS.tail addr)
-    in
-        first isJust (isOurs (Address addr') s) === (False, s)
+    case knownAddresses s of
+        ((Address addr, _, _):_) ->
+            let addr' = BS.cons (unWord8 prefix) (BS.drop 1 addr)
+            in first isJust (isOurs (Address addr') s) === (False, s)
+        [] -> error "expected known addresses"
 
 {-------------------------------------------------------------------------------
                                 Arbitrary Instances

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
@@ -343,7 +343,9 @@ prop_oursUnexpectedPrefix
 prop_oursUnexpectedPrefix s prefix =
     case knownAddresses s of
         ((Address addr, _, _):_) ->
-            let addr' = BS.cons (unWord8 prefix) (BS.drop 1 addr)
+            let addr' = case BS.uncons addr of
+                    Just (_, rest) -> BS.cons (unWord8 prefix) rest
+                    Nothing -> error "prop_oursUnexpectedPrefix: address is empty"
             in first isJust (isOurs (Address addr') s) === (False, s)
         [] -> error "expected known addresses"
 

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
@@ -301,13 +301,15 @@ prop_addressDiscoveryDoesNotChangeGapInvariance (CatalystSharedState accXPub' ac
     sharedState = mkSharedStateFromAccountXPub' @n accXPub' accIx' IncreasingChangeAddresses g pTemplate' dTemplate'
     addr = AddressPool.addressFromIx (getAddrPool sharedState) keyIx
     (_, sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
-    mapOfConsecutiveUnused
-        = drop 1
-        . L.dropWhile (== Unused)
+    mapOfConsecutiveUnused = case
+        ( L.dropWhile (== Unused)
         . L.map snd
         . L.sortOn fst
         . Map.elems . AddressPool.addresses
         $ getAddrPool sharedState'
+        ) of
+            (_:rest) -> rest
+            [] -> error "mapOfConsecutiveUnused: empty after dropWhile"
 
 preconditions
     :: Index 'Soft 'CredFromScriptK

--- a/lib/unit/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -27,8 +27,7 @@ import Data.Functor.Identity
     ( Identity (..)
     )
 import Data.List
-    ( foldl'
-    , sortOn
+    ( sortOn
     )
 import Data.Map
     ( Map

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -537,8 +537,7 @@ import Data.Function
     ( (&)
     )
 import Data.List
-    ( foldl'
-    , intercalate
+    ( intercalate
     )
 import Data.List.NonEmpty
     ( NonEmpty (..)

--- a/lib/unit/test/unit/Cardano/Wallet/CheckpointsSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/CheckpointsSpec.hs
@@ -199,7 +199,9 @@ prop_checkpointsEventuallyEqual args@(GenSparseCheckpointsArgs cfg h) =
         -> [SparseCheckpointsDB]
         -> Property
     prop_canNeverRollbackMoreThanKPlusGap (Quantity tip) dbs =
-        conjoin (forEachStep <$> drop 1 dbs)
+        case dbs of
+            (_:rest) -> conjoin (forEachStep <$> rest)
+            [] -> error "prop_canNeverRollbackMoreThanKPlusGap: empty dbs"
       where
         forEachStep (SparseCheckpointsDB db) =
             let

--- a/lib/unit/test/unit/Cardano/Wallet/CheckpointsSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/CheckpointsSpec.hs
@@ -199,7 +199,7 @@ prop_checkpointsEventuallyEqual args@(GenSparseCheckpointsArgs cfg h) =
         -> [SparseCheckpointsDB]
         -> Property
     prop_canNeverRollbackMoreThanKPlusGap (Quantity tip) dbs =
-        conjoin (forEachStep <$> L.tail dbs)
+        conjoin (forEachStep <$> drop 1 dbs)
       where
         forEachStep (SparseCheckpointsDB db) =
             let

--- a/lib/unit/test/unit/Cardano/Wallet/DB/MigrationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/MigrationSpec.hs
@@ -121,6 +121,7 @@ newtype MonadDatabase a = MonadDatabase
 instance MonadThrow MonadDatabase where
     throwIO = MonadDatabase . ExceptT . pure . Left . toException
     bracket = error "not defined"
+    annotateIO _ = id
 
 liftState :: State Database a -> MonadDatabase a
 liftState = MonadDatabase . lift

--- a/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -361,6 +361,7 @@ import qualified Control.Foldl as Foldl
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Test.QuickCheck as QC
@@ -1126,7 +1127,7 @@ validateGenerators = describe "Validate generators & shrinkers" $ do
     sanityCheckShrink = \case
         []  -> pure ()
         [x] -> sanityCheckShrink (shrinker x)
-        xs  -> sanityCheckShrink (concatMap shrinker [head xs, last xs])
+        xs  -> sanityCheckShrink (concatMap shrinker [NE.head (NE.fromList xs), NE.last (NE.fromList xs)])
 
 dbLayerUnused :: DBLayer m s
 dbLayerUnused = error "DBLayer not used during command generation"

--- a/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -252,8 +252,7 @@ import Data.Bifunctor
     ( first
     )
 import Data.Foldable
-    ( foldl'
-    , toList
+    ( toList
     )
 import Data.Functor.Classes
     ( Eq1

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V5Spec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V5Spec.hs
@@ -143,7 +143,7 @@ testMigrationDelegationsTable dbName = do
 -- all different slots
 generateDelegations :: Int -> SlotNo -> Gen [Delegations]
 generateDelegations n lslot = do
-    indices <- tail . scanl (+) 0 . fmap getPositive <$> replicateM n arbitrary
+    indices <- drop 1 . scanl (+) 0 . fmap getPositive <$> replicateM n arbitrary
     forM indices $ \i -> do
         let slot = lslot + i
         status <-

--- a/lib/unit/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -312,7 +312,7 @@ spec :: Spec
 spec = do
     describe "Buildable instances examples" $ do
         let block = blockchain !! 1
-        let utxo = utxoFromTx $ head $ transactions block
+        let utxo = utxoFromTx $ case transactions block of (t:_) -> t; [] -> error "expected transactions"
         it (show $ ShowFmt utxo) True
 
     describe "Compare Wallet impl. with Specification" $ do

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -966,7 +966,9 @@ allEras =
     ]
 
 eraNum :: AnyCardanoEra -> Int
-eraNum e = fst $ head $ filter ((== e) . snd) allEras
+eraNum e = case filter ((== e) . snd) allEras of
+    ((n, _):_) -> n
+    [] -> error "era not found"
 
 shelleyEraNum :: AnyRecentEra -> Int
 shelleyEraNum (AnyRecentEra era) =

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -653,7 +653,7 @@ walletListTransactionsWithLimit wallet@(_, _, _) =
                 pure  (tx ^. #txId, slot )
         pointInRange xs f = slotNoTime
                     $ SlotNo
-                    $ f $ unSlotNo (last xs) - unSlotNo (head xs)
+                    $ f $ unSlotNo (NE.last (NE.fromList xs)) - unSlotNo (NE.head (NE.fromList xs))
 
     in
     monadicIO $ do

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -127,9 +127,6 @@ import Data.Functor
 import Data.Generics.Internal.VL.Lens
     ( view
     )
-import Data.List
-    ( foldl'
-    )
 import Data.Map.Strict
     ( Map
     )

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -733,6 +733,7 @@ import Data.Functor
     ( ($>)
     , (<&>)
     )
+import qualified Data.Functor
 import Data.Functor.Contravariant
     ( (>$<)
     )
@@ -752,7 +753,6 @@ import Data.Generics.Product.Typed
 import Data.IntCast
     ( intCast
     )
-import qualified Data.Functor
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -752,9 +752,7 @@ import Data.Generics.Product.Typed
 import Data.IntCast
     ( intCast
     )
-import Data.List
-    ( foldl'
-    )
+import qualified Data.Functor
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )
@@ -1404,7 +1402,7 @@ restoreBlocks ctx tr blocks nodeTip = db & \DBLayer{..} -> atomically $ do
     -- not wrapping this into a call to 'atomically'.
     -- However, this only works if the latest database checkpoint, `cp0`,
     -- does not change in the meantime.
-    (filteredBlocks', cps') <- liftIO $ NE.unzip <$> applyBlocks blocks cp0
+    (filteredBlocks', cps') <- liftIO $ Data.Functor.unzip <$> applyBlocks blocks cp0
     let cps = NE.map snd cps'
         filteredBlocks = concat filteredBlocks'
         slotPoolDelegations =

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -87,7 +87,7 @@ import Cardano.Wallet.Primitive.Types
     , DelegationCertificate (..)
     , GenesisParameters (..)
     , Slot
-    , SlotNo
+    , SlotNo (..)
     , SortOrder (..)
     , StakeKeyCertificate (..)
     , WalletMetadata (..)
@@ -335,7 +335,9 @@ mRollbackTo requested (Database wid wal txs) =
 
     -- \| Find nearest checkpoint's slot before or equal to 'requested'.
     findNearestPoint :: [Wallet s] -> SlotNo
-    findNearestPoint = head . sortOn Down . mapMaybe fn
+    findNearestPoint wals = case sortOn Down (mapMaybe fn wals) of
+        (x:_) -> x
+        [] -> SlotNo 0
       where
         fn :: Wallet s -> Maybe SlotNo
         fn cp = if stip cp <= requested then Just (tip cp) else Nothing

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -337,7 +337,7 @@ mRollbackTo requested (Database wid wal txs) =
     findNearestPoint :: [Wallet s] -> SlotNo
     findNearestPoint wals = case sortOn Down (mapMaybe fn wals) of
         (x:_) -> x
-        [] -> SlotNo 0
+        [] -> error "findNearestPoint: no checkpoint before requested slot"
       where
         fn :: Wallet s -> Maybe SlotNo
         fn cp = if stip cp <= requested then Just (tip cp) else Nothing

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Model.hs
@@ -68,7 +68,6 @@ import Data.Delta
     )
 import Data.Foldable
     ( fold
-    , foldl'
     )
 import Data.Map.Strict
     ( Map

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Store.hs
@@ -64,8 +64,7 @@ import Data.ByteString
     )
 import Data.Either.Extra
 import Data.Foldable
-    ( foldl'
-    , forM_
+    ( forM_
     )
 import Data.Maybe
     ( maybeToList

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -515,9 +515,10 @@ shrinkAssetIds :: TxSeq -> TxSeq
 shrinkAssetIds s = mapAssetIds toSimpleAssetId s
   where
     toSimpleAssetId :: AssetId -> AssetId
-    toSimpleAssetId = mapToFunction
-        (NE.head simpleAssetIdsNE)
-        (Map.fromList $ F.toList (assetIds s) `zip` NE.toList simpleAssetIdsNE)
+    toSimpleAssetId = case simpleAssetIds of
+        (x:_) -> mapToFunction x
+            (Map.fromList $ F.toList (assetIds s) `zip` simpleAssetIds)
+        [] -> error "impossible: simpleAssetIds is infinite"
 
 -- | Simplifies the set of transaction identifiers within a 'TxSeq'.
 --
@@ -528,9 +529,10 @@ shrinkTxIds :: TxSeq -> TxSeq
 shrinkTxIds s = mapTxIds toSimpleTxId s
   where
     toSimpleTxId :: Hash "Tx" -> Hash "Tx"
-    toSimpleTxId = mapToFunction
-        (NE.head simpleTxIdsNE)
-        (Map.fromList $ F.toList (txIds s) `zip` NE.toList simpleTxIdsNE)
+    toSimpleTxId = case simpleTxIds of
+        (x:_) -> mapToFunction x
+            (Map.fromList $ F.toList (txIds s) `zip` simpleTxIds)
+        [] -> error "impossible: simpleTxIds is infinite"
 
 --------------------------------------------------------------------------------
 -- Internal interface
@@ -540,17 +542,16 @@ shrinkTxIds s = mapTxIds toSimpleTxId s
 -- Domain-specific constants
 --------------------------------------------------------------------------------
 
-simpleAssetIdsNE :: NonEmpty AssetId
-simpleAssetIdsNE
-    = NE.fromList
-    $ AssetId (UnsafeTokenPolicyId $ Hash mempty)
+simpleAssetIds :: [AssetId]
+simpleAssetIds
+    = AssetId (UnsafeTokenPolicyId $ Hash mempty)
     . UnsafeAssetName
     . T.encodeUtf8
     . T.pack
-    . show <$> [0 :: Integer .. 1000]
+    . show <$> [0 :: Integer ..]
 
-simpleTxIdsNE :: NonEmpty (Hash "Tx")
-simpleTxIdsNE = NE.fromList $ Hash . T.encodeUtf8 . T.pack . show <$> [0 :: Integer .. 1000]
+simpleTxIds :: [Hash "Tx"]
+simpleTxIds = Hash . T.encodeUtf8 . T.pack . show <$> [0 :: Integer ..]
 
 --------------------------------------------------------------------------------
 -- Domain-specific functions

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -516,8 +516,8 @@ shrinkAssetIds s = mapAssetIds toSimpleAssetId s
   where
     toSimpleAssetId :: AssetId -> AssetId
     toSimpleAssetId = mapToFunction
-        (head simpleAssetIds)
-        (Map.fromList $ F.toList (assetIds s) `zip` simpleAssetIds)
+        (NE.head simpleAssetIdsNE)
+        (Map.fromList $ F.toList (assetIds s) `zip` NE.toList simpleAssetIdsNE)
 
 -- | Simplifies the set of transaction identifiers within a 'TxSeq'.
 --
@@ -529,8 +529,8 @@ shrinkTxIds s = mapTxIds toSimpleTxId s
   where
     toSimpleTxId :: Hash "Tx" -> Hash "Tx"
     toSimpleTxId = mapToFunction
-        (head simpleTxIds)
-        (Map.fromList $ F.toList (txIds s) `zip` simpleTxIds)
+        (NE.head simpleTxIdsNE)
+        (Map.fromList $ F.toList (txIds s) `zip` NE.toList simpleTxIdsNE)
 
 --------------------------------------------------------------------------------
 -- Internal interface
@@ -540,16 +540,17 @@ shrinkTxIds s = mapTxIds toSimpleTxId s
 -- Domain-specific constants
 --------------------------------------------------------------------------------
 
-simpleAssetIds :: [AssetId]
-simpleAssetIds
-    = AssetId (UnsafeTokenPolicyId $ Hash mempty)
+simpleAssetIdsNE :: NonEmpty AssetId
+simpleAssetIdsNE
+    = NE.fromList
+    $ AssetId (UnsafeTokenPolicyId $ Hash mempty)
     . UnsafeAssetName
     . T.encodeUtf8
     . T.pack
-    . show <$> [0 :: Integer ..]
+    . show <$> [0 :: Integer .. 1000]
 
-simpleTxIds :: [Hash "Tx"]
-simpleTxIds = Hash . T.encodeUtf8 . T.pack . show <$> [0 :: Integer ..]
+simpleTxIdsNE :: NonEmpty (Hash "Tx")
+simpleTxIdsNE = NE.fromList $ Hash . T.encodeUtf8 . T.pack . show <$> [0 :: Integer .. 1000]
 
 --------------------------------------------------------------------------------
 -- Domain-specific functions

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -31,9 +31,6 @@ import Cardano.Wallet.Submissions.Submissions
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..)
     )
-import Data.Foldable
-    ( Foldable (..)
-    )
 import Fmt
     ( Buildable (..)
     )

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
@@ -46,10 +46,6 @@ import Control.Lens
     , (&)
     , (.~)
     )
-import Data.Foldable
-    ( Foldable (..)
-    )
-
 import qualified Data.Map.Strict as Map
 
 -- | Primitive operations to change a 'Submissions' store.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -112,7 +112,8 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
         packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
         tools = {
           cabal = { index-state = indexState; };
-          cabal-fmt = { index-state = indexState; };
+          # cabal-fmt doesn't support base-4.20 (GHC 9.10) yet
+          # cabal-fmt = { index-state = indexState; };
           haskell-language-server = {
             index-state = indexState;
             version = "latest";

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -99,7 +99,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc984";
+      compiler-nix-name = "ghc982";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";
@@ -280,12 +280,6 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             '';
             # haskell.nix patch for streaming-commons is already applied in 0.2.3.1
             packages.streaming-commons.patches = lib.mkForce [];
-            # fgl's {-# ANN #-} pragmas trigger TH evaluation via iserv-proxy
-            # which crashes during Windows cross-compilation
-            packages.fgl.postPatch = ''
-              sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Monad.hs
-              sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Query/Dominators.hs
-            '';
           })
 
           # Build fixes for library dependencies

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -99,7 +99,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc982";
+      compiler-nix-name = "ghc9101";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -301,6 +301,20 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Monad.hs
               sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Query/Dominators.hs
             '';
+            # cardano-addresses' System.Git.TH uses a TH splice that embeds
+            # a string literal, triggering a GHC 9.10 ByteCode.Asm panic
+            # (mallocStrings:spliceLit) during cross-compilation.
+            # Replace the TH splice with a plain string.
+            packages.cardano-addresses.postPatch = ''
+              cat > lib/System/Git/TH.hs << 'PATCH'
+{-# OPTIONS_HADDOCK hide #-}
+module System.Git.TH (gitRevParseHEAD) where
+import Prelude
+import Language.Haskell.TH (Exp (..), Lit (..), Q)
+gitRevParseHEAD :: Q Exp
+gitRevParseHEAD = pure (LitE (StringL "cross-compiled"))
+PATCH
+            '';
             # iserv-proxy (used for TH during cross-compilation) does not
             # support parallel module compilation — the protocol is strictly
             # synchronous.  Force -j1 globally for Windows builds.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -300,6 +300,10 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Monad.hs
               sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Query/Dominators.hs
             '';
+            # iserv-proxy (used for TH during cross-compilation) does not
+            # support parallel module compilation — the protocol is strictly
+            # synchronous.  Force -j1 globally for Windows builds.
+            ghcOptions = [ "-j1" ];
           })
 
           # Build fixes for library dependencies

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -280,6 +280,12 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             '';
             # haskell.nix patch for streaming-commons is already applied in 0.2.3.1
             packages.streaming-commons.patches = lib.mkForce [];
+            # fgl's {-# ANN #-} pragmas trigger TH evaluation via iserv-proxy
+            # which crashes during Windows cross-compilation
+            packages.fgl.postPatch = ''
+              sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Monad.hs
+              sed -i '/ANN.*HLint/d' Data/Graph/Inductive/Query/Dominators.hs
+            '';
           })
 
           # Build fixes for library dependencies

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -93,13 +93,13 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
       # this is a local variable, it controls only the index-state of the
       # tools
-      indexState = "2025-01-01T23:24:19Z";
+      indexState = "2026-01-20T00:00:00Z";
 
       localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;
 
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc966";
+      compiler-nix-name = "ghc984";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -1,25 +1,26 @@
 # Patch ghc-lib-parser genSym.c: replace atomic_inc64 with atomic_inc.
 # Upstream bug in 9.8.5.20250214, fix from:
 # https://github.com/digital-asset/ghc-lib/pull/571
-final: prev:
-let
-  patchGenSym = drv:
-    drv.overrideAttrs (old: {
-      postPatch = (old.postPatch or "") + ''
-        if [ -f compiler/cbits/genSym.c ] \
-            && grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
-          substituteInPlace compiler/cbits/genSym.c \
-            --replace-fail 'atomic_inc64' 'atomic_inc'
-        fi
-      '';
-    });
-in
-{
-  haskellPackages = prev.haskellPackages.override (old: {
-    overrides = final.lib.composeExtensions
-      (old.overrides or (_: _: {}))
+#
+# NOTE: This overlay only affects the top-level pkgs.haskellPackages.
+# Dev shell tools that depend on ghc-lib-parser (fourmolu, hlint,
+# stylish-haskell) are sourced from pkgs.haskellPackages in
+# nix/haskell.nix rather than from buildPackages.buildPackages,
+# because overlays don't propagate through buildPackages chains.
+final: prev: {
+  haskell = prev.haskell // {
+    packageOverrides = final.lib.composeExtensions
+      (prev.haskell.packageOverrides or (_: _: {}))
       (hfinal: hprev: {
-        ghc-lib-parser = patchGenSym hprev.ghc-lib-parser;
+        ghc-lib-parser = final.haskell.lib.compose.overrideCabal (drv: {
+          postPatch = (drv.postPatch or "") + ''
+            if [ -f compiler/cbits/genSym.c ] \
+                && grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
+              substituteInPlace compiler/cbits/genSym.c \
+                --replace-fail 'atomic_inc64' 'atomic_inc'
+            fi
+          '';
+        }) hprev.ghc-lib-parser;
       });
-  });
+  };
 }

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -1,17 +1,21 @@
 # Patch ghc-lib-parser genSym.c: replace atomic_inc64 with atomic_inc.
 # Upstream bug in 9.8.5.20250214, fix from:
 # https://github.com/digital-asset/ghc-lib/pull/571
+#
+# Applied via nixpkgs config.packageOverrides to ensure it propagates
+# through all package sets (including buildPackages.buildPackages).
 final: prev: {
-  haskellPackages = prev.haskellPackages.override {
-    overrides = hfinal: hprev: {
-      ghc-lib-parser = hprev.ghc-lib-parser.overrideAttrs (old: {
-        postPatch = (old.postPatch or "") + ''
-          if grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
-            substituteInPlace compiler/cbits/genSym.c \
-              --replace-fail 'atomic_inc64' 'atomic_inc'
-          fi
-        '';
-      });
-    };
+  haskell = prev.haskell // {
+    packageOverrides = hfinal: hprev:
+      (prev.haskell.packageOverrides or (_: _: {})) hfinal hprev // {
+        ghc-lib-parser = hprev.ghc-lib-parser.overrideAttrs (old: {
+          postPatch = (old.postPatch or "") + ''
+            if grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
+              substituteInPlace compiler/cbits/genSym.c \
+                --replace-fail 'atomic_inc64' 'atomic_inc'
+            fi
+          '';
+        });
+      };
   };
 }

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -1,21 +1,25 @@
 # Patch ghc-lib-parser genSym.c: replace atomic_inc64 with atomic_inc.
 # Upstream bug in 9.8.5.20250214, fix from:
 # https://github.com/digital-asset/ghc-lib/pull/571
-#
-# Applied via nixpkgs config.packageOverrides to ensure it propagates
-# through all package sets (including buildPackages.buildPackages).
-final: prev: {
-  haskell = prev.haskell // {
-    packageOverrides = hfinal: hprev:
-      (prev.haskell.packageOverrides or (_: _: {})) hfinal hprev // {
-        ghc-lib-parser = hprev.ghc-lib-parser.overrideAttrs (old: {
-          postPatch = (old.postPatch or "") + ''
-            if grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
-              substituteInPlace compiler/cbits/genSym.c \
-                --replace-fail 'atomic_inc64' 'atomic_inc'
-            fi
-          '';
-        });
-      };
-  };
+final: prev:
+let
+  patchGenSym = drv:
+    drv.overrideAttrs (old: {
+      postPatch = (old.postPatch or "") + ''
+        if [ -f compiler/cbits/genSym.c ] \
+            && grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
+          substituteInPlace compiler/cbits/genSym.c \
+            --replace-fail 'atomic_inc64' 'atomic_inc'
+        fi
+      '';
+    });
+in
+{
+  haskellPackages = prev.haskellPackages.override (old: {
+    overrides = final.lib.composeExtensions
+      (old.overrides or (_: _: {}))
+      (hfinal: hprev: {
+        ghc-lib-parser = patchGenSym hprev.ghc-lib-parser;
+      });
+  });
 }

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -6,8 +6,10 @@ final: prev: {
     overrides = hfinal: hprev: {
       ghc-lib-parser = hprev.ghc-lib-parser.overrideAttrs (old: {
         postPatch = (old.postPatch or "") + ''
-          substituteInPlace compiler/cbits/genSym.c \
-            --replace-fail 'atomic_inc64' 'atomic_inc'
+          if grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
+            substituteInPlace compiler/cbits/genSym.c \
+              --replace-fail 'atomic_inc64' 'atomic_inc'
+          fi
         '';
       });
     };

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -1,0 +1,15 @@
+# Patch ghc-lib-parser genSym.c: replace atomic_inc64 with atomic_inc.
+# Upstream bug in 9.8.5.20250214, fix from:
+# https://github.com/digital-asset/ghc-lib/pull/571
+final: prev: {
+  haskellPackages = prev.haskellPackages.override {
+    overrides = hfinal: hprev: {
+      ghc-lib-parser = hprev.ghc-lib-parser.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace compiler/cbits/genSym.c \
+            --replace-fail 'atomic_inc64' 'atomic_inc'
+        '';
+      });
+    };
+  };
+}

--- a/nix/rewrite-libs/nix/project.nix
+++ b/nix/rewrite-libs/nix/project.nix
@@ -31,7 +31,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc966";
+    compiler-nix-name = "ghc9101";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];

--- a/nix/set-git-rev/nix/project.nix
+++ b/nix/set-git-rev/nix/project.nix
@@ -31,7 +31,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc966";
+    compiler-nix-name = "ghc9101";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];


### PR DESCRIPTION
## Summary

- Bump GHC from 9.8.2 to 9.10.1
- Widen text constraint to `>= 2.0 && < 2.2`
- Add `allow-newer: hkd:base`
- Add `allow-newer: cabal-fmt:base` for dev shell
- Update helper projects (rewrite-libs, set-git-rev) to ghc9101

Builds on #5123 (GHC 9.8.2 bump).