### PR TITLE
Bump cardano-node to 10.5.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ index-state: 2026-01-29T00:00:00Z
 
 index-state:
   , hackage.haskell.org 2026-01-29T00:00:00Z
-  , cardano-haskell-packages 2026-01-28T00:00:00Z
+  , cardano-haskell-packages 2026-02-05T12:58:40Z
 
 packages:
   lib/address-derivation-discovery

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763670101,
-        "narHash": "sha256-3S6OSnW0Nn+YBVmuV0XnYQRAuS3i0F9lRdH4KQiN1uI=",
+        "lastModified": 1770297836,
+        "narHash": "sha256-Jnfz4OjZG+xvnCQ0KeUS7kaVAu7MsSgvwqFyyZjN+Hw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d341a38325d5d65cde10fa92af125b226c51615f",
+        "rev": "aae41da34344a6ad7cae51770df4ed1714b7a9c9",
         "type": "github"
       },
       "original": {
@@ -248,16 +248,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1763736877,
-        "narHash": "sha256-c1a6DzDlm+wzwa85TWeOFrPEldsfjiZw7+DcMMW9nc4=",
+        "lastModified": 1770307293,
+        "narHash": "sha256-66bbnASi59OLBth3VA4PPWqAFyllxfHICh1bbkf6F4k=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "6c034ec038d8d276a3595e10e2d38643f09bd1f2",
+        "rev": "b0a12592c4e996b57edf5bc5b9109ecc88c2273f",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.3",
+        "ref": "10.5.4",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -1179,15 +1179,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1750025513,
-        "narHash": "sha256-WUNoYIZvU9moc5ccwJcF22r+bUJXO5dWoRyLPs8bJic=",
+        "lastModified": 1769466714,
+        "narHash": "sha256-BORSlRJKEmYWHaNqEEUeM8b6pgNVzknFELMKM3rjyE8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f63aa2a49720526900fb5943db4123b5b8dcc534",
+        "rev": "f3ecc51c92ab72658c9b3b7289cfcc8a820a6316",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "cardano-node-release/10.5.4",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.5.3";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.5.4";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2543.1-hotfix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/lib/flaky-tests/src/FlakyTests/GHA.hs
+++ b/lib/flaky-tests/src/FlakyTests/GHA.hs
@@ -21,7 +21,6 @@ import Data.ByteString.Lazy
     )
 import Data.Maybe
     ( catMaybes
-    , mapMaybe
     )
 import Data.Proxy
     ( Proxy (..)

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -176,8 +176,7 @@ import Control.Monad.Class.MonadST
     ( MonadST
     )
 import Control.Monad.Class.MonadThrow
-    ( MonadMask
-    , MonadThrow
+    ( MonadEvaluate
     )
 import Control.Monad.Class.MonadTimer
     ( MonadTimer
@@ -825,7 +824,7 @@ type WalletNodeToClientProtocols m =
 mkWalletClient
     :: forall m block
      . ( block ~ CardanoBlock (StandardCrypto)
-       , MonadThrow m
+       , MonadEvaluate m
        , MonadST m
        , MonadTimer m
        , MonadAsync m
@@ -860,7 +859,7 @@ mkWalletClient tr pipeliningStrategy follower cfg nodeToClientVer =
 mkFetchBlockClient
     :: forall m block
      . ( block ~ CardanoBlock (StandardCrypto)
-       , MonadThrow m
+       , MonadEvaluate m
        , MonadST m
        , MonadTimer m
        )
@@ -891,7 +890,12 @@ mkFetchBlockClient cfg blockQ nodeToClientVer =
 -- purposes of querying delegations and rewards.
 mkDelegationRewardsClient
     :: forall m
-     . (MonadST m, MonadTimer m, MonadIO m, MonadAsync m, MonadMask m)
+     . ( MonadST m
+       , MonadTimer m
+       , MonadIO m
+       , MonadAsync m
+       , MonadEvaluate m
+       )
     => Tracer m Log
     -- ^ Base trace for underlying protocols
     -> CodecConfig (CardanoBlock StandardCrypto)
@@ -934,7 +938,7 @@ mkWalletToNodeProtocols
        , MonadST m
        , MonadTimer m
        , MonadAsync m
-       , MonadMask m
+       , MonadEvaluate m
        )
     => Tracer m Log
     -- ^ Base trace for underlying protocols

--- a/scripts/release/release-candidate.sh
+++ b/scripts/release/release-candidate.sh
@@ -79,10 +79,10 @@ sed -i "s|WALLET_VERSION=.*|WALLET_VERSION=$NEW_GIT_TAG|g" README.md
 git commit -am "Update cardano-wallet version in README.md"
 
 sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/ci/ruby-e2e.sh
-git commit -am "Update cardano-wallet version in ruby-e2e.sh"
+git diff --quiet || git commit -am "Update cardano-wallet version in ruby-e2e.sh"
 
 sed -i "s|RELEASE_WALLET_TAG=.*|RELEASE_WALLET_TAG=$NEW_CABAL_VERSION|g" run/common/docker/run.sh
-git commit -am "Update cardano-wallet version in run/common/docker/run.sh"
+git diff --quiet || git commit -am "Update cardano-wallet version in run/common/docker/run.sh"
 
 RELEASE_COMMIT=$(git rev-parse HEAD)
 


### PR DESCRIPTION
Closes #5172
Closes #5181

Bump [cardano-node 10.5.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.5.4) runtime and dependencies.

> **Note**: cardano-node 10.5.4 requires [libblst 0.3.14](https://github.com/supranational/blst/releases/tag/v0.3.14) when building from source. Our nix flake already pins this version.

### Changes

- **cardano-node runtime**: 10.5.3 → 10.5.4 (`flake.nix`, `flake.lock`)
- **CHaP index-state**: 2026-01-28 → 2026-02-05 (`cabal.project`)
- **MonadEvaluate constraint**: ouroboros-network 0.21 changed `runPeer`/`Stateful.runPeer` to require `MonadEvaluate m` instead of `MonadThrow`/`MonadMask` — updated `Network.Implementation` accordingly
- **Cleanup**: removed unused `mapMaybe` import in `FlakyTests.GHA`