### PR TITLE
fix: pass HAL_E2E_PREPROD_MNEMONICS secret to E2E tests

### DIFF
--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -29,4 +29,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run E2E tests
+        env:
+          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
         run: nix shell .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -202,4 +202,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run E2E tests
+        env:
+          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
         run: nix shell .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e


### PR DESCRIPTION
## Summary

- Pass `HAL_E2E_PREPROD_MNEMONICS` secret to E2E test steps in `linux-e2e.yml` and `macos-unit-tests.yml`

Closes #5132