### PR TITLE
fix: add concurrency groups and bump Mithril sync timeout

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -8,6 +8,10 @@ on:
     paths: ['specifications/**.lean']
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build E2E dependencies"

--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build wallet and node"
@@ -21,7 +25,7 @@ jobs:
     name: "Mainnet Boot Sync with Mithril"
     needs: build
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
-    timeout-minutes: 150
+    timeout-minutes: 250
     env:
       SUCCESS_STATUS: ready
       NODE_LOGS_FILE: ./logs/node.log
@@ -40,7 +44,7 @@ jobs:
           rm -rf logs databases
           mkdir -p logs
           ./snapshot.sh
-          ./run.sh sync 7200
+          ./run.sh sync 14400
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
       - "v*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]

--- a/.github/workflows/windows-tls-diagnostic.yml
+++ b/.github/workflows/windows-tls-diagnostic.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tls-diagnostic:
     name: "TLS Certificate Diagnostic"


### PR DESCRIPTION
## Summary

- Add `concurrency` groups with `cancel-in-progress: true` to 5 workflows that were missing them: `lean.yml`, `linux-e2e.yml`, `linux-mithril-sync.yml`, `publish.yml`, `windows-tls-diagnostic.yml`
- Bump Mithril sync timeout from 2.5h to 4h (job: 150→250 min, script: 7200→14400 sec)

Closes #5171
Closes #5176