### PR TITLE
fix: use readSignedObject for TLS client cert validation on Windows

### DIFF
--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -8,8 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-tests:
-    name: "Build Testing Bundle (Windows)"
+  build-e2e:
+    name: "Build E2E Bundle (Windows)"
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
@@ -17,22 +17,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cross-compile Windows test bundle
-        run: |
-          nix build -L -o result .#ci.artifacts.win64.tests
-          cp result/cardano-wallet-*-tests-win64.zip ./windows-tests.zip
+      - name: Cross-compile Windows E2E bundle
+        run: nix build -L .#ci.artifacts.win64.e2e -o result
 
-      - name: Upload test bundle
+      - name: Upload E2E bundle
         uses: actions/upload-artifact@v4
         with:
-          name: windows-tests
-          path: ./windows-tests.zip
+          name: win-e2e
+          path: result/
 
-  # Pending fix for #5110 (TLS)
   e2e-tests:
     name: "Windows E2E Tests"
-    if: false
-    needs: build-tests
+    needs: build-e2e
     runs-on: [self-hosted, Windows, x64, cardano-wallet-win]
     timeout-minutes: 120
     steps:
@@ -41,19 +37,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download test bundle
+      - name: Download E2E bundle
         uses: actions/download-artifact@v4
         with:
-          name: windows-tests
-
-      - name: Extract test bundle
-        run: |
-          New-Item -ItemType Directory -Force -Path windows-tests
-          tar -xf windows-tests.zip -C windows-tests
-
-      - name: Verify configs match
-        run: diff -r configs/cardano/preprod lib/integration/configs/cardano/preprod
+          name: win-e2e
+          path: e2e-bundle
 
       - name: Run E2E tests
-        working-directory: windows-tests
-        run: .\cardano-wallet-integration-test-e2e.exe
+        working-directory: e2e-bundle
+        env:
+          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+        run: .\e2e.exe

--- a/.github/workflows/windows-tls-diagnostic.yml
+++ b/.github/workflows/windows-tls-diagnostic.yml
@@ -1,0 +1,52 @@
+name: "Windows TLS Diagnostic"
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tls-diagnostic:
+    name: "TLS Certificate Diagnostic"
+    runs-on: [self-hosted, Windows, x64, cardano-wallet-win]
+    steps:
+      - name: "curl.exe → github.com (should work)"
+        run: |
+          curl.exe -sI https://github.com 2>&1 | Select-Object -First 5
+          Write-Host "Exit code: $LASTEXITCODE"
+
+      - name: "PowerShell → github.com (should work)"
+        run: |
+          try {
+            $r = Invoke-WebRequest -Uri https://github.com -UseBasicParsing
+            Write-Host "Status: $($r.StatusCode)"
+          } catch {
+            Write-Host "Failed: $_"
+          }
+
+      - name: "Show certificate chain for github.com"
+        run: |
+          $uri = [Uri]"https://github.com"
+          $tcp = New-Object Net.Sockets.TcpClient($uri.Host, 443)
+          $ssl = New-Object Net.Security.SslStream($tcp.GetStream(), $false)
+          $ssl.AuthenticateAsClient($uri.Host)
+          $cert = $ssl.RemoteCertificate
+          Write-Host "Subject: $($cert.Subject)"
+          Write-Host "Issuer: $($cert.Issuer)"
+          Write-Host "Valid: $($cert.GetEffectiveDateString()) - $($cert.GetExpirationDateString())"
+          $ssl.Dispose()
+          $tcp.Dispose()
+
+      - name: "List Local Machine ROOT store"
+        run: |
+          Get-ChildItem Cert:\LocalMachine\Root | Select-Object Subject, NotAfter | Format-Table -AutoSize
+
+      - name: "List Current User ROOT store"
+        run: |
+          Get-ChildItem Cert:\CurrentUser\Root | Select-Object Subject, NotAfter | Format-Table -AutoSize
+
+      - name: "Check USERTrust ECC in stores"
+        run: |
+          Write-Host "--- Local Machine ---"
+          Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -like "*USERTrust*" }
+          Write-Host "--- Current User ---"
+          Get-ChildItem Cert:\CurrentUser\Root | Where-Object { $_.Subject -like "*USERTrust*" }

--- a/flake.nix
+++ b/flake.nix
@@ -490,6 +490,16 @@
                     std-gen-seed = mkTest "std-gen-seed" windowsPackages.unit-std-gen-seed;
                     wai-middleware-logging = mkTest "wai-middleware-logging" windowsPackages.unit-wai-middleware-logging;
                   };
+                  e2e = import ./nix/windows-test-exe.nix {
+                    inherit pkgs;
+                    name = "e2e";
+                    test = windowsPackages.e2e;
+                    extraPkgs = [
+                      windowsPackages.cardano-wallet
+                      windowsPackages.cardano-node
+                      windowsPackages.cardano-cli
+                    ];
+                  };
                 };
             }
             # macos is never cross-compiled

--- a/justfile
+++ b/justfile
@@ -100,7 +100,7 @@ unit-tests-cabal:
 
 # run cardano-wallet-integration:e2e suite against the preprod network
 e2e:
-  nix shell '.#cardano-node' '.#cardano-wallet' '.#e2e' nixpkgs#gnutar nixpkgs#p7zip -c e2e
+  nix shell '.#cardano-node' '.#cardano-wallet' '.#e2e' nixpkgs#gnutar -c e2e
 
 add_missing_json_goldens:
     CREATE_MISSING_GOLDEN=1 just unit-tests-cabal-match "JSON"

--- a/lib/launcher/src/Cardano/Launcher/Mithril.hs
+++ b/lib/launcher/src/Cardano/Launcher/Mithril.hs
@@ -65,13 +65,11 @@ downloadMithril workingDir = withCurrentDirectory workingDir $ do
         fail $ "Failed to download " <> mithrilPackage
     putStrLn $ "Downloaded " <> mithrilPackage
 
-    -- Extract the gz archive using 7z.
-    putStrLn $ "Extracting " <> mithrilPackage <> " using 7z..."
-    callProcess "7z" ["x", mithrilPackage]
-
-    -- Extract the tar archive.
-    putStrLn $ "Extracting " <> mithrilTar <> " using tar..."
-    callProcess "tar" ["xf", mithrilTar]
+    -- Extract the tar.gz archive in one step.
+    -- Windows 10+ ships BSD tar with gzip support, so this works
+    -- cross-platform without requiring 7z.
+    putStrLn $ "Extracting " <> mithrilPackage <> "..."
+    callProcess "tar" ["xzf", mithrilPackage]
 
     let clientPath = workingDir </> ("mithril-client" <> if isWindows then ".exe" else "")
     mithrilClientExists <- doesFileExist clientPath
@@ -103,7 +101,6 @@ downloadMithril workingDir = withCurrentDirectory workingDir $ do
             other -> other
 
     version = "2543.1-hotfix"
-    mithrilTar    = "mithril-" <> version <> "-" <> platform <> ".tar"
-    mithrilPackage = mithrilTar <> ".gz"
+    mithrilPackage = "mithril-" <> version <> "-" <> platform <> ".tar.gz"
     downloadUrl   = "https://github.com/input-output-hk/mithril/releases/download/"
                    <> version <> "/" <> mithrilPackage


### PR DESCRIPTION
## Summary

- Fix `requireClientAuth` to use `readSignedObject` + `makeCertificateStore` instead of `readCertificateStore`
- `readCertificateStore` from `crypton-x509-store` fails on Windows when given a single PEM file, causing the server to reject all client certificates with `CertificateUnknown`
- Includes Windows TLS diagnostic workflow for cert store visibility

Fixes #5110

## Test

All 6 TLS unit tests pass on Linux:
```
Cardano.Wallet.Application.Tls
  TLS Client Authentication
    Can create a TLS default manager [✔]
    Check security program is available [✔]
    Can create a TLS manager [✔]
    Respond to authenticated client if TLS is enabled [✔]
    Deny client with wrong certificate if TLS is enabled [✔]
    Properly deny HTTP connection if TLS is enabled [✔]
```

Needs Windows CI validation — will trigger once #5142 merges (re-enables `wallet-application-tls` in Windows CI).