### PR TITLE
ci: enable workflow_dispatch on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
One-line change to add `workflow_dispatch` trigger so we can test the release workflow on feature branches before merging #5153.