### PR TITLE
ci: add --quiet to all nix commands in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - name: Build test and runtime derivations
         run: >-
-          nix build -L
+          nix build --quiet
           .#cardano-wallet .#cardano-node .#cardano-cli
           .#local-cluster .#integration-exe .#test-local-cluster-exe
           .#unit-cardano-wallet-unit .#unit-cardano-numeric
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - name: Build release artifacts (musl static)
         run: >-
-          nix build -L
+          nix build --quiet
           .#ci.artifacts.linux64.release .#dockerTestImage
 
 
@@ -66,7 +66,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build dev shell
-        run: nix build .#devShells.x86_64-linux.default.inputDerivation
+        run: nix build --quiet .#devShells.x86_64-linux.default.inputDerivation
 
   # ---------------------------------------------------------------------------
   # Nix check
@@ -98,119 +98,119 @@ jobs:
         include:
           - name: "cardano-wallet-application-tls"
             working-directory: lib/application-tls
-            command: nix run ../../.#unit-cardano-wallet-application-tls -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-application-tls -- +RTS -M2G -s -RTS
 
           - name: "cardano-balance-tx"
             working-directory: lib/balance-tx
-            command: nix run ../../.#unit-cardano-balance-tx -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-balance-tx -- +RTS -M2G -s -RTS
 
           - name: "cardano-numeric"
-            command: nix run .#unit-cardano-numeric -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-numeric -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-blackbox-benchmarks"
             working-directory: lib/wallet-benchmarks
-            command: nix run ../../.#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-launcher"
-            command: nix run .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-network-layer"
-            command: nix run .#unit-cardano-wallet-network-layer -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-network-layer -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-primitive"
             working-directory: lib/primitive
-            command: nix run ../../.#unit-cardano-wallet-primitive -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-primitive -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-secrets"
-            command: nix run .#unit-cardano-wallet-secrets -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-secrets -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-test-utils"
-            command: nix run .#unit-cardano-wallet-test-utils -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-test-utils -- +RTS -M2G -s -RTS
 
           - name: "delta-chain"
-            command: nix run .#unit-delta-chain -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-chain -- +RTS -M2G -s -RTS
 
           - name: "delta-store"
-            command: nix run .#unit-delta-store -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-store -- +RTS -M2G -s -RTS
 
           - name: "delta-table"
-            command: nix run .#unit-delta-table -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-table -- +RTS -M2G -s -RTS
 
           - name: "delta-types"
-            command: nix run .#unit-delta-types -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-types -- +RTS -M2G -s -RTS
 
           - name: "std-gen-seed"
-            command: nix run .#unit-std-gen-seed -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-std-gen-seed -- +RTS -M2G -s -RTS
 
           - name: "wai-middleware-logging"
-            command: nix run .#unit-wai-middleware-logging -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-wai-middleware-logging -- +RTS -M2G -s -RTS
 
           - name: "benchmark-history-test"
-            command: nix run .#unit-benchmark-history -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-benchmark-history -- +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Byron + CLI"
             working-directory: lib/unit
             command: >-
-              nix shell ../../.#cardano-cli -c
-              nix run ../../.#unit-cardano-wallet-unit --
+              nix shell --quiet ../../.#cardano-cli -c
+              nix run --quiet ../../.#unit-cardano-wallet-unit --
               --match "/Cardano.Byron./"
               --match "/Cardano.CLI/"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB.Sqlite + Pool"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.DB./"
               --match "/Cardano.Pool./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Address"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Address./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Api"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Api./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Balance"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Balance./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.DB./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Primitive"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Primitive./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Shelley"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Shelley./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Other Wallet"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet./"
               --skip "/Cardano.Wallet.Address./"
               --skip "/Cardano.Wallet.Api./"
@@ -222,8 +222,8 @@ jobs:
 
           - name: "wallet-unit / Control + Data"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Control./"
               --match "/Data./"
               -j1 +RTS -M2G -s -RTS
@@ -263,8 +263,8 @@ jobs:
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
           export INTEGRATION_TEST_DIR=integration-test-dir
-          nix shell .#cardano-node .#cardano-cli -c \
-            nix shell .#cardano-wallet .#local-cluster .#integration-exe \
+          nix shell --quiet .#cardano-node .#cardano-cli -c \
+            nix shell --quiet .#cardano-wallet .#local-cluster .#integration-exe \
               -c integration-exe -j6
 
       - name: Upload logs
@@ -295,7 +295,7 @@ jobs:
           CLUSTER_LOGS_DIR_PATH: local-cluster-logs
         run: |
           mkdir -p local-cluster-logs
-          nix shell .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \
+          nix shell --quiet .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \
             -c test-local-cluster-exe
 
       - name: Upload logs
@@ -372,7 +372,7 @@ jobs:
       - name: Build release package
         run: |
           rm -rf ./result/*
-          nix build -L -o result/linux .#ci.artifacts.linux64.release
+          nix build --quiet -o result/linux .#ci.artifacts.linux64.release
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -389,7 +389,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Evaluate shell
-        run: nix shell -L .#cardano-node .#cardano-cli .#cardano-wallet --command cardano-wallet version
+        run: nix shell --quiet .#cardano-node .#cardano-cli .#cardano-wallet --command cardano-wallet version
 
   # ---------------------------------------------------------------------------
   # Docker (needs: build-gate-artifacts)
@@ -411,7 +411,7 @@ jobs:
         id: build
         run: |
           mkdir -p artifacts
-          nix build -L .#dockerTestImage -o artifacts/docker-image.tgz
+          nix build --quiet .#dockerTestImage -o artifacts/docker-image.tgz
           output=$(docker load < artifacts/docker-image.tgz)
           tag=$(echo "$output" | sed -n 's/Loaded image: cardanofoundation\/cardano-wallet:\(.*\)/\1/p')
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
@@ -474,7 +474,7 @@ jobs:
           fetch-depth: 0
       - name: Build all macOS derivations
         run: >-
-          nix build -L
+          nix build --quiet
           .#unit-cardano-wallet-unit .#unit-cardano-numeric
           .#unit-cardano-balance-tx .#unit-cardano-wallet-primitive
           .#unit-cardano-wallet-secrets .#unit-cardano-wallet-test-utils
@@ -501,7 +501,7 @@ jobs:
       - name: Check nix version
         run: nix --version
       - name: Check flake info
-        run: nix flake info
+        run: nix flake --quiet info
 
   mac-local-cluster:
     name: "Local Cluster Tests (macOS)"
@@ -520,7 +520,7 @@ jobs:
           CLUSTER_LOGS_DIR_PATH: local-cluster-logs
         run: |
           mkdir -p local-cluster-logs
-          nix shell .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \
+          nix shell --quiet .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \
             -c test-local-cluster-exe
 
       - name: Upload logs
@@ -540,7 +540,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build macOS Intel package
-        run: nix build -L -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
+        run: nix build --quiet -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -557,7 +557,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build macOS Silicon package
-        run: nix build -L -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release
+        run: nix build --quiet -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -577,28 +577,28 @@ jobs:
       matrix:
         include:
           - name: "Check Code Format"
-            command: nix develop --command scripts/ci/check-code-format.sh
+            command: nix develop --quiet --command scripts/ci/check-code-format.sh
 
           - name: "Check HLint"
-            command: nix develop --command bash -c "echo +++ HLint ; hlint lib"
+            command: nix develop --quiet --command bash -c "echo +++ HLint ; hlint lib"
 
           - name: "Check Cabal Configure"
-            command: nix develop --command scripts/ci/check-haskell-nix-cabal.sh
+            command: nix develop --quiet --command scripts/ci/check-haskell-nix-cabal.sh
 
           - name: "Lint Bash Scripts"
             command: ./scripts/shellcheck.sh
 
           - name: "Check EOL"
-            command: nix develop --command scripts/enforce-eol.sh
+            command: nix develop --quiet --command scripts/enforce-eol.sh
 
           - name: "Validate Swagger"
-            command: nix develop path:./scripts/ci -c ./scripts/ci/validate-swagger.sh
+            command: nix develop --quiet path:./scripts/ci -c ./scripts/ci/validate-swagger.sh
 
           - name: "Print TODO List"
-            command: nix develop --command scripts/todo-list.sh
+            command: nix develop --quiet --command scripts/todo-list.sh
 
           - name: "Check HLS Works"
-            command: nix develop --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"
+            command: nix develop --quiet --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"
 
           - name: "Check git revision"
             command: scripts/ci/git-revision.sh
@@ -627,4 +627,4 @@ jobs:
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
           system: x86_64-linux
-        run: nix develop path:./scripts/ci -c ./scripts/ci/attic-cache.sh
+        run: nix develop --quiet path:./scripts/ci -c ./scripts/ci/attic-cache.sh

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build all benchmark derivations
-        run: nix build -L .#ci.benchmarks.all .#local-cluster .#cardano-node .#cardano-wallet
+        run: nix build --quiet .#ci.benchmarks.all .#local-cluster .#cardano-node .#cardano-wallet
 
   benchmarks:
     name: "${{ matrix.name }}"
@@ -32,7 +32,7 @@ jobs:
         include:
           - name: "API Benchmark"
             command: |
-              nix shell 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' -c \
+              nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' -c \
                 bash scripts/ci/bench-api.sh
             timeout: 20
             artifacts: |
@@ -51,7 +51,7 @@ jobs:
 
           - name: "DB Benchmark"
             command: |
-              nix shell 'nixpkgs#coreutils' -c \
+              nix shell --quiet 'nixpkgs#coreutils' -c \
                 bash scripts/ci/bench-db.sh
             timeout: 50
             artifacts: |
@@ -61,7 +61,7 @@ jobs:
 
           - name: "Read-blocks Benchmark"
             command: |
-              nix shell 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' -c \
+              nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' -c \
                 bash scripts/ci/bench-read-blocks.sh
             timeout: 20
             artifacts: |
@@ -71,7 +71,7 @@ jobs:
 
           - name: "Memory Benchmark"
             command: |
-              nix shell 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
+              nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
                 bash scripts/ci/bench-memory.sh
             timeout: 20
             artifacts: |
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run benchmark history
         run: |
-          nix shell .#benchmark-history 'nixpkgs#gh' -c \
+          nix shell --quiet .#benchmark-history 'nixpkgs#gh' -c \
             bash scripts/gha/benchmark-history.sh
 
       - name: Upload Benchmark History

--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build derivations
-        run: nix build -L .#cardano-node .#cardano-wallet .#e2e
+        run: nix build --quiet .#cardano-node .#cardano-wallet .#e2e
 
   e2e:
     name: "Run E2E Tests"
@@ -35,4 +35,4 @@ jobs:
       - name: Run E2E tests
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
-        run: nix shell .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
+        run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e

--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build derivations
-        run: nix build -L .#cardano-wallet .#cardano-node .#cardano-cli
+        run: nix build --quiet .#cardano-wallet .#cardano-node .#cardano-cli
 
   mithril-sync:
     name: "Mainnet Boot Sync with Mithril"

--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Build derivations
         run: >-
-          nix build -L
+          nix build --quiet
           .#cardano-node .#cardano-cli
           .#cardano-wallet .#local-cluster
           .#packages.aarch64-darwin.integration-exe
@@ -44,8 +44,8 @@ jobs:
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
           export INTEGRATION_TEST_DIR=integration-test-dir
-          nix shell .#cardano-node .#cardano-cli -c \
-            nix shell .#cardano-wallet .#local-cluster .#packages.aarch64-darwin.integration-exe \
+          nix shell --quiet .#cardano-node .#cardano-cli -c \
+            nix shell --quiet .#cardano-wallet .#local-cluster .#packages.aarch64-darwin.integration-exe \
               -c integration-exe -j6
 
       - name: Upload logs

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Build all test derivations
         run: >-
-          nix build -L
+          nix build --quiet
           .#unit-cardano-wallet-unit
           .#unit-cardano-numeric
           .#unit-cardano-balance-tx
@@ -54,116 +54,116 @@ jobs:
         include:
           - name: "cardano-wallet-application-tls"
             working-directory: lib/application-tls
-            command: nix run ../../.#unit-cardano-wallet-application-tls -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-application-tls -- +RTS -M2G -s -RTS
 
           - name: "cardano-balance-tx"
             working-directory: lib/balance-tx
-            command: nix run ../../.#unit-cardano-balance-tx -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-balance-tx -- +RTS -M2G -s -RTS
 
           - name: "cardano-numeric"
-            command: nix run .#unit-cardano-numeric -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-numeric -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-blackbox-benchmarks"
             working-directory: lib/wallet-benchmarks
-            command: nix run ../../.#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-blackbox-benchmarks -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-launcher"
-            command: nix run .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-launcher -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-network-layer"
-            command: nix run .#unit-cardano-wallet-network-layer -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-network-layer -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-primitive"
             working-directory: lib/primitive
-            command: nix run ../../.#unit-cardano-wallet-primitive -- +RTS -M2G -s -RTS
+            command: nix run --quiet ../../.#unit-cardano-wallet-primitive -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-secrets"
-            command: nix run .#unit-cardano-wallet-secrets -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-secrets -- +RTS -M2G -s -RTS
 
           - name: "cardano-wallet-test-utils"
-            command: nix run .#unit-cardano-wallet-test-utils -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-cardano-wallet-test-utils -- +RTS -M2G -s -RTS
 
           - name: "delta-chain"
-            command: nix run .#unit-delta-chain -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-chain -- +RTS -M2G -s -RTS
 
           - name: "delta-store"
-            command: nix run .#unit-delta-store -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-store -- +RTS -M2G -s -RTS
 
           - name: "delta-table"
-            command: nix run .#unit-delta-table -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-table -- +RTS -M2G -s -RTS
 
           - name: "delta-types"
-            command: nix run .#unit-delta-types -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-delta-types -- +RTS -M2G -s -RTS
 
           - name: "std-gen-seed"
-            command: nix run .#unit-std-gen-seed -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-std-gen-seed -- +RTS -M2G -s -RTS
 
           - name: "wai-middleware-logging"
-            command: nix run .#unit-wai-middleware-logging -- +RTS -M2G -s -RTS
+            command: nix run --quiet .#unit-wai-middleware-logging -- +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Byron + CLI"
             working-directory: lib/unit
             command: >-
-              nix shell ../../.#cardano-cli -c
-              nix run ../../.#unit-cardano-wallet-unit --
+              nix shell --quiet ../../.#cardano-cli -c
+              nix run --quiet ../../.#unit-cardano-wallet-unit --
               --match "/Cardano.Byron./"
               --match "/Cardano.CLI/"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB.Sqlite + Pool"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.DB./"
               --match "/Cardano.Pool./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Address"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Address./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Api"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Api./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Balance"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Balance./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.DB./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Primitive"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Primitive./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Shelley"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet.Shelley./"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Other Wallet"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Cardano.Wallet./"
               --skip "/Cardano.Wallet.Address./"
               --skip "/Cardano.Wallet.Api./"
@@ -175,8 +175,8 @@ jobs:
 
           - name: "wallet-unit / Control + Data"
             command: >-
-              nix shell .#cardano-cli -c
-              nix run .#unit-cardano-wallet-unit --
+              nix shell --quiet .#cardano-cli -c
+              nix run --quiet .#unit-cardano-wallet-unit --
               --match "/Control./"
               --match "/Data./"
               -j1 +RTS -M2G -s -RTS
@@ -205,4 +205,4 @@ jobs:
       - name: Run E2E tests
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
-        run: nix shell .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
+        run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,12 +54,12 @@ jobs:
             Source commit: ${{ github.sha }}
 
       - name: "❄ Install dependencies"
-        run: "nix develop .#docs --command mdbook --version"
+        run: "nix develop --quiet .#docs --command mdbook --version"
 
       - name: "📸 Build Documentation"
         run: |
           build_dir="$PUBLISH_DIR"
-          nix develop .#docs -c mdbook build -d "../../$build_dir" "docs/site"
+          nix develop --quiet .#docs -c mdbook build -d "../../$build_dir" "docs/site"
           ls -l "$build_dir"
           ./scripts/gh/update-docs.sh "$build_dir" ${{ steps.versions.outputs.tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build
-        run: nix build -L -o result .#${{ matrix.output }}
+        run: nix build --quiet -o result .#${{ matrix.output }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -100,10 +100,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LAST_RELEASE_DATE: ${{ needs.prepare.outputs.last-release-date }}
-        run: nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/make_changelog.sh
+        run: nix develop --quiet path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/make_changelog.sh
 
       - name: Generate API diff
-        run: nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/openapi-diff.sh
+        run: nix develop --quiet path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/openapi-diff.sh
 
       - name: Upload changelog artifacts
         uses: actions/upload-artifact@v4
@@ -169,7 +169,7 @@ jobs:
           path: artifacts/
 
       - name: Prepare release body
-        shell: nix shell nixpkgs#gettext -c bash -e {0}
+        shell: nix shell --quiet nixpkgs#gettext -c bash -e {0}
         run: |
           export CHANGES=$(cat artifacts/changes.md)
           export API_CHANGES=$(cat artifacts/api-diff.md)
@@ -178,11 +178,11 @@ jobs:
 
       - name: Delete existing release (nightly/test)
         if: env.IS_RELEASE == 'false'
-        shell: nix shell nixpkgs#gh -c bash -e {0}
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         run: gh release delete "${{ steps.tag.outputs.tag }}" --yes || true
 
       - name: Create GitHub release
-        shell: nix shell nixpkgs#gh -c bash -e {0}
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         run: |
           gh release create \
             -d \
@@ -196,7 +196,7 @@ jobs:
           path: build-artifacts/
 
       - name: Upload release artifacts
-        shell: nix shell nixpkgs#gh -c bash -e {0}
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           cd build-artifacts

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build benchmark derivations
-        run: nix build -L .#ci.benchmarks.restore
+        run: nix build --quiet .#ci.benchmarks.restore
 
   restore:
     name: "Restore ${{ matrix.bench }}"
@@ -61,7 +61,7 @@ jobs:
       - name: Run restore benchmark
         run: |
           mkdir -p "$TMPDIR"
-          nix shell 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
+          nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
             bash scripts/ci/bench-restore.sh \
               mainnet ${{ matrix.bench }} $HOME/databases/node/${{ matrix.node-db }}
 

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cross-compile Windows E2E bundle
-        run: nix build -L .#ci.artifacts.win64.e2e -o result
+        run: nix build --quiet .#ci.artifacts.win64.e2e -o result
 
       - name: Upload E2E bundle
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cross-compile Windows release package
         run: |
           rm -rf ./result/*
-          nix build -L -o result/windows .#ci.artifacts.win64.release
+          nix build --quiet -o result/windows .#ci.artifacts.win64.release
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cross-compile all Windows test bundles
         run: >-
-          nix build --no-link -L
+          nix build --no-link --quiet
           .#ci.artifacts.win64.tests.wallet-unit
           .#ci.artifacts.win64.tests.wallet-primitive
           .#ci.artifacts.win64.tests.wallet-secrets
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build (from cache)
-        run: nix build .#ci.artifacts.win64.tests.${{ matrix.name }} -o result
+        run: nix build --quiet .#ci.artifacts.win64.tests.${{ matrix.name }} -o result
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/docs/site/src/contributor/how/continuous-integration.md
+++ b/docs/site/src/contributor/how/continuous-integration.md
@@ -47,6 +47,23 @@ All CI for `cardano-wallet` runs on [GitHub Actions](https://github.com/cardano-
 | [`approve-docs.yml`](https://github.com/cardano-foundation/cardano-wallet/actions/workflows/approve-docs.yml) | PR target | Auto-approves docs-only PRs |
 | [`lean.yml`](https://github.com/cardano-foundation/cardano-wallet/actions/workflows/lean.yml) | push, PR | Lean specification checks (path-filtered to `specifications/`) |
 
+## Nix verbosity
+
+All `nix` commands in CI workflows must include the `--quiet` flag. This suppresses verbose build logs and warnings that clutter GitHub Actions output, making it easier to spot actual failures.
+
+```yaml
+# Good
+nix build --quiet .#cardano-wallet
+nix shell --quiet .#cardano-node -c cardano-node --version
+nix develop --quiet --command scripts/check.sh
+
+# Bad — missing --quiet
+nix build .#cardano-wallet
+nix build -L .#cardano-wallet
+```
+
+When adding or modifying workflow steps that invoke `nix`, always include `--quiet`.
+
 ## Self-hosted runners
 
 Several workflows run on self-hosted machines. The GHA runner service replaces the former Buildkite agent on these machines.

--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Enforce strict script execution modes
-set -euox pipefail
+set -euo pipefail
 
 # Function to display usage information
 usage() {

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -78,7 +78,7 @@ cleanup() {
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril?ref=2543.1-hotfix" -c $*
+    nix shell --quiet "github:input-output-hk/mithril?ref=2543.1-hotfix" -c $*
 }
 
 # Trap the cleanup function on exit

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -2,11 +2,11 @@
 # shellcheck shell=bash
 
 function mithril() {
-    nix shell 'github:input-output-hk/mithril?ref=2543.1-hotfix' --command mithril-client $@
+    nix shell --quiet 'github:input-output-hk/mithril?ref=2543.1-hotfix' --command mithril-client $@
 }
 
 function jq() {
-    nix shell 'nixpkgs#jq' --command jq $@
+    nix shell --quiet 'nixpkgs#jq' --command jq $@
 }
 
 set -euox pipefail

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -9,7 +9,7 @@ function jq() {
     nix shell --quiet 'nixpkgs#jq' --command jq $@
 }
 
-set -euox pipefail
+set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 

--- a/scripts/ci/attic-cache.sh
+++ b/scripts/ci/attic-cache.sh
@@ -6,11 +6,11 @@ attic login adrestia https://attic.cf-app.org/ "$ATTIC_TOKEN"
 
 # Dev shell
 # shellcheck disable=SC2154
-nix build --log-format raw-with-logs ".#devShells.${system}.default.inputDerivation" -o dev-shell
+nix build --quiet ".#devShells.${system}.default.inputDerivation" -o dev-shell
 attic push adrestia dev-shell
 
 # Core runtime derivations (shared across CI, E2E, benchmarks, mithril-sync)
-nix build --log-format raw-with-logs \
+nix build --quiet \
   .#cardano-wallet \
   .#cardano-node \
   .#cardano-cli \
@@ -21,15 +21,15 @@ nix build --log-format raw-with-logs \
 attic push adrestia ci-core
 
 # Benchmarks
-nix build --log-format raw-with-logs .#ci.benchmarks.all -o benchmarks
+nix build --quiet .#ci.benchmarks.all -o benchmarks
 attic push adrestia benchmarks
 
 # Linux release artifacts
-nix build --log-format raw-with-logs .#ci.artifacts.linux64.release -o linux-release
+nix build --quiet .#ci.artifacts.linux64.release -o linux-release
 attic push adrestia linux-release
 
 # Windows cross-compiled release and test bundles
-nix build --log-format raw-with-logs \
+nix build --quiet \
   .#ci.artifacts.win64.release \
   .#ci.artifacts.win64.tests.wallet-unit \
   .#ci.artifacts.win64.tests.wallet-primitive \

--- a/scripts/ci/attic-cache.sh
+++ b/scripts/ci/attic-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 attic login adrestia https://attic.cf-app.org/ "$ATTIC_TOKEN"
 

--- a/scripts/ci/bench-api.sh
+++ b/scripts/ci/bench-api.sh
@@ -19,7 +19,7 @@ results=api.txt
 echo "--- Build"
 nix --version
 
-nix build -L .#ci.benchmarks.api -o bench-api
+nix build --quiet .#ci.benchmarks.api -o bench-api
 bench="./bench-api/bin/api lib/benchmarks/data/api-bench"
 
 

--- a/scripts/ci/bench-db.sh
+++ b/scripts/ci/bench-db.sh
@@ -12,7 +12,7 @@ mkdir -p $TMPDIR
 rm -rf $bench_name
 
 echo "--- Build"
-nix build -L .#ci.benchmarks.db -o $bench_name
+nix build --quiet .#ci.benchmarks.db -o $bench_name
 
 echo "+++ Run benchmark"
 

--- a/scripts/ci/bench-latency.sh
+++ b/scripts/ci/bench-latency.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 echo "+++ Build & run latency benchmark"
 
-nix shell \
+nix shell --quiet \
   '.#local-cluster' \
   '.#cardano-node' \
   '.#cardano-wallet' \

--- a/scripts/ci/bench-memory.sh
+++ b/scripts/ci/bench-memory.sh
@@ -22,7 +22,7 @@ echo "error_log: $error_log"
 echo "------------------------ Setup done -------------------------------------"
 
 echo "------------------------ Nix call ---------------------------------------"
-nix shell \
+nix shell --quiet \
     '.#ci.benchmarks.memory' \
     '.#cardano-node' \
     '.#cardano-wallet' \

--- a/scripts/ci/bench-read-blocks.sh
+++ b/scripts/ci/bench-read-blocks.sh
@@ -20,7 +20,7 @@ log=read-blocks.log
 echo "--- Build"
 nix --version
 
-nix build -L .#ci.benchmarks.read-blocks -o bench-read-blocks
+nix build --quiet .#ci.benchmarks.read-blocks -o bench-read-blocks
 bench="./bench-read-blocks/bin/read-blocks"
 
 

--- a/scripts/ci/bench-restore.sh
+++ b/scripts/ci/bench-restore.sh
@@ -20,7 +20,7 @@ export TMPDIR="$TMPDIR/bench/restore"
 mkdir -p "$TMPDIR"
 
 echo "--- Build"
-nix build -L .#ci.benchmarks.restore -o bench-restore
+nix build --quiet .#ci.benchmarks.restore -o bench-restore
 
 echo "--- Run benchmarks - $network"
 

--- a/scripts/ci/ruby-e2e.sh
+++ b/scripts/ci/ruby-e2e.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 # absolutize paths
 

--- a/scripts/ci/validate-swagger.sh
+++ b/scripts/ci/validate-swagger.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 swagger-cli validate specifications/api/swagger.yaml

--- a/scripts/release/openapi-diff.sh
+++ b/scripts/release/openapi-diff.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 
 GOPATH=$(mktemp -d)

--- a/scripts/release/release-candidate.sh
+++ b/scripts/release/release-candidate.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env -S nix shell '.#cardano-node' 'nixpkgs#gnused' --command bash
 # shellcheck shell=bash
 
-set -euox pipefail
+set -euo pipefail
 
 # date from git tag
 # example v2023-04-04 -> 2023-04-04


### PR DESCRIPTION
## Summary

- Add `--quiet` to every `nix build`, `nix shell`, `nix run`, `nix develop`, and `nix flake` invocation across all 11 CI workflow files
- Replace `-L` (verbose log) and `--log-format raw-with-logs` with `--quiet`
- Add `--quiet` to nix commands inside CI scripts (`scripts/ci/`) and run helpers (`run/`)
- Remove xtrace (`set -euox` → `set -euo`) from 7 CI and run scripts
- Add "Nix verbosity" convention section to CI contributor docs

## Commits

1. **`--quiet` in workflows** — 11 workflow files + docs (26 files total)
2. **`--quiet` in scripts** — 9 CI/run scripts with nix commands
3. **remove xtrace** — 7 scripts with `set -euox` → `set -euo`

## Verification

```
grep -rn -E '\bnix (build|shell|run|develop|flake)\b' .github/workflows/ scripts/ run/ | grep -v -- '--quiet' | grep -v '^#'
```
returns only shebang comments — all active nix commands have `--quiet`.

```
grep -rn 'set -.*x' scripts/ run/ | grep -v '^#' | grep -v interactive-print
```
returns only commented-out lines.

Closes #5148, closes #5118