### PR TITLE
fix: dereference symlinks when copying nix store paths in release-build

### DIFF
--- a/nix/release-build.nix
+++ b/nix/release-build.nix
@@ -20,7 +20,7 @@ with pkgs.lib; let
     phases = ["installPhase"];
     installPhase =
       ''
-        cp -R ${exe} $out
+        cp -RL ${exe} $out
       ''
       + (optionalString (set-git-rev != null && gitrev != null) ''
         chmod +w $out/bin/*
@@ -28,7 +28,7 @@ with pkgs.lib; let
       '')
       + (optionalString (pkgs.stdenv.hostPlatform.isWindows && backend != null) ''
         # fixme: remove this
-        cp -Rv ${backend.deployments} $out/deployments
+        cp -RvL ${backend.deployments} $out/deployments
       '');
     meta.platforms = platforms.all;
     passthru =


### PR DESCRIPTION
## Summary
- `cp -R` → `cp -RL` in `nix/release-build.nix`
- DLLs in the haskell.nix output are symlinks to other store paths; `cp -R` preserves them, then `chmod +w` follows them to the read-only nix store and fails on the CI builder (nix 2.24.11)
- `-L` dereferences all symlinks, producing real copies that can be chmod'd

Fixes #5131