### PR TITLE
ci: expand Attic cache to all CI derivations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,7 +616,7 @@ jobs:
     name: "Attic Cache"
     needs: build-gate-quality
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,6 +616,7 @@ jobs:
     name: "Attic Cache"
     needs: build-gate-quality
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    timeout-minutes: 180
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,7 @@ jobs:
         run: ${{ matrix.command }}
 
   attic-cache:
-    name: "Dev Shell Attic Cache"
+    name: "Attic Cache"
     needs: build-gate-quality
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -622,7 +622,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Push dev shell to Attic
+      - name: Push derivations to Attic
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
           system: x86_64-linux

--- a/scripts/buildkite/main/attic-cache.sh
+++ b/scripts/buildkite/main/attic-cache.sh
@@ -27,3 +27,24 @@ attic push adrestia benchmarks
 # Linux release artifacts
 nix build --log-format raw-with-logs .#ci.artifacts.linux64.release -o linux-release
 attic push adrestia linux-release
+
+# Windows cross-compiled release and test bundles
+nix build --log-format raw-with-logs \
+  .#ci.artifacts.win64.release \
+  .#ci.artifacts.win64.tests.wallet-unit \
+  .#ci.artifacts.win64.tests.wallet-primitive \
+  .#ci.artifacts.win64.tests.wallet-secrets \
+  .#ci.artifacts.win64.tests.wallet-network-layer \
+  .#ci.artifacts.win64.tests.wallet-test-utils \
+  .#ci.artifacts.win64.tests.wallet-launcher \
+  .#ci.artifacts.win64.tests.cardano-numeric \
+  .#ci.artifacts.win64.tests.cardano-balance-tx \
+  .#ci.artifacts.win64.tests.wallet-blackbox-benchmarks \
+  .#ci.artifacts.win64.tests.delta-chain \
+  .#ci.artifacts.win64.tests.delta-store \
+  .#ci.artifacts.win64.tests.delta-table \
+  .#ci.artifacts.win64.tests.delta-types \
+  .#ci.artifacts.win64.tests.std-gen-seed \
+  .#ci.artifacts.win64.tests.wai-middleware-logging \
+  -o win-cross
+attic push adrestia win-cross

--- a/scripts/buildkite/main/attic-cache.sh
+++ b/scripts/buildkite/main/attic-cache.sh
@@ -4,7 +4,26 @@ set -euox pipefail
 
 attic login adrestia https://attic.cf-app.org/ "$ATTIC_TOKEN"
 
+# Dev shell
 # shellcheck disable=SC2154
 nix build --log-format raw-with-logs ".#devShells.${system}.default.inputDerivation" -o dev-shell
-
 attic push adrestia dev-shell
+
+# Core runtime derivations (shared across CI, E2E, benchmarks, mithril-sync)
+nix build --log-format raw-with-logs \
+  .#cardano-wallet \
+  .#cardano-node \
+  .#cardano-cli \
+  .#local-cluster \
+  .#integration-exe \
+  .#e2e \
+  -o ci-core
+attic push adrestia ci-core
+
+# Benchmarks
+nix build --log-format raw-with-logs .#ci.benchmarks.all -o benchmarks
+attic push adrestia benchmarks
+
+# Linux release artifacts
+nix build --log-format raw-with-logs .#ci.artifacts.linux64.release -o linux-release
+attic push adrestia linux-release


### PR DESCRIPTION
## Summary
- Push core runtime derivations to Attic (cardano-wallet, cardano-node, cardano-cli, local-cluster, integration-exe, e2e)
- Push benchmark derivations (ci.benchmarks.all)
- Push linux release artifacts (ci.artifacts.linux64.release)

Note: benchmark runners still need to be configured to use Attic as a substituter (requires SSH access to the runner).

Closes #5151