### PR TITLE
feat: add flaky-tests package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -71,6 +71,7 @@ packages:
   lib/delta-store
   lib/delta-table
   lib/delta-types
+  lib/flaky-tests
   lib/faucet
   lib/integration
   lib/iohk-monitoring-extra
@@ -192,6 +193,9 @@ cabal-lib-version: 3.6
 test-show-details: direct
 
 package cardano-wallet-buildkite
+  tests: True
+
+package flaky-tests
   tests: True
 
 package delta-chain

--- a/lib/flaky-tests/LICENSE
+++ b/lib/flaky-tests/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/flaky-tests/exe/flaky-tests.hs
+++ b/lib/flaky-tests/exe/flaky-tests.hs
@@ -11,7 +11,7 @@ import Data.Text
     ( Text
     )
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding as T
 import GitHub
     ( Auth (..)
     )
@@ -85,7 +85,7 @@ main = do
             hPutStrLn stderr "GITHUB_TOKEN env var not set"
             exitFailure
         Just token -> do
-            let auth = OAuth (TE.encodeUtf8 (T.pack token))
+            let auth = OAuth (T.encodeUtf8 (T.pack token))
                 cfg =
                     defaultFetchConfig
                         { cfgBranch = mBranch

--- a/lib/flaky-tests/exe/flaky-tests.hs
+++ b/lib/flaky-tests/exe/flaky-tests.hs
@@ -1,0 +1,112 @@
+module Main where
+
+import Prelude
+
+import Data.Aeson
+    ( encode
+    )
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Map.Strict as Map
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import GitHub
+    ( Auth (..)
+    )
+import Options.Applicative
+    ( Parser
+    , execParser
+    , fullDesc
+    , help
+    , helper
+    , info
+    , long
+    , metavar
+    , optional
+    , progDesc
+    , short
+    , strOption
+    , (<**>)
+    )
+import System.Environment
+    ( lookupEnv
+    )
+import System.Exit
+    ( exitFailure
+    )
+import System.IO
+    ( hPutStrLn
+    , stderr
+    )
+
+import FlakyTests.GHA
+    ( FetchConfig (..)
+    , defaultFetchConfig
+    , fetchFlakyRuns
+    )
+import FlakyTests.Types
+    ( FlakyEntry (..)
+    , FlakySummary (..)
+    , RunInfo (..)
+    , TestFailure (..)
+    )
+
+newtype Options = Options
+    { optBranch :: Maybe Text
+    }
+
+parseOptions :: Parser Options
+parseOptions =
+    Options
+        <$> optional
+            ( strOption
+                ( long "branch"
+                    <> short 'b'
+                    <> metavar "BRANCH"
+                    <> help "Filter by branch (default: master)"
+                )
+            )
+
+main :: IO ()
+main = do
+    Options mBranch <-
+        execParser
+            $ info
+                (parseOptions <**> helper)
+                ( fullDesc
+                    <> progDesc
+                        "Collect flaky test data from GH Actions"
+                )
+    mToken <- lookupEnv "GITHUB_TOKEN"
+    case mToken of
+        Nothing -> do
+            hPutStrLn stderr "GITHUB_TOKEN env var not set"
+            exitFailure
+        Just token -> do
+            let auth = OAuth (TE.encodeUtf8 (T.pack token))
+                cfg =
+                    defaultFetchConfig
+                        { cfgBranch = mBranch
+                        }
+            result <- fetchFlakyRuns auth cfg
+            case result of
+                Left err -> do
+                    hPutStrLn stderr $ "GitHub API error: " <> show err
+                    exitFailure
+                Right pairs -> do
+                    let summary = aggregate pairs
+                    BL.putStrLn (encode summary)
+
+aggregate :: [(RunInfo, [TestFailure])] -> FlakySummary
+aggregate pairs =
+    FlakySummary
+        $ Map.fromListWith merge
+            [ (testPath tf, FlakyEntry 1 [ri])
+            | (ri, tfs) <- pairs
+            , tf <- tfs
+            ]
+  where
+    merge (FlakyEntry c1 r1) (FlakyEntry c2 r2) =
+        FlakyEntry (c1 + c2) (r1 <> r2)

--- a/lib/flaky-tests/flaky-tests.cabal
+++ b/lib/flaky-tests/flaky-tests.cabal
@@ -1,0 +1,97 @@
+cabal-version: 3.0
+name:          flaky-tests
+version:       0.2025.12.15
+description:   Mine GH Actions history for flaky test detection
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Cardano Foundation (High Assurance Lab)
+maintainer:    hal@cardanofoundation.org
+synopsis:      Flaky test collector for Conway integration tests
+copyright:     2025 Cardano Foundation
+build-type:    Simple
+
+common language
+  default-language:   Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    OverloadedStrings
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
+
+common opts-lib
+  ghc-options:
+    -O2 -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
+    -Wunused-foralls -Wunused-foralls -fprint-explicit-foralls
+    -fprint-explicit-kinds -Wcompat -Widentities
+    -Werror=incomplete-patterns -Wredundant-constraints
+    -Wpartial-fields -Wtabs -fhelpful-errors -fprint-expanded-synonyms
+    -fwarn-unused-do-bind -fwarn-incomplete-uni-patterns
+    -freverse-errors
+
+common opts-exe
+  import:      opts-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:          language, opts-lib
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , containers
+    , github
+    , http-client
+    , http-client-tls
+    , http-types
+    , text
+    , time
+    , vector
+    , zip-archive
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+  hs-source-dirs:  src
+  exposed-modules:
+    FlakyTests.GHA
+    FlakyTests.HspecParser
+    FlakyTests.Types
+
+executable flaky-tests
+  import:         language, opts-exe
+  main-is:        flaky-tests.hs
+  hs-source-dirs: exe
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , containers
+    , flaky-tests
+    , github
+    , optparse-applicative
+    , text
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+test-suite unit
+  import:             language, opts-exe
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test/unit
+  main-is:            flaky-tests-unit-test.hs
+  build-tool-depends: hspec-discover:hspec-discover
+  build-depends:
+    , base
+    , bytestring
+    , flaky-tests
+    , hspec
+    , text
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+  other-modules:
+    FlakyTests.HspecParserSpec

--- a/lib/flaky-tests/flaky-tests.cabal
+++ b/lib/flaky-tests/flaky-tests.cabal
@@ -93,5 +93,4 @@ test-suite unit
   if flag(release)
     ghc-options: -O2 -Werror
 
-  other-modules:
-    FlakyTests.HspecParserSpec
+  other-modules:      FlakyTests.HspecParserSpec

--- a/lib/flaky-tests/src/FlakyTests/GHA.hs
+++ b/lib/flaky-tests/src/FlakyTests/GHA.hs
@@ -255,4 +255,3 @@ extractConwayLog zipBytes =
         let name = T.toLower (T.pack (eRelativePath e))
         in  T.isInfixOf "conway" name
                 && T.isInfixOf "integration" name
-

--- a/lib/flaky-tests/src/FlakyTests/GHA.hs
+++ b/lib/flaky-tests/src/FlakyTests/GHA.hs
@@ -27,13 +27,14 @@ import Data.ByteString.Lazy
     )
 import qualified Data.ByteString.Lazy as BL
 import Data.Maybe
-    ( mapMaybe
+    ( catMaybes
+    , mapMaybe
     )
 import Data.Text
     ( Text
     )
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import GitHub
     ( Auth (..)
@@ -133,7 +134,7 @@ fetchFlakyRuns auth cfg = do
                     <> show total
                     <> ")"
             pairs <- mapM (processRun auth manager cfg) runList
-            pure (Right (mapMaybe id pairs))
+            pure (Right (catMaybes pairs))
 
 processRun
     :: Auth
@@ -154,7 +155,7 @@ processRun auth manager cfg run = do
     mLog <- downloadConwayLog auth manager cfg runIdVal
     case mLog of
         Nothing -> do
-            hPutStrLn stderr $ "  No Conway log found"
+            hPutStrLn stderr "  No Conway log found"
             pure Nothing
         Just logContent -> do
             let (mSummary, failures) = parseLog logContent
@@ -201,7 +202,7 @@ downloadConwayLog auth manager cfg runIdVal = do
     mZip <- downloadZip auth manager apiUrl
     case mZip of
         Nothing -> do
-            hPutStrLn stderr $ "  Failed to download logs zip"
+            hPutStrLn stderr "  Failed to download logs zip"
             pure Nothing
         Just zipBytes -> do
             let archive = toArchive zipBytes
@@ -247,7 +248,7 @@ extractConwayLog zipBytes =
             [] -> Nothing
             (e : _) ->
                 Just
-                    $ TE.decodeUtf8
+                    $ T.decodeUtf8
                     $ BL.toStrict
                     $ fromEntry e
   where

--- a/lib/flaky-tests/src/FlakyTests/GHA.hs
+++ b/lib/flaky-tests/src/FlakyTests/GHA.hs
@@ -1,0 +1,258 @@
+-- |
+-- Copyright: © 2025 Cardano Foundation
+-- License: Apache-2.0
+--
+-- GH Actions API integration for fetching workflow run logs.
+module FlakyTests.GHA
+    ( fetchFlakyRuns
+    , FetchConfig (..)
+    , defaultFetchConfig
+    )
+where
+
+import Prelude
+
+import Data.Proxy
+    ( Proxy (..)
+    )
+
+import Codec.Archive.Zip
+    ( Archive (..)
+    , Entry (..)
+    , fromEntry
+    , toArchive
+    )
+import Data.ByteString.Lazy
+    ( ByteString
+    )
+import qualified Data.ByteString.Lazy as BL
+import Data.Maybe
+    ( mapMaybe
+    )
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Vector as V
+import GitHub
+    ( Auth (..)
+    , Error
+    , WithTotalCount (..)
+    , executeRequest
+    , untagId
+    )
+import GitHub.Data.Actions.WorkflowRuns
+    ( WorkflowRun (..)
+    )
+import GitHub.Data.Name
+    ( mkName
+    )
+import GitHub.Data.Options
+    ( optionsWorkflowRunBranch
+    , optionsWorkflowRunStatus
+    )
+import GitHub.Data.Request
+    ( FetchCount (FetchAtLeast)
+    )
+import GitHub.Endpoints.Actions.WorkflowRuns
+    ( workflowRunsR
+    )
+import Network.HTTP.Client
+    ( Manager
+    , Request (..)
+    , httpLbs
+    , parseRequest
+    , responseBody
+    , responseStatus
+    )
+import Network.HTTP.Client.TLS
+    ( newTlsManager
+    )
+import Network.HTTP.Types.Status
+    ( statusCode
+    )
+import System.IO
+    ( hPutStrLn
+    , stderr
+    )
+
+import FlakyTests.HspecParser
+    ( parseLog
+    )
+import FlakyTests.Types
+    ( RunInfo (..)
+    , TestFailure (..)
+    )
+
+-- | Configuration for fetching flaky test data.
+data FetchConfig = FetchConfig
+    { cfgOwner :: !Text
+    , cfgRepo :: !Text
+    , cfgBranch :: !(Maybe Text)
+    , cfgMaxRuns :: !Int
+    , cfgMaxFailures :: !Int
+    }
+    deriving (Eq, Show)
+
+-- | Default config for cardano-wallet Conway integration tests.
+defaultFetchConfig :: FetchConfig
+defaultFetchConfig =
+    FetchConfig
+        { cfgOwner = "cardano-foundation"
+        , cfgRepo = "cardano-wallet"
+        , cfgBranch = Just "master"
+        , cfgMaxRuns = 50
+        , cfgMaxFailures = 10
+        }
+
+-- | Fetch workflow runs and extract flaky test failures.
+-- Returns a list of @(RunInfo, [TestFailure])@ pairs for
+-- runs with 1–maxFailures failures.
+fetchFlakyRuns
+    :: Auth
+    -> FetchConfig
+    -> IO (Either Error [(RunInfo, [TestFailure])])
+fetchFlakyRuns auth cfg = do
+    manager <- newTlsManager
+    let owner = mkName Proxy (cfgOwner cfg)
+        repo = mkName Proxy (cfgRepo cfg)
+        mods =
+            optionsWorkflowRunStatus "failure"
+                <> maybe mempty optionsWorkflowRunBranch (cfgBranch cfg)
+        count = FetchAtLeast (fromIntegral (cfgMaxRuns cfg))
+    result <- executeRequest auth $ workflowRunsR owner repo mods count
+    case result of
+        Left err -> pure (Left err)
+        Right (WithTotalCount runs total) -> do
+            let runList = V.toList runs
+            hPutStrLn stderr
+                $ "Found "
+                    <> show (length runList)
+                    <> " failed runs (total: "
+                    <> show total
+                    <> ")"
+            pairs <- mapM (processRun auth manager cfg) runList
+            pure (Right (mapMaybe id pairs))
+
+processRun
+    :: Auth
+    -> Manager
+    -> FetchConfig
+    -> WorkflowRun
+    -> IO (Maybe (RunInfo, [TestFailure]))
+processRun auth manager cfg run = do
+    let runIdVal = untagId (workflowRunWorkflowRunId run)
+        runUrl' =
+            "https://github.com/"
+                <> cfgOwner cfg
+                <> "/"
+                <> cfgRepo cfg
+                <> "/actions/runs/"
+                <> T.pack (show runIdVal)
+    hPutStrLn stderr $ "Processing run " <> show runIdVal <> "..."
+    mLog <- downloadConwayLog auth manager cfg runIdVal
+    case mLog of
+        Nothing -> do
+            hPutStrLn stderr $ "  No Conway log found"
+            pure Nothing
+        Just logContent -> do
+            let (mSummary, failures) = parseLog logContent
+            hPutStrLn stderr
+                $ "  Summary: "
+                    <> show mSummary
+                    <> ", failures extracted: "
+                    <> show (length failures)
+            case mSummary of
+                Nothing -> pure Nothing
+                Just (totalEx, failCount)
+                    | failCount >= 1
+                    , failCount <= cfgMaxFailures cfg ->
+                        let info =
+                                RunInfo
+                                    { runId = runIdVal
+                                    , runDate = workflowRunCreatedAt run
+                                    , runTotalExamples = totalEx
+                                    , runFailureCount = failCount
+                                    , runUrl = runUrl'
+                                    }
+                        in  pure (Just (info, failures))
+                    | otherwise -> pure Nothing
+
+-- | Download the log zip for a run and extract the Conway
+-- integration test log file.
+downloadConwayLog
+    :: Auth
+    -> Manager
+    -> FetchConfig
+    -> Int
+    -> IO (Maybe Text)
+downloadConwayLog auth manager cfg runIdVal = do
+    -- The github package's downloadWorkflowRunLogsR returns a
+    -- redirect URI. We handle it manually via http-client.
+    let apiUrl =
+            "https://api.github.com/repos/"
+                <> T.unpack (cfgOwner cfg)
+                <> "/"
+                <> T.unpack (cfgRepo cfg)
+                <> "/actions/runs/"
+                <> show runIdVal
+                <> "/logs"
+    mZip <- downloadZip auth manager apiUrl
+    case mZip of
+        Nothing -> do
+            hPutStrLn stderr $ "  Failed to download logs zip"
+            pure Nothing
+        Just zipBytes -> do
+            let archive = toArchive zipBytes
+                names = map eRelativePath (zEntries archive)
+            hPutStrLn stderr
+                $ "  Zip entries: " <> show names
+            pure (extractConwayLog zipBytes)
+
+downloadZip
+    :: Auth
+    -> Manager
+    -> String
+    -> IO (Maybe ByteString)
+downloadZip auth manager url = do
+    req <- parseRequest url
+    let token = case auth of
+            OAuth t -> t
+            _ -> error "flaky-tests: only OAuth auth is supported"
+        req' =
+            req
+                { requestHeaders =
+                    [ ("Authorization", "Bearer " <> token)
+                    , ("Accept", "application/vnd.github+json")
+                    , ("User-Agent", "flaky-tests")
+                    , ("X-GitHub-Api-Version", "2022-11-28")
+                    ]
+                }
+    resp <- httpLbs req' manager
+    if statusCode (responseStatus resp) == 200
+        then pure (Just (responseBody resp))
+        else pure Nothing
+
+-- | Extract the Conway integration test log from a zip archive.
+-- Looks for files matching @*Conway Integration Tests*@ or
+-- @*conway*integration*@.
+extractConwayLog :: ByteString -> Maybe Text
+extractConwayLog zipBytes =
+    let archive = toArchive zipBytes
+        entries = zEntries archive
+        conwayEntries =
+            filter isConwayEntry entries
+    in  case conwayEntries of
+            [] -> Nothing
+            (e : _) ->
+                Just
+                    $ TE.decodeUtf8
+                    $ BL.toStrict
+                    $ fromEntry e
+  where
+    isConwayEntry e =
+        let name = T.toLower (T.pack (eRelativePath e))
+        in  T.isInfixOf "conway" name
+                && T.isInfixOf "integration" name
+

--- a/lib/flaky-tests/src/FlakyTests/HspecParser.hs
+++ b/lib/flaky-tests/src/FlakyTests/HspecParser.hs
@@ -1,0 +1,133 @@
+-- |
+-- Copyright: © 2025 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Parse hspec log output from GH Actions.
+module FlakyTests.HspecParser
+    ( parseLog
+    , extractSummary
+    , extractFailures
+    , stripTimestamps
+    , stripAnsi
+    )
+where
+
+import Prelude
+
+import Data.Char
+    ( isDigit
+    )
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text as T
+
+import FlakyTests.Types
+    ( TestFailure (..)
+    )
+
+-- | Strip GHA timestamp prefixes of the form
+-- @2026-02-10T14:40:35.4702189Z @
+stripTimestamps :: Text -> Text
+stripTimestamps = T.unlines . map stripLine . T.lines
+  where
+    stripLine line =
+        -- Pattern: YYYY-MM-DDTHH:MM:SS.NNNNNNNZ<space>
+        -- Find "Z " and check prefix looks like a timestamp
+        case T.breakOn "Z " line of
+            (prefix, rest)
+                | not (T.null rest)
+                , T.length prefix >= 20
+                , T.length prefix <= 35
+                , looksLikeTimestamp prefix ->
+                    T.drop 2 rest -- drop "Z "
+            _ -> line
+    looksLikeTimestamp t =
+        -- Check starts with digit (year) and contains 'T'
+        case T.uncons t of
+            Just (c, _) -> isDigit c && T.isInfixOf "T" t
+            Nothing -> False
+
+-- | Strip ANSI escape codes from text.
+stripAnsi :: Text -> Text
+stripAnsi = go
+  where
+    go t = case T.breakOn "\ESC[" t of
+        (before, rest)
+            | T.null rest -> before
+            | otherwise ->
+                let afterEsc = T.drop 2 rest -- drop "\ESC["
+                    afterCode = T.dropWhile isParamChar afterEsc
+                    -- drop the final command character (e.g. 'm')
+                    remaining =
+                        if T.null afterCode
+                            then afterCode
+                            else T.drop 1 afterCode
+                in  before <> go remaining
+    isParamChar c = isDigit c || c == ';'
+
+-- | Extract the summary line @N examples, M failures@.
+-- Returns @Nothing@ if not found.
+extractSummary :: Text -> Maybe (Int, Int)
+extractSummary input =
+    let ls = T.lines (stripAnsi (stripTimestamps input))
+    in  case filter isSummaryLine ls of
+            [] -> Nothing
+            xs -> parseSummary (last xs)
+  where
+    isSummaryLine l =
+        T.isInfixOf "example" l && T.isInfixOf "failure" l
+    parseSummary l =
+        let ws = T.words (T.strip l)
+        in  case ws of
+                (exTxt : "examples," : fTxt : _) ->
+                    case (readMaybe exTxt, readMaybe fTxt) of
+                        (Just ex, Just f) -> Just (ex, f)
+                        _ -> Nothing
+                _ -> Nothing
+
+-- | Extract failed test names from numbered failure lines.
+-- Looks for lines like @  N) Describe, Context, test name@.
+extractFailures :: Text -> [TestFailure]
+extractFailures input =
+    let cleaned = stripAnsi (stripTimestamps input)
+        ls = T.lines cleaned
+    in  mapMaybe parseFailureLine ls
+  where
+    parseFailureLine l =
+        let trimmed = T.stripStart l
+        in  case T.break (== ')') trimmed of
+                (numPart, rest)
+                    | not (T.null numPart)
+                    , T.all isDigit numPart
+                    , Just afterParen <-
+                        T.stripPrefix ")" rest ->
+                        let name = T.strip afterParen
+                        in  if T.null name
+                                then Nothing
+                                else
+                                    Just
+                                        TestFailure
+                                            { testPath = name
+                                            , errorSummary = ""
+                                            }
+                _ -> Nothing
+
+-- | Parse a full log: extract summary and failures.
+parseLog
+    :: Text
+    -> (Maybe (Int, Int), [TestFailure])
+parseLog input = (extractSummary input, extractFailures input)
+
+-- Helpers
+
+readMaybe :: (Read a) => Text -> Maybe a
+readMaybe t = case reads (T.unpack t) of
+    [(x, "")] -> Just x
+    _ -> Nothing
+
+mapMaybe :: (a -> Maybe b) -> [a] -> [b]
+mapMaybe _ [] = []
+mapMaybe f (x : xs) = case f x of
+    Just y -> y : mapMaybe f xs
+    Nothing -> mapMaybe f xs

--- a/lib/flaky-tests/src/FlakyTests/Types.hs
+++ b/lib/flaky-tests/src/FlakyTests/Types.hs
@@ -1,0 +1,88 @@
+-- |
+-- Copyright: © 2025 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Data types for flaky test collection.
+module FlakyTests.Types
+    ( TestFailure (..)
+    , RunInfo (..)
+    , FlakySummary (..)
+    , FlakyEntry (..)
+    )
+where
+
+import Prelude
+
+import Data.Aeson
+    ( ToJSON (..)
+    , object
+    , (.=)
+    )
+import Data.Map.Strict
+    ( Map
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Time
+    ( UTCTime
+    )
+
+-- | A single test failure extracted from a log.
+data TestFailure = TestFailure
+    { testPath :: !Text
+    -- ^ Comma-separated describe hierarchy
+    , errorSummary :: !Text
+    -- ^ First line of the error message
+    }
+    deriving (Eq, Ord, Show)
+
+instance ToJSON TestFailure where
+    toJSON tf =
+        object
+            [ "test_path" .= testPath tf
+            , "error_summary" .= errorSummary tf
+            ]
+
+-- | Metadata about a GH Actions workflow run.
+data RunInfo = RunInfo
+    { runId :: !Int
+    , runDate :: !UTCTime
+    , runTotalExamples :: !Int
+    , runFailureCount :: !Int
+    , runUrl :: !Text
+    }
+    deriving (Eq, Ord, Show)
+
+instance ToJSON RunInfo where
+    toJSON ri =
+        object
+            [ "run_id" .= runId ri
+            , "date" .= runDate ri
+            , "total_examples" .= runTotalExamples ri
+            , "failure_count" .= runFailureCount ri
+            , "url" .= runUrl ri
+            ]
+
+-- | A single entry in the flaky summary.
+data FlakyEntry = FlakyEntry
+    { flakyCount :: !Int
+    , flakyRuns :: ![RunInfo]
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FlakyEntry where
+    toJSON fe =
+        object
+            [ "count" .= flakyCount fe
+            , "runs" .= flakyRuns fe
+            ]
+
+-- | Aggregated flaky test results: test name → frequency and runs.
+newtype FlakySummary = FlakySummary
+    { unFlakySummary :: Map Text FlakyEntry
+    }
+    deriving (Eq, Show)
+
+instance ToJSON FlakySummary where
+    toJSON = toJSON . unFlakySummary

--- a/lib/flaky-tests/test/unit/FlakyTests/HspecParserSpec.hs
+++ b/lib/flaky-tests/test/unit/FlakyTests/HspecParserSpec.hs
@@ -1,0 +1,84 @@
+module FlakyTests.HspecParserSpec (spec) where
+
+import Prelude
+
+import qualified Data.ByteString as BS
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text.Encoding as TE
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import FlakyTests.HspecParser
+    ( extractFailures
+    , extractSummary
+    , stripAnsi
+    , stripTimestamps
+    )
+import FlakyTests.Types
+    ( TestFailure (..)
+    )
+
+readGolden :: IO Text
+readGolden = do
+    bs <- BS.readFile "test/golden/conway-integration.log"
+    pure (TE.decodeUtf8 bs)
+
+spec :: Spec
+spec = describe "HspecParser" $ do
+    describe "stripTimestamps" $ do
+        it "removes GHA timestamp prefixes" $ do
+            let input =
+                    "2026-02-10T14:40:35.4702189Z hello world"
+            stripTimestamps input `shouldBe` "hello world\n"
+
+        it "leaves non-timestamped lines alone" $ do
+            let input = "no timestamp here"
+            stripTimestamps input `shouldBe` "no timestamp here\n"
+
+    describe "stripAnsi" $ do
+        it "removes ANSI color codes" $ do
+            let input = "\ESC[38;5;1mFAILED\ESC[0m"
+            stripAnsi input `shouldBe` "FAILED"
+
+        it "handles text without ANSI codes" $ do
+            stripAnsi "plain text" `shouldBe` "plain text"
+
+    describe "extractSummary (golden)" $ do
+        it "extracts correct example and failure counts" $ do
+            golden <- readGolden
+            extractSummary golden `shouldBe` Just (8, 3)
+
+    describe "extractFailures (golden)" $ do
+        it "extracts all 3 failed test names" $ do
+            golden <- readGolden
+            let failures = extractFailures golden
+            length failures `shouldBe` 3
+
+        it "extracts correct test paths" $ do
+            golden <- readGolden
+            let failures = extractFailures golden
+                paths = map testPath failures
+            paths
+                `shouldBe` [ "API Specifications, SHELLEY_WALLETS,"
+                                <> " WALLETS_UPDATE_PASS_01a"
+                                <> " - passphraseLastUpdate gets updated"
+                           , "API Specifications, TRANSACTIONS,"
+                                <> " TRANS_ESTIMATE_01"
+                                <> " - Can estimate fees"
+                           , "API Specifications, STAKE_POOLS,"
+                                <> " POOLS_JOIN_01 - Can join a pool"
+                           ]
+
+    describe "extractSummary (inline)" $ do
+        it "parses summary without timestamps" $ do
+            let input = "  42 examples, 5 failures"
+            extractSummary input `shouldBe` Just (42, 5)
+
+        it "returns Nothing for non-summary text" $ do
+            extractSummary "no summary here" `shouldBe` Nothing

--- a/lib/flaky-tests/test/unit/FlakyTests/HspecParserSpec.hs
+++ b/lib/flaky-tests/test/unit/FlakyTests/HspecParserSpec.hs
@@ -6,7 +6,7 @@ import qualified Data.ByteString as BS
 import Data.Text
     ( Text
     )
-import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding as T
 import Test.Hspec
     ( Spec
     , describe
@@ -27,7 +27,7 @@ import FlakyTests.Types
 readGolden :: IO Text
 readGolden = do
     bs <- BS.readFile "test/golden/conway-integration.log"
-    pure (TE.decodeUtf8 bs)
+    pure (T.decodeUtf8 bs)
 
 spec :: Spec
 spec = describe "HspecParser" $ do

--- a/lib/flaky-tests/test/unit/flaky-tests-unit-test.hs
+++ b/lib/flaky-tests/test/unit/flaky-tests-unit-test.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
## Summary

New `lib/flaky-tests` package that mines GH Actions history for flaky test detection in Conway Integration Tests.

## Design Decisions

### Standalone package in `lib/flaky-tests`

Follows the same pattern as `lib/buildkite` — a self-contained CI tooling package with its own executable. Keeps flaky test analysis decoupled from the wallet codebase.

### `github` package for the GH Actions API

The [github](https://hackage.haskell.org/package/github-0.30.0.1) Haskell package provides typed bindings to the GitHub API including workflow runs. For log downloads, we bypass the library's redirect-based `downloadWorkflowRunLogsR` and use `http-client` directly against the `/actions/runs/{id}/logs` endpoint, since the library returns a `URI` that requires a second HTTP hop.

### Direct log parsing vs structured API

GH Actions does not expose test results in a structured format — only raw log files inside zip archives. The parser strips GHA timestamp prefixes (variable-length, matched by pattern rather than fixed offset) and ANSI escape codes, then extracts:
- Summary line: `N examples, M failures`
- Numbered failure lines: `N) Describe, Context, test name`

### Flaky signal: 1–10 failures per run

Runs with hundreds of failures indicate infrastructure problems (node crash, network issues), not flaky tests. The 1–10 threshold isolates genuine test flakiness. This is configurable via `cfgMaxFailures`.

### Conway log extraction from zip

Each workflow run's logs download as a zip with one file per job. We match entries containing both "conway" and "integration" (case-insensitive) in the filename.

### JSON output to stdout, diagnostics to stderr

The executable outputs a JSON map of test name → `{count, runs}` to stdout for piping/scripting. Progress and diagnostic messages go to stderr.

## Package Structure

```
lib/flaky-tests/
├── src/FlakyTests/
│   ├── Types.hs        — TestFailure, RunInfo, FlakyEntry, FlakySummary + ToJSON
│   ├── HspecParser.hs  — Timestamp/ANSI stripping, summary/failure extraction
│   └── GHA.hs          — Fetch runs, download log zips, extract Conway logs
├── exe/flaky-tests.hs  — CLI: GITHUB_TOKEN env, --branch flag
└── test/
    ├── unit/FlakyTests/HspecParserSpec.hs  — 9 tests
    └── golden/conway-integration.log       — Synthetic log with real ANSI codes
```

## Usage

```bash
GITHUB_TOKEN=$(gh auth token) cabal run exe:flaky-tests -O0 -- --branch master
```

## Known Limitations (Milestone 1)

- Queries `workflowRunsR` across all workflows — should target specific workflow IDs (691747 for old CI, 231342299 for Linux Integration Tests) to avoid downloading irrelevant logs
- No caching of downloaded zips
- No progress bar for large fetches