### PR TITLE
Add attic watch-store services for builder machines

### DIFF
--- a/scripts/machines/attic-watch-store.service
+++ b/scripts/machines/attic-watch-store.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Attic watch-store for adrestia cache
+After=network-online.target nix-daemon.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/nix/var/nix/profiles/default/bin/attic watch-store adrestia
+Restart=on-failure
+RestartSec=30
+Environment=ATTIC_CONFIG_DIR=/root/.config/attic
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/machines/com.attic.watch-store.plist
+++ b/scripts/machines/com.attic.watch-store.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.attic.watch-store</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/nix/var/nix/profiles/default/bin/attic</string>
+    <string>watch-store</string>
+    <string>adrestia</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/var/log/attic-watch-store.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/var/log/attic-watch-store.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/machines/setup-attic-watch.sh
+++ b/scripts/machines/setup-attic-watch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${ATTIC_TOKEN:-}" ]; then
+  echo "ERROR: ATTIC_TOKEN environment variable is required" >&2
+  exit 1
+fi
+
+# Install attic-client if not already on PATH
+if ! command -v attic &>/dev/null; then
+  echo "Installing attic-client..."
+  nix profile install github:zhaofengli/attic
+fi
+
+# Configure attic login
+echo "Configuring attic login for adrestia cache..."
+attic login adrestia https://attic.cf-app.org/ "$ATTIC_TOKEN"
+
+# Detect OS and install the appropriate service
+case "$(uname -s)" in
+  Linux)
+    echo "Installing systemd service..."
+    cp "$SCRIPT_DIR/attic-watch-store.service" /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl enable --now attic-watch-store.service
+    echo "Verifying..."
+    if systemctl is-active --quiet attic-watch-store.service; then
+      echo "attic-watch-store is running"
+    else
+      echo "ERROR: service failed to start" >&2; exit 1
+    fi
+    ;;
+  Darwin)
+    echo "Installing launchd plist..."
+    cp "$SCRIPT_DIR/com.attic.watch-store.plist" /Library/LaunchDaemons/
+    launchctl bootstrap system /Library/LaunchDaemons/com.attic.watch-store.plist
+    echo "Verifying..."
+    if launchctl print system/com.attic.watch-store &>/dev/null; then
+      echo "attic-watch-store is running"
+    else
+      echo "ERROR: service failed to start" >&2; exit 1
+    fi
+    ;;
+  *)
+    echo "ERROR: unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add persistent `attic watch-store adrestia` daemon configs for builder machines, keeping the Attic cache warm between nightly garbage collections
- **systemd unit** (`scripts/machines/attic-watch-store.service`) for Linux builders
- **launchd plist** (`scripts/machines/com.attic.watch-store.plist`) for macOS builders
- **Setup script** (`scripts/machines/setup-attic-watch.sh`) that installs attic-client, configures login, detects OS, and enables the service

## Test plan

- [x] Shellcheck passes on the setup script
- [x] Run `ATTIC_TOKEN=... sudo -E ./scripts/machines/setup-attic-watch.sh` on Linux builder
- [x] Run `ATTIC_TOKEN=... sudo -E ./scripts/machines/setup-attic-watch.sh` on macOS builder
- [x] Verify store paths appear in Attic after a `nix build`

Closes #5167