### PR TITLE
refactor: remove redundant deriving Typeable

### DIFF
--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
@@ -227,7 +227,7 @@ data Role
     = UtxoExternal
     | UtxoInternal
     | MutableAccount
-    deriving (Generic, Typeable, Show, Eq, Ord, Bounded)
+    deriving (Generic, Show, Eq, Ord, Bounded)
 
 instance NFData Role
 

--- a/lib/api/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Client.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -59,7 +58,6 @@ import Cardano.Wallet.Api.Types
     , ApiBalanceTransactionPostDataT
     , ApiByronWallet
     , ApiBytesT (..)
-    , ApiCoinSelectionT
     , ApiConstructTransactionDataT
     , ApiConstructTransactionT
     , ApiDecodeTransactionPostData
@@ -71,10 +69,8 @@ import Cardano.Wallet.Api.Types
     , ApiPoolSpecifier
     , ApiPostRandomAddressData
     , ApiPutAddressesDataT
-    , ApiSelectCoinsDataT
     , ApiSerialisedTransaction (..)
     , ApiSignTransactionPostData
-    , ApiStakeKeysT
     , ApiT (..)
     , ApiTransactionT
     , ApiTxId (..)
@@ -484,21 +480,3 @@ networkClient =
             , networkParameters = _networkParameters
             , networkClock = _networkClock
             }
-
---
--- Type families
---
-
-type instance ApiAddressT Aeson.Value = Aeson.Value
-type instance ApiStakeKeysT Aeson.Value = Aeson.Value
-type instance ApiAddressIdT Aeson.Value = Text
-type instance ApiCoinSelectionT Aeson.Value = Aeson.Value
-type instance ApiSelectCoinsDataT Aeson.Value = Aeson.Value
-type instance ApiTransactionT Aeson.Value = Aeson.Value
-type instance ApiConstructTransactionT Aeson.Value = Aeson.Value
-type instance ApiConstructTransactionDataT Aeson.Value = Aeson.Value
-type instance PostTransactionOldDataT Aeson.Value = Aeson.Value
-type instance PostTransactionFeeOldDataT Aeson.Value = Aeson.Value
-type instance ApiPutAddressesDataT Aeson.Value = Aeson.Value
-type instance ApiBalanceTransactionPostDataT Aeson.Value = Aeson.Value
-type instance ApiDecodedTransactionT Aeson.Value = Aeson.Value

--- a/lib/api/src/Cardano/Wallet/Api/Lib/ApiAsArray.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Lib/ApiAsArray.hs
@@ -26,7 +26,6 @@ import Data.Maybe
     )
 import Data.Typeable
     ( Proxy (..)
-    , Typeable
     )
 import GHC.Base
     ( Symbol
@@ -44,7 +43,7 @@ import Prelude
 --
 -- The number of items permitted in the array is dependent on the wrapped type.
 newtype ApiAsArray (s :: Symbol) a = ApiAsArray a
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving newtype (Monoid, Semigroup)
     deriving anyclass (NFData)
 

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -844,12 +844,12 @@ data ApiAddressWithPath (n :: NetworkDiscriminant) = ApiAddressWithPath
     , state :: !(ApiT AddressState)
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiAddressWithPath n)
     deriving anyclass (NFData)
 
 newtype ApiCosignerIndex = ApiCosignerIndex Word8
-    deriving stock (Data, Eq, Generic, Show, Typeable)
+    deriving stock (Data, Eq, Generic, Show)
     deriving newtype (FromJSON, ToJSON)
     deriving anyclass (NFData)
 
@@ -864,7 +864,7 @@ data ApiCredential
 newtype ApiCredentialType = ApiCredentialType
     { unApiCredentialType :: CredentialType
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultSum CredentialType
     deriving anyclass (NFData)
 
@@ -895,14 +895,14 @@ data AnyAddress = AnyAddress
 data ApiSelectCoinsData (n :: NetworkDiscriminant)
     = ApiSelectForPayment (ApiSelectCoinsPayments n)
     | ApiSelectForDelegation ApiSelectCoinsAction
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
 
 data ApiSelectCoinsPayments (n :: NetworkDiscriminant) = ApiSelectCoinsPayments
     { payments :: NonEmpty (ApiTxOutput n)
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     , metadata :: !(Maybe (ApiT TxMetadata))
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiSelectCoinsPayments n)
@@ -929,7 +929,7 @@ data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
     , depositsReturned :: ![ApiAmount]
     , metadata :: !(Maybe ApiBase64)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelection n)
     deriving anyclass (NFData)
 
@@ -939,7 +939,7 @@ data ApiCoinSelectionChange (n :: NetworkDiscriminant) = ApiCoinSelectionChange
     , assets :: !ApiWalletAssets
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiCoinSelectionChange n)
@@ -950,7 +950,7 @@ data ApiCoinSelectionOutput (n :: NetworkDiscriminant) = ApiCoinSelectionOutput
     , amount :: !ApiAmount
     , assets :: !ApiWalletAssets
     }
-    deriving (Eq, Ord, Generic, Show, Typeable)
+    deriving (Eq, Ord, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiCoinSelectionOutput n)
@@ -964,7 +964,7 @@ data ApiCoinSelectionCollateral (n :: NetworkDiscriminant)
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     , amount :: !ApiAmount
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiCoinSelectionCollateral n)
@@ -1250,7 +1250,7 @@ data ApiConstructTransaction (n :: NetworkDiscriminant) = ApiConstructTransactio
     , coinSelection :: !(ApiCoinSelection n)
     , fee :: !ApiAmount
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 -- | Index of the stake key.
@@ -1295,7 +1295,7 @@ data ApiConstructTransactionData (n :: NetworkDiscriminant)
     , referencePolicyScriptTemplate :: !(Maybe (ApiT (Script Cosigner)))
     , encoding :: !(Maybe ApiSealedTxEncoding)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiConstructTransactionData n)
@@ -1304,7 +1304,7 @@ data ApiConstructTransactionData (n :: NetworkDiscriminant)
 newtype ApiPaymentDestination (n :: NetworkDiscriminant)
     = -- | Pay amounts to one or more addresses.
       ApiPaymentAddresses (NonEmpty (AddressAmount (ApiAddressIdT n)))
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 -- | Times where transactions are valid.
@@ -1362,7 +1362,7 @@ data PostTransactionOldData (n :: NetworkDiscriminant) = PostTransactionOldData
     , metadata :: !(Maybe TxMetadataWithSchema)
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (PostTransactionOldData n)
@@ -1375,7 +1375,7 @@ data PostTransactionFeeOldData (n :: NetworkDiscriminant)
     , metadata :: !(Maybe TxMetadataWithSchema)
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (PostTransactionFeeOldData n)
@@ -1397,7 +1397,7 @@ data ApiExternalInput (n :: NetworkDiscriminant) = ApiExternalInput
     , assets :: !ApiWalletAssets
     , datum :: !(Maybe (ApiT Write.DatumHash))
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiExternalInput n)
     deriving anyclass (NFData)
 
@@ -1591,7 +1591,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , scriptIntegrity :: Maybe (ApiT (Hash "ScriptIntegrity"))
     , extraSignatures :: [ApiT (Hash "ExtraSignature")]
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiTransaction n)
     deriving anyclass (NFData)
 
@@ -1621,14 +1621,14 @@ data ApiTxInput (n :: NetworkDiscriminant) = ApiTxInput
     { source :: !(Maybe (ApiTxOutput n))
     , input :: !(ApiT TxIn)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 data ApiTxCollateral (n :: NetworkDiscriminant) = ApiTxCollateral
     { source :: !(Maybe (AddressAmountNoAssets (ApiAddress n)))
     , input :: !(ApiT TxIn)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 data AddressAmountNoAssets addr = AddressAmountNoAssets
@@ -1752,7 +1752,7 @@ newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant)
     = ApiWalletMigrationPlanPostData
     { addresses :: NonEmpty (ApiAddress n)
     }
-    deriving (Eq, Generic, Typeable)
+    deriving (Eq, Generic)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiWalletMigrationPlanPostData n)
@@ -1764,7 +1764,7 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol)
     { passphrase :: !(ApiT (Passphrase s))
     , addresses :: !(NonEmpty (ApiAddress n))
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiWalletMigrationPostData n s)
@@ -1773,7 +1773,7 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol)
 newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
     { addresses :: [ApiAddress n]
     }
-    deriving (Eq, Generic, Typeable)
+    deriving (Eq, Generic)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiPutAddressesData n)
     deriving anyclass (NFData)
     deriving (Show) via (Quiet (ApiPutAddressesData n))
@@ -1794,7 +1794,7 @@ data ApiWalletMigrationPlan (n :: NetworkDiscriminant) = ApiWalletMigrationPlan
     , balanceLeftover :: ApiWalletMigrationBalance
     , balanceSelected :: ApiWalletMigrationBalance
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiWalletMigrationPlan n)
@@ -3652,3 +3652,17 @@ instance FromJSON (ApiT (Script Cosigner)) where
     parseJSON = fmap ApiT . parseJSON
 instance ToJSON (ApiT (Script Cosigner)) where
     toJSON = toJSON . getApiT
+
+type instance ApiAddressT Aeson.Value = Aeson.Value
+type instance ApiStakeKeysT Aeson.Value = Aeson.Value
+type instance ApiAddressIdT Aeson.Value = Text
+type instance ApiCoinSelectionT Aeson.Value = Aeson.Value
+type instance ApiSelectCoinsDataT Aeson.Value = Aeson.Value
+type instance ApiTransactionT Aeson.Value = Aeson.Value
+type instance ApiConstructTransactionT Aeson.Value = Aeson.Value
+type instance ApiConstructTransactionDataT Aeson.Value = Aeson.Value
+type instance PostTransactionOldDataT Aeson.Value = Aeson.Value
+type instance PostTransactionFeeOldDataT Aeson.Value = Aeson.Value
+type instance ApiPutAddressesDataT Aeson.Value = Aeson.Value
+type instance ApiBalanceTransactionPostDataT Aeson.Value = Aeson.Value
+type instance ApiDecodedTransactionT Aeson.Value = Aeson.Value

--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -108,9 +108,6 @@ import Data.Text
 import Data.Time.Clock
     ( UTCTime
     )
-import Data.Typeable
-    ( Typeable
-    )
 import Data.Word
     ( Word32
     )
@@ -259,7 +256,7 @@ data ApiErrorInfo
     | TranslationByronTxOutInContext
     | BalanceTxInlinePlutusV3ScriptNotSupportedInBabbage
     | UnsupportedEra !ApiErrorUnsupportedEra
-    deriving (Eq, Generic, Show, Data, Typeable)
+    deriving (Eq, Generic, Show, Data)
     deriving anyclass (NFData)
 
 instance FromJSON ApiErrorInfo where
@@ -284,7 +281,7 @@ data ApiErrorUnsupportedEra = ApiErrorUnsupportedEra
     , supportedEras :: !(Set ApiEra)
     -- ^ The set of eras that we currently support.
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiErrorUnsupportedEra
     deriving anyclass (NFData)
 
@@ -294,7 +291,7 @@ data ApiErrorSharedWalletNoSuchCosigner = ApiErrorSharedWalletNoSuchCosigner
     , credentialType
         :: !ApiCredentialType
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorSharedWalletNoSuchCosigner
@@ -308,7 +305,7 @@ data ApiErrorTxOutputLovelaceInsufficient = ApiErrorTxOutputLovelaceInsufficient
     , txOutputLovelaceRequiredMinimum
         :: !ApiAmount
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorTxOutputLovelaceInsufficient
@@ -327,7 +324,7 @@ data ApiErrorOutputTokenQuantityExceedsLimit
     , maxQuantity
         :: !TokenQuantity
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorOutputTokenQuantityExceedsLimit
@@ -340,7 +337,7 @@ data ApiErrorOutputTokenBundleSizeExceedsLimit
     , bundleSize
         :: !Natural
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorOutputTokenBundleSizeExceedsLimit
@@ -353,7 +350,7 @@ data ApiErrorBalanceTxUnderestimatedFee = ApiErrorBalanceTxUnderestimatedFee
     , candidateTxHex :: Text
     , candidateTxReadable :: Text
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorBalanceTxUnderestimatedFee
@@ -363,7 +360,7 @@ data ApiErrorNodeNotYetInRecentEra = ApiErrorNodeNotYetInRecentEra
     { nodeEra :: ApiEra
     , supportedRecentEras :: Set ApiEra
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorNodeNotYetInRecentEra
@@ -374,7 +371,7 @@ data ApiErrorMissingWitnessesInTransaction
     { expectedNumberOfKeyWits :: !Natural
     , detectedNumberOfKeyWits :: !Natural
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorMissingWitnessesInTransaction
@@ -383,7 +380,7 @@ data ApiErrorMissingWitnessesInTransaction
 data ApiErrorNotEnoughMoney = ApiErrorNotEnoughMoney
     { shortfall :: !ApiErrorNotEnoughMoneyShortfall
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiErrorNotEnoughMoney
     deriving anyclass (NFData)
 
@@ -391,7 +388,7 @@ data ApiErrorNotEnoughMoneyShortfall = ApiErrorNotEnoughMoneyShortfall
     { ada :: !ApiAmount
     , assets :: !ApiWalletAssets
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorNotEnoughMoneyShortfall
@@ -400,21 +397,21 @@ data ApiErrorNotEnoughMoneyShortfall = ApiErrorNotEnoughMoneyShortfall
 data ApiErrorNoSuchPool = ApiErrorNoSuchPool
     { poolId :: !PoolId
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiErrorNoSuchPool
     deriving anyclass (NFData)
 
 data ApiErrorNoSuchWallet = ApiErrorNoSuchWallet
     { walletId :: !(ApiT WalletId)
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiErrorNoSuchWallet
     deriving anyclass (NFData)
 
 data ApiErrorNoSuchTransaction = ApiErrorNoSuchTransaction
     { transactionId :: !(ApiT (Hash "Tx"))
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorNoSuchTransaction
@@ -423,7 +420,7 @@ data ApiErrorNoSuchTransaction = ApiErrorNoSuchTransaction
 data ApiErrorTransactionAlreadyInLedger = ApiErrorTransactionAlreadyInLedger
     { transactionId :: !(ApiT (Hash "Tx"))
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorTransactionAlreadyInLedger
@@ -433,7 +430,7 @@ data ApiErrorStartTimeLaterThanEndTime = ApiErrorStartTimeLaterThanEndTime
     { startTime :: UTCTime
     , endTime :: UTCTime
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorStartTimeLaterThanEndTime
@@ -442,7 +439,7 @@ data ApiErrorStartTimeLaterThanEndTime = ApiErrorStartTimeLaterThanEndTime
 data ApiErrorWrongEncryptionPassphrase = ApiErrorWrongEncryptionPassphrase
     { walletId :: !(ApiT WalletId)
     }
-    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (Data, Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord ApiErrorWrongEncryptionPassphrase

--- a/lib/api/src/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Transaction.hs
@@ -136,9 +136,6 @@ import Data.Text
 import Data.Text.Class
     ( toText
     )
-import Data.Typeable
-    ( Typeable
-    )
 import Data.Word
     ( Word32
     , Word8
@@ -211,7 +208,7 @@ data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
     , validityInterval :: Maybe ApiValidityIntervalExplicit
     , witnessCount :: ApiWitnessCount
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving
         (FromJSON, ToJSON)
         via DefaultRecord (ApiDecodedTransaction n)
@@ -231,7 +228,7 @@ data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
     , amount :: ApiAmount
     , assets :: ApiWalletAssets
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletInput n)
     deriving anyclass (NFData)
 
@@ -255,7 +252,7 @@ mkApiWitnessCount WitnessCount{verificationKey, scripts, bootstrap} =
 data ApiTxInputGeneral (n :: NetworkDiscriminant)
     = ExternalInput (ApiT TxIn)
     | WalletInput (ApiWalletInput n)
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 instance HasSNetworkId n => FromJSON (ApiTxInputGeneral n) where
@@ -280,7 +277,7 @@ instance HasSNetworkId n => ToJSON (ApiTxInputGeneral n) where
     toJSON (WalletInput content) = toJSON content
 
 data ResourceContext = External | Our
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 data ApiWithdrawalGeneral (n :: NetworkDiscriminant) = ApiWithdrawalGeneral
@@ -297,7 +294,7 @@ data ApiWalletOutput (n :: NetworkDiscriminant) = ApiWalletOutput
     , assets :: ApiWalletAssets
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletOutput n)
     deriving anyclass (NFData)
 
@@ -332,7 +329,7 @@ type ApiTxOutput n = AddressAmount (ApiAddress n)
 data ApiTxOutputGeneral (n :: NetworkDiscriminant)
     = ExternalOutput (ApiTxOutput n)
     | WalletOutput (ApiWalletOutput n)
-    deriving (Eq, Generic, Show, Typeable)
+    deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
 instance HasSNetworkId n => FromJSON (ApiTxOutputGeneral n) where

--- a/lib/api/src/Cardano/Wallet/Api/Types/WalletAsset.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/WalletAsset.hs
@@ -37,9 +37,6 @@ import Data.Data
 import Data.Hashable
     ( Hashable
     )
-import Data.Typeable
-    ( Typeable
-    )
 import GHC.Generics
     ( Generic
     )
@@ -56,6 +53,6 @@ data ApiWalletAsset = ApiWalletAsset
     , assetName :: !(ApiT W.AssetName)
     , quantity :: !Natural
     }
-    deriving (Data, Eq, Generic, Hashable, Ord, Show, Typeable)
+    deriving (Data, Eq, Generic, Hashable, Ord, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletAsset
     deriving anyclass (NFData)

--- a/lib/api/src/Cardano/Wallet/Api/Types/WalletAssets.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/WalletAssets.hs
@@ -38,9 +38,6 @@ import Data.Data
 import Data.Hashable
     ( Hashable
     )
-import Data.Typeable
-    ( Typeable
-    )
 import GHC.Exts
     ( IsList (fromList, toList)
     )
@@ -63,7 +60,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 newtype ApiWalletAssets = ApiWalletAssets
     { getApiWalletAssets :: [ApiWalletAsset]
     }
-    deriving (Data, Eq, Generic, Ord, Show, Typeable)
+    deriving (Data, Eq, Generic, Ord, Show)
     deriving newtype
         (Hashable, IsList, Semigroup, Monoid, FromJSON, ToJSON)
     deriving anyclass (NFData)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
@@ -68,7 +68,6 @@ import qualified Data.Text as T
 --              addresses. Genesis file needs to be passed explicitly when
 --              starting the application.
 data NetworkDiscriminant = Mainnet | Testnet Nat
-    deriving (Typeable)
 
 class NetworkDiscriminantCheck k where
     networkDiscriminantCheck :: SNetworkId n -> Word8 -> Bool

--- a/lib/ui/src/common/Cardano/Wallet/UI/Common/Handlers/SSE.hs
+++ b/lib/ui/src/common/Cardano/Wallet/UI/Common/Handlers/SSE.hs
@@ -13,9 +13,6 @@ where
 import Control.Monad.Fix
     ( fix
     )
-import Data.Typeable
-    ( Typeable
-    )
 import Lucid
     ( Html
     , renderBS
@@ -46,7 +43,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Network.HTTP.Media as M
 
 -- | Imitate the Servant JSON and OctetStream implementations
-data EventStream deriving (Typeable)
+data EventStream
 
 instance Accept EventStream where
     contentType _ = "text" M.// "event-stream"

--- a/lib/unit/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -122,9 +122,6 @@ import Data.String
 import Data.Text
     ( Text
     )
-import Data.Typeable
-    ( Typeable
-    )
 import GHC.TypeLits
     ( Symbol
     )
@@ -146,14 +143,11 @@ newtype ExpectedError = ExpectedError String
     deriving newtype (IsString)
 
 newtype PathParam (t :: *) = PathParam Text
-    deriving (Typeable)
 
 newtype BodyParam (t :: *) = BodyParam ByteString
-    deriving (Typeable)
 
 newtype Header (headerName :: Symbol) (contentType :: *)
     = Header BS.ByteString
-    deriving (Typeable)
 
 --
 -- Class Declaration

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -192,9 +192,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               # and test suites.
               doCoverage = coverage;
 
-              # GHC 9.12: suppress 'deriving Typeable' warning (all types
-              # auto-derive Typeable, making explicit deriving redundant).
-              ghcOptions = [ "-Wno-deriving-typeable" ];
+              ghcOptions = [];
             });
           }
 


### PR DESCRIPTION
## Summary
- Remove all explicit `deriving (Typeable)` clauses — redundant since GHC 7.10
- Move orphan type family instances from `Client.hs` to `Types.hs`
- Remove `-Wno-deriving-typeable` GHC flag from nix config

Extracted from #5197 to keep the node bump PR focused on era changes.