### PR TITLE
Add wallet-key-export executable with musl static build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           .#unit-delta-chain .#unit-delta-store .#unit-delta-table
           .#unit-delta-types .#unit-std-gen-seed .#unit-wai-middleware-logging
           .#unit-benchmark-history
+          .#wallet-key-export .#wallet-key-export-test
 
   build-gate-artifacts:
     name: "Build Gate (Linux Artifacts)"
@@ -144,6 +145,11 @@ jobs:
 
           - name: "benchmark-history-test"
             command: nix run --quiet .#unit-benchmark-history -- +RTS -M2G -s -RTS
+
+          - name: "wallet-key-export-test"
+            command: >-
+              nix shell --quiet .#wallet-key-export -c
+              nix run --quiet .#wallet-key-export-test -- +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Byron + CLI"
             working-directory: lib/unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: >-
           nix build --quiet
           .#ci.artifacts.linux64.release .#dockerTestImage
+          .#ci.artifacts.wallet-key-export-static
 
 
   build-gate-quality:
@@ -374,6 +375,25 @@ jobs:
         with:
           name: linux-release-package
           path: result/linux/
+
+  artifacts-wallet-key-export:
+    name: "Build wallet-key-export (static)"
+    needs: build-gate-artifacts
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build static binary
+        run: |
+          rm -rf ./result/*
+          nix build --quiet -o result/wallet-key-export .#ci.artifacts.wallet-key-export-static
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wallet-key-export-linux-static
+          path: result/wallet-key-export/bin/wallet-key-export
 
   artifacts-shell:
     name: "Evaluate Linux Shell"

--- a/docs/site/src/user/cli.md
+++ b/docs/site/src/user/cli.md
@@ -718,6 +718,49 @@ Available options:
 
 Show the software version.
 
+## wallet-key-export
+
+A standalone offline utility for extracting root private keys from a cardano-wallet SQLite database. This does not require the wallet server to be running.
+
+### Usage
+
+```
+wallet-key-export <path-to-wallet.db> <wallet-id>
+```
+
+The tool will:
+
+1. Read the encrypted root key from the database
+2. Auto-detect Byron vs Shelley key format
+3. Prompt for the spending passphrase (or read from stdin when piped)
+4. Verify the passphrase against the stored hash
+5. Decrypt and output the key in two formats:
+   - **Raw XPrv (hex)**: 256 hex characters (128 bytes)
+   - **Text Envelope**: JSON compatible with `cardano-cli`
+
+### Example
+
+```
+> wallet-key-export /path/to/wallet.db a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+Key type: Shelley
+
+=== Raw XPrv (hex) ===
+<256 hex chars>
+
+=== Text Envelope ===
+{
+    "type": "PaymentExtendedSigningKeyShelley_ed25519_bip32",
+    "description": "Payment Signing Key",
+    "cborHex": "5880<256 hex chars>"
+}
+```
+
+The passphrase can also be piped for scripted usage:
+
+```
+echo "my-spending-passphrase" | wallet-key-export wallet.db <wallet-id>
+```
+
 
 ## Bash Shell Command Completion
 

--- a/flake.nix
+++ b/flake.nix
@@ -280,7 +280,7 @@
                   backend = self.cardano-node;
                 };
                 # Local test cluster and mock metadata server
-                inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server;
+                inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server wallet-key-export;
                 inherit (project.hsPkgs.cardano-wallet-benchmarks.components.exes) benchmark-history;
                 inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
                 integration-exe = project.hsPkgs.cardano-wallet-integration.components.exes.integration-exe;
@@ -541,6 +541,7 @@
               };
             };
           imagePackages = mkPackages walletProject.projectCross.musl64;
+          staticPackages = mkPackages walletProject.projectCross.musl64;
         in
         rec {
 
@@ -558,6 +559,9 @@
             // rec {
               dockerImage = mkDockerImage true imagePackages;
               dockerTestImage = mkDockerImage false imagePackages;
+            }
+            // lib.optionalAttrs buildPlatform.isLinux {
+              wallet-key-export-static = staticPackages.wallet-key-export;
             }
             //
 

--- a/flake.nix
+++ b/flake.nix
@@ -593,6 +593,7 @@
                 };
               ci.artifacts = mkReleaseArtifacts walletProject // {
                 dockerImage = packages.dockerImage;
+                wallet-key-export-static = staticPackages.wallet-key-export;
               };
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -318,6 +318,7 @@
                 unit-std-gen-seed = project.hsPkgs.std-gen-seed.components.tests.unit;
                 unit-wai-middleware-logging = project.hsPkgs.wai-middleware-logging.components.tests.unit;
                 unit-benchmark-history = project.hsPkgs.cardano-wallet-benchmarks.components.tests.benchmark-history-test;
+                wallet-key-export-test = project.hsPkgs.cardano-wallet.components.tests.wallet-key-export-test;
 
                 # Combined project coverage report
                 testCoverageReport = coveredProject.projectCoverageReport;

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -286,6 +286,25 @@ library mock-token-metadata
 
   exposed-modules: Cardano.Wallet.TokenMetadata.MockServer
 
+executable wallet-key-export
+  import:        language, opts-exe
+  main-is:       exe/wallet-key-export.hs
+  build-depends:
+    , address-derivation-discovery
+    , base
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto
+    , cardano-wallet
+    , cardano-wallet-secrets
+    , memory
+    , monad-logger
+    , mtl
+    , persistent
+    , persistent-sqlite
+    , resourcet
+    , text
+
 -- Triggers this https://github.com/haskell/cabal/issues/6470
 -- if moved to an external library
 executable mock-token-metadata-server

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -305,6 +305,35 @@ executable wallet-key-export
     , resourcet
     , text
 
+test-suite wallet-key-export-test
+  import:        language, opts-exe
+  type:          exitcode-stdio-1.0
+  main-is:       exe/wallet-key-export-test.hs
+  build-depends:
+    , address-derivation-discovery
+    , base
+    , base16-bytestring
+    , bytestring
+    , cardano-addresses
+    , cardano-crypto
+    , cardano-wallet
+    , cardano-wallet-primitive
+    , cardano-wallet-secrets
+    , contra-tracer
+    , directory
+    , memory
+    , persistent
+    , persistent-sqlite
+    , process
+    , QuickCheck
+    , temporary
+    , text
+    , text-class
+    , time
+
+  build-tool-depends:
+    cardano-wallet:wallet-key-export
+
 -- Triggers this https://github.com/haskell/cabal/issues/6470
 -- if moved to an external library
 executable mock-token-metadata-server

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -9,9 +9,9 @@
 -- License: Apache-2.0
 --
 -- E2E round-trip test for the wallet-key-export executable.
--- Generates a random Shelley root key, stores it in a temp SQLite DB,
--- runs wallet-key-export, and verifies the extracted hex matches
--- the expected decrypted XPrv.
+-- Generates random Shelley and Byron root keys, stores them in a temp
+-- SQLite DB, runs wallet-key-export, and verifies the extracted hex
+-- matches the expected decrypted XPrv.
 module Main (main) where
 
 import Cardano.Crypto.Wallet
@@ -55,6 +55,9 @@ import Cardano.Wallet.Gen
 import Cardano.Wallet.Primitive.Passphrase
     ( encryptPassphrase
     , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Legacy
+    ( encryptPassphraseTestingOnly
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
@@ -119,7 +122,9 @@ import Test.QuickCheck.Test
     )
 import Prelude
 
+import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
@@ -133,9 +138,13 @@ main = do
                 putStrLn "wallet-key-export not found in PATH"
                 exitFailure
             Just path -> pure path
-    result <-
-        quickCheckResult $ withMaxSuccess 20 $ prop_shelleyRoundtrip exe
-    if isSuccess result
+    results <-
+        mapM
+            quickCheckResult
+            [ withMaxSuccess 20 $ prop_shelleyRoundtrip exe
+            , withMaxSuccess 20 $ prop_byronRoundtrip exe
+            ]
+    if all isSuccess results
         then putStrLn "All tests passed."
         else exitFailure
 
@@ -146,8 +155,7 @@ genUserPassphrase = do
     chars <- vectorOf n (choose ('a', 'z'))
     pure $ T.pack chars
 
--- | Property: storing a Shelley root key in a SQLite DB and running
--- wallet-key-export recovers the same decrypted XPrv.
+-- | Shelley: PBKDF2 passphrase scheme.
 prop_shelleyRoundtrip :: FilePath -> Property
 prop_shelleyRoundtrip exe =
     forAll
@@ -157,22 +165,58 @@ prop_shelleyRoundtrip exe =
             <*> genWalletId
         )
         $ \(mnemonic, passText, wid) ->
-            ioProperty $ shelleyRoundtrip exe mnemonic passText wid
+            ioProperty $ do
+                let userPass = mkUserPass passText
+                    encPass = preparePassphrase EncryptWithPBKDF2 userPass
+                    key = generateKeyFromSeed (mnemonic, Nothing) encPass
+                (_, passHash) <- encryptPassphrase userPass
+                let (rootHex, hashHex) = serializeXPrv ShelleyKeyS (key, passHash)
+                    xprv = getRawKey ShelleyKeyS key
+                    expected =
+                        B16.encode
+                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
+                runExportTest exe wid rootHex hashHex passText expected
 
-shelleyRoundtrip
-    :: FilePath -> SomeMnemonic -> T.Text -> WalletId -> IO Property
-shelleyRoundtrip exe mnemonic passText wid = do
-    let userPass =
-            Passphrase (BA.convert (T.encodeUtf8 passText))
-                :: Passphrase "user"
-        encPass = preparePassphrase EncryptWithPBKDF2 userPass
-        key = generateKeyFromSeed (mnemonic, Nothing) encPass
-    (_, passHash) <- encryptPassphrase userPass
-    let (rootHex, hashHex) = serializeXPrv ShelleyKeyS (key, passHash)
+-- | Byron: Scrypt passphrase scheme.
+prop_byronRoundtrip :: FilePath -> Property
+prop_byronRoundtrip exe =
+    forAll
+        ( (,,)
+            <$> (SomeMnemonic <$> genMnemonic @12)
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, passText, wid) ->
+            ioProperty $ do
+                let userPass = mkUserPass passText
+                    encPass = preparePassphrase EncryptWithScrypt userPass
+                    key = Byron.generateKeyFromSeed mnemonic encPass
+                passHash <- encryptPassphraseTestingOnly 64 encPass
+                let (rootHex, hashHex) = serializeXPrv ByronKeyS (key, passHash)
+                    xprv = getRawKey ByronKeyS key
+                    expected =
+                        B16.encode
+                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
+                runExportTest exe wid rootHex hashHex passText expected
 
+mkUserPass :: T.Text -> Passphrase "user"
+mkUserPass t = Passphrase (BA.convert (T.encodeUtf8 t))
+
+emptyPass :: Passphrase "encryption"
+emptyPass = mempty
+
+-- | Shared test logic: write key to temp DB, run the tool, compare output.
+runExportTest
+    :: FilePath
+    -> WalletId
+    -> BS.ByteString
+    -> BS.ByteString
+    -> T.Text
+    -> BS.ByteString
+    -> IO Property
+runExportTest exe wid rootHex hashHex passText expected =
     withSystemTempFile "wallet-export-test.db" $ \dbPath handle -> do
         hClose handle
-        -- Create schema and insert test data
         dbResult <-
             withSqliteContextFile
                 nullTracer
@@ -196,12 +240,6 @@ shelleyRoundtrip exe mnemonic passText wid = do
                         (T.unpack passText ++ "\n")
 
                 let extractedHex = extractHexFromOutput stdout_
-                    xprv = getRawKey ShelleyKeyS key
-                    emptyPass =
-                        mempty :: Passphrase "encryption"
-                    expected =
-                        B16.encode
-                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
 
                 pure
                     $ counterexample ("stdout: " <> stdout_)

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -150,6 +150,8 @@ main = do
             , withMaxSuccess 20 $ prop_byronRoundtrip exe
             , withMaxSuccess 20 $ prop_wrongPassphrase exe
             , withMaxSuccess 20 $ prop_wrongPassphraseByron exe
+            , withMaxSuccess 20 $ prop_wrongSchemeShelley exe
+            , withMaxSuccess 20 $ prop_wrongSchemeByron exe
             ]
     if all isSuccess results
         then putStrLn "All tests passed."
@@ -316,6 +318,65 @@ prop_wrongPassphraseByron exe =
                         rootHex
                         hashHex
                         wrongPass
+
+-- | Correct passphrase but wrong scheme must fail.
+-- Shelley key stored with Scrypt hash: tool assumes PBKDF2, fails.
+prop_wrongSchemeShelley :: FilePath -> Property
+prop_wrongSchemeShelley exe =
+    forAll
+        ( (,,)
+            <$> genShelleyMnemonic
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, userPass, wid) ->
+            ioProperty $ do
+                let encPass =
+                        preparePassphrase EncryptWithScrypt userPass
+                    key =
+                        generateKeyFromSeed
+                            (mnemonic, Nothing)
+                            encPass
+                passHash <-
+                    encryptPassphraseTestingOnly 64 encPass
+                let (rootHex, hashHex) =
+                        serializeXPrv ShelleyKeyS (key, passHash)
+                -- Tool detects Shelley, assumes PBKDF2, but hash
+                -- is Scrypt — should fail even with correct pass.
+                runWrongPassTest
+                    exe
+                    wid
+                    rootHex
+                    hashHex
+                    userPass
+
+-- | Correct passphrase but wrong scheme must fail.
+-- Byron key stored with PBKDF2 hash: tool assumes Scrypt, fails.
+prop_wrongSchemeByron :: FilePath -> Property
+prop_wrongSchemeByron exe =
+    forAll
+        ( (,,)
+            <$> genByronMnemonic
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, userPass, wid) ->
+            ioProperty $ do
+                let encPass =
+                        preparePassphrase EncryptWithPBKDF2 userPass
+                    key =
+                        Byron.generateKeyFromSeed mnemonic encPass
+                (_, passHash) <- encryptPassphrase userPass
+                let (rootHex, hashHex) =
+                        serializeXPrv ByronKeyS (key, passHash)
+                -- Tool detects Byron, assumes Scrypt, but hash
+                -- is PBKDF2 — should fail even with correct pass.
+                runWrongPassTest
+                    exe
+                    wid
+                    rootHex
+                    hashHex
+                    userPass
 
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -60,7 +60,8 @@ import Cardano.Wallet.Primitive.Passphrase.Gen
     ( genUserPassphrase
     )
 import Cardano.Wallet.Primitive.Passphrase.Legacy
-    ( encryptPassphraseTestingOnly
+    ( PassphraseHashLength
+    , encryptPassphraseTestingOnly
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
@@ -111,12 +112,14 @@ import Test.QuickCheck
     ( Gen
     , Property
     , counterexample
+    , elements
     , forAll
     , ioProperty
     , oneof
     , withMaxSuccess
     , (.&&.)
     , (===)
+    , (==>)
     )
 import Test.QuickCheck.Test
     ( isSuccess
@@ -145,6 +148,7 @@ main = do
             quickCheckResult
             [ withMaxSuccess 20 $ prop_shelleyRoundtrip exe
             , withMaxSuccess 20 $ prop_byronRoundtrip exe
+            , withMaxSuccess 20 $ prop_wrongPassphrase exe
             ]
     if all isSuccess results
         then putStrLn "All tests passed."
@@ -166,6 +170,10 @@ genSecondFactor =
         , Just . SomeMnemonic <$> genMnemonic @9
         , Just . SomeMnemonic <$> genMnemonic @12
         ]
+
+-- | Generate a Scrypt hash length (32, 64, or 128 bytes).
+genScryptHashLength :: Gen PassphraseHashLength
+genScryptHashLength = elements [32, 64, 128]
 
 -- | Generate a Byron mnemonic (12 or 15 words).
 genByronMnemonic :: Gen SomeMnemonic
@@ -214,21 +222,24 @@ prop_shelleyRoundtrip exe =
                     userPass
                     expected
 
--- | Byron: Scrypt passphrase scheme with varied mnemonic sizes.
+-- | Byron: Scrypt passphrase scheme with varied mnemonic sizes
+-- and hash lengths.
 prop_byronRoundtrip :: FilePath -> Property
 prop_byronRoundtrip exe =
     forAll
-        ( (,,)
+        ( (,,,)
             <$> genByronMnemonic
             <*> genUserPassphrase
+            <*> genScryptHashLength
             <*> genWalletId
         )
-        $ \(mnemonic, userPass, wid) ->
+        $ \(mnemonic, userPass, hashLen, wid) ->
             ioProperty $ do
                 let encPass =
                         preparePassphrase EncryptWithScrypt userPass
                     key = Byron.generateKeyFromSeed mnemonic encPass
-                passHash <- encryptPassphraseTestingOnly 64 encPass
+                passHash <-
+                    encryptPassphraseTestingOnly hashLen encPass
                 let (rootHex, hashHex) =
                         serializeXPrv ByronKeyS (key, passHash)
                     xprv = getRawKey ByronKeyS key
@@ -248,6 +259,28 @@ prop_byronRoundtrip exe =
                     hashHex
                     userPass
                     expected
+
+-- | Wrong passphrase must cause the tool to exit with failure.
+prop_wrongPassphrase :: FilePath -> Property
+prop_wrongPassphrase exe =
+    forAll
+        ( (,,,)
+            <$> genShelleyMnemonic
+            <*> genUserPassphrase
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, userPass, wrongPass, wid) ->
+            userPass /= wrongPass ==>
+                ioProperty $ do
+                    let encPass =
+                            preparePassphrase EncryptWithPBKDF2 userPass
+                        key =
+                            generateKeyFromSeed (mnemonic, Nothing) encPass
+                    (_, passHash) <- encryptPassphrase userPass
+                    let (rootHex, hashHex) =
+                            serializeXPrv ShelleyKeyS (key, passHash)
+                    runWrongPassTest exe wid rootHex hashHex wrongPass
 
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty
@@ -306,6 +339,48 @@ runExportTest exe wid rootHex hashHex userPass expected =
                             ("exit: " <> show exitCode)
                         $ (exitCode === ExitSuccess)
                         .&&. (extractedHex === expected)
+
+-- | Test that a wrong passphrase causes the tool to fail.
+runWrongPassTest
+    :: FilePath
+    -> WalletId
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Passphrase "user"
+    -> IO Property
+runWrongPassTest exe wid rootHex hashHex wrongPass =
+    withSystemTempFile "wallet-export-test.db"
+        $ \dbPath handle -> do
+            hClose handle
+            dbResult <-
+                withSqliteContextFile
+                    nullTracer
+                    dbPath
+                    noManualMigration
+                    migrateAll
+                    $ \db ->
+                        runQuery db $ do
+                            insertWallet wid
+                            insert_
+                                $ PrivateKey wid rootHex hashHex
+            case dbResult of
+                Left err ->
+                    pure
+                        $ counterexample
+                            ("DB migration error: " <> show err)
+                        $ False === True
+                Right () -> do
+                    let widHex = T.unpack (toText wid)
+                        passText = passphraseToText wrongPass
+                    (exitCode, stdout_, _stderr) <-
+                        readCreateProcessWithExitCode
+                            (proc exe [dbPath, widHex])
+                            (T.unpack passText ++ "\n")
+                    pure
+                        $ counterexample
+                            ("stdout: " <> stdout_)
+                        $ exitCode
+                            === ExitFailure 1
 
 -- | Extract the hex line from wallet-key-export output.
 -- Looks for the line after "=== Raw XPrv (hex) ===".

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- E2E round-trip test for the wallet-key-export executable.
+-- Generates a random Shelley root key, stores it in a temp SQLite DB,
+-- runs wallet-key-export, and verifies the extracted hex matches
+-- the expected decrypted XPrv.
+module Main (main) where
+
+import Cardano.Crypto.Wallet
+    ( unXPrv
+    , xPrvChangePass
+    )
+import Cardano.DB.Sqlite
+    ( runQuery
+    , withSqliteContextFile
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( noManualMigration
+    )
+import Cardano.Mnemonic
+    ( SomeMnemonic (..)
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( generateKeyFromSeed
+    )
+import Cardano.Wallet.Address.Keys.PersistPrivateKey
+    ( serializeXPrv
+    )
+import Cardano.Wallet.Address.Keys.WalletKey
+    ( getRawKey
+    )
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( PrivateKey (..)
+    , Wallet (..)
+    , migrateAll
+    )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( BlockId (..)
+    )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (..)
+    )
+import Cardano.Wallet.Gen
+    ( genMnemonic
+    , genWalletId
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( encryptPassphrase
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..)
+    , PassphraseScheme (..)
+    )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex
+    )
+import Control.Tracer
+    ( nullTracer
+    )
+import Data.Text.Class
+    ( toText
+    )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    )
+import Database.Persist
+    ( insert_
+    )
+import Database.Persist.Sql
+    ( SqlPersistT
+    )
+import System.Directory
+    ( findExecutable
+    )
+import System.Exit
+    ( ExitCode (..)
+    , exitFailure
+    )
+import System.IO
+    ( hClose
+    )
+import System.IO.Temp
+    ( withSystemTempFile
+    )
+import System.Process
+    ( proc
+    , readCreateProcessWithExitCode
+    )
+import Test.QuickCheck
+    ( Gen
+    , Property
+    , choose
+    , counterexample
+    , forAll
+    , ioProperty
+    , vectorOf
+    , withMaxSuccess
+    , (.&&.)
+    , (===)
+    )
+import Test.QuickCheck.Test
+    ( isSuccess
+    , quickCheckResult
+    )
+import Prelude
+
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+main :: IO ()
+main = do
+    exe <-
+        findExecutable "wallet-key-export" >>= \case
+            Nothing -> do
+                putStrLn "wallet-key-export not found in PATH"
+                exitFailure
+            Just path -> pure path
+    result <-
+        quickCheckResult $ withMaxSuccess 20 $ prop_shelleyRoundtrip exe
+    if isSuccess result
+        then putStrLn "All tests passed."
+        else exitFailure
+
+-- | Generate a user passphrase of 10–50 lowercase ASCII chars.
+genUserPassphrase :: Gen T.Text
+genUserPassphrase = do
+    n <- choose (10 :: Int, 50)
+    chars <- vectorOf n (choose ('a', 'z'))
+    pure $ T.pack chars
+
+-- | Property: storing a Shelley root key in a SQLite DB and running
+-- wallet-key-export recovers the same decrypted XPrv.
+prop_shelleyRoundtrip :: FilePath -> Property
+prop_shelleyRoundtrip exe =
+    forAll
+        ( (,,)
+            <$> (SomeMnemonic <$> genMnemonic @12)
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, passText, wid) ->
+            ioProperty $ shelleyRoundtrip exe mnemonic passText wid
+
+shelleyRoundtrip
+    :: FilePath -> SomeMnemonic -> T.Text -> WalletId -> IO Property
+shelleyRoundtrip exe mnemonic passText wid = do
+    let userPass =
+            Passphrase (BA.convert (T.encodeUtf8 passText))
+                :: Passphrase "user"
+        encPass = preparePassphrase EncryptWithPBKDF2 userPass
+        key = generateKeyFromSeed (mnemonic, Nothing) encPass
+    (_, passHash) <- encryptPassphrase userPass
+    let (rootHex, hashHex) = serializeXPrv ShelleyKeyS (key, passHash)
+
+    withSystemTempFile "wallet-export-test.db" $ \dbPath handle -> do
+        hClose handle
+        -- Create schema and insert test data
+        dbResult <-
+            withSqliteContextFile
+                nullTracer
+                dbPath
+                noManualMigration
+                migrateAll
+                $ \db ->
+                    runQuery db $ do
+                        insertWallet wid
+                        insert_ $ PrivateKey wid rootHex hashHex
+        case dbResult of
+            Left err ->
+                pure
+                    $ counterexample ("DB migration error: " <> show err)
+                    $ False === True
+            Right () -> do
+                let widHex = T.unpack (toText wid)
+                (exitCode, stdout_, _stderr) <-
+                    readCreateProcessWithExitCode
+                        (proc exe [dbPath, widHex])
+                        (T.unpack passText ++ "\n")
+
+                let extractedHex = extractHexFromOutput stdout_
+                    xprv = getRawKey ShelleyKeyS key
+                    emptyPass =
+                        mempty :: Passphrase "encryption"
+                    expected =
+                        B16.encode
+                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
+
+                pure
+                    $ counterexample ("stdout: " <> stdout_)
+                    $ counterexample ("exit: " <> show exitCode)
+                    $ (exitCode === ExitSuccess)
+                    .&&. (extractedHex === expected)
+
+-- | Extract the hex line from wallet-key-export output.
+-- Looks for the line after "=== Raw XPrv (hex) ===".
+extractHexFromOutput :: String -> B8.ByteString
+extractHexFromOutput output =
+    case dropWhile (/= "=== Raw XPrv (hex) ===") (lines output) of
+        (_ : hexLine : _) -> B8.pack hexLine
+        _ -> error $ "Could not parse hex from output:\n" <> output
+
+-- | Insert a wallet row to satisfy foreign key constraints.
+insertWallet :: WalletId -> SqlPersistT IO ()
+insertWallet wid =
+    insert_
+        $ Wallet
+            { walId = wid
+            , walName = "test-wallet"
+            , walCreationTime = posixSecondsToUTCTime 1506203091
+            , walPassphraseLastUpdatedAt = Nothing
+            , walPassphraseScheme = Nothing
+            , walGenesisHash = BlockId dummyHash
+            , walGenesisStart = posixSecondsToUTCTime 1506203091
+            }
+  where
+    dummyHash =
+        Hash
+            $ unsafeFromHex
+                "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -149,6 +149,7 @@ main = do
             [ withMaxSuccess 20 $ prop_shelleyRoundtrip exe
             , withMaxSuccess 20 $ prop_byronRoundtrip exe
             , withMaxSuccess 20 $ prop_wrongPassphrase exe
+            , withMaxSuccess 20 $ prop_wrongPassphraseByron exe
             ]
     if all isSuccess results
         then putStrLn "All tests passed."
@@ -281,6 +282,40 @@ prop_wrongPassphrase exe =
                     let (rootHex, hashHex) =
                             serializeXPrv ShelleyKeyS (key, passHash)
                     runWrongPassTest exe wid rootHex hashHex wrongPass
+
+-- | Wrong passphrase with Byron/Scrypt scheme.
+prop_wrongPassphraseByron :: FilePath -> Property
+prop_wrongPassphraseByron exe =
+    forAll
+        ( (,,,)
+            <$> genByronMnemonic
+            <*> genUserPassphrase
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, userPass, wrongPass, wid) ->
+            userPass /= wrongPass ==>
+                ioProperty $ do
+                    let encPass =
+                            preparePassphrase
+                                EncryptWithScrypt
+                                userPass
+                        key =
+                            Byron.generateKeyFromSeed
+                                mnemonic
+                                encPass
+                    passHash <-
+                        encryptPassphraseTestingOnly 64 encPass
+                    let (rootHex, hashHex) =
+                            serializeXPrv
+                                ByronKeyS
+                                (key, passHash)
+                    runWrongPassTest
+                        exe
+                        wid
+                        rootHex
+                        hashHex
+                        wrongPass
 
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 -- |
--- Copyright: © 2024 Cardano Foundation
+-- Copyright: © 2026 Cardano Foundation
 -- License: Apache-2.0
 --
 -- E2E round-trip test for the wallet-key-export executable.
@@ -111,6 +111,7 @@ import Test.QuickCheck
     , counterexample
     , forAll
     , ioProperty
+    , oneof
     , vectorOf
     , withMaxSuccess
     , (.&&.)
@@ -155,49 +156,106 @@ genUserPassphrase = do
     chars <- vectorOf n (choose ('a', 'z'))
     pure $ T.pack chars
 
--- | Shelley: PBKDF2 passphrase scheme.
+-- | Generate a Shelley mnemonic (15 or 24 words).
+genShelleyMnemonic :: Gen SomeMnemonic
+genShelleyMnemonic =
+    oneof
+        [ SomeMnemonic <$> genMnemonic @15
+        , SomeMnemonic <$> genMnemonic @24
+        ]
+
+-- | Generate an optional second-factor mnemonic for Shelley.
+genSecondFactor :: Gen (Maybe SomeMnemonic)
+genSecondFactor =
+    oneof
+        [ pure Nothing
+        , Just . SomeMnemonic <$> genMnemonic @9
+        , Just . SomeMnemonic <$> genMnemonic @12
+        ]
+
+-- | Generate a Byron mnemonic (12 or 15 words).
+genByronMnemonic :: Gen SomeMnemonic
+genByronMnemonic =
+    oneof
+        [ SomeMnemonic <$> genMnemonic @12
+        , SomeMnemonic <$> genMnemonic @15
+        ]
+
+-- | Shelley: PBKDF2 passphrase scheme with optional second factor.
 prop_shelleyRoundtrip :: FilePath -> Property
 prop_shelleyRoundtrip exe =
     forAll
-        ( (,,)
-            <$> (SomeMnemonic <$> genMnemonic @12)
+        ( (,,,)
+            <$> genShelleyMnemonic
+            <*> genSecondFactor
             <*> genUserPassphrase
             <*> genWalletId
         )
-        $ \(mnemonic, passText, wid) ->
+        $ \(mnemonic, secondFactor, passphrase, wid) ->
             ioProperty $ do
-                let userPass = mkUserPass passText
-                    encPass = preparePassphrase EncryptWithPBKDF2 userPass
-                    key = generateKeyFromSeed (mnemonic, Nothing) encPass
+                let userPass = mkUserPass passphrase
+                    encPass =
+                        preparePassphrase EncryptWithPBKDF2 userPass
+                    key =
+                        generateKeyFromSeed
+                            (mnemonic, secondFactor)
+                            encPass
                 (_, passHash) <- encryptPassphrase userPass
-                let (rootHex, hashHex) = serializeXPrv ShelleyKeyS (key, passHash)
+                let (rootHex, hashHex) =
+                        serializeXPrv ShelleyKeyS (key, passHash)
                     xprv = getRawKey ShelleyKeyS key
                     expected =
                         B16.encode
-                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
-                runExportTest exe wid rootHex hashHex passText expected
+                            ( unXPrv
+                                ( xPrvChangePass
+                                    encPass
+                                    emptyPass
+                                    xprv
+                                )
+                            )
+                runExportTest
+                    exe
+                    wid
+                    rootHex
+                    hashHex
+                    passphrase
+                    expected
 
--- | Byron: Scrypt passphrase scheme.
+-- | Byron: Scrypt passphrase scheme with varied mnemonic sizes.
 prop_byronRoundtrip :: FilePath -> Property
 prop_byronRoundtrip exe =
     forAll
         ( (,,)
-            <$> (SomeMnemonic <$> genMnemonic @12)
+            <$> genByronMnemonic
             <*> genUserPassphrase
             <*> genWalletId
         )
-        $ \(mnemonic, passText, wid) ->
+        $ \(mnemonic, passphrase, wid) ->
             ioProperty $ do
-                let userPass = mkUserPass passText
-                    encPass = preparePassphrase EncryptWithScrypt userPass
+                let userPass = mkUserPass passphrase
+                    encPass =
+                        preparePassphrase EncryptWithScrypt userPass
                     key = Byron.generateKeyFromSeed mnemonic encPass
                 passHash <- encryptPassphraseTestingOnly 64 encPass
-                let (rootHex, hashHex) = serializeXPrv ByronKeyS (key, passHash)
+                let (rootHex, hashHex) =
+                        serializeXPrv ByronKeyS (key, passHash)
                     xprv = getRawKey ByronKeyS key
                     expected =
                         B16.encode
-                            (unXPrv (xPrvChangePass encPass emptyPass xprv))
-                runExportTest exe wid rootHex hashHex passText expected
+                            ( unXPrv
+                                ( xPrvChangePass
+                                    encPass
+                                    emptyPass
+                                    xprv
+                                )
+                            )
+                runExportTest
+                    exe
+                    wid
+                    rootHex
+                    hashHex
+                    passphrase
+                    expected
 
 mkUserPass :: T.Text -> Passphrase "user"
 mkUserPass t = Passphrase (BA.convert (T.encodeUtf8 t))
@@ -205,7 +263,8 @@ mkUserPass t = Passphrase (BA.convert (T.encodeUtf8 t))
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty
 
--- | Shared test logic: write key to temp DB, run the tool, compare output.
+-- | Shared test logic: write key to temp DB, run the tool,
+-- compare output.
 runExportTest
     :: FilePath
     -> WalletId
@@ -214,46 +273,57 @@ runExportTest
     -> T.Text
     -> BS.ByteString
     -> IO Property
-runExportTest exe wid rootHex hashHex passText expected =
-    withSystemTempFile "wallet-export-test.db" $ \dbPath handle -> do
-        hClose handle
-        dbResult <-
-            withSqliteContextFile
-                nullTracer
-                dbPath
-                noManualMigration
-                migrateAll
-                $ \db ->
-                    runQuery db $ do
-                        insertWallet wid
-                        insert_ $ PrivateKey wid rootHex hashHex
-        case dbResult of
-            Left err ->
-                pure
-                    $ counterexample ("DB migration error: " <> show err)
-                    $ False === True
-            Right () -> do
-                let widHex = T.unpack (toText wid)
-                (exitCode, stdout_, _stderr) <-
-                    readCreateProcessWithExitCode
-                        (proc exe [dbPath, widHex])
-                        (T.unpack passText ++ "\n")
+runExportTest exe wid rootHex hashHex passphrase expected =
+    withSystemTempFile "wallet-export-test.db"
+        $ \dbPath handle -> do
+            hClose handle
+            dbResult <-
+                withSqliteContextFile
+                    nullTracer
+                    dbPath
+                    noManualMigration
+                    migrateAll
+                    $ \db ->
+                        runQuery db $ do
+                            insertWallet wid
+                            insert_
+                                $ PrivateKey wid rootHex hashHex
+            case dbResult of
+                Left err ->
+                    pure
+                        $ counterexample
+                            ("DB migration error: " <> show err)
+                        $ False === True
+                Right () -> do
+                    let widHex = T.unpack (toText wid)
+                    (exitCode, stdout_, _stderr) <-
+                        readCreateProcessWithExitCode
+                            (proc exe [dbPath, widHex])
+                            (T.unpack passphrase ++ "\n")
 
-                let extractedHex = extractHexFromOutput stdout_
+                    let extractedHex =
+                            extractHexFromOutput stdout_
 
-                pure
-                    $ counterexample ("stdout: " <> stdout_)
-                    $ counterexample ("exit: " <> show exitCode)
-                    $ (exitCode === ExitSuccess)
-                    .&&. (extractedHex === expected)
+                    pure
+                        $ counterexample
+                            ("stdout: " <> stdout_)
+                        $ counterexample
+                            ("exit: " <> show exitCode)
+                        $ (exitCode === ExitSuccess)
+                        .&&. (extractedHex === expected)
 
 -- | Extract the hex line from wallet-key-export output.
 -- Looks for the line after "=== Raw XPrv (hex) ===".
 extractHexFromOutput :: String -> B8.ByteString
 extractHexFromOutput output =
-    case dropWhile (/= "=== Raw XPrv (hex) ===") (lines output) of
+    case dropWhile
+        (/= "=== Raw XPrv (hex) ===")
+        (lines output) of
         (_ : hexLine : _) -> B8.pack hexLine
-        _ -> error $ "Could not parse hex from output:\n" <> output
+        _ ->
+            error
+                $ "Could not parse hex from output:\n"
+                    <> output
 
 -- | Insert a wallet row to satisfy foreign key constraints.
 insertWallet :: WalletId -> SqlPersistT IO ()
@@ -262,11 +332,13 @@ insertWallet wid =
         $ Wallet
             { walId = wid
             , walName = "test-wallet"
-            , walCreationTime = posixSecondsToUTCTime 1506203091
+            , walCreationTime =
+                posixSecondsToUTCTime 1506203091
             , walPassphraseLastUpdatedAt = Nothing
             , walPassphraseScheme = Nothing
             , walGenesisHash = BlockId dummyHash
-            , walGenesisStart = posixSecondsToUTCTime 1506203091
+            , walGenesisStart =
+                posixSecondsToUTCTime 1506203091
             }
   where
     dummyHash =

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -56,6 +56,9 @@ import Cardano.Wallet.Primitive.Passphrase
     ( encryptPassphrase
     , preparePassphrase
     )
+import Cardano.Wallet.Primitive.Passphrase.Gen
+    ( genUserPassphrase
+    )
 import Cardano.Wallet.Primitive.Passphrase.Legacy
     ( encryptPassphraseTestingOnly
     )
@@ -107,12 +110,10 @@ import System.Process
 import Test.QuickCheck
     ( Gen
     , Property
-    , choose
     , counterexample
     , forAll
     , ioProperty
     , oneof
-    , vectorOf
     , withMaxSuccess
     , (.&&.)
     , (===)
@@ -149,13 +150,6 @@ main = do
         then putStrLn "All tests passed."
         else exitFailure
 
--- | Generate a user passphrase of 10–50 lowercase ASCII chars.
-genUserPassphrase :: Gen T.Text
-genUserPassphrase = do
-    n <- choose (10 :: Int, 50)
-    chars <- vectorOf n (choose ('a', 'z'))
-    pure $ T.pack chars
-
 -- | Generate a Shelley mnemonic (15 or 24 words).
 genShelleyMnemonic :: Gen SomeMnemonic
 genShelleyMnemonic =
@@ -191,10 +185,9 @@ prop_shelleyRoundtrip exe =
             <*> genUserPassphrase
             <*> genWalletId
         )
-        $ \(mnemonic, secondFactor, passphrase, wid) ->
+        $ \(mnemonic, secondFactor, userPass, wid) ->
             ioProperty $ do
-                let userPass = mkUserPass passphrase
-                    encPass =
+                let encPass =
                         preparePassphrase EncryptWithPBKDF2 userPass
                     key =
                         generateKeyFromSeed
@@ -218,7 +211,7 @@ prop_shelleyRoundtrip exe =
                     wid
                     rootHex
                     hashHex
-                    passphrase
+                    userPass
                     expected
 
 -- | Byron: Scrypt passphrase scheme with varied mnemonic sizes.
@@ -230,10 +223,9 @@ prop_byronRoundtrip exe =
             <*> genUserPassphrase
             <*> genWalletId
         )
-        $ \(mnemonic, passphrase, wid) ->
+        $ \(mnemonic, userPass, wid) ->
             ioProperty $ do
-                let userPass = mkUserPass passphrase
-                    encPass =
+                let encPass =
                         preparePassphrase EncryptWithScrypt userPass
                     key = Byron.generateKeyFromSeed mnemonic encPass
                 passHash <- encryptPassphraseTestingOnly 64 encPass
@@ -254,14 +246,16 @@ prop_byronRoundtrip exe =
                     wid
                     rootHex
                     hashHex
-                    passphrase
+                    userPass
                     expected
-
-mkUserPass :: T.Text -> Passphrase "user"
-mkUserPass t = Passphrase (BA.convert (T.encodeUtf8 t))
 
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty
+
+-- | Convert a passphrase to text for piping to stdin.
+passphraseToText :: Passphrase "user" -> T.Text
+passphraseToText (Passphrase bytes) =
+    T.decodeUtf8 (BA.convert bytes)
 
 -- | Shared test logic: write key to temp DB, run the tool,
 -- compare output.
@@ -270,10 +264,10 @@ runExportTest
     -> WalletId
     -> BS.ByteString
     -> BS.ByteString
-    -> T.Text
+    -> Passphrase "user"
     -> BS.ByteString
     -> IO Property
-runExportTest exe wid rootHex hashHex passphrase expected =
+runExportTest exe wid rootHex hashHex userPass expected =
     withSystemTempFile "wallet-export-test.db"
         $ \dbPath handle -> do
             hClose handle
@@ -296,10 +290,11 @@ runExportTest exe wid rootHex hashHex passphrase expected =
                         $ False === True
                 Right () -> do
                     let widHex = T.unpack (toText wid)
+                        passText = passphraseToText userPass
                     (exitCode, stdout_, _stderr) <-
                         readCreateProcessWithExitCode
                             (proc exe [dbPath, widHex])
-                            (T.unpack passphrase ++ "\n")
+                            (T.unpack passText ++ "\n")
 
                     let extractedHex =
                             extractHexFromOutput stdout_

--- a/lib/wallet/exe/wallet-key-export.hs
+++ b/lib/wallet/exe/wallet-key-export.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Extract a wallet root private key from a cardano-wallet SQLite database.
+-- Auto-detects Byron vs Shelley key format, verifies the spending passphrase,
+-- decrypts the XPrv, and outputs both raw hex and cardano-cli text envelope.
+module Main (main) where
+
+import Cardano.Crypto.Wallet
+    ( unXPrv
+    , xPrvChangePass
+    )
+import Cardano.Wallet.Address.Keys.PersistPrivateKey
+    ( unsafeDeserializeXPrv
+    )
+import Cardano.Wallet.Address.Keys.WalletKey
+    ( getRawKey
+    )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (..)
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( checkPassphrase
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( ErrWrongPassphrase (..)
+    , Passphrase (..)
+    , PassphraseScheme (..)
+    )
+import Control.Monad
+    ( when
+    )
+import Control.Monad.Logger
+    ( runNoLoggingT
+    )
+import Control.Monad.Reader
+    ( runReaderT
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Database.Persist.Sql
+    ( PersistValue (..)
+    , Single (..)
+    , rawSql
+    )
+import Database.Persist.Sqlite
+    ( withSqliteConn
+    )
+import Prelude
+import System.Environment
+    ( getArgs
+    )
+import System.Exit
+    ( exitFailure
+    )
+import System.IO
+    ( hFlush
+    , hGetEcho
+    , hSetEcho
+    , stdin
+    , stdout
+    )
+import Control.Monad.Trans.Resource
+    ( runResourceT
+    )
+
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as TIO
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        [dbPath, walletId] -> run dbPath (T.pack walletId)
+        _ -> do
+            putStrLn "Usage: wallet-key-export <path-to-wallet.db> <wallet-id>"
+            exitFailure
+
+run :: FilePath -> T.Text -> IO ()
+run dbPath walletId = do
+    -- Read root key and hash from the SQLite database
+    (rootHex, hashHex) <- readPrivateKey dbPath walletId
+
+    -- Auto-detect key type: Byron keys contain ':' separator
+    let isByron = B8.elem ':' rootHex
+
+    -- Deserialize and extract XPrv + PassphraseHash
+    let (xprv, passHash, scheme) =
+            if isByron
+                then
+                    let (key, h) =
+                            unsafeDeserializeXPrv ByronKeyS (rootHex, hashHex)
+                    in  (getRawKey ByronKeyS key, h, EncryptWithScrypt)
+                else
+                    let (key, h) =
+                            unsafeDeserializeXPrv ShelleyKeyS (rootHex, hashHex)
+                    in  (getRawKey ShelleyKeyS key, h, EncryptWithPBKDF2)
+
+    putStrLn
+        $ "Key type: "
+            <> if isByron then "Byron" else "Shelley"
+
+    -- Prompt for passphrase
+    userPass <- promptPassphrase
+
+    -- Verify passphrase
+    case checkPassphrase scheme userPass passHash of
+        Left ErrWrongPassphrase -> do
+            putStrLn "Error: wrong passphrase"
+            exitFailure
+        Right () -> pure ()
+
+    -- Decrypt: change passphrase from user's to empty
+    let prepared = preparePassphrase scheme userPass
+        emptyPass = mempty :: Passphrase "encryption"
+        decrypted = xPrvChangePass prepared emptyPass xprv
+
+    -- Output raw hex (128 bytes = 256 hex chars)
+    let hexKey = B16.encode (unXPrv decrypted)
+    putStrLn ""
+    putStrLn "=== Raw XPrv (hex) ==="
+    B8.putStrLn hexKey
+
+    -- Output cardano-cli text envelope JSON
+    let (envType, cborPrefix) =
+            if isByron
+                then
+                    ( "PaymentSigningKeyByron_ed25519_bip32" :: String
+                    , "5880"
+                    )
+                else
+                    ( "PaymentExtendedSigningKeyShelley_ed25519_bip32"
+                    , "5880"
+                    )
+        cborHex = B8.pack cborPrefix <> hexKey
+    putStrLn ""
+    putStrLn "=== Text Envelope ==="
+    putStrLn "{"
+    putStrLn $ "    \"type\": \"" <> envType <> "\","
+    putStrLn "    \"description\": \"Payment Signing Key\","
+    putStrLn $ "    \"cborHex\": \"" <> B8.unpack cborHex <> "\""
+    putStrLn "}"
+
+readPrivateKey :: FilePath -> T.Text -> IO (ByteString, ByteString)
+readPrivateKey dbPath walletId = do
+    result <-
+        runResourceT
+            . runNoLoggingT
+            $ withSqliteConn (T.pack dbPath)
+            $ runReaderT
+            $ do
+                rows <-
+                    rawSql
+                        "SELECT root, hash FROM private_key WHERE wallet_id = ?"
+                        [PersistText walletId]
+                pure rows
+    case result of
+        [(Single root, Single hash)] ->
+            pure (T.encodeUtf8 root, T.encodeUtf8 hash)
+        [] -> do
+            putStrLn
+                $ "Error: no private key found for wallet "
+                    <> T.unpack walletId
+            exitFailure
+        _ -> do
+            putStrLn "Error: unexpected number of rows in private_key table"
+            exitFailure
+
+promptPassphrase :: IO (Passphrase "user")
+promptPassphrase = do
+    putStr "Enter spending passphrase: "
+    hFlush stdout
+    echoWas <- hGetEcho stdin
+    hSetEcho stdin False
+    input <- TIO.getLine
+    hSetEcho stdin echoWas
+    putStrLn ""
+    when (T.null input) $ do
+        putStrLn "Error: empty passphrase"
+        exitFailure
+    pure $ Passphrase $ BA.convert $ T.encodeUtf8 input

--- a/lib/wallet/exe/wallet-key-export.hs
+++ b/lib/wallet/exe/wallet-key-export.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2024 Cardano Foundation
@@ -45,6 +43,9 @@ import Control.Monad.Logger
 import Control.Monad.Reader
     ( runReaderT
     )
+import Control.Monad.Trans.Resource
+    ( runResourceT
+    )
 import Data.ByteString
     ( ByteString
     )
@@ -56,7 +57,6 @@ import Database.Persist.Sql
 import Database.Persist.Sqlite
     ( withSqliteConn
     )
-import Prelude
 import System.Environment
     ( getArgs
     )
@@ -66,13 +66,12 @@ import System.Exit
 import System.IO
     ( hFlush
     , hGetEcho
+    , hIsTerminalDevice
     , hSetEcho
     , stdin
     , stdout
     )
-import Control.Monad.Trans.Resource
-    ( runResourceT
-    )
+import Prelude
 
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Base16 as B16
@@ -162,12 +161,9 @@ readPrivateKey dbPath walletId = do
             . runNoLoggingT
             $ withSqliteConn (T.pack dbPath)
             $ runReaderT
-            $ do
-                rows <-
-                    rawSql
-                        "SELECT root, hash FROM private_key WHERE wallet_id = ?"
-                        [PersistText walletId]
-                pure rows
+            $ rawSql
+                "SELECT root, hash FROM private_key WHERE wallet_id = ?"
+                [PersistText walletId]
     case result of
         [(Single root, Single hash)] ->
             pure (T.encodeUtf8 root, T.encodeUtf8 hash)
@@ -182,13 +178,18 @@ readPrivateKey dbPath walletId = do
 
 promptPassphrase :: IO (Passphrase "user")
 promptPassphrase = do
-    putStr "Enter spending passphrase: "
-    hFlush stdout
-    echoWas <- hGetEcho stdin
-    hSetEcho stdin False
+    isTerm <- hIsTerminalDevice stdin
+    when isTerm $ do
+        putStr "Enter spending passphrase: "
+        hFlush stdout
+    oldEcho <-
+        if isTerm
+            then Just <$> (hGetEcho stdin <* hSetEcho stdin False)
+            else pure Nothing
     input <- TIO.getLine
-    hSetEcho stdin echoWas
-    putStrLn ""
+    case oldEcho of
+        Just e -> hSetEcho stdin e >> putStrLn ""
+        Nothing -> pure ()
     when (T.null input) $ do
         putStrLn "Error: empty passphrase"
         exitFailure

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -334,6 +334,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               # Apply fully static options to our Haskell executables
               packages.cardano-wallet-benchmarks.components.benchmarks.restore = fullyStaticOptions;
               packages.cardano-wallet-application.components.exes.cardano-wallet = fullyStaticOptions;
+              packages.cardano-wallet.components.exes.wallet-key-export = fullyStaticOptions;
               packages.cardano-wallet-integration.components.tests.integration = fullyStaticOptions;
               packages.cardano-wallet-unit.components.tests.unit = fullyStaticOptions;
               packages.cardano-wallet-benchmarks.components.benchmarks.db = fullyStaticOptions;


### PR DESCRIPTION
## Summary

- Standalone tool to extract a root private key from a cardano-wallet SQLite database
- Auto-detects Byron vs Shelley key format, verifies spending passphrase, decrypts XPrv
- Outputs raw hex and cardano-cli text envelope JSON
- Musl static binary available via `nix build .#wallet-key-export-static`

## Usage

```
wallet-key-export <path-to-wallet.db> <wallet-id>
```

## Test plan

- [x] `nix develop -c cabal build exe:wallet-key-export -O0` compiles cleanly
- [x] `nix build .#wallet-key-export-static` produces a statically linked binary
- [x] Run against a Shelley wallet DB and verify correct key extraction
- [x] Run against a Byron wallet DB and verify correct key extraction
- [x] Wrong passphrase is rejected