### PR TITLE
ci: add macOS boot sync workflow and update GHA migration docs

### DIFF
--- a/.github/workflows/macos-boot-sync.yml
+++ b/.github/workflows/macos-boot-sync.yml
@@ -3,7 +3,6 @@ name: macOS Boot Sync
 on:
   push:
     branches: [master]
-  pull_request:  # temporary – remove after first successful run
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/macos-boot-sync.yml
+++ b/.github/workflows/macos-boot-sync.yml
@@ -1,0 +1,61 @@
+name: macOS Boot Sync
+
+on:
+  push:
+    branches: [master]
+  pull_request:  # temporary – remove after first successful run
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  XDG_CACHE_HOME: /tmp/nix-eval-cache/${{ github.job }}
+
+jobs:
+  boot-syncs:
+    name: "${{ matrix.name }}"
+    runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Preview Network Boot Sync"
+            dir: run/preview/nix
+            timeout: 600
+            status: syncing
+            network: testnet
+
+          - name: "Mainnet Boot Sync"
+            dir: run/mainnet/nix
+            timeout: 600
+            status: syncing
+            network: mainnet
+
+    env:
+      SUCCESS_STATUS: ${{ matrix.status }}
+      NODE_LOGS_FILE: ./logs/node.log
+      WALLET_LOGS_FILE: ./logs/wallet.log
+      CLEANUP_DB: "true"
+      NETWORK: ${{ matrix.network }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run boot sync
+        working-directory: ${{ matrix.dir }}
+        run: |
+          rm -rf logs databases
+          mkdir -p logs
+          ./run.sh sync ${{ matrix.timeout }}
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-boot-sync-logs-${{ strategy.job-index }}
+          path: ${{ matrix.dir }}/logs/

--- a/run/common/nix/run-wallet.sh
+++ b/run/common/nix/run-wallet.sh
@@ -38,10 +38,10 @@ NODE_CONFIGS=${NODE_CONFIGS:=$LOCAL_NODE_CONFIGS}
 
 
 # Generate a random port for the wallet service and export it
-RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+RANDOM_PORT=$(( RANDOM % 63001 + 2000 ))
 WALLET_PORT=${WALLET_PORT:=$RANDOM_PORT}
 
-RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+RANDOM_PORT=$(( RANDOM % 63001 + 2000 ))
 WALLET_UI_PORT=${WALLET_UI_PORT:=$RANDOM_PORT}
 
 # Define the wallet logs file

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -122,13 +122,13 @@ if [[ -z ${NO_WALLET-} ]]; then
     echo "Starting the wallet service..."
 
     # Generate a random port for the wallet service and export it
-    RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+    RANDOM_PORT=$(( RANDOM % 63001 + 2000 ))
     WALLET_PORT=${WALLET_PORT:=$RANDOM_PORT}
 
-    RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+    RANDOM_PORT=$(( RANDOM % 63001 + 2000 ))
     WALLET_UI_PORT=${WALLET_UI_PORT:=$RANDOM_PORT}
 
-    RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+    RANDOM_PORT=$(( RANDOM % 63001 + 2000 ))
     # Define the wallet logs file
     LOCAL_WALLET_LOGS_FILE=./wallet.log
     WALLET_LOGS_FILE="${WALLET_LOGS_FILE:=$LOCAL_WALLET_LOGS_FILE}"


### PR DESCRIPTION
## Summary
- Add macOS boot sync workflow (preview + mainnet) on self-hosted runner (#5129)
- Replace Buildkite references with GitHub Actions in docs (#5137)
- Add GHA migration decision log

## Test plan
- [x] macOS boot sync jobs (preview + mainnet) run on this PR
- [x] Remove `pull_request` trigger after successful run