### PR TITLE
fix: clean up E2E temp directories on cancellation

### DIFF
--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -34,3 +34,7 @@ jobs:
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
         run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
+
+      - name: Cleanup temp directories
+        if: always()
+        run: rm -rf /tmp/e2e-* /tmp/test-cluster*


### PR DESCRIPTION
## Summary

- Add `if: always()` cleanup step to the E2E workflow to remove `/tmp/e2e-*` and `/tmp/test-cluster*` after each run

## Problem

When E2E tests get cancelled (timeout or `cancel-in-progress`), the process is SIGKILL'd and `withSystemTempDirectory` cleanup never runs. Each cancelled run leaks ~17GB in `/tmp`. Four stale dirs accumulated to ~57GB, filled the runner's 63GB tmpfs, and broke all CI jobs with `database or disk is full` errors on the nix eval cache.

## Test plan

- [x] Manually cleaned `/tmp` on `builder-new` (93% → 1%)
- [x] Re-triggered failed CI runs
- [ ] Verify next E2E cancellation leaves no stale dirs