### PR TITLE
fix: set working-directory for blackbox-benchmarks test

### DIFF
--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -64,7 +64,8 @@ jobs:
             command: nix run .#unit-cardano-numeric -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-blackbox-benchmarks"
-            command: nix run .#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
+            working-directory: lib/wallet-benchmarks
+            command: nix run ../../.#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-launcher"
             command: nix run .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS


### PR DESCRIPTION
## Summary
- Add `working-directory: lib/wallet-benchmarks` to the blackbox-benchmarks matrix entry in both `ci.yml` and `macos-unit-tests.yml`
- The test reads `test/data/hoogle-pmap.txt` via a relative path, so it must run from the package directory (like other tests with hardcoded relative paths)
- Fixes the `cardano-wallet-blackbox-benchmarks` failure on macOS since #5142