### PR TITLE
ci: migrate restoration benchmarks to GitHub Actions

### DIFF
--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - bench: baseline
+          - bench: base
             node-db: mainnet-1
           # TODO: enable after testing
           # - bench: seq0

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -1,0 +1,79 @@
+name: Restoration Benchmarks
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      to-tip-timeout:
+        description: "Node sync timeout in hours"
+        type: choice
+        default: "4"
+        options:
+          - "infinite"
+          - "1"
+          - "2"
+          - "4"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: "Build benchmarks"
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build benchmark derivations
+        run: nix build -L .#ci.benchmarks.restore
+
+  restore:
+    name: "Restore ${{ matrix.bench }}"
+    needs: build
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
+    timeout-minutes: 1380
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - bench: baseline
+            node-db: mainnet-1
+          # TODO: enable after testing
+          # - bench: seq0
+          #   node-db: mainnet-2
+          # - bench: seq1
+          #   node-db: mainnet-3
+          # - bench: rnd5
+          #   node-db: mainnet-4
+    env:
+      LC_ALL: C.UTF-8
+      TMPDIR: /tmp/gha-bench
+      TO_TIP_TIMEOUT: ${{ inputs.to-tip-timeout }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run restore benchmark
+        run: |
+          mkdir -p "$TMPDIR"
+          nix shell 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
+            bash scripts/buildkite/main/bench-restore.sh \
+              mainnet ${{ matrix.bench }} $HOME/databases/node/${{ matrix.node-db }}
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: restore-${{ matrix.bench }}
+          path: |
+            *.txt
+            *.log
+            *.svg
+            *.hp
+          if-no-files-found: ignore

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Restoration Benchmarks
 
 on:
-  pull_request:
+  schedule:
+    - cron: "0 0 * * 1" # every Monday at midnight UTC
   workflow_dispatch:
     inputs:
       to-tip-timeout:
@@ -42,13 +43,12 @@ jobs:
         include:
           - bench: base
             node-db: mainnet-1
-          # TODO: enable after testing
-          # - bench: seq0
-          #   node-db: mainnet-2
-          # - bench: seq1
-          #   node-db: mainnet-3
-          # - bench: rnd5
-          #   node-db: mainnet-4
+          - bench: seq0
+            node-db: mainnet-2
+          - bench: seq1
+            node-db: mainnet-3
+          - bench: rnd5
+            node-db: mainnet-4
     env:
       LC_ALL: C.UTF-8
       TMPDIR: /tmp/gha-bench


### PR DESCRIPTION
## Summary

Migrates the weekly restoration benchmarks from Buildkite to GitHub Actions.

- New `restoration-benchmarks.yml` workflow (weekly schedule + manual dispatch)
- Runs every Monday at midnight UTC
- Two-stage pipeline: build gate then sequential restore matrix
- All 4 restore variants enabled: `base`, `seq0`, `seq1`, `rnd5`
- Each variant uses a dedicated mainnet node DB copy (`mainnet-1` through `mainnet-4`)
- Reuses existing `scripts/buildkite/main/bench-restore.sh` script
- Artifacts (logs, heap profiles, SVG plots) uploaded per variant
- 23-hour timeout per variant, sequential execution (`max-parallel: 1`)

### Infrastructure changes on benchmark-new
- Node DB copies moved from `/var/lib/buildkite-agent/databases/node/` to `/home/gha-runner/databases/node/`
- Ownership transferred to `gha-runner`

### Tested
- [Successful baseline run](https://github.com/cardano-foundation/cardano-wallet/actions/runs/21901865353) — node picked up existing DB without full replay, wallet restoration completed

Closes #5127