### PR TITLE
fix: run restoration benchmarks in parallel

### DIFF
--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -38,7 +38,6 @@ jobs:
     timeout-minutes: 1380
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         include:
           - bench: base


### PR DESCRIPTION
## Summary

- Remove `max-parallel: 1` from restoration benchmarks matrix
- Each benchmark already uses a dedicated node-db (`mainnet-1` through `mainnet-4`), so no DB conflict
- With 8 bench runners available, all 4 benchmarks can run concurrently instead of sequentially

Closes #5184