### PR TITLE
Bump GHC to 9.12.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1763670101,
-        "narHash": "sha256-3S6OSnW0Nn+YBVmuV0XnYQRAuS3i0F9lRdH4KQiN1uI=",
+        "lastModified": 1770875053,
+        "narHash": "sha256-s0f9jZBP/Uwujvi/OmgcEYlOfnB2+tYLwpO5ax92Vqo=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d341a38325d5d65cde10fa92af125b226c51615f",
+        "rev": "6b379a15b507029fb0642a948bad7ff5af494bda",
         "type": "github"
       },
       "original": {
@@ -505,23 +505,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "ghc910X": {
       "flake": false,
       "locked": {
@@ -578,16 +561,32 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1742257465,
-        "narHash": "sha256-+TFf3A0YGCp84ySQtOyf7NnFUhygbYDg+xrZDw/OQ8g=",
+        "lastModified": 1762302430,
+        "narHash": "sha256-thtGuIGrodKEfZPh+Sv22m1BR2zxNQY8RCsGlBWroj4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d64feaae2cc7d84e3886fdb0901986606f9aa2a2",
+        "rev": "c5dc9e01d45948892915b5394f23986277fb0ccb",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -674,14 +673,16 @@
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
         "flake-compat": "flake-compat_4",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": [
           "hackage"
         ],
         "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
         "hls": "hls",
         "hls-1.10": "hls-1.10_2",
         "hls-2.0": "hls-2.0_2",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
         "hls-2.2": "hls-2.2_2",
         "hls-2.3": "hls-2.3_2",
         "hls-2.4": "hls-2.4_2",
@@ -701,16 +702,17 @@
         "nixpkgs-2311": "nixpkgs-2311_2",
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1742259110,
-        "narHash": "sha256-HywkFnFtiujE9HfU2yZfjsT1+nGmsKLUJGW03kR7mow=",
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "605a567596c1572a9b4488741a86ba16584d3052",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       },
       "original": {
@@ -799,6 +801,40 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -1468,16 +1504,32 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1739151041,
-        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1757716134,
+        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1531,11 +1583,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1737110817,
-        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -1703,11 +1755,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1742256713,
-        "narHash": "sha256-uOcYxLNixdsZivcz9hhOlVWO7nogwIFsWJxlRvDSgyk=",
+        "lastModified": 1762301584,
+        "narHash": "sha256-yLihKEbngbLV1EhuLJSencMCtrDM2sYGsVZkX8xlSK8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "27c2471ebf3c5b77ee2f817a51a31c4ee5ef9a82",
+        "rev": "ce12bd44df0b5488bdbbe8762d79379e2bc76d62",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -163,12 +163,13 @@
               buildModules,
               config,
               lib,
+              options,
               ...
             }:
             {
               packages =
                 { }
-                // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc) {
+                // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc && options.packages ? crypton-x509-system) {
                   # Workaround for broken nixpkgs darwin.security_tool in
                   # Mojave. This mirrors the workaround in nixpkgs
                   # haskellPackages.

--- a/lib/application/cardano-wallet-application.cabal
+++ b/lib/application/cardano-wallet-application.cabal
@@ -44,7 +44,7 @@ executable cardano-wallet
   import:           language, opts-exe
   main-is:          cardano-wallet.hs
   hs-source-dirs:   app/shelley
-  build-depends:    base >=4.18.2.0 && <4.21
+  build-depends:    base >=4.18.2.0 && <4.22
   default-language: Haskell2010
   build-depends:
     , base

--- a/lib/faucet/lib/Cardano/Faucet/Types.hs
+++ b/lib/faucet/lib/Cardano/Faucet/Types.hs
@@ -51,9 +51,6 @@ import Data.Aeson
     , parseJSON
     , (.:)
     )
-import Data.Typeable
-    ( Typeable
-    )
 import GHC.Generics
     ( Generic
     )
@@ -174,7 +171,7 @@ newtype AddressIndex = AddressIndex { addressIndexToNatural :: Natural }
     deriving stock (Show, Generic)
 
 newtype Mnemonic = Mnemonic { toSomeMnemonic :: SomeMnemonic }
-    deriving stock (Show, Generic, Typeable)
+    deriving stock (Show, Generic)
 
 instance ToJSON Mnemonic where
     toJSON = toJSON . someMnemonicToSentence . toSomeMnemonic

--- a/lib/primitive/test/data/Cardano/Wallet/Primitive/Types/BlockSummarySpec.hs
+++ b/lib/primitive/test/data/Cardano/Wallet/Primitive/Types/BlockSummarySpec.hs
@@ -131,8 +131,6 @@ instance Arbitrary BlockEvents where
     arbitrary = do
         sl <- genSlotNo
         ht <- blockHeight <$> genBlockHeader sl
-        BlockEvents
-            (At sl)
-            ht
-            <$> (wholeList <$> resize 2 (listOf1 genTx))
+        BlockEvents (At sl) ht . wholeList
+            <$> resize 2 (listOf1 genTx)
             <*> pure (wholeList [])

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
@@ -489,8 +489,8 @@ instance Arbitrary SL.UnitInterval where
     shrink = map unsafeBoundRational . shrink . SL.unboundRational
 
 instance Arbitrary SlotId where
-    arbitrary = SlotId
-        <$> (W.EpochNo . fromIntegral <$> choose (0, 10 :: Word32))
+    arbitrary = SlotId . W.EpochNo . fromIntegral
+        <$> choose (0, 10 :: Word32)
         <*> (W.SlotInEpoch <$> choose (0, 10))
 
 instance Arbitrary SomeMnemonic where

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1733,8 +1733,8 @@ instance Arbitrary StakePoolFlag where
     arbitrary = genericArbitrary
 
 instance Arbitrary StakePoolMetrics where
-    arbitrary = StakePoolMetrics
-        <$> (Quantity . fromIntegral <$> choose (1::Integer, 1_000_000_000_000))
+    arbitrary = StakePoolMetrics . Quantity . fromIntegral
+        <$> choose (1::Integer, 1_000_000_000_000)
         <*> arbitrary
         <*> (choose (0.0, 5.0))
         <*> (Quantity . fromIntegral <$> choose (1::Integer, 22_600_000))
@@ -2268,8 +2268,8 @@ instance Arbitrary ApiTokenAmountFingerprint where
         name <- genAssetName
         policyid <- arbitrary
         let fingerprint = ApiT $ mkTokenFingerprint policyid name
-        ApiTokenAmountFingerprint (ApiT name)
-            <$> (fromIntegral <$> choose @Int (1, 10_000))
+        ApiTokenAmountFingerprint (ApiT name) . fromIntegral
+            <$> choose @Int (1, 10_000)
             <*> pure fingerprint
 
 instance Arbitrary ApiTokens where
@@ -2354,8 +2354,8 @@ instance HasSNetworkId n => Arbitrary (ApiMintBurnDataFromScript n) where
         <*> arbitrary
 
 instance HasSNetworkId n => Arbitrary (ApiMintBurnDataFromInput n) where
-    arbitrary = ApiMintBurnDataFromInput
-        <$> (ReferenceInput <$> arbitrary)
+    arbitrary = (ApiMintBurnDataFromInput . ReferenceInput
+        <$> arbitrary)
         <*> arbitrary
         <*> oneof
             [ Just . ApiT <$> genAssetName

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -461,8 +461,8 @@ instance Arbitrary WalletId where
 
 instance Arbitrary WalletMetadata where
     shrink _ = []
-    arbitrary =  WalletMetadata
-        <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
+    arbitrary =  (WalletMetadata . WalletName
+        <$> elements ["bulbazaur", "charmander", "squirtle"])
         <*> genUniformTime
         <*> oneof
             [ pure Nothing

--- a/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -1038,8 +1038,8 @@ genDBParams
        )
     => Gen (DBLayerParams s)
 genDBParams =
-    DBLayerParams
-        <$> (getInitialCheckpoint <$> arbitrary)
+    (DBLayerParams . getInitialCheckpoint
+        <$> arbitrary)
         <*> pure RestorationPointAtGenesis
         <*> arbitrary
         <*> fmap unGenTxHistory arbitrary

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -1542,8 +1542,8 @@ instance Arbitrary Tx where
     shrink = shrinkTx
 
 instance Arbitrary TxIn where
-    arbitrary = TxIn
-        <$> (Hash . B8.pack <$> vector 32)
+    arbitrary = TxIn . Hash . B8.pack
+        <$> vector 32
         <*> scale (`mod` 3) arbitrary
 
 instance Arbitrary TxOut where

--- a/lib/wallet/src/Cardano/Pool/DB/Model.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Model.hs
@@ -366,8 +366,8 @@ mListRetiredPools epochNo = do
 
 mReadPoolLifeCycleStatus :: PoolId -> ModelOp PoolLifeCycleStatus
 mReadPoolLifeCycleStatus poolId =
-    determinePoolLifeCycleStatus
-        <$> (lookupLatestCertificate <$> get #registrations)
+    (determinePoolLifeCycleStatus . lookupLatestCertificate
+        <$> get #registrations)
         <*> (lookupLatestCertificate <$> get #retirements)
   where
     lookupLatestCertificate

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -576,7 +576,7 @@ instance FromJSON BatchResponse where
     parseJSON =  withObject "BatchResponse" $ \o -> do
         (xs :: [Value]) <- o .: "subjects"
         let maybeParseItem v = fmap Just (parseJSON v) <|> pure Nothing
-        BatchResponse <$> (catMaybes <$> mapM maybeParseItem xs)
+        BatchResponse . catMaybes <$> mapM maybeParseItem xs
 
 instance ToJSON Subject where
     toJSON = String . unSubject
@@ -608,8 +608,8 @@ instance FromJSON SubjectProperties where
             propName = fromString $ symbolVal (Proxy @name)
 
 instance (HasValidator name, FromJSON (PropertyValue name)) => FromJSON (Property name) where
-    parseJSON = withObject "Property value" $ \o -> Property
-            <$> (validate <$> o .: "value")
+    parseJSON = withObject "Property value" $ \o -> (Property . validate
+            <$> (o .: "value"))
             <*> o .:? "signatures" .!= []
             <*> o .:? "sequenceNumber" .!= 0
       where

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -99,7 +99,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc9101";
+      compiler-nix-name = "ghc9122";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";
@@ -191,6 +191,10 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               # Enable Haskell Program Coverage for all local libraries
               # and test suites.
               doCoverage = coverage;
+
+              # GHC 9.12: suppress 'deriving Typeable' warning (all types
+              # auto-derive Typeable, making explicit deriving redundant).
+              ghcOptions = [ "-Wno-deriving-typeable" ];
             });
           }
 

--- a/nix/rewrite-libs/nix/project.nix
+++ b/nix/rewrite-libs/nix/project.nix
@@ -31,7 +31,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9101";
+    compiler-nix-name = "ghc9122";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];

--- a/nix/set-git-rev/nix/project.nix
+++ b/nix/set-git-rev/nix/project.nix
@@ -31,7 +31,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9101";
+    compiler-nix-name = "ghc9122";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];


### PR DESCRIPTION
## Summary

- Bump compiler from GHC 9.10.1 to 9.12.2 for all platforms (native Linux, Windows cross-compilation, macOS)
- Bump `set-git-rev` and `rewrite-libs` subsidiary tools from GHC 9.10.1 to 9.12.2
- Update CHaP and flake.lock inputs for 9.12.2 compatibility
- Suppress `deriving Typeable` warnings (redundant in GHC 9.12, all types auto-derive Typeable)
- Remove 3 GHC 9.10 Windows cross-compilation workarounds that are no longer needed
- Guard `crypton-x509-system` overlay for macOS compatibility with GHC 9.12

## Windows cross-compilation

Windows cross-compilation builds and passes all checks locally:

- `cardano-wallet.exe`, `cardano-node`, `cardano-cli`, `bech32`, `cardano-address` — all pass
- All binaries confirmed statically linked
- Release zip produced successfully
- All 16 Windows test bundles built successfully

### Removed GHC 9.10 workarounds

GHC 9.12 fixes several iserv-proxy issues that required workarounds for Windows cross-compilation:

- **`cardano-addresses` TH splice hack** — GHC 9.10 had a `ByteCode.Asm panic (mallocStrings:spliceLit)` when cross-compiling TH splices; fixed in 9.12
- **`fgl` ANN pragma stripping** — `{-# ANN #-}` pragmas triggered iserv-proxy crashes; fixed in 9.12
- **`-j1` global flag** — iserv-proxy couldn't handle parallel module compilation; works in 9.12

The remaining Windows patches (`unix-compat`, `unix-time`, `crypton-x509-system`, `streaming-commons`) are genuine library compatibility fixes unrelated to GHC version.

## Subsidiary tools

The subsidiary tools (`set-git-rev`, `rewrite-libs`) were previously pinned to GHC 9.10.1, which forced nix to compile a separate GHC from source. Bumping them to 9.12.2 allows reuse of the cached GHC 9.12.2 compiler (11 derivations → 3).

## Linux benchmarks comparison (9.6.6 → 9.8.2 → 9.10.1 → 9.12.2)

Runs: [9.6.6](https://github.com/cardano-foundation/cardano-wallet/actions/runs/21914025608) (master pre-bump) · [9.8.2](https://github.com/cardano-foundation/cardano-wallet/actions/runs/21914955047) · [9.10.1](https://github.com/cardano-foundation/cardano-wallet/actions/runs/21941654279) (master post-merge) · [9.12.2](https://github.com/cardano-foundation/cardano-wallet/actions/runs/21949393997)

### Memory (RSS at startup)

| GHC | KB | vs 9.6.6 |
|-----|-----|----------|
| 9.6.6 | 64,336 | baseline |
| 9.8.2 | 61,860 | -3.8% |
| 9.10.1 | 65,140 | +1.2% |
| **9.12.2** | **59,532** | **-7.5%** |

### Read-blocks (ms, lower = better)

| Blocks | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|--------|-------|-------|--------|--------|
| 10 | 0.493 | 0.447 | 0.491 | **0.415** |
| 100 | 5.20 | 4.67 | 4.95 | **4.41** |
| 1,000 | 58.7 | 51.3 | 54.8 | **48.9** |
| 10,000 | 620 | **529** | 608 | 551 |

### DB — UTxO Write (seconds)

| Workload | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|----------|-------|-------|--------|--------|
| 100k ada-only | 0.738 | **0.695** | 0.799 | 0.747 |
| 10k 10-assets | 0.757 | **0.750** | 0.908 | 0.777 |
| 10k 20-assets | 1.469 | **1.393** | 1.594 | 1.455 |

### DB — UTxO Read (seconds)

| Workload | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|----------|-------|-------|--------|--------|
| 10k ada-only | **0.000297** | 0.000312 | 0.000335 | 0.000645 |
| 100k ada-only | **0.00274** | 0.00294 | 0.00379 | 0.00336 |

⚠️ 9.12.2 shows a 2x regression on 10k UTxO reads (0.645ms vs 0.297ms baseline). Tracked in #5170.

### DB — TxHistory Write (seconds, heavy workloads)

| Workload | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|----------|-------|-------|--------|--------|
| 1000 50i+100o (run 3) | 61.6 | **59.4** | 63.4 | 66.1 |
| 10000 10i+10o | 6.85 | **6.70** | 7.19 | 7.47 |

### DB — TxHistory Read (seconds)

| Workload | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|----------|-------|-------|--------|--------|
| 1000 DESC * | 2.47 | 2.44 | 2.41 | **2.38** |
| 10k DESC 42..1337 | 3.81 | 3.80 | 3.76 | **3.64** |
| 10k DESC 40..60 | 7.69 | 7.68 | 7.50 | **7.35** |

### API Benchmark (seconds)

| Operation | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|-----------|-------|-------|--------|--------|
| Shelley postTx | 0.306 | 0.302 | 0.348 | **0.291** |
| Shared listTx | 0.141 | 0.141 | 0.166 | **0.125** |
| Byron listTx | 0.296 | 0.264 | 0.277 | **0.242** |
| Byron postTx | 0.275 | 0.273 | 0.284 | **0.252** |

### Latency — 2-fixture baseline (ms)

| Operation | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|-----------|-------|-------|--------|--------|
| postTransaction | 130.7 | 138.8 | 132.6 | **127.9** |
| postTxFee | 20.0 | **18.9** | 25.3 | 19.3 |
| listStakePools | 44.3 | 54.3 | 59.0 | **43.1** |

### Latency — Massive UTxOs stress test (ms)

| Operation | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|-----------|-------|-------|--------|--------|
| getWallet | 370.2 | 405.5 | 358.3 | **305.2** |
| listTransactions | 5294.6 | 5315.4 | 5680.8 | **5114.1** |
| postTxFee | 845.4 | 877.0 | 954.8 | **845.2** |
| listAddresses | 1386.1 | **1326.8** | 2097.5 | 1539.6 |

### Verdict

| Benchmark | 9.6.6 | 9.8.2 | 9.10.1 | 9.12.2 |
|-----------|-------|-------|--------|--------|
| Memory footprint | — | better | worse | **best** (-7.5%) |
| Read-blocks | worst | good | — | **best** |
| DB writes (UTxO) | — | **best** | worst | good |
| DB reads (UTxO) | **best** | good | — | worst (2x on 10k) |
| DB TxHistory write | — | **best** | — | worst (+11%) |
| DB TxHistory read | — | — | — | **best** |
| API operations | — | — | regressions | **best** |
| Latency (typical) | good | good | regressions | **best** |
| Latency (massive) | good | good | worst | **best** |

**9.12.2** wins on memory, read-blocks, API, and latency. It has regressions on UTxO reads (2x on 10k) and heavy TxHistory writes (+11%) compared to 9.8.2, which are DB-bound workloads where the compiler difference may be magnified by serialization code.

## Changes

- `nix/haskell.nix`: `ghc9101` → `ghc9122`, add `-Wno-deriving-typeable`, remove 3 Windows workarounds
- `nix/set-git-rev/nix/project.nix`: `ghc9101` → `ghc9122`
- `nix/rewrite-libs/nix/project.nix`: `ghc9101` → `ghc9122`
- `flake.nix`: guard `crypton-x509-system` overlay with `optionalAttrs`
- `flake.lock`: updated CHaP, removed stale `ghc-8.6.5-iohk` input
- `lib/faucet/lib/Cardano/Faucet/Types.hs`: remove redundant `deriving Typeable`
- `cardano-wallet-application.cabal`: version bound update

Closes #5164