### PR TITLE
fix: use GITHUB_TOKEN for gh-pages publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.WILLIAM_KING_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           enable_jekyll: false
           publish_dir: ${{ env.PUBLISH_DIR }}
           keep_files: true


### PR DESCRIPTION
## Summary

Replace `WILLIAM_KING_TOKEN` with `GITHUB_TOKEN` in the Publish Docs workflow. The bot token no longer has push access to the repo, causing gh-pages deploys to fail with 403.

Failed run: https://github.com/cardano-foundation/cardano-wallet/actions/runs/21906614946/job/63248473836