### PR TITLE
docs: update dependencies page, add fourmolu ADR, fix CI decisions

### DIFF
--- a/docs/site/src/SUMMARY.md
+++ b/docs/site/src/SUMMARY.md
@@ -61,6 +61,8 @@
       - [Updating Dependencies](contributor/notes/updating-dependencies.md)
       - [Notes from upgrading GHC version](contributor/notes/notes-from-upgrading-ghc-version.md)
     - [Decisions Record](contributor/decisions.md)
+      - [2026-02-12 - Fourmolu Migration](contributor/decisions/2026-02-12-fourmolu-migration.md)
+      - [2026-02-10 - Migrate CI to GitHub Actions](contributor/decisions/2026-02-10-migrate-ci-to-github-actions.md)
       - [2025-02-03 - Manage versions in Cabal](contributor/decisions/2025-02-03-dependency-versions.md)
       - [2024-12-03 - Store documents alongside code](contributor/decisions/2024-12-03-document-with-code.md)
       - [2024-03-23 - Release Process](contributor/decisions/2024-03-13-release-process.md)

--- a/docs/site/src/contributor/decisions/2023-01-27-continuous-integration.md
+++ b/docs/site/src/contributor/decisions/2023-01-27-continuous-integration.md
@@ -5,6 +5,7 @@
 | Started      | 2022-12-06 |
 | Decided      | 2023-01-27 |
 | Last amended | 2023-04-04 |
+| Superseded   | [2026-02-10 — Migrate CI to GitHub Actions](2026-02-10-migrate-ci-to-github-actions.md) |
 
 ## **Why**
 

--- a/docs/site/src/contributor/decisions/2026-02-10-migrate-ci-to-github-actions.md
+++ b/docs/site/src/contributor/decisions/2026-02-10-migrate-ci-to-github-actions.md
@@ -56,3 +56,11 @@ The [2023 decision](2023-01-27-continuous-integration.md) chose Buildkite primar
 - Buildkite required separate account access and agent token management, creating a bus-factor risk for maintenance handover
 
 GitHub Actions eliminates these issues while retaining the self-hosted runner capability needed for platform-specific builds.
+
+## **References**
+
+- [#5105](https://github.com/cardano-foundation/cardano-wallet/pull/5105) — initial CI migration
+- [#5124](https://github.com/cardano-foundation/cardano-wallet/pull/5124) — build gates
+- [#5149](https://github.com/cardano-foundation/cardano-wallet/pull/5149) — restoration benchmarks
+- [#5153](https://github.com/cardano-foundation/cardano-wallet/pull/5153) — release automation
+- [#5168](https://github.com/cardano-foundation/cardano-wallet/pull/5168) — Attic cache

--- a/docs/site/src/contributor/decisions/2026-02-12-fourmolu-migration.md
+++ b/docs/site/src/contributor/decisions/2026-02-12-fourmolu-migration.md
@@ -1,0 +1,43 @@
+# **Fourmolu Migration**
+
+|              |                 |
+|--------------|-----------------|
+| Decided      | 2026-02-12      |
+| Decided by   | Paolo Veronelli |
+
+## **Why**
+
+The project previously used [stylish-haskell](https://github.com/haskell/stylish-haskell) for formatting imports and language pragmas. However, stylish-haskell only handled a narrow subset of formatting concerns — it did not format function definitions, type signatures, expressions, or any other code outside of imports and pragmas. This left most formatting decisions to manual convention enforcement.
+
+[Fourmolu](https://github.com/fourmolu/fourmolu) is a full-source Haskell formatter that handles all code, not just imports. Adopting it eliminates formatting discussions during code review and ensures consistent style across the entire codebase.
+
+## **Decision**
+
+Replace stylish-haskell with fourmolu as the project's code formatter. Configuration is in `fourmolu.yaml` at the repository root.
+
+Key settings:
+
+```yaml
+comma-style: leading
+function-arrows: leading
+import-export-style: leading
+indentation: 4
+column-limit: 70
+haddock-style: single-line
+record-brace-space: false
+respectful: true
+```
+
+This supersedes the stylish-haskell section in [Coding Standards](../what/coding-standards.md).
+
+## **Rationale**
+
+- **Full coverage**: fourmolu formats all Haskell source code, not just imports and pragmas
+- **Deterministic**: running `fourmolu --mode inplace` on any file produces canonical output, eliminating formatting debates
+- **Leading style**: the leading commas/arrows setting aligns with the project's existing variable-length indentation avoidance policy
+- **70-character column limit**: slightly narrower than the historical 80-character guideline, producing more readable diffs
+
+## **References**
+
+- [PR #5169](https://github.com/cardano-foundation/cardano-wallet/pull/5169) — initial fourmolu migration
+- [fourmolu configuration docs](https://fourmolu.github.io/fourmolu/config/current/)

--- a/docs/site/src/contributor/notes/updating-dependencies.md
+++ b/docs/site/src/contributor/notes/updating-dependencies.md
@@ -20,17 +20,86 @@ is defined in the `devShells.default` attribute of `flake.nix`.
 
 [`nix flake`](https://nixos.wiki/wiki/Flakes) manages the file [`flake.lock`](https://github.com/cardano-foundation/cardano-wallet/blob/master/flake.lock).
 
-## Updating node backends
+## Bumping cardano-node
 
-### `cardano-node` Haskell dependencies
+This is the most involved dependency update. The cardano-wallet ecosystem depends on many Cardano Haskell libraries that must all be updated in lockstep.
 
-To bump to a new version:
+### Overview
 
-1. In `cardano-wallet/cabal.project`, update
-   the dependency revisions to match your chosen version of
-   `cardano-node/cabal.project`.
-2. Run `./nix/regenerate.sh` (or let CI do it)
+1. Choose the target cardano-node version (e.g. 10.2.0)
+2. Clone/checkout all Cardano dependency repos at matching tags
+3. Extract changelogs between current and target versions
+4. Align `flake.lock` CHaP with cardano-node's CHaP
+5. Freeze dependencies
+6. Determine sublibrary order (`cabal-plan topo`)
+7. Update `.cabal` files in topological order (one commit per sublibrary)
+8. Update `cabal.project` (index-state, source-repository-package)
+9. Update the cardano-node input in `flake.nix`
+10. Final summary commit
 
-### Jörmungandr
+### Cardano Haskell Packages (CHaP)
 
-Follow the instructions in [`nix/jormungandr.nix`](https://github.com/cardano-foundation/cardano-wallet/blob/master/nix/jormungandr.nix).
+CHaP is the custom Hackage repository for Cardano packages, hosted at `https://chap.intersectmbo.org/`. The `index-state` in `cabal.project` controls which package versions are visible:
+
+```cabal
+index-state:
+  , hackage.haskell.org 2025-01-01T23:24:19Z
+  , cardano-haskell-packages 2025-03-01T00:00:00Z
+```
+
+**Critical**: use the same CHaP revision as cardano-node to avoid Windows cross-compilation failures (wine/iserv socket errors caused by transitive dependency mismatches).
+
+```bash
+# Get cardano-node's CHaP rev
+cd /code/cardano-node && git checkout <target-version>
+cat flake.lock | jq '.nodes.CHaP.locked.rev'
+
+# Update cardano-wallet to use same CHaP
+nix flake update CHaP --override-input CHaP \
+  github:intersectmbo/cardano-haskell-packages/<rev>
+```
+
+### Dependency bounds
+
+Standard format for version bounds in `.cabal` files:
+
+```cabal
+build-depends:
+    aeson >= 2.1.2.1 && < 2.2
+  , base >= 4.18 && < 5
+  , cardano-api >= 10.0 && < 10.1
+```
+
+Lower bound = exact version from freeze; upper bound = next minor version.
+
+### Source repository packages
+
+For packages not yet on CHaP or when you need a specific commit:
+
+```cabal
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/cardano-addresses
+    tag: 2bca06deaa60e54a5322ac757387d744bf043367
+    --sha256: 1y1mzfly7jac40b9g4xc078rcm5zqhc3xxv77kwxi10yph1jwq7z
+    subdir: command-line
+            core
+```
+
+Get the SHA256 with `nix flake prefetch github:owner/repo/commit-sha`.
+
+## CHaP-only dependency bump
+
+When a Cardano library updates on CHaP without a full cardano-node version bump:
+
+1. Bump the CHaP `index-state` in `cabal.project` to a timestamp that includes the new package version
+2. Update version bounds in affected `.cabal` files
+3. Build and test: `cabal build all -O0`
+
+## GHC bump
+
+1. Update the `haskell.nix` pin in `flake.lock`
+2. Set the compiler version in `flake.nix`
+3. Fix build errors (imports, extensions, warnings-as-errors)
+4. Update the Windows cross-compilation overlay if needed
+5. Re-enable or disable tools that depend on GHC version (e.g. HLS, weeder)

--- a/docs/site/src/contributor/what/coding-standards.md
+++ b/docs/site/src/contributor/what/coding-standards.md
@@ -23,7 +23,7 @@ Each proposal should start with a section justifying the standard with rational 
         - [Exception 1: URLs in comments](#exception-1-urls-in-comments)
     - [Use only a single blank line between top-level definitions](#use-only-a-single-blank-line-between-top-level-definitions)
     - [Avoid Variable-Length Indentation](#avoid-variable-length-indentation)
-    - [Fourmolu is used to format code](#fourmolu-is-used-to-format-code)
+    - [Fourmolu is used for code formatting](#fourmolu-is-used-for-code-formatting)
   - [Haskell Practices](#haskell-practices)
     - [Favor `newtype` and tagged type over type-aliases](#favor-newtype-and-tagged-type-over-type-aliases)
     - [Language extensions are specified on top of each module](#language-extensions-are-specified-on-top-of-each-module)
@@ -322,58 +322,82 @@ data MyRecord = MyRecord
 </details>
 
 
-### Fourmolu is used to format code
+### Fourmolu is used for code formatting
 
-The project uses [Fourmolu](https://github.com/fourmolu/fourmolu) for code formatting,
-configured via the `fourmolu.yaml` file at the root of the project. Fourmolu handles
-all formatting including imports, language pragmas, and whitespace cleanup.
+Contributors should use [fourmolu](https://github.com/fourmolu/fourmolu) to format all Haskell source code. The configuration is in `fourmolu.yaml` at the root of the project. Run `fourmolu --mode inplace <file>` to format a file.
 
 Imports are automatically grouped by `import-grouping: by-qualified`:
 
 1. Unqualified imports
 2. Qualified imports
 
+> **Why**
+>
+> Automatic formatting eliminates time spent aligning code manually and
+> prevents formatting-related merge conflicts. Fourmolu handles all Haskell
+> source code (not just imports and pragmas), producing deterministic output.
+
 <details>
-  <summary>See example</summary>
+    <summary>See fourmolu.yaml configuration</summary>
 
-  ```hs
-  {-# LANGUAGE BangPatterns #-}
-  {-# LANGUAGE DataKinds #-}
-  {-# LANGUAGE DeriveGeneric #-}
-  {-# LANGUAGE DerivingStrategies #-}
-  {-# LANGUAGE FlexibleContexts #-}
-  {-# LANGUAGE TupleSections #-}
-  {-# LANGUAGE TypeApplications #-}
-  {-# LANGUAGE TypeFamilies #-}
+```yaml
+comma-style: leading
+function-arrows: leading
+import-export-style: leading
+haddock-style: single-line
+in-style: left-align
+indent-wheres: false
+indentation: 4
+let-style: auto
+newlines-between-decls: 1
+record-brace-space: false
+respectful: true
+single-constraint-parens: auto
+column-limit: 70
+```
+</details>
 
-  module Main where
+<details>
+    <summary>See import grouping example</summary>
 
-  import Control.Applicative
-      ( (<|>) )
-  import Control.Arrow
-      ( first )
-  import Control.Concurrent.MVar
-      ( modifyMVar_, newMVar, putMVar, readMVar, takeMVar )
-  import Crypto.Hash.Algorithms
-      ( Blake2b_224, Blake2b_256, SHA3_256, SHA512 (..) )
-  import Lens.Micro
-      ( at, (%~), (&), (.~), (^.) )
-  import Network.HTTP.Client
-      ( Manager
-      , defaultRequest
-      , httpLbs
-      , path
-      , port
-      , responseBody
-      , responseStatus
-      )
+```hs
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
-  import qualified Codec.CBOR.Decoding as CBOR
-  import qualified Codec.CBOR.Encoding as CBOR
-  import qualified Codec.CBOR.Read as CBOR
-  import qualified Codec.CBOR.Write as CBOR
-  import qualified Crypto.Cipher.ChaChaPoly1305 as Poly
-  ```
+module Main where
+
+import Control.Applicative
+    ( (<|>) )
+import Control.Arrow
+    ( first )
+import Control.Concurrent.MVar
+    ( modifyMVar_, newMVar, putMVar, readMVar, takeMVar )
+import Crypto.Hash.Algorithms
+    ( Blake2b_224, Blake2b_256, SHA3_256, SHA512 (..) )
+import Lens.Micro
+    ( at, (%~), (&), (.~), (^.) )
+import Network.HTTP.Client
+    ( Manager
+    , defaultRequest
+    , httpLbs
+    , path
+    , port
+    , responseBody
+    , responseStatus
+    )
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Crypto.Cipher.ChaChaPoly1305 as Poly
+```
 </details>
 
 ## Haskell Practices


### PR DESCRIPTION
## Summary

- Rewrite `updating-dependencies.md`: replace stale Jörmungandr / `./nix/regenerate.sh` / Buildkite references with cardano-node bump, CHaP-only bump, and GHC bump sections (sourced from `.claude/skills/cardano-deps/SKILL.md`)
- Add fourmolu migration ADR (`2026-02-12-fourmolu-migration.md`)
- Replace stylish-haskell with fourmolu in `coding-standards.md` and `building.md`
- Mark 2023-01-27 CI decision as superseded by 2026-02-10 GHA migration
- Add PR references (#5105, #5124, #5149, #5153, #5168) to GHA migration ADR
- Add missing entries to `SUMMARY.md`

Closes #5173, closes #5174