### PR TITLE
docs: add MkDocs site for cardano-coin-selection

### DIFF
--- a/.github/workflows/coin-selection-docs.yml
+++ b/.github/workflows/coin-selection-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy coin-selection docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/coin-selection/**"
+      - "lib/coin-selection/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - run: pip install mkdocs-material pymdown-extensions
+      - run: mkdocs build --strict
+        working-directory: docs/coin-selection
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/coin-selection/site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/coin-selection-docs.yml
+++ b/.github/workflows/coin-selection-docs.yml
@@ -7,6 +7,11 @@ on:
       - "docs/coin-selection/**"
       - "lib/coin-selection/**"
 
+  pull_request:
+    paths:
+      - "docs/coin-selection/**"
+      - "lib/coin-selection/**"
+
   workflow_dispatch:
 
 concurrency:
@@ -37,6 +42,7 @@ jobs:
           path: docs/coin-selection/site
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/coin-selection/docs/concepts/change-generation.md
+++ b/docs/coin-selection/docs/concepts/change-generation.md
@@ -1,0 +1,101 @@
+# Change Generation
+
+After selecting inputs, the algorithm must distribute the excess value into
+**change outputs** that are sent back to the wallet. This is handled by the
+`makeChange` function.
+
+## The chicken-and-egg problem
+
+There is a circular dependency between change and fees:
+
+- To compute the **fee**, we need to know the transaction size, which depends
+  on the change outputs.
+- To compute the **change**, we need to subtract the fee from the excess
+  value.
+
+```mermaid
+flowchart LR
+    A[Change outputs] -->|affect| B[Transaction size]
+    B -->|determines| C[Fee]
+    C -->|affects| A
+```
+
+### Resolution
+
+The algorithm resolves this with a two-phase approach:
+
+1. **Predict change shape** -- call `makeChange` with zero fees and zero
+   minimum ada quantities. This always succeeds and yields the correct
+   **asset composition** of change (but not the correct ada amounts).
+
+2. **Estimate fee from skeleton** -- use the predicted change shape (number
+   of change outputs and their asset sets) to estimate the transaction fee.
+
+3. **Compute actual change** -- call `makeChange` with the estimated fee and
+   real minimum ada quantities.
+
+4. **Retry if needed** -- if there isn't enough ada to cover both the fee and
+   the minimum ada quantities of change outputs, select one more ada-only input
+   and repeat from step 2.
+
+```mermaid
+flowchart TD
+    A[Predict change with fee=0] --> B[Compute fee from skeleton]
+    B --> C[Compute actual change]
+    C --> D{Enough ada?}
+    D -->|Yes| E[Return selection result]
+    D -->|No| F{More ada-only UTxOs available?}
+    F -->|Yes| G[Select one more ada-only UTxO]
+    G --> B
+    F -->|No| H[Return UnableToConstructChange error]
+```
+
+## Change for user-specified assets
+
+For assets that appear in the user's requested outputs, the change quantity is
+distributed **proportionally** to the original output weights.
+
+Given an excess quantity $e$ of asset $a$ and output weights
+$w_1, w_2, \ldots, w_n$:
+
+$$
+\text{change}_i = \left\lfloor e \cdot \frac{w_i}{\sum_j w_j} \right\rfloor + r_i
+$$
+
+where $r_i \in \{0, 1\}$ are rounding corrections ensuring the total equals
+$e$ exactly. See [Partitioning](../math/partitioning.md) for details.
+
+## Change for non-user-specified assets
+
+Assets that were **not** in the original outputs but were selected as side
+effects (because they shared a UTxO with a desired asset) are distributed
+using the [padCoalesce](../math/coalescing.md) algorithm.
+
+These change maps are sorted in **ascending partial order**, which ensures
+that when combined with user-specified change maps, the smallest maps are
+merged with the smallest maps.
+
+## Assigning ada to change maps
+
+After computing the asset change maps, the algorithm assigns ada quantities:
+
+1. Assign the **minimum required ada** to each change map (based on its token
+   bundle size).
+
+2. Distribute any **remaining ada** proportionally to the original output
+   coins.
+
+If there isn't enough ada to cover all minimum quantities, the algorithm drops
+**empty** change maps (those with no native tokens) from the start of the
+list, reducing the total minimum ada required.
+
+!!! info "Invariant"
+    The number of change outputs is **at least** the number of user-specified
+    outputs (unless ada is insufficient to fund that many change outputs).
+
+## Splitting oversized change
+
+If a change output exceeds the maximum allowed token bundle size, it is split
+into smaller bundles using `equipartitionAssets`. If any individual token
+quantity exceeds the protocol maximum, it is split using
+`equipartitionQuantitiesWithUpperBound`.

--- a/docs/coin-selection/docs/concepts/collateral.md
+++ b/docs/coin-selection/docs/concepts/collateral.md
@@ -1,0 +1,102 @@
+# Collateral Selection
+
+Plutus script transactions on Cardano require **collateral** -- a set of
+ada-only UTxOs that will be forfeited if the script fails validation.
+The `Cardano.CoinSelection.Collateral` module provides a dedicated algorithm
+for selecting collateral.
+
+## Requirements
+
+The protocol imposes two constraints on collateral:
+
+1. **Size**: at most `maximumCollateralInputCount` UTxOs can be used
+2. **Value**: the total value must be at least
+   `minimumCollateralPercentage`% of the transaction fee
+
+$$
+\text{collateral} \geq \left\lceil \frac{\text{fee} \times \text{percentage}}{100} \right\rceil
+$$
+
+## Dual-strategy approach
+
+The algorithm tries two strategies in sequence, picking the first that succeeds:
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Strategy 1: Smallest-first]
+    B --> C{Succeeded?}
+    C -->|Yes| D[Return smallest selection]
+    C -->|No| E[Strategy 2: Largest-first]
+    E --> F{Succeeded?}
+    F -->|Yes| G[Return largest selection]
+    F -->|No| H[Return error with largest combination]
+```
+
+### Strategy 1: Smallest-first
+
+This strategy produces an **optimal** result -- the smallest possible total
+collateral amount.
+
+1. Sort available coins in ascending order
+2. Trim the list: discard coins after the first one that individually exceeds
+   the minimum
+3. Enumerate all combinations of size 1, 2, ..., up to `maximumSelectionSize`
+4. For each size, find the smallest combination that meets the minimum
+5. Return the overall smallest valid combination
+
+!!! warning "Search space limit"
+    The number of combinations can be exponential. The algorithm guards against
+    this with a configurable `searchSpaceLimit` (default: 1,000,000). If the
+    required search space exceeds this limit, the strategy fails without
+    computing a result.
+
+The search space for selecting $k$ coins from $n$ available is:
+
+$$
+\binom{n}{k} = \frac{n!}{k!(n-k)!}
+$$
+
+### Strategy 2: Largest-first
+
+This fallback strategy always produces a result if one exists:
+
+1. Take the `maximumSelectionSize` largest coins
+2. Enumerate all submaps of this small set (at most $2^k$ submaps where
+   $k \leq$ `maximumSelectionSize`, typically 3)
+3. Return the smallest submap that meets the minimum
+
+Since `maximumSelectionSize` is typically very small (3), this strategy
+is always fast.
+
+## Properties
+
+If the selection **succeeds**, the result satisfies:
+
+$$
+\begin{aligned}
+\sum \text{coinsSelected} &\geq \text{minimumSelectionAmount} \\
+|\text{coinsSelected}| &\leq \text{maximumSelectionSize} \\
+\text{coinsSelected} &\subseteq \text{coinsAvailable}
+\end{aligned}
+$$
+
+If the selection **fails**, the error reports:
+
+$$
+\begin{aligned}
+\sum \text{largestCombination} &< \text{minimumSelectionAmount} \\
+|\text{largestCombination}| &\leq \text{maximumSelectionSize} \\
+\text{largestCombination} &\subseteq \text{coinsAvailable}
+\end{aligned}
+$$
+
+## Integration with balance selection
+
+Collateral selection runs **after** the main balance selection. The balance
+selection reserves space for collateral inputs ahead of time by adding
+`maximumCollateralInputCount` to the skeleton input count when estimating fees.
+
+This ensures the fee already accounts for the collateral inputs, even though
+the exact collateral UTxOs are not yet known. The slight overestimation (since
+fewer collateral inputs may actually be needed) results in a marginally higher
+fee, which is acceptable given the small size of `maximumCollateralInputCount`.

--- a/docs/coin-selection/docs/concepts/minting-burning.md
+++ b/docs/coin-selection/docs/concepts/minting-burning.md
@@ -1,0 +1,116 @@
+# Minting and Burning
+
+Transactions on Cardano can **mint** (create) and **burn** (destroy) native
+tokens. These operations interact with coin selection because they change the
+value balance of the transaction.
+
+## Minting as extra input
+
+Minting tokens provides **input value** from "the void":
+
+$$
+\text{total input} = \sum \text{UTxO inputs} + \text{extra ada source} + \text{minted tokens}
+$$
+
+By minting tokens, we decrease the burden on the selection algorithm -- fewer
+UTxO entries need to be selected.
+
+## Burning as extra output
+
+Burning tokens consumes **output value** to "the void":
+
+$$
+\text{total output} = \sum \text{user outputs} + \text{extra ada sink} + \text{burned tokens}
+$$
+
+By burning tokens, we increase the burden on the selection algorithm -- more
+UTxO entries are needed.
+
+## Integration with change generation
+
+Minted and burned tokens are integrated into the change generation process for
+**non-user-specified assets** (assets that were not in the original output set).
+
+### Key properties
+
+The change bundles must maintain these properties throughout minting and
+burning operations:
+
+1. The number of change bundles **equals** the number of user-specified outputs
+2. The change bundles are in **ascending partial order**
+3. The change bundles maximise the number of **large** bundles
+
+### Adding minted values
+
+Minted tokens are added to the **largest** change bundle (the last element in
+the ascending-ordered list):
+
+```
+Before minting 4 of asset A:
+
+    [ [          ("B",  7) ]
+    [ [("A", 1), ("B",  8) ]
+    [ [("A", 2), ("B",  9) ]
+    [ [("A", 3), ("B",  9) ]
+    [ [("A", 4), ("B", 12) ]   <-- add here
+
+After:
+
+    [ [          ("B",  7) ]
+    [ [("A", 1), ("B",  8) ]
+    [ [("A", 2), ("B",  9) ]
+    [ [("A", 3), ("B",  9) ]
+    [ [("A", 8), ("B", 12) ]   <-- increased by 4
+```
+
+Adding to the largest bundle trivially maintains the ascending partial order.
+
+### Removing burned values
+
+Burned tokens are removed from the **smallest** change bundles first,
+traversing left to right:
+
+```
+Before burning 4 of asset A:
+
+    [ [          ("B",  7) ]   <-- start here (already 0)
+    [ [("A", 1), ("B",  8) ]   <-- reduce by 1
+    [ [("A", 2), ("B",  9) ]   <-- reduce by 2
+    [ [("A", 3), ("B",  9) ]   <-- reduce by 1
+    [ [("A", 4), ("B", 12) ]
+
+After:
+
+    [ [          ("B",  7) ]   <-- unchanged (was already 0)
+    [ [          ("B",  8) ]   <-- reduced by 1, eliminated
+    [ [          ("B",  9) ]   <-- reduced by 2, eliminated
+    [ [("A", 2), ("B",  9) ]   <-- reduced by 1
+    [ [("A", 4), ("B", 12) ]
+```
+
+!!! note "Why smallest first?"
+    Removing from the smallest bundles preserves the ascending partial order
+    and removes the "least useful" bundles first, maximising the overall
+    usefulness of the remaining change.
+
+### Formal property: ascending partial order
+
+For a list of token maps $[m_1, m_2, \ldots, m_n]$ to be in ascending partial
+order, we require:
+
+$$
+\forall\, i < j: \quad m_i \leq m_j
+$$
+
+where $\leq$ is the partial order on `TokenMap` (every quantity in $m_i$ is
+less than or equal to its counterpart in $m_j$).
+
+Both the minting and burning operations preserve this property, as proven by
+the following arguments:
+
+- **Minting**: adding to the maximum element cannot violate the ordering of
+  any pair $(m_i, m_n)$ since $m_n$ only increases.
+
+- **Burning**: reducing from left to right reduces $m_i$ by at most $q_i$
+  (its own quantity), so $m_i \leq m_{i+1}$ is maintained because $m_{i+1}$
+  is reduced by a smaller or equal amount.

--- a/docs/coin-selection/docs/concepts/selection-strategies.md
+++ b/docs/coin-selection/docs/concepts/selection-strategies.md
@@ -1,0 +1,104 @@
+# Selection Strategies
+
+The library provides two selection strategies that control **how much** of each
+asset the algorithm selects relative to the minimum required.
+
+## SelectionStrategyOptimal
+
+The default strategy. For each asset, the algorithm targets approximately
+**twice** the minimum required amount:
+
+$$
+\text{target}(a) = 2 \times \text{minimum}(a)
+$$
+
+This means that after paying for the required outputs, the remaining value is
+returned as change that is roughly the **same size** as the original outputs.
+
+!!! success "When to use"
+    Use for most transactions. This strategy helps the wallet's UTxO
+    distribution evolve to match the user's typical payment patterns,
+    increasing the likelihood that future selections succeed and lowering
+    amortized transaction costs.
+
+### Example
+
+If the user sends 100 ada, the algorithm targets selecting ~200 ada worth of
+inputs, producing ~100 ada in change. This change output is similar in size
+to the payment, maintaining a balanced UTxO set.
+
+## SelectionStrategyMinimal
+
+Selects **just enough** of each asset to meet the minimum required:
+
+$$
+\text{target}(a) = 1 \times \text{minimum}(a)
+$$
+
+The selection terminates as soon as the minimum is covered.
+
+!!! warning "When to use"
+    Use only as a fallback when the optimal strategy fails. Regular use of the
+    minimal strategy leads to small, fragmented change outputs that degrade the
+    wallet's UTxO set over time.
+
+### Example
+
+If the user sends 100 ada, the algorithm selects ~100 ada of inputs, producing
+very little change. The small change outputs are less useful for future
+transactions.
+
+## The Round-Robin algorithm
+
+Both strategies share the same underlying **Random-Round-Robin** algorithm.
+The algorithm processes each asset in turn, selecting UTxOs randomly until
+all assets reach their target.
+
+```mermaid
+flowchart TD
+    A[Build selector for each asset] --> B[Reverse list, ada selector last]
+    B --> C{Any selector can improve?}
+    C -->|Yes| D[Run next selector]
+    D --> E{Improvement?}
+    E -->|Yes| F[Keep selector in queue]
+    E -->|No| G[Remove selector from queue]
+    F --> C
+    G --> C
+    C -->|No| H[Selection complete]
+```
+
+### Selection step logic
+
+For a given asset, a single selection step works as follows:
+
+1. If the current selected quantity is **below** the minimum, select another
+   UTxO containing that asset.
+
+2. If the current selected quantity is **at or above** the minimum, select
+   another UTxO only if it brings the total **closer to the target** (but not
+   further away).
+
+$$
+\text{improvement}(s') = |q(s') - \text{target}| < |q(s) - \text{target}|
+$$
+
+where $q(s)$ is the selected quantity of the asset in state $s$.
+
+### UTxO selection priority
+
+When selecting a UTxO for a given asset $a$, the algorithm tries these filters
+in order of priority:
+
+1. **Singleton**: a UTxO containing **only** asset $a$ (and ada)
+2. **Pair**: a UTxO containing asset $a$ and **exactly one** other asset
+3. **Any**: any UTxO containing asset $a$
+
+This priority order minimises "collateral damage" -- the selection of
+unwanted assets alongside the desired one.
+
+### Ada is selected last
+
+The ada selector is run **last** in the round-robin. Since every UTxO
+necessarily contains ada, selecting UTxOs for other assets first increases the
+probability that the ada requirement is already satisfied without needing
+additional ada-only inputs.

--- a/docs/coin-selection/docs/concepts/utxo-model.md
+++ b/docs/coin-selection/docs/concepts/utxo-model.md
@@ -1,0 +1,69 @@
+# The UTxO Model
+
+## UTxO vs Account model
+
+Cardano uses the **UTxO** (Unspent Transaction Output) model, in contrast to
+the account-based model used by Ethereum. In the UTxO model, value is stored
+in discrete, indivisible outputs -- analogous to banknotes.
+
+!!! info "Key property"
+    A UTxO can only be spent **once**, in its **entirety**. You cannot spend
+    part of a UTxO -- you must consume the whole thing and return any excess
+    as **change**.
+
+### Analogy with cash
+
+| Cash                        | UTxO                                |
+|-----------------------------|-------------------------------------|
+| Pay with a $20 note         | Consume a UTxO as a transaction input |
+| Receive change              | Create a change output              |
+| Can't use the same note twice | A UTxO can only be spent once     |
+| Can't split a note in two shops | Must wait for change before spending it |
+
+### Consequences
+
+Because each UTxO is indivisible:
+
+- **Concurrency**: having many UTxOs allows more transactions to be made in
+  parallel. With only one large UTxO, you can only send one transaction at a
+  time (and must wait for change).
+
+- **Privacy**: each time you spend from an address, that address and its
+  spending key are exposed. Address reuse weakens privacy.
+
+- **Fragmentation**: creating too many small UTxOs ("dust") makes future
+  transactions more expensive, since more inputs are needed to reach the
+  required amount.
+
+## Why coin selection matters
+
+For every transaction, the wallet must decide **which UTxOs to consume** as
+inputs. This is the coin selection problem. A good algorithm must:
+
+1. **Cover the required amount** -- the total value of selected inputs must be
+   at least the total value of all outputs plus the transaction fee.
+
+2. **Respect transaction size limits** -- the protocol limits the maximum
+   transaction size, which in turn limits the number of inputs and outputs.
+
+3. **Maintain a healthy UTxO set** -- the selection strategy should ensure that
+   the wallet's UTxO distribution evolves over time to remain useful for future
+   transactions.
+
+4. **Preserve privacy** -- change outputs should not be easily distinguishable
+   from payment outputs by an outside observer.
+
+## Multi-asset UTxOs
+
+On Cardano, a single UTxO can carry **ada** (lovelace) and any number of
+**native tokens**. This makes coin selection significantly more complex than
+on Bitcoin, where each UTxO only carries a single asset.
+
+The coin selection algorithm must satisfy requirements for **all** assets
+simultaneously -- it is not sufficient to handle each asset independently.
+
+!!! warning "Minimum ada requirement"
+    Every UTxO on Cardano must contain a minimum amount of ada, determined by
+    the size of its token bundle. UTxOs carrying many different native tokens
+    require more ada. The coin selection algorithm must account for this when
+    generating change outputs.

--- a/docs/coin-selection/docs/data-structures/utxo-index.md
+++ b/docs/coin-selection/docs/data-structures/utxo-index.md
@@ -1,0 +1,120 @@
+# UTxO Index
+
+The `UTxOIndex` is the core data structure powering coin selection. It indexes
+a UTxO set by asset identifier, enabling efficient lookup and random selection
+of UTxOs containing a particular asset.
+
+## Problem
+
+Given a UTxO set with thousands of entries, the selection algorithm needs to
+repeatedly find a UTxO containing a specific asset. A naive linear scan is
+$O(n)$ per lookup, making the overall selection $O(n \cdot k)$ where $k$ is
+the number of distinct assets.
+
+## Solution
+
+The `UTxOIndex` maintains several indices over the same UTxO set:
+
+```haskell
+data UTxOIndex u = UTxOIndex
+    { indexAll        :: MonoidMap Asset (Set u)
+    , indexSingletons :: MonoidMap Asset (Set u)
+    , indexPairs      :: MonoidMap Asset (Set u)
+    , balance         :: TokenBundle
+    , universe        :: Map u TokenBundle
+    }
+```
+
+| Field | Description |
+|-------|-------------|
+| `indexAll` | All UTxOs containing a given asset |
+| `indexSingletons` | UTxOs containing *only* that asset (plus ada) |
+| `indexPairs` | UTxOs containing that asset and exactly one other |
+| `balance` | Total balance across all entries |
+| `universe` | Complete mapping from UTxO id to value |
+
+## Selection filters
+
+The index supports three selection filters, tried in priority order:
+
+```haskell
+data SelectionFilter asset
+    = SelectSingleton asset    -- UTxO with only this asset
+    | SelectPairWith  asset    -- UTxO with this asset + one other
+    | SelectAnyWith   asset    -- Any UTxO with this asset
+```
+
+### Why this priority?
+
+Selecting a UTxO that contains only the desired asset avoids "collateral
+damage" -- accidentally pulling in large quantities of unrelated assets.
+
+| Filter | Collateral damage | Use case |
+|--------|-------------------|----------|
+| `SelectSingleton` | None | Ideal: clean, targeted selection |
+| `SelectPairWith` | Minimal (one extra asset) | Good compromise |
+| `SelectAnyWith` | Potentially high | Fallback when others fail |
+
+## Random selection
+
+```haskell
+selectRandom
+    :: MonadRandom m
+    => UTxOIndex u
+    -> SelectionFilter Asset
+    -> m (Maybe ((u, TokenBundle), UTxOIndex u))
+```
+
+The function:
+
+1. Looks up the set of UTxOs matching the filter
+2. Randomly selects one from the set
+3. Returns the selected UTxO and the index with that entry removed
+
+Random selection is key to the self-organising property of the algorithm --
+over time, it produces a UTxO distribution that mirrors the user's payment
+patterns.
+
+### selectRandomWithPriority
+
+Tries a list of filters in order, returning the first successful selection:
+
+```haskell
+selectRandomWithPriority
+    :: MonadRandom m
+    => UTxOIndex u
+    -> NonEmpty (SelectionFilter Asset)
+    -> m (Maybe ((u, TokenBundle), UTxOIndex u))
+```
+
+## Operations
+
+| Operation | Complexity | Description |
+|-----------|------------|-------------|
+| `fromMap` | $O(n \cdot a)$ | Build from a `Map u TokenBundle` |
+| `insert` | $O(\log n \cdot a)$ | Insert a single entry |
+| `delete` | $O(\log n \cdot a)$ | Delete a single entry |
+| `lookup` | $O(\log n)$ | Look up a UTxO by id |
+| `balance` | $O(1)$ | Total balance of all entries |
+| `size` | $O(1)$ | Number of entries |
+| `assets` | $O(1)$ | Set of all asset identifiers |
+| `selectRandom` | $O(\log n)$ | Random selection with filter |
+
+where $n$ is the number of UTxOs and $a$ is the average number of assets per
+UTxO.
+
+## Invariant
+
+The index maintains an internal invariant ensuring consistency between the
+universe (the complete map) and the various asset indices. This invariant is
+checked by `checkInvariant` and is verified in the test suite after every
+operation.
+
+The invariant ensures:
+
+1. Every UTxO in the universe appears in exactly the correct index entries
+2. The balance equals the sum of all values in the universe
+3. A UTxO appears in `indexSingletons` for asset $a$ iff it contains only
+   asset $a$ and ada
+4. A UTxO appears in `indexPairs` for asset $a$ iff it contains asset $a$
+   and exactly one other non-ada asset

--- a/docs/coin-selection/docs/data-structures/utxo-selection.md
+++ b/docs/coin-selection/docs/data-structures/utxo-selection.md
@@ -1,0 +1,110 @@
+# UTxO Selection
+
+The `UTxOSelection` type represents the state of a coin selection in progress.
+It tracks which UTxOs have been selected and which are still available.
+
+## Structure
+
+A `UTxOSelection` consists of two disjoint `UTxOIndex` sets:
+
+```haskell
+data State u = State
+    { leftover :: UTxOIndex u  -- UTxOs not yet selected
+    , selected :: UTxOIndex u  -- UTxOs already selected
+    }
+```
+
+```mermaid
+stateDiagram-v2
+    state UTxOSelection {
+        [*] --> Leftover: fromIndex
+        Leftover --> Selected: select
+    }
+    state Leftover {
+        note right of Leftover: UTxOs available\nfor selection
+    }
+    state Selected {
+        note right of Selected: UTxOs already\nchosen as inputs
+    }
+```
+
+## Types
+
+The module provides two types:
+
+| Type | Guarantee |
+|------|-----------|
+| `UTxOSelection u` | May have zero selected entries |
+| `UTxOSelectionNonEmpty u` | Has at least one selected entry |
+
+The `UTxOSelectionNonEmpty` type is used as evidence that the selection has
+made progress, which is important for constructing the final transaction
+(which requires at least one input).
+
+## Construction
+
+```haskell
+-- All UTxOs in the leftover set, none selected
+fromIndex :: UTxOIndex u -> UTxOSelection u
+
+-- UTxOs matching the predicate are pre-selected
+fromIndexFiltered :: Ord u
+    => (u -> Bool) -> UTxOIndex u -> UTxOSelection u
+
+-- Construct from explicit leftover/selected pair
+fromIndexPair :: Ord u
+    => (UTxOIndex u, UTxOIndex u) -> UTxOSelection u
+```
+
+## Core operation: select
+
+The `select` function moves a single UTxO from the leftover set to the
+selected set:
+
+```haskell
+select :: Ord u
+    => u -> UTxOSelection u -> Maybe (UTxOSelectionNonEmpty u)
+```
+
+Key properties:
+
+- Returns `Nothing` if the given UTxO is not in the leftover set
+- Always returns `UTxOSelectionNonEmpty` (the selection is guaranteed
+  non-empty after a successful select)
+- The total available balance remains constant:
+
+$$
+\text{availableBalance}(s) = \text{availableBalance}(\text{select}(u, s))
+$$
+
+## Balances
+
+| Function | Returns |
+|----------|---------|
+| `availableBalance` | `selectedBalance + leftoverBalance` (constant) |
+| `selectedBalance` | Balance of selected UTxOs |
+| `leftoverBalance` | Balance of unselected UTxOs |
+
+## Sub-selection relation
+
+A selection $s_1$ is a **sub-selection** of $s_2$ if $s_2$ can be reached
+from $s_1$ by zero or more applications of `select`:
+
+$$
+s_1 \subseteq s_2 \iff \exists\, u_1, \ldots, u_k: \text{select}(u_k, \ldots \text{select}(u_1, s_1)\ldots) = s_2
+$$
+
+This relation is checked by `isSubSelectionOf` and is useful in property
+tests to verify that selections are consistent.
+
+## Usage in coin selection
+
+The `UTxOSelection` is threaded through the entire selection process:
+
+1. **Start**: `fromIndex` creates a selection with all UTxOs as leftover
+2. **Round-robin**: each selection step calls `select` to move a UTxO from
+   leftover to selected
+3. **Change generation**: the selected set is used to compute the total input
+   value
+4. **Result**: the selected entries become the transaction inputs; the leftover
+   set is returned to the wallet

--- a/docs/coin-selection/docs/getting-started.md
+++ b/docs/coin-selection/docs/getting-started.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+## Installation
+
+Add `cardano-coin-selection` to your `build-depends` in your `.cabal` file:
+
+```cabal
+build-depends:
+    , cardano-coin-selection
+```
+
+The package is available from the [Cardano Haskell Package repository (CHaP)](https://github.com/intersectmbo/cardano-haskell-packages).
+
+Add CHaP to your `cabal.project`:
+
+```
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+```
+
+## Module imports
+
+The library is designed around qualified imports:
+
+```haskell
+import qualified Cardano.CoinSelection as CS
+import qualified Cardano.CoinSelection.Balance as Balance
+import qualified Cardano.CoinSelection.Collateral as Collateral
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
+```
+
+## Defining a selection context
+
+Before performing a selection, you need to define a `SelectionContext` that
+specifies your address and UTxO identifier types:
+
+```haskell
+data MyContext
+
+instance SelectionContext MyContext where
+    type Address MyContext = MyAddress
+    type UTxO    MyContext = MyTxIn
+```
+
+The only requirements are that both associated types have `Ord` and `Show`
+instances.
+
+## Performing a selection
+
+The main entry point is `Cardano.CoinSelection.performSelection`:
+
+```haskell
+import Cardano.CoinSelection
+    ( Selection
+    , SelectionConstraints (..)
+    , SelectionError
+    , SelectionParams (..)
+    , performSelection
+    )
+
+result :: Either (SelectionError MyContext) (Selection MyContext)
+result = runExceptT $ performSelection constraints params
+```
+
+The `performSelection` function:
+
+1. Selects inputs from the UTxO set to cover user-specified outputs
+2. Selects inputs to cover collateral (if required)
+3. Produces change outputs to return excess value
+4. Balances the selection to pay for the transaction fee
+
+See the [Tutorial](tutorial.md) for a complete worked example.

--- a/docs/coin-selection/docs/index.md
+++ b/docs/coin-selection/docs/index.md
@@ -1,0 +1,45 @@
+# cardano-coin-selection
+
+Coin selection algorithms for the Cardano blockchain.
+
+This library provides a complete solution for selecting UTxO entries to fund
+transactions on Cardano, including multi-asset support, change generation, fee
+estimation, minting/burning, and collateral selection.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `Cardano.CoinSelection` | High-level entry point combining balance and collateral selection |
+| `Cardano.CoinSelection.Balance` | Random-Round-Robin algorithm for multi-asset UTxO sets |
+| `Cardano.CoinSelection.Collateral` | Dual-strategy collateral selection |
+| `Cardano.CoinSelection.UTxOIndex` | Asset-indexed UTxO set with O(1) asset lookup |
+| `Cardano.CoinSelection.UTxOSelection` | Selected/leftover state machine |
+| `Cardano.CoinSelection.Context` | Type class for selection contexts |
+| `Cardano.CoinSelection.Size` | Token bundle size assessment |
+
+## Quick links
+
+- [Getting Started](getting-started.md) -- installation and basic usage
+- [Tutorial](tutorial.md) -- step-by-step coin selection walkthrough
+- [Selection Strategies](concepts/selection-strategies.md) -- Optimal vs Minimal
+- [UTxO Index](data-structures/utxo-index.md) -- the core data structure
+- [References](references.md) -- papers and blog posts
+
+## Design principles
+
+The coin selection algorithm is designed around several key principles:
+
+1. **Self-organisation**: the UTxO set should evolve over time to resemble the
+   typical distribution of payments made by the wallet owner, increasing the
+   likelihood that future selections succeed.
+
+2. **Privacy**: change outputs should be roughly the same size and shape as
+   user-specified outputs, making it harder for an observer to distinguish
+   change from payments.
+
+3. **Efficiency**: the algorithm must terminate in bounded time and produce
+   selections that minimise fees.
+
+4. **Correctness**: all selections satisfy a set of formally verified
+   properties -- checked by the test suite via QuickCheck.

--- a/docs/coin-selection/docs/javascripts/mathjax.js
+++ b/docs/coin-selection/docs/javascripts/mathjax.js
@@ -1,0 +1,12 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};

--- a/docs/coin-selection/docs/math/coalescing.md
+++ b/docs/coin-selection/docs/math/coalescing.md
@@ -1,0 +1,99 @@
+# Coalescing: padCoalesce
+
+The `padCoalesce` function adjusts a list to match a target length while
+preserving the total sum. It is used to distribute non-user-specified asset
+quantities across change outputs.
+
+## Definition
+
+Given a source list $S$ and a target list $T$:
+
+$$
+\text{padCoalesce}(S, T) = S'
+\quad\text{where}\quad
+|S'| = |T|
+\quad\text{and}\quad
+\sum S' = \sum S
+$$
+
+The result $S'$ is always sorted in ascending order.
+
+## Algorithm
+
+The function first sorts the source list, then:
+
+- If $|S| < |T|$: **pad** by inserting `mempty` until the lengths match
+- If $|S| > |T|$: **coalesce** by merging the two smallest elements until
+  the lengths match
+- If $|S| = |T|$: return the sorted source unchanged
+
+### Padding
+
+Repeatedly insert `mempty` (zero) into the sorted list:
+
+$$
+[a_1, a_2, \ldots, a_k] \xrightarrow{\text{pad}}
+[0, a_1, a_2, \ldots, a_k]
+$$
+
+Since $0 \leq a_i$ for all $i$, the ascending order is preserved.
+
+### Coalescing
+
+Repeatedly merge the two smallest elements:
+
+$$
+[a_1, a_2, a_3, \ldots, a_k] \xrightarrow{\text{coalesce}}
+[a_3, \ldots, (a_1 + a_2), \ldots, a_k]
+$$
+
+The merged element $(a_1 + a_2)$ is re-inserted in sorted position. The
+sum is preserved because $a_1 + a_2$ replaces both $a_1$ and $a_2$.
+
+## Examples
+
+```haskell
+-- Padding: source shorter than target
+>>> padCoalesce [Sum 1] (replicate 4 ())
+[Sum 0, Sum 0, Sum 0, Sum 1]
+
+-- Coalescing: source longer than target
+>>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 3 ())
+[Sum 3, Sum 4, Sum 8]
+
+>>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 2 ())
+[Sum 7, Sum 8]
+
+>>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 1 ())
+[Sum 15]
+```
+
+### Worked example: coalescing [8, 4, 2, 1] to length 2
+
+1. Sort: $[1, 2, 4, 8]$, need to reduce from 4 to 2
+2. Coalesce smallest pair: $1 + 2 = 3$, insert: $[3, 4, 8]$
+3. Coalesce smallest pair: $3 + 4 = 7$, insert: $[7, 8]$
+4. Length matches target. Result: $[7, 8]$
+
+Sum check: $1 + 2 + 4 + 8 = 15 = 7 + 8$
+
+## Properties
+
+1. **Length preservation**: $|\text{result}| = |\text{target}|$
+
+2. **Sum preservation**: $\sum \text{result} = \sum \text{source}$
+
+3. **Ascending order**: the result is sorted in ascending order
+
+4. **Maximises large values**: coalescing the smallest pair at each step
+   ensures that large values are preserved as much as possible
+
+## Usage in coin selection
+
+`padCoalesce` is used by `makeChangeForNonUserSpecifiedAsset` to distribute
+the quantities of a non-user-specified asset across the correct number of
+change outputs.
+
+For example, if asset B was found in 9 selected UTxOs with quantities
+$[9, 1, 8, 2, 7, 3, 6, 4, 5]$ and the user requested 5 outputs, then
+`padCoalesce` reduces these 9 quantities down to 5 change values.

--- a/docs/coin-selection/docs/math/equipartition.md
+++ b/docs/coin-selection/docs/math/equipartition.md
@@ -1,0 +1,90 @@
+# Equipartition
+
+An **equipartition** of a natural number $n$ into $k$ parts is a partition
+where all parts differ by at most 1.
+
+## equipartitionNatural
+
+$$
+\text{equipartitionNatural}(n, k) = [p_1, \ldots, p_k]
+$$
+
+where:
+
+$$
+p_i \in \left\{ \left\lfloor \frac{n}{k} \right\rfloor, \left\lceil \frac{n}{k} \right\rceil \right\}
+\quad\text{and}\quad
+\sum_{i=1}^{k} p_i = n
+$$
+
+The result is sorted in ascending order.
+
+### Examples
+
+```haskell
+>>> equipartitionNatural 10 (() :| [(), ()])
+2 :| [3, 5]  -- actually: 3 :| [3, 4]
+
+>>> equipartitionNatural 7 (() :| [(), ()])
+2 :| [2, 3]
+```
+
+### Implementation
+
+`equipartitionNatural` is implemented as a special case of
+[`partitionNatural`](partitioning.md) where all weights are 1:
+
+```haskell
+equipartitionNatural n count =
+    NE.reverse $ unsafePartitionNatural n (1 <$ count)
+```
+
+## equipartitionQuantitiesWithUpperBound
+
+This function splits a `TokenBundle` into multiple bundles such that no
+individual token quantity exceeds a given upper bound.
+
+Given a bundle $b$ and maximum quantity $q_{\max}$:
+
+$$
+\text{equipartitionQuantitiesWithUpperBound}(b, q_{\max}) = [b_1, \ldots, b_m]
+$$
+
+where:
+
+- For each asset $a$ and each $b_i$: $\text{qty}(b_i, a) \leq q_{\max}$
+- $\sum_i b_i = b$ (the total is preserved)
+- $m$ is minimised
+
+The number of parts needed for a single asset with quantity $q$ is:
+
+$$
+m(q) = \left\lceil \frac{q}{q_{\max}} \right\rceil
+$$
+
+The overall number of parts is the maximum across all assets:
+
+$$
+m = \max_a \left\lceil \frac{\text{qty}(b, a)}{q_{\max}} \right\rceil
+$$
+
+## equipartitionAssets
+
+Splits a `TokenBundle` into $k$ bundles by evenly distributing the **assets**
+(not quantities) across the parts, then equipartitioning each asset's quantity.
+
+This is used when a change output has too many distinct assets to fit in a
+single transaction output. The bundle is repeatedly halved until each part
+is within the size limit.
+
+## Usage in coin selection
+
+These functions are used during change generation to split oversized change
+outputs:
+
+1. **`splitBundlesWithExcessiveAssetCounts`** -- uses `equipartitionAssets`
+   to split bundles that exceed the maximum token bundle size.
+
+2. **`splitBundlesWithExcessiveTokenQuantities`** -- uses
+   `equipartitionQuantitiesWithUpperBound` to split bundles containing
+   quantities that exceed the protocol maximum.

--- a/docs/coin-selection/docs/math/equipartition.md
+++ b/docs/coin-selection/docs/math/equipartition.md
@@ -23,7 +23,7 @@ The result is sorted in ascending order.
 
 ```haskell
 >>> equipartitionNatural 10 (() :| [(), ()])
-2 :| [3, 5]  -- actually: 3 :| [3, 4]
+3 :| [3, 4]
 
 >>> equipartitionNatural 7 (() :| [(), ()])
 2 :| [2, 3]

--- a/docs/coin-selection/docs/math/partial-orders.md
+++ b/docs/coin-selection/docs/math/partial-orders.md
@@ -1,0 +1,117 @@
+# Partial Orders
+
+The `TokenMap` and `TokenBundle` types use **partial ordering** instead of
+total ordering. This page explains why, and how partial orders are used in the
+coin selection algorithm.
+
+## Why no Ord instance?
+
+Consider two token maps:
+
+```haskell
+p = fromFlatList [(assetA, 2), (assetB, 1)]
+q = fromFlatList [(assetA, 1), (assetB, 2)]
+```
+
+Neither $p \leq q$ nor $q \leq p$ holds -- they are **incomparable**.
+
+A total ordering (like lexicographic) could be defined, but it would not be
+consistent with the arithmetic properties of token maps. For example,
+under lexicographic ordering we might have $p > q$, but we could not conclude
+that $p - q$ is non-negative (it would be $(1, -1)$, which is not a valid
+token map).
+
+!!! danger "Type error on Ord"
+    Both `TokenMap` and `TokenBundle` generate a **compile-time type error**
+    if you try to use them with `Ord`:
+
+    ```
+    Ord not supported for token maps
+    Ord not supported for token bundles
+    ```
+
+    This prevents accidental misuse.
+
+## The partial order
+
+The `PartialOrd` instance defines:
+
+$$
+x \leq y \iff \forall\, a: \text{qty}(x, a) \leq \text{qty}(y, a)
+$$
+
+In Haskell:
+
+```haskell
+instance PartialOrd TokenMap where
+    leq = MonoidMap.isSubmapOf `on` unTokenMap
+```
+
+### Examples
+
+```haskell
+x = fromFlatList [(assetA, 1)]
+y = fromFlatList [(assetA, 2), (assetB, 1)]
+-- x `leq` y  ==  True  (x is strictly less than y)
+
+p = fromFlatList [(assetA, 2), (assetB, 1)]
+q = fromFlatList [(assetA, 1), (assetB, 2)]
+-- p `leq` q  ==  False (incomparable)
+-- q `leq` p  ==  False (incomparable)
+```
+
+## TokenBundle partial order
+
+For `TokenBundle`, which combines a `Coin` with a `TokenMap`:
+
+$$
+(c_1, m_1) \leq (c_2, m_2) \iff c_1 \leq c_2 \land m_1 \leq m_2
+$$
+
+```haskell
+instance PartialOrd TokenBundle where
+    b1 `leq` b2 =
+        (&&)
+            (coin b1 <= coin b2)
+            (tokens b1 `leq` tokens b2)
+```
+
+## Lexicographic ordering (when needed)
+
+When an arbitrary total ordering is needed (e.g., for use as a `Map` key or
+`Set` element), both types provide a `Lexicographic` newtype:
+
+```haskell
+newtype Lexicographic a = Lexicographic { unLexicographic :: a }
+
+instance Ord (Lexicographic TokenMap) where
+    compare = comparing (toNestedList . unLexicographic)
+```
+
+## Usage in coin selection
+
+The partial order is fundamental to the change generation algorithm:
+
+- **Ascending partial order of change maps**: the non-user-specified change
+  maps are maintained in ascending partial order, which ensures that when
+  combined with user-specified change, the smallest maps are paired with the
+  smallest.
+
+- **Balance sufficiency check**: the algorithm checks whether the available
+  UTxO balance is sufficient by verifying that the required balance is less
+  than or equal (in the partial order) to the available balance.
+
+- **Selection delta**: the surplus/deficit of a selection is computed using
+  the truncated subtraction $(\backslash\!\!>)$, which is the monus operation
+  on the partial order.
+
+### The `inAscendingPartialOrder` predicate
+
+The `Cardano.Numeric.Util` module provides:
+
+```haskell
+inAscendingPartialOrder :: (Foldable f, PartialOrd a) => f a -> Bool
+```
+
+This checks that consecutive pairs satisfy `leq`, and is used in property
+tests to verify that change maps are correctly ordered.

--- a/docs/coin-selection/docs/math/partitioning.md
+++ b/docs/coin-selection/docs/math/partitioning.md
@@ -1,0 +1,101 @@
+# Partitioning Natural Numbers
+
+The `partitionNatural` function from `Cardano.Numeric.Util` distributes a
+natural number into parts proportional to a list of weights. It is used
+throughout the coin selection algorithm to split quantities fairly.
+
+## Definition
+
+Given a target $n \in \mathbb{N}$ and weights $w_1, w_2, \ldots, w_k$ with
+$W = \sum_i w_i > 0$:
+
+$$
+\text{partitionNatural}(n, [w_1, \ldots, w_k]) = [p_1, \ldots, p_k]
+$$
+
+where each $p_i$ is within unity of the ideal proportion:
+
+$$
+\left| p_i - n \cdot \frac{w_i}{W} \right| < 1
+$$
+
+## Algorithm
+
+The algorithm computes the partition in five steps:
+
+### Step 1: Compute ideal (rational) proportions
+
+$$
+q_i = n \cdot \frac{w_i}{W} \in \mathbb{Q}
+$$
+
+### Step 2: Attach indices
+
+Associate each $q_i$ with its original position $i$ so the ordering can be
+restored later.
+
+### Step 3: Sort by fractional part
+
+Sort the indexed proportions in **descending** order of their fractional parts
+$\{q_i\}$, breaking ties by descending integral part $\lfloor q_i \rfloor$.
+
+### Step 4: Apply roundings
+
+Compute the shortfall:
+
+$$
+s = n - \sum_{i=1}^{k} \lfloor q_i \rfloor
+$$
+
+Round **up** the first $s$ elements (those with the largest fractional parts)
+and round **down** the rest:
+
+$$
+p_{\sigma(i)} = \begin{cases}
+\lceil q_{\sigma(i)} \rceil & \text{if } i \leq s \\
+\lfloor q_{\sigma(i)} \rfloor & \text{if } i > s
+\end{cases}
+$$
+
+where $\sigma$ is the permutation from step 3.
+
+### Step 5: Restore original order
+
+Sort by the original indices to produce the final result.
+
+## Guarantees
+
+1. **Length preservation**: $|\text{result}| = |\text{weights}|$
+
+2. **Sum preservation**: $\sum_i p_i = n$
+
+3. **Proportionality**: each $p_i$ is within 1 of the ideal proportion
+
+4. **Non-negative**: all $p_i \geq 0$
+
+## Examples
+
+```haskell
+>>> partitionNatural 9 (1 :| [1, 1])
+Just (3 :| [3, 3])
+
+>>> partitionNatural 10 (1 :| [])
+Just (10 :| [])
+
+>>> partitionNatural 30 (1 :| [2, 4, 8])
+Just (2 :| [4, 8, 16])
+```
+
+## Usage in coin selection
+
+The `partitionNatural` function is used in several places:
+
+- **`makeChangeForCoin`**: distributes surplus ada across change outputs
+  proportionally to the original output coin values.
+
+- **`makeChangeForUserSpecifiedAsset`**: distributes surplus token quantities
+  across change outputs proportionally to the original output quantities of
+  that asset.
+
+- **`equipartitionNatural`**: a special case where all weights are equal,
+  producing an equipartition.

--- a/docs/coin-selection/docs/references.md
+++ b/docs/coin-selection/docs/references.md
@@ -1,0 +1,47 @@
+# References
+
+## Blog posts
+
+- **Self Organisation in Coin Selection**
+  ([IOHK blog](https://iohk.io/blog/self-organisation-in-coin-selection/))
+  -- describes how random coin selection leads to a self-organising UTxO
+  distribution that mirrors the user's payment patterns.
+
+- **The Challenges of Optimizing Unspent Output Selection**
+  ([Jameson Lopp](https://medium.com/@lopp/the-challenges-of-optimizing-unspent-output-selection-a3e5d05d13ef))
+  -- a survey of coin selection approaches for Bitcoin, many of which apply
+  to Cardano's UTxO model.
+
+## Cardano documentation
+
+- **Cardano Wallet User Guide**
+  ([GitHub Pages](https://cardano-foundation.github.io/cardano-wallet/))
+  -- the full documentation for the cardano-wallet project, which uses
+  this coin selection library.
+
+- **Cardano Ledger Specification**
+  ([GitHub](https://github.com/intersectmbo/cardano-ledger))
+  -- the formal specification of the Cardano ledger, including transaction
+  validation rules that constrain coin selection.
+
+## Related libraries
+
+- **`cardano-numeric`** -- provides `partitionNatural`, `equipartitionNatural`,
+  and `padCoalesce` used by the coin selection algorithm.
+
+- **`cardano-wallet-primitive`** -- provides `TokenMap`, `TokenBundle`, `Coin`,
+  and related types used throughout the library.
+
+## Haddock documentation
+
+The most detailed documentation is in the Haddock comments within the source
+code itself:
+
+| Module | Key documentation |
+|--------|-------------------|
+| `Cardano.CoinSelection.Balance` | Round-robin algorithm, change generation, minting/burning |
+| `Cardano.CoinSelection.Collateral` | Dual-strategy collateral selection |
+| `Cardano.CoinSelection.UTxOIndex.Internal` | Index invariants, selection filters |
+| `Cardano.CoinSelection.UTxOSelection` | State machine semantics |
+| `Cardano.Numeric.Util` | padCoalesce, partitionNatural proofs |
+| `Cardano.Wallet.Primitive.Types.TokenMap` | Partial ordering rationale |

--- a/docs/coin-selection/docs/stylesheets/extra.css
+++ b/docs/coin-selection/docs/stylesheets/extra.css
@@ -1,0 +1,16 @@
+.md-typeset .admonition {
+    font-size: 0.85rem;
+}
+
+.md-typeset code {
+    font-size: 0.82em;
+}
+
+.md-typeset .mermaid {
+    margin: 1em 0;
+}
+
+.md-typeset mjx-container {
+    overflow-x: auto;
+    padding: 0.25em 0;
+}

--- a/docs/coin-selection/docs/tutorial.md
+++ b/docs/coin-selection/docs/tutorial.md
@@ -1,0 +1,160 @@
+# Tutorial
+
+This tutorial walks through a complete coin selection from start to finish.
+
+## Scenario
+
+Alice has a wallet with the following UTxO set and wants to send 15 ada and
+3 tokens of asset X to Bob.
+
+### Alice's UTxO set
+
+| UTxO | Ada | Asset X |
+|------|-----|---------|
+| u1   | 10  | 0       |
+| u2   | 5   | 2       |
+| u3   | 20  | 0       |
+| u4   | 3   | 5       |
+
+### Desired output
+
+| Recipient | Ada | Asset X |
+|-----------|-----|---------|
+| Bob       | 15  | 3       |
+
+## Step 1: Build the UTxO index
+
+The first step is to build a `UTxOIndex` from Alice's UTxO set. The index
+maintains a mapping from each asset to the subset of UTxOs containing that
+asset, enabling efficient random selection.
+
+```haskell
+let utxoIndex = UTxOIndex.fromMap $ Map.fromList
+        [ (u1, TokenBundle (Coin 10) mempty)
+        , (u2, TokenBundle (Coin 5)  (TokenMap.singleton assetX (TokenQuantity 2)))
+        , (u3, TokenBundle (Coin 20) mempty)
+        , (u4, TokenBundle (Coin 3)  (TokenMap.singleton assetX (TokenQuantity 5)))
+        ]
+```
+
+## Step 2: Configure selection parameters
+
+```haskell
+let params = SelectionParams
+        { outputsToCover =
+            [ (bobAddress, TokenBundle (Coin 15)
+                (TokenMap.singleton assetX (TokenQuantity 3)))
+            ]
+        , utxoAvailableForInputs = UTxOSelection.fromIndex utxoIndex
+        , utxoAvailableForCollateral = mempty
+        , collateralRequirement = SelectionCollateralNotRequired
+        , extraCoinIn  = Coin 0
+        , extraCoinOut = Coin 0
+        , assetsToMint = mempty
+        , assetsToBurn = mempty
+        , selectionStrategy = SelectionStrategyOptimal
+        }
+```
+
+## Step 3: The selection algorithm runs
+
+Internally, the algorithm proceeds through several phases:
+
+### Phase 1: Random-Round-Robin selection
+
+```mermaid
+flowchart TD
+    A[Start with empty selection] --> B{Any asset below target?}
+    B -->|Yes| C[Pick asset with largest deficit]
+    C --> D[Randomly select UTxO containing that asset]
+    D --> E[Move UTxO from leftover to selected]
+    E --> B
+    B -->|No| F{Ada below target?}
+    F -->|Yes| G[Randomly select ada-only UTxO]
+    G --> E
+    F -->|No| H[Selection complete]
+```
+
+With the **Optimal** strategy, the algorithm targets **twice** the minimum
+required amount of each asset. This produces change outputs that are roughly
+the same size as the user-specified outputs.
+
+For our example, the algorithm needs at least 3 tokens of asset X. With the
+optimal strategy it targets 6. It might select:
+
+- **u4** (3 ada, 5 asset X) -- provides 5 of the targeted 6 asset X
+- **u2** (5 ada, 2 asset X) -- provides 2 more asset X (total: 7, close to target 6)
+- **u3** (20 ada) -- provides additional ada to reach the ada target
+
+### Phase 2: Change generation
+
+Once inputs are selected, the algorithm computes change:
+
+$$
+\text{change} = \sum \text{inputs} + \text{mints} - \sum \text{outputs} - \text{burns} - \text{fee}
+$$
+
+For our example (assuming fee = 0.2 ada):
+
+| | Ada | Asset X |
+|---|---|---|
+| Inputs (u2 + u3 + u4) | 28 | 7 |
+| Outputs (Bob) | -15 | -3 |
+| Fee | -0.2 | 0 |
+| **Change** | **12.8** | **4** |
+
+The change is distributed proportionally to the original outputs. Since there
+is only one output, all change goes into a single change output sent back to
+Alice.
+
+### Phase 3: Fee estimation loop
+
+There is a chicken-and-egg problem: we need to know the fee to compute change,
+but we need to know the change to compute the fee (since change affects
+transaction size).
+
+```mermaid
+flowchart TD
+    A[Predict change shape with zero fee] --> B[Estimate fee from skeleton]
+    B --> C[Compute actual change with estimated fee]
+    C --> D{Enough ada for change + fee?}
+    D -->|Yes| E[Done]
+    D -->|No| F[Select one more ada-only input]
+    F --> B
+```
+
+The algorithm resolves this by:
+
+1. First computing a "prediction" of change with zero fees
+2. Using that prediction to estimate the fee
+3. Then computing actual change with the real fee
+4. If ada is insufficient, selecting one more input and repeating
+
+## Step 4: Inspect the result
+
+```haskell
+case result of
+    Left err -> handleError err
+    Right selection -> do
+        -- Selected inputs (non-empty list)
+        let inputs = CS.inputs selection
+
+        -- User-specified outputs
+        let outputs = CS.outputs selection
+
+        -- Generated change outputs (sent back to Alice)
+        let change = CS.change selection
+
+        -- The selection surplus covers the fee
+        let surplus = CS.selectionDeltaAllAssets selection
+```
+
+## Summary
+
+The coin selection algorithm balances several competing concerns:
+
+- **Covering the outputs**: enough value must be selected
+- **Minimising fees**: don't select unnecessarily many inputs
+- **Self-organisation**: target ~2x the minimum to produce useful change
+- **Privacy**: change should resemble typical outputs
+- **Correctness**: all invariants are maintained and verified

--- a/docs/coin-selection/mkdocs.yml
+++ b/docs/coin-selection/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: cardano-coin-selection
+site_description: Coin selection algorithms for the Cardano blockchain
+site_url: https://cardano-foundation.github.io/cardano-wallet/coin-selection/
+repo_url: https://github.com/cardano-foundation/cardano-wallet
+repo_name: cardano-foundation/cardano-wallet
+
+theme:
+  name: material
+  palette:
+    scheme: slate
+    primary: blue
+    accent: light blue
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Tutorial: tutorial.md
+  - Concepts:
+      - UTxO Model: concepts/utxo-model.md
+      - Selection Strategies: concepts/selection-strategies.md
+      - Change Generation: concepts/change-generation.md
+      - Minting & Burning: concepts/minting-burning.md
+      - Collateral: concepts/collateral.md
+  - Mathematics:
+      - Partitioning: math/partitioning.md
+      - Equipartition: math/equipartition.md
+      - Partial Orders: math/partial-orders.md
+      - Coalescing: math/coalescing.md
+  - Data Structures:
+      - UTxO Index: data-structures/utxo-index.md
+      - UTxO Selection: data-structures/utxo-selection.md
+  - References: references.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+extra_javascript:
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
+extra_css:
+  - stylesheets/extra.css
+
+plugins:
+  - search

--- a/docs/coin-selection/mkdocs.yml
+++ b/docs/coin-selection/mkdocs.yml
@@ -65,6 +65,7 @@ markdown_extensions:
       custom_checkbox: true
 
 extra_javascript:
+  - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:

--- a/justfile
+++ b/justfile
@@ -5,6 +5,14 @@ LC_ALL := 'C.UTF-8'
 default:
   @just --list
 
+# serve coin-selection docs locally
+docs-serve:
+  cd docs/coin-selection && mkdocs serve
+
+# build coin-selection docs (strict mode)
+docs-build:
+  cd docs/coin-selection && mkdocs build --strict
+
 # check that the code is formatted with stylish-haskell
 syntax:
   scripts/buildkite/main/check-code-format.sh


### PR DESCRIPTION
## Summary

- Add MkDocs documentation site for the `cardano-coin-selection` library
- 15 pages covering concepts, algorithms, mathematical foundations, and data structures
- Material theme with MathJax for LaTeX math, mermaid diagrams, code snippets
- GitHub Actions workflow for deploying to GitHub Pages
- Justfile recipes: `docs-serve`, `docs-build`

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [ ] `mkdocs serve` renders all pages correctly (math, mermaid, code)
- [ ] Review content accuracy against source Haddock comments