### PR TITLE
refactor: centralize version bounds in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -161,6 +161,36 @@ constraints:
   -- Cardano Node dependencies:
   , io-classes -asserts
 
+  -- Pinned cardano-ecosystem versions (node 10.5.4):
+  , cardano-api ==10.16.4.0
+  , cardano-binary ==1.7.2.0
+  , cardano-crypto-class ==2.2.3.2
+  , cardano-crypto-praos ==2.2.1.1
+  , cardano-crypto-wrapper ==1.6.1.0
+  , cardano-data ==1.2.4.1
+  , cardano-ledger-allegra ==1.7.0.0
+  , cardano-ledger-alonzo ==1.13.0.0
+  , cardano-ledger-api ==1.11.0.0
+  , cardano-ledger-babbage ==1.11.0.0
+  , cardano-ledger-byron ==1.1.0.0
+  , cardano-ledger-conway ==1.19.0.0
+  , cardano-ledger-core ==1.17.0.0
+  , cardano-ledger-mary ==1.8.0.0
+  , cardano-ledger-shelley ==1.16.0.0
+  , cardano-protocol-tpraos ==1.4.0.0
+  , cardano-slotting ==0.2.0.1
+  , cardano-strict-containers ==0.1.6.0
+  , ouroboros-consensus ==0.27.0.0
+  , ouroboros-consensus-cardano ==0.25.1.1
+  , ouroboros-consensus-diffusion ==0.23.1.0
+  , ouroboros-consensus-protocol ==0.12.0.0
+  , ouroboros-network ==0.21.6.1
+  , ouroboros-network-api ==0.14.2.0
+  , ouroboros-network-framework ==0.18.1.0
+  , ouroboros-network-protocols ==0.14.1.0
+  , plutus-core ==1.45.0.0
+  , plutus-ledger-api ==1.45.0.0
+  , plutus-tx ==1.45.0.0
 
 -- Related to: https://github.com/haskell/cabal/issues/8554
 if impl(ghc == 8.10.7)

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -47,13 +47,13 @@ library
     , binary
     , bytestring
     , cardano-addresses            >=4.0.2    && <4.1
-    , cardano-crypto               >=1.2.0    && <1.3
-    , cardano-crypto-class         ^>=2.2.3
-    , cardano-ledger-api           >=1.11.0.0 && <1.12
-    , cardano-ledger-byron         >=1.1.0.0  && <1.2
-    , cardano-ledger-core          >=1.17.0.0 && <1.18
-    , cardano-ledger-shelley       >=1.16.0.0 && <1.17
-    , cardano-slotting             >=0.2.0.0  && <0.3
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-slotting
     , cardano-wallet-primitive
     , cardano-wallet-secrets
     , cborg
@@ -68,7 +68,7 @@ library
     , int-cast
     , lens
     , memory
-    , ouroboros-consensus-cardano  >=0.25.0.0 && <0.26
+    , ouroboros-consensus-cardano
     , QuickCheck
     , quiet
     , random

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -40,13 +40,13 @@ library
     , binary
     , bytestring
     , cardano-addresses             >=4.0.2     && <4.1
-    , cardano-api                   >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-binary                >=1.7.1.0   && <1.8
-    , cardano-crypto                >=1.2.0     && <1.3
-    , cardano-ledger-api            >=1.11.0.0  && <1.12
-    , cardano-ledger-core           >=1.17.0.0  && <1.18
+    , cardano-binary
+    , cardano-crypto
+    , cardano-ledger-api
+    , cardano-ledger-core
     , cardano-wallet
     , cardano-wallet-launcher
     , cardano-wallet-network-layer

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -39,7 +39,7 @@ library
   hs-source-dirs:  lib/main
   build-depends:
     , cardano-balance-tx:internal
-    , cardano-ledger-api           >=1.11.0.0 && <1.12
+    , cardano-ledger-api
 
   exposed-modules:
     Cardano.Write.Eras
@@ -53,20 +53,20 @@ library internal
     , base                         >=4.14      && <5
     , bytestring                   >=0.10.6    && <0.13
     , cardano-addresses            >=4.0.2     && <4.1
-    , cardano-api                  >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-coin-selection
-    , cardano-crypto-class         ^>=2.2.3
-    , cardano-ledger-allegra       >=1.7.0.0   && <1.8
-    , cardano-ledger-alonzo        >=1.13.0.0  && <1.14
-    , cardano-ledger-api           >=1.11.0.0  && <1.12
-    , cardano-ledger-babbage       >=1.11.0.0  && <1.12
+    , cardano-crypto-class
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-conway        >=1.19.0.0  && <1.20
-    , cardano-ledger-core          >=1.17.0.0  && <1.18
-    , cardano-ledger-mary          >=1.8.0.0   && <1.9
-    , cardano-ledger-shelley       >=1.16.0.0  && <1.17
-    , cardano-slotting             >=0.2.0.0   && <0.3
-    , cardano-strict-containers    >=0.1.3.0   && <0.2
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , cborg                        >=0.2.1     && <0.3
@@ -80,8 +80,8 @@ library internal
     , MonadRandom                  >=0.6       && <0.7
     , monoid-subclasses            >=1.2.5.1   && <1.3
     , nonempty-containers          >=0.3.4.5   && <0.4
-    , ouroboros-consensus          >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano  >=0.25.0.0  && <0.26
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
     , pretty-simple                >=4.1.2.0   && <4.2
     , QuickCheck                   >=2.14      && <2.16.0
     , serialise                    >=0.2.6.1   && <0.3
@@ -116,28 +116,28 @@ test-suite test
     , base
     , bytestring
     , cardano-addresses               >=4.0.2     && <4.1
-    , cardano-api                     >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-api-extra
     , cardano-balance-tx:internal
-    , cardano-binary                  >=1.7.1.0   && <1.8
+    , cardano-binary
     , cardano-coin-selection
-    , cardano-crypto                  >=1.2.0     && <1.3
-    , cardano-crypto-class            ^>=2.2.3
-    , cardano-crypto-wrapper          >=1.5.1.3   && <1.7
-    , cardano-ledger-alonzo           >=1.13.0.0  && <1.14
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-alonzo
     , cardano-ledger-alonzo-test      >=1.3.0.1   && <1.4
-    , cardano-ledger-api              >=1.11.0.0  && <1.12
-    , cardano-ledger-babbage          >=1.11.0.0  && <1.12
+    , cardano-ledger-api
+    , cardano-ledger-babbage
     , cardano-ledger-babbage:testlib
-    , cardano-ledger-byron            >=1.1.0.0   && <1.2
-    , cardano-ledger-conway           >=1.19.0.0  && <1.20
+    , cardano-ledger-byron
+    , cardano-ledger-conway
     , cardano-ledger-conway:testlib
-    , cardano-ledger-core             >=1.17.0.0  && <1.18
+    , cardano-ledger-core
     , cardano-ledger-mary:testlib     >=1.8.0.0   && <1.9
-    , cardano-ledger-shelley          >=1.16.0.0  && <1.17
+    , cardano-ledger-shelley
     , cardano-numeric
-    , cardano-slotting                >=0.2.0.0   && <0.3
-    , cardano-strict-containers       >=0.1.3.0   && <0.2
+    , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet-primitive
     , cardano-wallet-secrets
     , cardano-wallet-test-utils
@@ -158,9 +158,9 @@ test-suite test
     , MonadRandom
     , monoid-subclasses
     , nonempty-containers
-    , ouroboros-consensus             >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano     >=0.25.0.0  && <0.26
-    , ouroboros-network-api           >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-network-api
     , QuickCheck                      >=2.14      && <2.16
     , quickcheck-classes              >=0.6.5     && <0.7
     , sop-extras                      >=0.4.0.0   && <0.5

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -142,7 +142,7 @@ benchmark latency
     , aeson
     , base
     , cardano-addresses                     >=4.0.2    && <4.1
-    , cardano-ledger-core                   >=1.17.0.0 && <1.18
+    , cardano-ledger-core
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application
@@ -189,8 +189,8 @@ benchmark db
     , base
     , bytestring
     , cardano-addresses                >=4.0.2     && <4.1
-    , cardano-api                      >=10.16.0.0 && <10.17
-    , cardano-crypto                   >=1.2.0     && <1.3
+    , cardano-api
+    , cardano-crypto
     , cardano-wallet
     , cardano-wallet-benchmarks
     , cardano-wallet-network-layer
@@ -231,7 +231,7 @@ benchmark api
     , aeson
     , base
     , bytestring
-    , cardano-api                      >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-balance-tx
     , cardano-balance-tx:internal
     , cardano-wallet

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -41,18 +41,18 @@ library
     , aeson
     , base
     , bytestring
-    , cardano-api                                  >=10.16.0.0 && <10.17
-    , cardano-binary                               >=1.7.1.0   && <1.8
-    , cardano-crypto-class                         ^>=2.2.3
+    , cardano-api
+    , cardano-binary
+    , cardano-crypto-class
     , cardano-crypto-test                          >=1.5.0.2   && <1.7
-    , cardano-ledger-alonzo                        >=1.13.0.0  && <1.14
-    , cardano-ledger-api                           >=1.11.0.0  && <1.12
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
     , cardano-ledger-byron-test                    >=1.5.2.0   && <1.6
     , cardano-ledger-conway:testlib                >=1.19.0.0  && <1.20
-    , cardano-ledger-core                          >=1.17.0.0  && <1.18
+    , cardano-ledger-core
     , cardano-ledger-core:testlib
-    , cardano-ledger-shelley                       >=1.16.0.0  && <1.17
-    , cardano-strict-containers                    >=0.1.3.0   && <0.2
+    , cardano-ledger-shelley
+    , cardano-strict-containers
     , cardano-wallet-test-utils
     , containers
     , hedgehog-quickcheck

--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -160,23 +160,23 @@ library
   build-depends:
     , base                          >=4.14     && <5
     , bytestring                    >=0.10.6   && <0.13
-    , cardano-crypto                >=1.1.2    && <1.4
-    , cardano-crypto-class          >=2.2.3.0  && <2.3
-    , cardano-crypto-praos          >=2.2.0.0  && <2.3
-    , cardano-crypto-wrapper        >=1.5.1.3  && <1.7
-    , cardano-data                  >=1.2.3.1  && <1.3
-    , cardano-ledger-allegra        >=1.7.0.0  && <1.8
-    , cardano-ledger-alonzo         >=1.13.0.0 && <1.14
-    , cardano-ledger-api            >=1.11.0.0 && <1.12
-    , cardano-ledger-babbage        >=1.11.0.0 && <1.12
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-praos
+    , cardano-crypto-wrapper
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-byron          >=1.1.0.0  && <1.2
-    , cardano-ledger-conway         >=1.19.0.0 && <1.20
-    , cardano-ledger-core           >=1.17.0.0 && <1.18
-    , cardano-ledger-mary           >=1.8.0.0  && <1.9
-    , cardano-ledger-shelley        >=1.16.0.0 && <1.17
-    , cardano-protocol-tpraos       >=1.4.0.0  && <1.5
-    , cardano-strict-containers     >=0.1.3.0  && <0.2
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-strict-containers
     , containers                    >=0.5      && <0.8
     , deepseq                       >=1.4.4    && <1.6
     , fmt                           >=0.6.3.0  && <0.7
@@ -185,10 +185,10 @@ library
     , memory                        >=0.18.0   && <0.19
     , nothunks                      >=0.1.5    && <0.4
     , operational                   >=0.2.4.2  && <0.3
-    , ouroboros-consensus           >=0.27.0.0 && <0.28
-    , ouroboros-consensus-cardano   >=0.25.0.0 && <0.26
-    , ouroboros-consensus-protocol  >=0.12.0.0 && <0.13
-    , ouroboros-network-api         >=0.14.0.0 && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-protocol
+    , ouroboros-network-api
     , QuickCheck                    >=2.14     && <2.16.0
     , text                          >=1.2      && <2.2
     , time                          >=1.12.2   && <1.15
@@ -218,9 +218,9 @@ test-suite test
   build-depends:
     , base
     , bytestring
-    , cardano-ledger-api   >=1.11.0.0 && <1.12
-    , cardano-ledger-core  >=1.17.0.0 && <1.18
-    , cardano-ledger-mary  >=1.8.0.0  && <1.9
+    , cardano-ledger-api
+    , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-wallet-read
     , hspec                >=2.11.0   && <2.12
     , lens

--- a/lib/delta-chain/delta-chain.cabal
+++ b/lib/delta-chain/delta-chain.cabal
@@ -48,7 +48,7 @@ library
     , delta-types
     , exceptions
     , generic-lens
-    , io-classes         >=1.5.0.0 && <1.9
+    , io-classes
     , monad-logger
     , persistent
     , persistent-sqlite

--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -30,7 +30,7 @@ library
       base
     , delta-types
     , fmt
-    , io-classes    >=1.5.0.0 && <1.9
+    , io-classes
     , mtl
     , QuickCheck
     , transformers

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -44,7 +44,7 @@ library
     , containers
     , delta-store
     , delta-types
-    , io-classes     >=1.5.0.0 && <1.9
+    , io-classes
     , Only           ==0.1
     , sqlite-simple
     , text

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -52,7 +52,7 @@ library framework
     , bech32-th
     , bytestring
     , cardano-addresses                    >=4.0.2    && <4.1
-    , cardano-ledger-shelley               >=1.16.0.0 && <1.17
+    , cardano-ledger-shelley
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application
@@ -136,12 +136,12 @@ library scenarios
     , bech32-th
     , bytestring
     , cardano-addresses                     >=4.0.2     && <4.1
-    , cardano-api                           >=10.16.0.0 && <10.17
-    , cardano-crypto                        >=1.2.0     && <1.3
-    , cardano-crypto-class                  ^>=2.2.3
-    , cardano-ledger-alonzo                 >=1.13.0.0  && <1.14
-    , cardano-ledger-core                   >=1.17.0.0  && <1.18
-    , cardano-protocol-tpraos               >=1.4.0.0   && <1.5
+    , cardano-api
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-core
+    , cardano-protocol-tpraos
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -104,13 +104,13 @@ library
     , base58-bytestring                  >=0.1       && <0.2
     , bytestring                         >=0.10.6    && <0.13
     , cardano-addresses                  >=4.0.2     && <4.1
-    , cardano-api                        >=10.16.0.0 && <10.17
-    , cardano-binary                     >=1.7.1.0   && <1.8
+    , cardano-api
+    , cardano-binary
     , cardano-cli                        >=10.11.0.0
-    , cardano-data                       >=1.2.3.1   && <1.3
-    , cardano-ledger-api                 >=1.11.0.0  && <1.12
-    , cardano-ledger-core                >=1.17.0.0  && <1.18
-    , cardano-ledger-shelley             >=1.16.0.0  && <1.17
+    , cardano-data
+    , cardano-ledger-api
+    , cardano-ledger-core
+    , cardano-ledger-shelley
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
     , cardano-wallet-primitive
@@ -130,7 +130,7 @@ library
     , http-media                         >=0.8.1.1   && <0.9
     , insert-ordered-containers          >=0.2.3     && <0.3
     , int-cast                           >=0.2.0.0   && <0.3
-    , io-classes                         >=1.5.0.0   && <1.9
+    , io-classes
     , iohk-monitoring                    >=0.2.0.0   && <0.3
     , iohk-monitoring-extra
     , lens                               >=5.2.3     && <5.4
@@ -142,8 +142,8 @@ library
     , OddWord                            >=1.0.1.1   && <1.1
     , openapi3                           >=3.2.3     && <3.3
     , optparse-applicative               >=0.18.1.0  && <0.19
-    , ouroboros-network                  >=0.21.0.0  && <0.22
-    , ouroboros-network-api              >=0.14.0.0  && <0.15
+    , ouroboros-network
+    , ouroboros-network-api
     , pathtype                           >=0.8.1.3   && <0.9
     , profunctors                        >=5.6.2     && <5.7
     , QuickCheck                         >=2.14      && <2.16
@@ -232,13 +232,13 @@ common test-common
     , base
     , bytestring
     , cardano-addresses                    >=4.0.2    && <4.1
-    , cardano-binary                       >=1.7.1.0  && <1.8
-    , cardano-ledger-alonzo                >=1.13.0.0 && <1.14
-    , cardano-ledger-babbage               >=1.11.0.0 && <1.12
-    , cardano-ledger-byron                 >=1.1.0.0  && <1.2
-    , cardano-ledger-core                  >=1.17.0.0 && <1.18
-    , cardano-ledger-mary                  >=1.8.0.0  && <1.9
-    , cardano-ledger-shelley               >=1.16.0.0 && <1.17
+    , cardano-binary
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
@@ -255,8 +255,8 @@ common test-common
     , local-cluster:local-cluster-process
     , mtl
     , openapi3
-    , ouroboros-consensus-cardano          >=0.25.0.0 && <0.26
-    , ouroboros-network                    >=0.21.0.0 && <0.22
+    , ouroboros-consensus-cardano
+    , ouroboros-network
     , pathtype
     , QuickCheck
     , streaming                            >=0.2.4    && <0.3

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -68,19 +68,19 @@ library
   build-depends:
     , base                           >=4.14      && <5
     , bytestring                     >=0.10.6    && <0.13
-    , cardano-api                    >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-binary                 >=1.7.1.0   && <1.8
-    , cardano-crypto-class           ^>=2.2.3
-    , cardano-ledger-alonzo          >=1.13.0.0  && <1.14
-    , cardano-ledger-api             >=1.11.0.0  && <1.12
-    , cardano-ledger-babbage         >=1.11.0.0  && <1.12
-    , cardano-ledger-byron           >=1.1.0.0   && <1.2
-    , cardano-ledger-core            >=1.17.0.0  && <1.18
-    , cardano-ledger-mary            >=1.8.0.0   && <1.9
-    , cardano-ledger-shelley         >=1.16.0.0  && <1.17
-    , cardano-slotting               >=0.2.0.0   && <0.3
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-slotting
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-read            >=1.0.0.0   && <1.1
@@ -89,19 +89,19 @@ library
     , contra-tracer                  >=0.1       && <0.3
     , exceptions                     >=0.10.7    && <0.11
     , fmt                            >=0.6.3     && <0.7
-    , io-classes                     >=1.5.0.0   && <1.9
+    , io-classes
     , iohk-monitoring                >=0.2.0.0   && <0.3
     , iohk-monitoring-extra
     , network-mux                    >=0.6       && <0.10
     , nothunks                       >=0.1.5     && <0.4
-    , ouroboros-consensus            >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano    >=0.25.0.0  && <0.26
-    , ouroboros-consensus-diffusion  >=0.23.0.0  && <0.24
-    , ouroboros-consensus-protocol   >=0.12.0.0  && <0.13
-    , ouroboros-network              >=0.21.0.0  && <0.22
-    , ouroboros-network-api          >=0.14.0.0  && <0.15
-    , ouroboros-network-framework    >=0.18.0.0  && <0.19
-    , ouroboros-network-protocols    >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion
+    , ouroboros-consensus-protocol
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-protocols
     , parallel                       >=3.2.2     && <3.3
     , retry                          >=0.9.3     && <0.10
     , safe                           >=0.3.19    && <0.4
@@ -130,7 +130,7 @@ test-suite unit
     , containers
     , contra-tracer
     , hspec                         >=2.11.0  && <2.12
-    , io-classes                    >=1.5.0.0 && <1.9
+    , io-classes
     , QuickCheck                    >=2.14    && <2.16
     , text
     , transformers

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -46,26 +46,26 @@ library
     , binary
     , bytestring
     , cardano-addresses             >=4.0.2     && <4.1
-    , cardano-api                   >=10.16.0.0 && <10.17
-    , cardano-binary                >=1.7.1.0   && <1.8
-    , cardano-crypto                >=1.2.0     && <1.3
-    , cardano-crypto-class          ^>=2.2.3
+    , cardano-api
+    , cardano-binary
+    , cardano-crypto
+    , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-data                  >=1.2.3.1   && <1.3
-    , cardano-ledger-allegra        >=1.7.0.0   && <1.8
-    , cardano-ledger-alonzo         >=1.13.0.0  && <1.14
-    , cardano-ledger-api            >=1.11.0.0  && <1.12
-    , cardano-ledger-babbage        >=1.11.0.0  && <1.12
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-byron          >=1.1.0.0   && <1.2
-    , cardano-ledger-conway         >=1.19.0.0  && <1.20
-    , cardano-ledger-core           >=1.17.0.0  && <1.18
-    , cardano-ledger-mary           >=1.8.0.0   && <1.9
-    , cardano-ledger-shelley        >=1.16.0.0  && <1.17
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
     , cardano-numeric
     , cardano-protocol-tpraos
-    , cardano-slotting              >=0.2.0.0   && <0.3
-    , cardano-strict-containers     >=0.1.3.0   && <0.2
+    , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet-launcher
     , cardano-wallet-read
     , cardano-wallet-test-utils
@@ -94,11 +94,11 @@ library
     , network-uri
     , nothunks
     , OddWord
-    , ouroboros-consensus           >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano   >=0.25.0.0  && <0.26
-    , ouroboros-consensus-protocol  >=0.12.0.0  && <0.13
-    , ouroboros-network             >=0.21.0.0  && <0.22
-    , ouroboros-network-api         >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-protocol
+    , ouroboros-network
+    , ouroboros-network-api
     , pretty-simple
     , QuickCheck
     , quiet
@@ -229,16 +229,16 @@ test-suite test
     , binary
     , bytestring
     , cardano-addresses               >=4.0.2     && <4.1
-    , cardano-api                     >=10.16.0.0 && <10.17
-    , cardano-crypto-class            ^>=2.2.3
+    , cardano-api
+    , cardano-crypto-class
     , cardano-ledger-allegra:testlib  >=1.7.0.0   && <1.8
-    , cardano-ledger-api              >=1.11.0.0  && <1.12
-    , cardano-ledger-babbage          >=1.11.0.0  && <1.12
-    , cardano-ledger-core             >=1.17.0.0  && <1.18
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-core
     , cardano-ledger-core:testlib
-    , cardano-ledger-shelley          >=1.16.0.0  && <1.17
+    , cardano-ledger-shelley
     , cardano-numeric
-    , cardano-slotting                >=0.2.0.0   && <0.3
+    , cardano-slotting
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers
@@ -255,9 +255,9 @@ test-suite test
     , iohk-monitoring                 >=0.2.0.0   && <0.3
     , lens
     , memory
-    , ouroboros-consensus             >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano     >=0.25.0.0  && <0.26
-    , ouroboros-network-api           >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-network-api
     , QuickCheck
     , quickcheck-classes
     , quickcheck-instances

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
     , base
     , bytestring
-    , cardano-crypto     >=1.2.0 && <1.3
+    , cardano-crypto
     , cborg
     , crypto-primitives
     , deepseq

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -120,7 +120,7 @@ library shelley
     , base
     , bytestring
     , cardano-addresses             >=4.0.2   && <4.1
-    , cardano-slotting              >=0.2.0.0 && <0.3
+    , cardano-slotting
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-primitive

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -44,7 +44,7 @@ library test-common
   build-depends:
     , base
     , bytestring
-    , cardano-api                   >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-balance-tx
     , cardano-balance-tx:internal
     , cardano-wallet
@@ -74,17 +74,17 @@ test-suite unit
     , bech32-th
     , bytestring
     , cardano-addresses                   >=4.0.2     && <4.1
-    , cardano-api                         >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-api-extra
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-crypto                      >=1.2.0     && <1.3
-    , cardano-crypto-class                ^>=2.2.3
-    , cardano-ledger-alonzo               >=1.13.0.0  && <1.14
-    , cardano-ledger-babbage              >=1.11.0.0  && <1.12
-    , cardano-ledger-core                 >=1.17.0.0  && <1.18
-    , cardano-ledger-shelley              >=1.16.0.0  && <1.17
-    , cardano-slotting                    >=0.2.0.0   && <0.3
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-babbage
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-slotting
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application
@@ -125,7 +125,7 @@ test-suite unit
     , http-media
     , http-types
     , int-cast
-    , io-classes                          >=1.5.0.0   && <1.9
+    , io-classes
     , io-sim
     , iohk-monitoring                     >=0.2.0.0   && <0.3
     , iohk-monitoring-extra
@@ -143,9 +143,9 @@ test-suite unit
     , OddWord
     , openapi3
     , optparse-applicative
-    , ouroboros-consensus                 >=0.27.0.0  && <0.28
-    , ouroboros-network                   >=0.21.0.0  && <0.22
-    , ouroboros-network-api               >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
     , pathtype
     , persistent
     , persistent-sqlite

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -49,19 +49,19 @@ library
     , base
     , bytestring
     , cardano-addresses             >=4.0.2     && <4.1
-    , cardano-api                   >=10.16.0.0 && <10.17
+    , cardano-api
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-binary                >=1.7.1.0   && <1.8
-    , cardano-crypto                >=1.2.0     && <1.3
-    , cardano-crypto-class          ^>=2.2.3
+    , cardano-binary
+    , cardano-crypto
+    , cardano-crypto-class
     , cardano-crypto-wrapper
-    , cardano-ledger-allegra        >=1.7.0.0   && <1.8
-    , cardano-ledger-api            >=1.11.0.0  && <1.12
-    , cardano-ledger-byron          >=1.1.0.0   && <1.2
-    , cardano-ledger-core           >=1.17.0.0  && <1.18
-    , cardano-slotting              >=0.2.0.0   && <0.3
-    , cardano-strict-containers     >=0.1.3.0   && <0.2
+    , cardano-ledger-allegra
+    , cardano-ledger-api
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
@@ -91,7 +91,7 @@ library
     , http-client-tls
     , http-types
     , int-cast
-    , io-classes                    >=1.5.0.0   && <1.9
+    , io-classes
     , iohk-monitoring               >=0.2.0.0   && <0.3
     , iohk-monitoring-extra
     , lens
@@ -107,10 +107,10 @@ library
     , OddWord
     , optparse-applicative
     , ordered-containers
-    , ouroboros-consensus           >=0.27.0.0  && <0.28
-    , ouroboros-consensus-cardano   >=0.25.0.0  && <0.26
-    , ouroboros-network             >=0.21.0.0  && <0.22
-    , ouroboros-network-api         >=0.14.0.0  && <0.15
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-network
+    , ouroboros-network-api
     , path-pieces
     , persistent
     , persistent-sqlite


### PR DESCRIPTION
## Summary
- Strip cardano-ecosystem version bounds from all `.cabal` files
- Pin resolved versions as `==` constraints in `cabal.project`
- Pre-existing nix-provided packages (io-classes, cardano-crypto, cardano-prelude) excluded from pins

Extracted from #5197 to keep the node bump PR focused on era changes.