### PR TITLE
chore: bump cardano-node to 10.6.2

### DIFF
--- a/ERA-CHANGES.md
+++ b/ERA-CHANGES.md
@@ -1,0 +1,462 @@
+# cardano-node 10.6.2 Bump — DijkstraEra Changes
+
+## Overview
+
+This document describes all changes required to bump cardano-wallet from
+cardano-node 10.5.x to 10.6.2, which introduces **DijkstraEra** (the 8th
+Cardano era, protocol version 12).
+
+**Branch**: `chore/bump-node-10.6.2`
+**PR**: #5197
+
+---
+
+## 1. Build System & Dependencies
+
+### 1.1 `flake.nix` / `flake.lock`
+
+- **haskell.nix** pinned to a newer rev supporting GHC and Dijkstra ledger.
+- **CHaP** advanced to `2026-02-09`; Hackage rolled back to `2025-09-29` to
+  avoid breakage from newer upstream packages while CHaP carries the node
+  10.6.2 ecosystem.
+- Old legacy inputs removed (`ghc-8.6.5-iohk`, `ghc910X`, `ghc911`, `hydra`,
+  `nix`, `lowdown-src`, `nixpkgs-regression`, `em`).
+
+### 1.2 `nix/haskell.nix`
+
+- **Removed `-Wno-deriving-typeable`**: GHC 9.12 warns on redundant `deriving
+  Typeable`. Source code cleaned up instead (see §6).
+- **streaming-commons Windows patch**: Reverted the `mkForce []` override —
+  haskell.nix's built-in patch is still needed until `index-state` resolves
+  `streaming-commons >= 0.2.3.1`.
+
+### 1.3 `cabal.project`
+
+Key dependency bumps:
+
+| Package | Old | New |
+|---|---|---|
+| `cardano-api` | 10.16 | **10.23.0.0** |
+| `cardano-ledger-core` | 1.17 | **1.18.0.0** |
+| `cardano-ledger-alonzo` | 1.13 | **1.14.0.0** |
+| `cardano-ledger-babbage` | 1.11 | **1.12.0.0** |
+| `cardano-ledger-conway` | 1.19 | **1.20.0.0** |
+| `cardano-ledger-shelley` | 1.16 | **1.17.0.0** |
+| `ouroboros-consensus` | 0.27 | **0.30.0.1** |
+| `ouroboros-consensus-cardano` | 0.25 | **0.26.0.3** |
+| `ouroboros-network` | — | **0.22.6.0** |
+| `plutus-core/ledger-api/tx` | — | **1.57.0.0** |
+| `io-classes` | — | **1.8.0.1** |
+
+Other changes:
+- All `.cabal` files drop per-package version bounds for Cardano ecosystem deps;
+  pinning is now centralised in `cabal.project` `constraints:`.
+- `allow-newer` for `strict-stm:io-classes` / `si-timers:io-classes` removed
+  (io-classes 1.8 is compatible).
+- `source-repository-package` for cardano-cli removed (resolved via CHaP).
+- Package renames: `crypton-asn1-encoding` → `asn1-encoding`,
+  `time-hourglass` → `hourglass`.
+
+---
+
+## 2. `cardano-wallet-read` (Read Layer)
+
+The lowest-level era-indexed layer. Every type family and era-dispatch function
+gains a `Dijkstra` branch.
+
+### 2.1 Era Definition — `KnownEras.hs`
+
+DijkstraEra is the 8th member (index 7):
+
+```haskell
+type KnownEras =
+    '[ ByronEra, ShelleyEra, AllegraEra, MaryEra
+     , AlonzoEra, BabbageEra, ConwayEra, DijkstraEra ]
+
+indexOfEra Dijkstra = 7
+```
+
+`Era` GADT, `IsEra` instance, and `Dijkstra` type alias all added.
+
+### 2.2 Era-Indexed Existentials — `EraValue.hs`
+
+`parseEraIndex 7 = Just $ EraValue Dijkstra`. All instances (`Show`, `Eq`,
+`Ord`, `NFData`) gain Dijkstra cases.
+
+### 2.3 Transaction Type Family — `Tx.hs`
+
+**Significant refactor.** Previously:
+- Shelley–Mary used `ShelleyTx` directly
+- Alonzo–Conway used `AlonzoTx` directly
+
+Now **all post-Byron eras use `Core.Tx era`** (the associated type from
+`EraTx`):
+
+```haskell
+type family TxT era where
+    TxT Byron    = Byron.ATxAux ()
+    TxT Shelley  = Core.Tx Shelley
+    TxT Allegra  = Core.Tx Allegra
+    ...
+    TxT Dijkstra = Core.Tx Dijkstra
+```
+
+**Why**: The ledger now wraps each era's internal tx in a newtype, e.g.
+`MkDijkstraTx (AlonzoTx DijkstraEra)`. `Core.Tx` is the abstract unified
+type.
+
+### 2.4 Block Type Family — `Block.hs`
+
+```haskell
+BlockT Dijkstra = O.ShelleyBlock (Praos O.StandardCrypto) Dijkstra
+```
+
+`fromConsensusBlock` gains:
+```haskell
+O.BlockDijkstra block -> EraValue (Block block :: Block Dijkstra)
+```
+
+### 2.5 Block Transaction Extraction — `Txs.hs`
+
+Constraint simplified:
+- Old: `EraSegWits era, EncCBOR (ShelleyProtocolHeader proto)`
+- New: `EraBlockBody era`
+
+Body extraction changes from `toList (fromTxSeq txs)` to
+`toList (txs ^. txSeqBlockBodyL)` (new lens-based API).
+
+### 2.6 Header Hash Extraction — `HeaderHash.hs`
+
+Constraints `EncCBOR`, `EncCBORGroup`, `Core.Era`,
+`ShelleyProtocolHeader` all removed. Simplified to:
+
+```haskell
+getHeaderHashShelley
+    :: ProtocolHeaderSupportsEnvelope (praos StandardCrypto)
+    => O.ShelleyBlock (praos StandardCrypto) era -> ShelleyHash
+```
+
+### 2.7 Transaction Feature Type Families
+
+Every feature (Inputs, Outputs, Fee, Mint, Certificates, Withdrawals,
+CollateralInputs, CollateralOutputs, ReferenceInputs, ExtraSigs, Validity,
+Integrity, Metadata, Witnesses) gains `Dijkstra` case. Pattern: Dijkstra uses
+same underlying ledger type as Conway, with these exceptions:
+
+- **Certificates**: `CertificatesType Dijkstra = StrictSeq (DijkstraTxCert
+  Dijkstra)` — Dijkstra has its own certificate type.
+- **ExtraSigs**: uses `reqSignerHashesTxBodyG` (getter) instead of
+  `reqSignerHashesTxBodyL` (lens).
+
+### 2.8 Withdrawals — `Withdrawals.hs`
+
+Refactored from standalone `shelleyWithdrawals` function with `view` to inline
+`tx ^. bodyTxL . withdrawalsTxBodyL`, adding an explicit `EraTx` constraint.
+
+### 2.9 Transaction Generator — `Dijkstra.hs` (NEW)
+
+New module `Cardano.Wallet.Read.Tx.Gen.Dijkstra` providing `mkDijkstraTx`.
+Key observations:
+
+- Constructs via `MkDijkstraTx $ AlonzoTx body wits valid aux`
+- `DijkstraTxBody` has two new fields vs Conway:
+  - `guards :: OSet (Credential 'Guard)` — a new credential role
+  - An additional empty field
+- Uses `natVersion @12` (protocol version 12, Conway was 10)
+
+### 2.10 Other Generator Updates
+
+All existing era generators updated to use era-specific `Tx` newtype
+constructors (`MkAllegraTx`, `MkAlonzoTx`, `MkBabbageTx`, `MkConwayTx`) and
+`Core.Tx era` / `L.TxBody era` instead of concrete types.
+
+---
+
+## 3. `cardano-wallet-primitive` (Primitive Layer)
+
+### 3.1 Certificates — `Certificates.hs`
+
+New `mkDijkstraCertsK` handles `DijkstraTxCert`:
+
+```haskell
+data DijkstraTxCert era
+    = DijkstraTxCertDeleg (DijkstraDelegCert era)
+    | DijkstraTxCertPool PoolCert
+    | DijkstraTxCertGov (ConwayGovCert era)
+```
+
+`DijkstraDelegCert` subtypes:
+- `DijkstraRegCert` — stake key registration (with deposit)
+- `DijkstraUnRegCert` — deregistration (with deposit return)
+- `DijkstraDelegCert` — delegation to pool/DRep
+- `DijkstraRegDelegCert` — combined registration + delegation
+
+Pool certs reuse `PoolCert` (`RegPool`/`RetirePool`). Gov certs reuse
+`ConwayGovCert`.
+
+### 3.2 Outputs — `Outputs.hs`
+
+New `fromDijkstraTxOut`, identical structure to `fromConwayTxOut`:
+
+```haskell
+fromDijkstraTxOut
+    :: Babbage.BabbageTxOut DijkstraEra
+    -> (W.TxOut, Maybe (AlonzoScript DijkstraEra))
+```
+
+### 3.3 Scripts — `Scripts.hs`
+
+New `dijkstraAnyExplicitScript`. All era functions updated:
+`Alonzo.TimelockScript` → `Alonzo.NativeScript`.
+
+### 3.4 Witness Count — `WitnessCount.hs`
+
+New `dijkstraWitnessCount` following same pattern as `conwayWitnessCount`,
+using `fromDijkstraTxOut` and `dijkstraAnyExplicitScript`.
+
+### 3.5 Protocol Parameters & Block Processing — `Shelley.hs`
+
+1. **`fromDijkstraPParams`**: New function, identical structure to
+   `fromConwayPParams`. Decentralisation fixed at 0%.
+
+2. **`nodeToClientVersions`**: Extended from `[V_16, V_17]` to
+   `[V_16 .. V_22]` for Dijkstra support.
+
+3. **Constraint simplifications**: `getProducer`, `getBabbageProducer`,
+   `getConwayProducer` drop `Era era`, `EncCBORGroup (TxSeq era)` constraints.
+
+4. **`fromPoolDistr`**: Changed from `Consensus.PoolDistr crypto` to
+   `Ledger.PoolDistr` (monomorphic). Types moved to `Cardano.Ledger.State`.
+
+5. **Certificate witness handling**: `cardanoCertKeysForWitnesses` now uses
+   `Cardano.Compat.selectStakeCredentialWitness` (from
+   `Cardano.Api.Compatible.Certificate`).
+
+### 3.6 Script Conversion — `Convert.hs`
+
+- `toWalletScript`: catch-all for new timelock constructors
+- `toPlutusScriptInfo`: new `Ledger.PlutusV4 -> PlutusVersionV4`
+
+### 3.7 Metadata — `Metadata.hs`
+
+Gains Dijkstra case in era dispatch (same pattern as Conway).
+
+### 3.8 Mint — `Mint.hs`
+
+Gains Dijkstra case for minting/burning policy extraction.
+
+### 3.9 Collateral Outputs — `CollateralOutputs.hs`
+
+Gains Dijkstra case using `fromDijkstraTxOut`.
+
+---
+
+## 4. `cardano-balance-tx` (Balance Transaction Engine)
+
+### 4.1 `RecentEraConstraints` — `Eras.hs`
+
+Drops the constraint `Core.Tx era ~ Babbage.AlonzoTx era`. Now that `Core.Tx`
+is a newtype per era (not a type synonym for `AlonzoTx`), this equality no
+longer holds. `fromAnyCardanoEra` gains `_ -> Nothing` for Dijkstra.
+
+### 4.2 Script Downgrade — `Tx.hs`
+
+`downgradeScript` updated: `TimelockScript` → `Alonzo.NativeScript`.
+
+### 4.3 Transaction Update — `Balance.hs`
+
+`toLedgerScript` in `updateTx`: `TimelockScript` → `NativeScript` for both
+Babbage and Conway.
+
+### 4.4 Script Integrity Hash — `Redeemers.hs`
+
+**Substantial rewrite** of `addScriptIntegrityHash`:
+
+1. `Alonzo.txdats'` renamed to `Alonzo.txdats`
+2. `hashScriptIntegrity` now takes a single `ScriptIntegrity` record instead
+   of three arguments
+3. **Critical fix**: When all components (redeemers, datums, language views)
+   are empty, sets `SNothing` instead of computing an empty hash:
+
+```haskell
+integrityHash
+    | Map.null (view Alonzo.unRedeemersL rdmrs)
+    , Map.null (view Alonzo.unTxDatsL dats)
+    , Set.null langViews = SNothing
+    | otherwise =
+        SJust $ Alonzo.hashScriptIntegrity
+              $ Alonzo.ScriptIntegrity rdmrs dats langViews
+```
+
+This fix (commit `ffda1e6fa3`) was needed because the ledger now rejects
+transactions with a non-empty integrity hash but no Plutus scripts.
+
+### 4.5 Witness Estimation — `Sign.hs`
+
+`estimateDelegSigningKeys` refactored from pattern-matching on
+`CardanoApi.ShelleyRelatedCertificate` / `ConwayCertificate` to using
+`Exp.Certificate` (experimental API):
+
+```haskell
+estimateDelegSigningKeys (Exp.Certificate txCert) =
+    case txCert of
+        Shelley.RegTxCert _          -> 0
+        Shelley.DelegStakeTxCert c _ -> estimateWitNumForCred c
+        Shelley.UnRegTxCert c        -> estimateWitNumForCred c
+        _                            -> 1
+```
+
+`toTimelockScript`: `Alonzo.TimelockScript` → `Alonzo.NativeScript`.
+
+---
+
+## 5. Network Layer
+
+### 5.1 Node Protocol Client — `Implementation.hs`
+
+- **`codecConfig`**: 8th `ShelleyCodecConfig` for Dijkstra.
+- **Mux tracer**: `nctMuxTracer = nullTracer` → `nctMuxTracers = nullTracers`
+  (mux library API change to a record of tracers).
+- **New constraints**: `MonadThrow m` / `MonadMask m` on client functions
+  (ouroboros-network-framework API change).
+- **`_getUTxOByTxIn`**: `error` stub for Dijkstra.
+
+### 5.2 Era Dispatch — `LocalStateQuery/Extra.hs`
+
+`onAnyEra` and `onAnyEra'` gain an 8th `onDijkstra` parameter.
+`QueryIfCurrentDijkstra` from consensus. `eraIndexToAnyCardanoEra` maps
+index 7 to `DijkstraEra`.
+
+### 5.3 Local State Queries
+
+- **`StakeDistribution.hs`**: Uses `Shelley.GetStakeDistribution2` instead of
+  `GetStakeDistribution`.
+- **`UTxO.hs`**: `error` stub for Dijkstra with TODO.
+- **`PParams.hs`**, **`RewardAccount.hs`**: Pass same Shelley query for
+  Dijkstra.
+
+---
+
+## 6. API Layer
+
+### 6.1 Era Mapping — `Api/Types/Era.hs`
+
+Both `fromReadEra` and `fromAnyCardanoEra` gain `error` stubs for Dijkstra.
+
+### 6.2 API Types — `Api/Types.hs`
+
+`Aeson.Value` type family instances moved from `Client.hs` to `Types.hs`,
+eliminating orphan instances.
+
+### 6.3 Typeable Cleanup — `Api/Types/Error.hs`
+
+All API error types drop `deriving Typeable` (redundant in GHC 9.12).
+
+---
+
+## 7. Wallet Core
+
+### 7.1 `Wallet.hs`
+
+`pparamsInRecentEra`: `error` stub for Dijkstra.
+
+### 7.2 `Pools.hs`
+
+`forAllBlocks`: `error` stub for `BlockDijkstra`.
+
+### 7.3 `Transaction.hs`
+
+- `withRecentEraLedgerTx`: `error` stub for Dijkstra.
+- New `certToLedger` bridges deprecated `Cardano.Api.Certificate` to
+  `Cardano.Api.Experimental.Certificate`.
+- `{-# OPTIONS_GHC -Wno-deprecations #-}` added (temporary).
+
+### 7.4 `Delegation.hs` / `Voting.hs`
+
+`-Wno-deprecations` added. `Cardano.Api.Shelley` → `Cardano.Api`.
+
+---
+
+## 8. DijkstraEra Wiring Pattern
+
+The systematic pattern for adding each era:
+
+1. **Type family**: `TypeFamily Dijkstra = <ledger type>` (usually same as
+   Conway)
+2. **Era dispatch**: `Dijkstra -> <implementation>` case in `getEra*`
+   functions
+3. **`fromConsensusBlock`**: Map `O.BlockDijkstra` to `EraValue`
+4. **`onAnyEra`**: Add 8th parameter
+5. **Local state queries**: Add Dijkstra query (or `error` stub)
+6. **API mapping**: `error` stubs until `ApiDijkstra` exists
+
+### DijkstraEra vs Conway
+
+Structurally very similar — Praos consensus, `BabbageTxOut`, `AlonzoScript`,
+same integrity/validity/fee mechanisms. Differences:
+
+| Aspect | Conway | Dijkstra |
+|---|---|---|
+| Protocol version | 10 | **12** |
+| Certificate type | `ConwayTxCert` | **`DijkstraTxCert`** |
+| Required signers | lens (`reqSignerHashesTxBodyL`) | **getter** (`reqSignerHashesTxBodyG`) |
+| New credential role | — | **`Guard`** |
+| TxBody fields | — | **2 additional empty fields** |
+| Plutus | V1–V3 | V1–**V4** |
+
+---
+
+## 9. TODOs & Error Stubs
+
+`TODO.md` catalogs 16 `error` stubs across 14 files that must be implemented
+when DijkstraEra is promoted to `RecentEra`:
+
+| File | Function |
+|---|---|
+| `Api/Types/Era.hs` | `fromReadEra`, `fromAnyCardanoEra` |
+| `Write/Tx.hs` | `upgradeToOutputConway` |
+| `Network/Implementation.hs` | `_getUTxOByTxIn` |
+| `LocalStateQuery/UTxO.hs` | `getUTxOByTxIn` |
+| `Convert.hs` | `toWalletScript` |
+| `Read/Eras.hs` | `fromAnyCardanoEra` |
+| `Outputs.hs` | `txOutFromOutput` |
+| `Sealed.hs` | `fromCardanoApiTx` |
+| `TxExtended.hs` | `fromCardanoTx` |
+| `Shelley.hs` | `toCardanoEra` |
+| `Wallet.hs` | `pparamsInRecentEra` |
+| `Pools.hs` | `forAllBlocks` |
+| `Transaction.hs` | `withRecentEraLedgerTx` |
+
+Plus 3 files needing certificate API migration (`-Wno-deprecations`):
+`Transaction.hs`, `Delegation.hs`, `Voting.hs`.
+
+---
+
+## 10. Upstream Breaking Changes Reference
+
+### cardano-ledger
+
+- **Tx newtype per era**: `MkDijkstraTx (AlonzoTx era)` etc. Use `Core.Tx era`.
+- **`TimelockScript` → `NativeScript`**
+- **`PoolParams`/`PoolMetadata`/`PoolDistr`** → `Cardano.Ledger.State`
+- **`txdats'` → `txdats`**
+- **`hashScriptIntegrity`**: single `ScriptIntegrity` record, not 3 args
+- **`PlutusV4`**: new language version
+- **Constraint simplification**: `EraBlockBody` replaces `EraSegWits` +
+  `EncCBOR` combos
+- **`fromTxSeq` → `txSeqBlockBodyL`** (lens)
+
+### cardano-api
+
+- **`Cardano.Api.Shelley`** deprecated → merged into `Cardano.Api`
+- **Certificate API**: `Cardano.Api.Certificate` deprecated →
+  `Cardano.Api.Experimental.Certificate`
+- **`selectStakeCredentialWitness`** → `Cardano.Api.Compatible.Certificate`
+
+### ouroboros-network / ouroboros-consensus
+
+- **`BlockDijkstra`**, **`QueryIfCurrentDijkstra`**: new constructors
+- **`GetStakeDistribution2`**: replaces/augments `GetStakeDistribution`
+- **`NodeToClientV_18..V_22`**: new protocol versions
+- **`nctMuxTracer` → `nctMuxTracers`** (record of tracers)
+- **`MonadThrow`/`MonadMask`**: new constraints on client functions

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,60 @@
+# TODO: cardano-node 10.6.2 bump
+
+## Promote DijkstraEra to a RecentEra
+
+The following functions use `error` stubs for DijkstraEra and need proper
+implementation once Dijkstra is promoted to a `RecentEra`:
+
+- `lib/api/src/Cardano/Wallet/Api/Types/Era.hs`
+  - `fromReadEra`: add `ApiDijkstra` constructor and mapping
+  - `fromAnyCardanoEra`: add `ApiDijkstra` mapping
+
+- `lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs`
+  - `upgradeToOutputConway`: handle Dijkstra downgrade case
+
+- `lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Http/ServiceSpec.hs`
+  - `txOutFromOutput`: implement Dijkstra case
+
+- `lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs`
+  - `_getUTxOByTxIn`: implement Dijkstra query
+
+- `lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs`
+  - `getUTxOByTxIn`: implement Dijkstra local state query
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs`
+  - `toWalletScript`: handle new script cases
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Eras.hs`
+  - `fromAnyCardanoEra`: implement Dijkstra case
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs`
+  - `txOutFromOutput`: implement Dijkstra case
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs`
+  - `fromCardanoApiTx`: implement Dijkstra case
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/TxExtended.hs`
+  - `fromCardanoTx`: implement Dijkstra case
+
+- `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs`
+  - `toCardanoEra`: implement Dijkstra case
+  - `forAllBlocks`: implement Dijkstra case
+
+- `lib/wallet/src/Cardano/Wallet.hs`
+  - `pparamsInRecentEra`: implement Dijkstra case
+
+- `lib/wallet/src/Cardano/Wallet/Pools.hs`
+  - `withRecentEraLedgerTx`: implement Dijkstra case
+
+- `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs`
+  - Various functions with wildcard `_ -> error` patterns
+
+## Migrate from deprecated Cardano.Api.Certificate
+
+The following files suppress deprecation warnings with
+`{-# OPTIONS_GHC -Wno-deprecations #-}` and need migration from
+`Cardano.Api.Certificate` to `Cardano.Api.Experimental.Certificate`:
+
+- `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs`
+- `lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs`
+- `lib/wallet/src/Cardano/Wallet/Transaction/Voting.hs`

--- a/cabal.project
+++ b/cabal.project
@@ -215,37 +215,6 @@ constraints:
   , plutus-ledger-api ==1.57.0.0
   , plutus-tx ==1.57.0.0
 
-  -- Pinned cardano-ecosystem versions (node 10.5.4):
-  , cardano-api ==10.16.4.0
-  , cardano-binary ==1.7.2.0
-  , cardano-crypto-class ==2.2.3.2
-  , cardano-crypto-praos ==2.2.1.1
-  , cardano-crypto-wrapper ==1.6.1.0
-  , cardano-data ==1.2.4.1
-  , cardano-ledger-allegra ==1.7.0.0
-  , cardano-ledger-alonzo ==1.13.0.0
-  , cardano-ledger-api ==1.11.0.0
-  , cardano-ledger-babbage ==1.11.0.0
-  , cardano-ledger-byron ==1.1.0.0
-  , cardano-ledger-conway ==1.19.0.0
-  , cardano-ledger-core ==1.17.0.0
-  , cardano-ledger-mary ==1.8.0.0
-  , cardano-ledger-shelley ==1.16.0.0
-  , cardano-protocol-tpraos ==1.4.0.0
-  , cardano-slotting ==0.2.0.1
-  , cardano-strict-containers ==0.1.6.0
-  , ouroboros-consensus ==0.27.0.0
-  , ouroboros-consensus-cardano ==0.25.1.1
-  , ouroboros-consensus-diffusion ==0.23.1.0
-  , ouroboros-consensus-protocol ==0.12.0.0
-  , ouroboros-network ==0.21.6.1
-  , ouroboros-network-api ==0.14.2.0
-  , ouroboros-network-framework ==0.18.1.0
-  , ouroboros-network-protocols ==0.14.1.0
-  , plutus-core ==1.45.0.0
-  , plutus-ledger-api ==1.45.0.0
-  , plutus-tx ==1.45.0.0
-
 -- Related to: https://github.com/haskell/cabal/issues/8554
 if impl(ghc == 8.10.7)
   constraints: process == 1.6.13.2

--- a/cabal.project
+++ b/cabal.project
@@ -49,11 +49,11 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
-index-state: 2026-01-29T00:00:00Z
+index-state: 2025-09-29T13:55:56Z
 
 index-state:
-  , hackage.haskell.org 2026-01-29T00:00:00Z
-  , cardano-haskell-packages 2026-02-05T12:58:40Z
+  , hackage.haskell.org 2025-09-29T13:55:56Z
+  , cardano-haskell-packages 2026-02-09T17:36:58Z
 
 packages:
   lib/address-derivation-discovery
@@ -158,9 +158,7 @@ allow-newer:
   , plutus-core:cardano-crypto
   , cardano-wallet-read:cardano-crypto
   , cardano-ledger-byron-test:cardano-ledger-byron
-  , strict-stm:io-classes
   , cardano-cli:cardano-api
-  , si-timers:io-classes
   , hkd:base
 constraints:
     base >= 4.18.2.0 && < 5
@@ -181,8 +179,41 @@ constraints:
   , katip >= 0.8.7.4
 
 
-  -- Cardano Node dependencies:
+  -- Cardano Node 10.6.2 dependencies:
+  , cardano-api ==10.23.0.0
+  , cardano-binary ==1.7.2.0
+  , cardano-crypto ==1.2.0
+  , cardano-crypto-class ==2.2.3.2
+  , cardano-crypto-praos ==2.2.1.1
+  , cardano-crypto-wrapper ==1.6.1.0
+  , cardano-data ==1.2.4.1
+  , cardano-ledger-allegra ==1.8.0.0
+  , cardano-ledger-alonzo ==1.14.0.0
+  , cardano-ledger-api ==1.12.1.0
+  , cardano-ledger-babbage ==1.12.0.0
+  , cardano-ledger-binary ==1.7.1.0
+  , cardano-ledger-byron ==1.2.0.0
+  , cardano-ledger-conway ==1.20.0.0
+  , cardano-ledger-core ==1.18.0.0
+  , cardano-ledger-mary ==1.9.0.0
+  , cardano-ledger-shelley ==1.17.0.0
+  , cardano-prelude ==0.2.1.0
+  , cardano-protocol-tpraos ==1.4.1.0
+  , cardano-slotting ==0.2.0.1
+  , cardano-strict-containers ==0.1.6.0
+  , io-classes ==1.8.0.1
   , io-classes -asserts
+  , ouroboros-consensus ==0.30.0.1
+  , ouroboros-consensus-cardano ==0.26.0.3
+  , ouroboros-consensus-diffusion ==0.26.0.0
+  , ouroboros-consensus-protocol ==0.13.0.0
+  , ouroboros-network ==0.22.6.0
+  , ouroboros-network-api ==0.16.0.0
+  , ouroboros-network-framework ==0.19.3.0
+  , ouroboros-network-protocols ==0.15.2.0
+  , plutus-core ==1.57.0.0
+  , plutus-ledger-api ==1.57.0.0
+  , plutus-tx ==1.57.0.0
 
   -- Pinned cardano-ecosystem versions (node 10.5.4):
   , cardano-api ==10.16.4.0
@@ -345,14 +376,4 @@ package bitvec
    flags: -simd
 
 -- -------------------------------------------------------------------------
--- cardano-cli: Pin to specific version to avoid Nix package database conflicts
--- See: https://github.com/IntersectMBO/cardano-cli
-
-source-repository-package
-  type: git
-  location: https://github.com/IntersectMBO/cardano-cli
-  tag: cardano-cli-10.11.0.0
-  --sha256: sha256-pJkhKwmXVvE5aulIMUe7TtlI53h5t8y720Zn3EJ/YnU=
-  subdir:
-    cardano-cli
 

--- a/cabal.project
+++ b/cabal.project
@@ -49,10 +49,10 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
-index-state: 2025-09-29T13:55:56Z
+index-state: 2026-01-29T00:00:00Z
 
 index-state:
-  , hackage.haskell.org 2025-09-29T13:55:56Z
+  , hackage.haskell.org 2026-01-29T00:00:00Z
   , cardano-haskell-packages 2026-02-09T17:36:58Z
 
 packages:
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-ledger-read
-  tag: 7b6adf7cc7a55e8bf6cc591e915598660124b286
-  --sha256: 07psh8fw7d6kgjr449qip5skphyg3y0wf6l0wqwjnwwnw0jgi9rs
+  tag: 0ce0e7a8a8c0e9e9073cec9407a9e851d05ed13d
+  --sha256: 0c32h8z0bldxn1215aj4i3brxl8vhk4v35by3hscw1dxcjm8kw70
 
 -- END cardano-ledger-read
 --------------------------------------------------------------------------------
@@ -141,8 +141,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-balance-transaction
-  tag: a069da87ad0ced93f1f9e66061f1e9228a881f59
-  --sha256: 1xsjcs1qsg8x1cnzw4zxh15ddjam7zrgi68h3b2ckj76ywlhh20f
+  tag: 98e7f4155451e357410e266dd6c754d58ead3b7f
+  --sha256: 1p8xhf4ly37lqs45663vk786k1mv8dzgji6wiz2s2ysn9zqq3kda
 
 -- END cardano-balance-tx
 --------------------------------------------------------------------------------

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1770875053,
-        "narHash": "sha256-s0f9jZBP/Uwujvi/OmgcEYlOfnB2+tYLwpO5ax92Vqo=",
+        "lastModified": 1770667523,
+        "narHash": "sha256-NTZeJP2ETCS/9hAUottupnhI7b5RmYKiB4jJqhyvHhs=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "6b379a15b507029fb0642a948bad7ff5af494bda",
+        "rev": "da32b7c7513f0f5383d233a0f97e03538b0c7726",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1770297836,
-        "narHash": "sha256-Jnfz4OjZG+xvnCQ0KeUS7kaVAu7MsSgvwqFyyZjN+Hw=",
+        "lastModified": 1770667523,
+        "narHash": "sha256-NTZeJP2ETCS/9hAUottupnhI7b5RmYKiB4jJqhyvHhs=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "aae41da34344a6ad7cae51770df4ed1714b7a9c9",
+        "rev": "da32b7c7513f0f5383d233a0f97e03538b0c7726",
         "type": "github"
       },
       "original": {
@@ -205,6 +205,7 @@
     "cardano-automation": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hackageNix": "hackageNix",
         "haskellNix": [
           "cardano-node-runtime",
           "haskellNix"
@@ -215,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741965132,
-        "narHash": "sha256-SjNEfsLa+2FKS4GlszaH0fO/QGJbooNFMYU1GVdJToo=",
+        "lastModified": 1764682512,
+        "narHash": "sha256-yY3yIBmiCKsZ7YN++ttEKZiVMIHjjlAngFWaTGvBBvg=",
         "owner": "input-output-hk",
         "repo": "cardano-automation",
-        "rev": "78d16a837d74a72822041ee1b970daa73ac83b9e",
+        "rev": "9a91636c94317bff98ebf6b913f8c38beef0b374",
         "type": "github"
       },
       "original": {
@@ -233,10 +234,9 @@
         "CHaP": "CHaP_2",
         "cardano-automation": "cardano-automation",
         "customConfig": "customConfig",
-        "em": "em",
         "empty-flake": "empty-flake",
         "flake-compat": "flake-compat",
-        "hackageNix": "hackageNix",
+        "hackageNix": "hackageNix_2",
         "haskellNix": "haskellNix",
         "incl": "incl",
         "iohkNix": "iohkNix",
@@ -248,16 +248,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1770307293,
-        "narHash": "sha256-66bbnASi59OLBth3VA4PPWqAFyllxfHICh1bbkf6F4k=",
+        "lastModified": 1770822424,
+        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "b0a12592c4e996b57edf5bc5b9109ecc88c2273f",
+        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.4",
+        "ref": "10.6.2",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -336,22 +336,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "empty-flake",
-        "type": "github"
-      }
-    },
-    "em": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1685015066,
-        "narHash": "sha256-etAdEoYhtvjTw1ITh28WPNfwvvb5t/fpwCP6s7odSiQ=",
-        "owner": "deepfire",
-        "repo": "em",
-        "rev": "af69bb5c2ac2161434d8fea45f920f8f359587ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "deepfire",
-        "repo": "em",
         "type": "github"
       }
     },
@@ -488,60 +472,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -559,6 +489,23 @@
       }
     },
     "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
         "lastModified": 1762302430,
@@ -591,19 +538,50 @@
         "type": "github"
       }
     },
-    "hackageNix": {
+    "hackage-internal_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1745281520,
-        "narHash": "sha256-dk/70Cmjx8fGSURcAHQnowETeAOElzDxn0wH/P4DUWA=",
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4c98778277c642e326b3cb7c2c9cbb9163b9ffbd",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759154585,
+        "narHash": "sha256-OC5Y3E20bwkfMVlB2uhf7eF/FcuC1JD/BXkxR8rMjR4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "7e61ac3eb4cc042b37c6511b65984f59fe6d40de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768311066,
+        "narHash": "sha256-g2WdhScDFQNkJs2GBjWIGG49upIQuBshgaeAxddujrE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "adbb09d536f3a2797f9bd0762a0577a30672b8b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -616,15 +594,17 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": [
           "cardano-node-runtime",
           "hackageNix"
         ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -632,36 +612,33 @@
         "hls-2.6": "hls-2.6",
         "hls-2.7": "hls-2.7",
         "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "cardano-node-runtime",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1718797200,
-        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
         "type": "github"
       }
     },
@@ -676,13 +653,13 @@
         "hackage": [
           "hackage"
         ],
-        "hackage-for-stackage": "hackage-for-stackage",
-        "hackage-internal": "hackage-internal",
-        "hls": "hls",
+        "hackage-for-stackage": "hackage-for-stackage_2",
+        "hackage-internal": "hackage-internal_2",
+        "hls": "hls_2",
         "hls-1.10": "hls-1.10_2",
         "hls-2.0": "hls-2.0_2",
-        "hls-2.10": "hls-2.10",
-        "hls-2.11": "hls-2.11",
+        "hls-2.10": "hls-2.10_2",
+        "hls-2.11": "hls-2.11_2",
         "hls-2.2": "hls-2.2_2",
         "hls-2.3": "hls-2.3_2",
         "hls-2.4": "hls-2.4_2",
@@ -690,7 +667,7 @@
         "hls-2.6": "hls-2.6_2",
         "hls-2.7": "hls-2.7_2",
         "hls-2.8": "hls-2.8_2",
-        "hls-2.9": "hls-2.9",
+        "hls-2.9": "hls-2.9_2",
         "hpc-coveralls": "hpc-coveralls_2",
         "iserv-proxy": [
           "iserv-proxy"
@@ -700,9 +677,9 @@
         ],
         "nixpkgs-2305": "nixpkgs-2305_2",
         "nixpkgs-2311": "nixpkgs-2311_2",
-        "nixpkgs-2405": "nixpkgs-2405",
-        "nixpkgs-2411": "nixpkgs-2411",
-        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2405": "nixpkgs-2405_2",
+        "nixpkgs-2411": "nixpkgs-2411_2",
+        "nixpkgs-2505": "nixpkgs-2505_2",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2"
@@ -822,7 +799,41 @@
         "type": "github"
       }
     },
+    "hls-2.10_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11_2": {
       "flake": false,
       "locked": {
         "lastModified": 1747306193,
@@ -1094,6 +1105,39 @@
         "type": "github"
       }
     },
+    "hls-2.9_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -1126,30 +1170,6 @@
         "type": "github"
       }
     },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "cardano-node-runtime",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
     "incl": {
       "inputs": {
         "nixlib": "nixlib"
@@ -1179,16 +1199,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1769466714,
-        "narHash": "sha256-BORSlRJKEmYWHaNqEEUeM8b6pgNVzknFELMKM3rjyE8=",
+        "lastModified": 1770069549,
+        "narHash": "sha256-jHgw8KL0/TFGY2aVwxhD0DeDq7sl5Ti7jAp8T3RLNb0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f3ecc51c92ab72658c9b3b7289cfcc8a820a6316",
+        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "cardano-node-release/10.5.4",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -1220,11 +1239,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
         "type": "github"
       },
       "original": {
@@ -1248,22 +1267,6 @@
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
         "type": "github"
       }
     },
@@ -1291,27 +1294,6 @@
         "type": "github"
       }
     },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nixlib": {
       "locked": {
         "lastModified": 1667696192,
@@ -1327,109 +1309,13 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -1457,11 +1343,11 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
@@ -1503,6 +1389,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2405_2": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2411": {
       "locked": {
         "lastModified": 1748037224,
@@ -1519,7 +1421,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411_2": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505_2": {
       "locked": {
         "lastModified": 1757716134,
         "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
@@ -1550,35 +1484,19 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -1740,11 +1658,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1718756571,
-        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1770023366,
-        "narHash": "sha256-RKeZFJfSwQM3rKQroWkGQb67a40/pI4A+baMTDlig/M=",
+        "lastModified": 1771029998,
+        "narHash": "sha256-n2OPFR7msGuDHi03FsSSTkw5uyO6/odXCH42033/Yjs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3581af2b492410bcf8150ea6432878336ff822fe",
+        "rev": "26b99ff043af013c9c1c929976ce7dcd8f04d3d7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.5.4";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.6.2";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2543.1-hotfix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -46,7 +46,7 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses            >=4.0.2    && <4.1
+    , cardano-addresses
     , cardano-crypto
     , cardano-crypto-class
     , cardano-ledger-api

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -39,7 +39,7 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses             >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-balance-tx
     , cardano-binary
@@ -67,7 +67,7 @@ library
     , http-media
     , http-types
     , int-cast
-    , iohk-monitoring               >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , memory
     , mtl
     , network-uri

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -147,9 +147,7 @@ import Cardano.Address.Script
     )
 import Cardano.Api
     ( SerialiseAsCBOR (..)
-    )
-import Cardano.Api.Shelley
-    ( StakeAddress (..)
+    , StakeAddress (..)
     )
 import Cardano.BM.Tracing
     ( HasPrivacyAnnotation (..)
@@ -321,6 +319,13 @@ import Cardano.Wallet.Api.Http.Server.Handlers.MintBurn
     ( convertApiAssetMintBurn
     , getTxApiAssetMintBurn
     )
+-- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
+--     ( getNetworkInformation
+--     , makeApiBlockReference
+--     , makeApiBlockReferenceFromHeader
+--     , makeApiSlotReference
+--     )
+
 import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
 import Cardano.Wallet.Api.Http.Server.Handlers.TxCBOR
     ( ParsedTxCBOR (..)

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -65,6 +65,7 @@ import Text.Show
 import Prelude
     ( Bounded
     , Enum
+    , error
     )
 
 import qualified Cardano.Balance.Tx.Eras as Write
@@ -106,6 +107,8 @@ fromReadEra (Read.EraValue era) = case era of
     Read.Alonzo -> ApiAlonzo
     Read.Babbage -> ApiBabbage
     Read.Conway -> ApiConway
+    -- TODO: add ApiDijkstra once DijkstraEra is promoted to a RecentEra
+    Read.Dijkstra -> error "fromReadEra: DijkstraEra not yet supported"
 
 fromAnyCardanoEra :: AnyCardanoEra -> ApiEra
 fromAnyCardanoEra = \case
@@ -116,6 +119,8 @@ fromAnyCardanoEra = \case
     AnyCardanoEra AlonzoEra -> ApiAlonzo
     AnyCardanoEra BabbageEra -> ApiBabbage
     AnyCardanoEra ConwayEra -> ApiConway
+    -- TODO: add ApiDijkstra once DijkstraEra is promoted to a RecentEra
+    AnyCardanoEra DijkstraEra -> error "fromAnyCardanoEra: DijkstraEra not yet supported"
 
 toAnyCardanoEra :: ApiEra -> AnyCardanoEra
 toAnyCardanoEra = \case

--- a/lib/application-tls/cardano-wallet-application-tls.cabal
+++ b/lib/application-tls/cardano-wallet-application-tls.cabal
@@ -38,26 +38,26 @@ library
   import:          language, opts-lib
   hs-source-dirs:  lib
   build-depends:
-    , aeson                    >=2
+    , aeson
     , base
     , base64-bytestring
     , bytestring
     , crypton
-    , crypton-asn1-encoding
-    , crypton-asn1-types
+    , asn1-encoding
+    , asn1-types
     , crypton-x509
     , crypton-x509-store
     , crypton-x509-validation
-    , data-default             >=0.8.0.0 && <0.9
+    , data-default
     , data-default-class
     , directory
     , exceptions
     , filepath
-    , ip                       >=1.7.4
+    , ip
     , text
-    , time-hourglass
+    , hourglass
     , tls
-    , warp-tls                 >=3.4.7
+    , warp-tls
     , wide-word
     , yaml
 
@@ -81,7 +81,7 @@ test-suite unit
     , crypton-x509
     , crypton-x509-store
     , crypton-x509-system
-    , data-default                    >=0.8.0.0 && <0.9
+    , data-default
     , directory
     , filepath
     , hspec

--- a/lib/application-tls/cardano-wallet-application-tls.cabal
+++ b/lib/application-tls/cardano-wallet-application-tls.cabal
@@ -43,8 +43,8 @@ library
     , base64-bytestring
     , bytestring
     , crypton
-    , asn1-encoding
-    , asn1-types
+    , crypton-asn1-encoding
+    , crypton-asn1-types
     , crypton-x509
     , crypton-x509-store
     , crypton-x509-validation
@@ -55,7 +55,7 @@ library
     , filepath
     , ip
     , text
-    , hourglass
+    , time-hourglass
     , tls
     , warp-tls
     , wide-word

--- a/lib/application/cardano-wallet-application.cabal
+++ b/lib/application/cardano-wallet-application.cabal
@@ -44,7 +44,7 @@ executable cardano-wallet
   import:           language, opts-exe
   main-is:          cardano-wallet.hs
   hs-source-dirs:   app/shelley
-  build-depends:    base >=4.18.2.0 && <4.22
+  build-depends:    base
   default-language: Haskell2010
   build-depends:
     , base
@@ -56,9 +56,9 @@ executable cardano-wallet
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , contra-tracer
-    , iohk-monitoring                     >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
-    , lobemo-backend-ekg                  >=0.2.0.0 && <0.3
+    , lobemo-backend-ekg
     , network-uri
     , optparse-applicative
     , text
@@ -106,7 +106,7 @@ library
     , ansi-terminal
     , base
     , bytestring
-    , cardano-addresses               >=4.0.2   && <4.1
+    , cardano-addresses
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application-tls
@@ -120,7 +120,7 @@ library
     , filepath
     , fmt
     , http-client
-    , iohk-monitoring                 >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , network
     , ntp-client

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -66,7 +66,7 @@ library
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring                       >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , JuicyPixels
     , local-cluster
@@ -107,7 +107,7 @@ benchmark restore
     , aeson
     , base
     , bytestring
-    , cardano-addresses             >=4.0.2   && <4.1
+    , cardano-addresses
     , cardano-balance-tx
     , cardano-wallet
     , cardano-wallet-api
@@ -121,7 +121,7 @@ benchmark restore
     , crypto-primitives
     , filepath
     , fmt
-    , iohk-monitoring               >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , optparse-applicative
     , say
@@ -140,7 +140,7 @@ benchmark latency
   build-depends:
     , aeson
     , base
-    , cardano-addresses                     >=4.0.2    && <4.1
+    , cardano-addresses
     , cardano-ledger-core
     , cardano-wallet
     , cardano-wallet-api
@@ -162,7 +162,7 @@ benchmark latency
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring                       >=0.2.0.0  && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , local-cluster
     , mtl
@@ -187,7 +187,7 @@ benchmark db
     , address-derivation-discovery
     , base
     , bytestring
-    , cardano-addresses                >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-crypto
     , cardano-wallet
@@ -209,7 +209,7 @@ benchmark db
     , filepath
     , fmt
     , foldl
-    , iohk-monitoring                  >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , memory
     , mtl
@@ -241,7 +241,7 @@ benchmark api
     , containers
     , filepath
     , fmt
-    , iohk-monitoring                  >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , mtl
     , say

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -44,11 +44,11 @@ library
     , cardano-api
     , cardano-binary
     , cardano-crypto-class
-    , cardano-crypto-test                          >=1.5.0.2   && <1.7
+    , cardano-crypto-test
     , cardano-ledger-alonzo
     , cardano-ledger-api
-    , cardano-ledger-byron-test                    >=1.5.2.0   && <1.6
-    , cardano-ledger-conway:testlib                >=1.19.0.0  && <1.20
+    , cardano-ledger-byron-test
+    , cardano-ledger-conway:testlib
     , cardano-ledger-core
     , cardano-ledger-core:testlib
     , cardano-ledger-shelley

--- a/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
+++ b/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
@@ -1331,7 +1331,7 @@ genCostModels = do
     pure $ Map.fromList costModels
   where
     plutusVersions :: [Language]
-    plutusVersions = [minBound .. maxBound]
+    plutusVersions = [PlutusV1, PlutusV2, PlutusV3]
 
     fromLanguage :: Language -> AnyPlutusScriptVersion
     fromLanguage = toEnum . fromEnum

--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -138,17 +138,17 @@ library
     , cardano-ledger-read
     , cardano-ledger-shelley
     , cardano-strict-containers
-    , containers                    >=0.5      && <0.8
-    , fmt                           >=0.6.3.0  && <0.7
-    , generics-sop                  >=0.5.1.4  && <0.6
-    , lens                          >=5.2.3    && <5.4
-    , memory                        >=0.18.0   && <0.19
-    , nothunks                      >=0.1.5    && <0.4
-    , operational                   >=0.2.4.2  && <0.3
-    , QuickCheck                    >=2.14     && <2.16.0
-    , text                          >=1.2      && <2.2
-    , time                          >=1.12.2   && <1.15
-    , transformers                  >=0.6.1.0  && <0.7
+    , containers                 >=0.5     && <0.8
+    , fmt                        >=0.6.3.0 && <0.7
+    , generics-sop               >=0.5.1.4 && <0.6
+    , lens                       >=5.2.3   && <5.4
+    , memory                     >=0.18.0  && <0.19
+    , nothunks                   >=0.1.5   && <0.4
+    , operational                >=0.2.4.2 && <0.3
+    , QuickCheck                 >=2.14    && <2.16.0
+    , text                       >=1.2     && <2.2
+    , time                       >=1.12.2  && <1.15
+    , transformers               >=0.6.1.0 && <0.7
 
   hs-source-dirs:   haskell
   default-language: Haskell2010

--- a/lib/cardano-wallet-read/cardano-wallet-read.cabal
+++ b/lib/cardano-wallet-read/cardano-wallet-read.cabal
@@ -98,6 +98,7 @@ library
     Cardano.Wallet.Read.Tx.Gen.Babbage
     Cardano.Wallet.Read.Tx.Gen.Byron
     Cardano.Wallet.Read.Tx.Gen.Conway
+    Cardano.Wallet.Read.Tx.Gen.Dijkstra
     Cardano.Wallet.Read.Tx.Gen.Mary
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
@@ -118,8 +119,8 @@ library
     Cardano.Wallet.Read.Tx.Validity
 
   build-depends:
-    , base                          >=4.14     && <5
-    , bytestring                    >=0.10.6   && <0.13
+    , base
+    , bytestring
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
@@ -132,6 +133,7 @@ library
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-dijkstra
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-ledger-shelley
@@ -177,8 +179,8 @@ test-suite test
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-wallet-read
-    , hspec                >=2.11.0   && <2.12
+    , hspec
     , lens
     , memory
-    , QuickCheck           >=2.14     && <2.16.0
-    , with-utf8            >=1.1.0.0  && <1.2
+    , QuickCheck
+    , with-utf8

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Address.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Address.hs
@@ -65,6 +65,7 @@ fromEraCompactAddr = case theEra :: Era era of
     Alonzo -> onAddress id
     Babbage -> onAddress id
     Conway -> onAddress id
+    Dijkstra -> onAddress id
 
 -- Helper function for type inference.
 onAddress :: (L.CompactAddrType era -> t) -> L.CompactAddr era -> t

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Eras.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Eras.hs
@@ -12,6 +12,7 @@ module Cardano.Wallet.Read.Eras
     , Babbage
     , Byron
     , Conway
+    , Dijkstra
     , Mary
     , Shelley
     , KnownEras
@@ -48,6 +49,7 @@ import Cardano.Read.Ledger.Eras
     , Babbage
     , Byron
     , Conway
+    , Dijkstra
     , Era (..)
     , IsEra (..)
     , KnownEras

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/PParams/Mock.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/PParams/Mock.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.BaseTypes
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , CompactForm (CompactCoin)
     )
 import Cardano.Ledger.Conway.PParams
     ( ConwayPParams
@@ -134,7 +135,7 @@ mockPParamsConway = Read.PParams $ unsafeWrap conwayPParams
             , -- \^ Maximal block header size
               bppKeyDeposit = ada 2
             , -- \^ The amount of a key registration deposit
-              bppPoolDeposit = lovelace 500_000_000
+              bppPoolDeposit = CompactCoin 500_000_000
             , -- \^ The amount of a pool registration deposit
               bppEMax = EpochInterval 18
             , -- \^ Maximum number of epochs in the future a pool retirement is allowed to

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/CollateralInputs.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/CollateralInputs.hs
@@ -39,6 +39,7 @@ getCollateralInputs = case theEra :: Era era of
     Alonzo -> unCollateralInputs . L.getEraCollateralInputs
     Babbage -> unCollateralInputs . L.getEraCollateralInputs
     Conway -> unCollateralInputs . L.getEraCollateralInputs
+    Dijkstra -> unCollateralInputs . L.getEraCollateralInputs
 
 unCollateralInputs
     :: L.CollateralInputs era -> L.CollateralInputsType era

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen.hs
@@ -26,6 +26,9 @@ import Cardano.Wallet.Read.Tx.Gen.Byron
 import Cardano.Wallet.Read.Tx.Gen.Conway
     ( mkConwayTx
     )
+import Cardano.Wallet.Read.Tx.Gen.Dijkstra
+    ( mkDijkstraTx
+    )
 import Cardano.Wallet.Read.Tx.Gen.Mary
     ( mkMaryTx
     )
@@ -47,5 +50,6 @@ mkTxEra = case theEra @era of
     Alonzo -> g mkAlonzoTx
     Babbage -> g mkBabbageTx
     Conway -> g mkConwayTx
+    Dijkstra -> g mkDijkstraTx
   where
     g f = Tx . f

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Allegra.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Allegra.hs
@@ -7,12 +7,15 @@ module Cardano.Wallet.Read.Tx.Gen.Allegra
     )
 where
 
+import Cardano.Ledger.Allegra.Tx
+    ( Tx (MkAllegraTx)
+    )
 import Cardano.Ledger.Allegra.TxAuxData
     ( AllegraTxAuxData
     )
 import Cardano.Ledger.Allegra.TxBody
-    ( AllegraTxBody (..)
-    , StrictMaybe (..)
+    ( StrictMaybe (..)
+    , TxBody (AllegraTxBody)
     , ValidityInterval (..)
     )
 import Cardano.Ledger.Api
@@ -49,11 +52,13 @@ import Data.Maybe.Strict
     )
 import Prelude
 
+import Cardano.Ledger.Core qualified as L
+
 mkAllegraTx
     :: TxParameters
-    -> ShelleyTx AllegraEra
+    -> L.Tx AllegraEra
 mkAllegraTx TxParameters{txInputs, txOutputs} =
-    ShelleyTx (body txInputs txOutputs) wits aux
+    MkAllegraTx $ ShelleyTx (body txInputs txOutputs) wits aux
 
 aux :: StrictMaybe (AllegraTxAuxData AllegraEra)
 aux = maybeToStrictMaybe Nothing
@@ -61,7 +66,7 @@ aux = maybeToStrictMaybe Nothing
 body
     :: NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> AllegraTxBody AllegraEra
+    -> TxBody AllegraEra
 body ins outs =
     AllegraTxBody
         (txins ins)
@@ -76,5 +81,5 @@ body ins outs =
 exampleValidity :: ValidityInterval
 exampleValidity = ValidityInterval SNothing SNothing
 
-exampleAllegraTx :: ShelleyTx AllegraEra
+exampleAllegraTx :: L.Tx AllegraEra
 exampleAllegraTx = mkAllegraTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Alonzo.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Alonzo.hs
@@ -10,14 +10,17 @@ where
 import Cardano.Ledger.Alonzo.Tx
     ( AlonzoTx (AlonzoTx)
     , IsValid (..)
+    , Tx (MkAlonzoTx)
     )
 import Cardano.Ledger.Alonzo.TxAuxData
     ( AlonzoTxAuxData
     )
 import Cardano.Ledger.Alonzo.TxBody
-    ( AlonzoTxBody (..)
-    , AlonzoTxOut (..)
-    , ScriptIntegrityHash
+    ( ScriptIntegrityHash
+    , TxBody (AlonzoTxBody)
+    )
+import Cardano.Ledger.Alonzo.TxOut
+    ( AlonzoTxOut (AlonzoTxOut)
     )
 import Cardano.Ledger.Alonzo.TxWits
     ( AlonzoTxWits
@@ -86,11 +89,13 @@ import Data.Set
     )
 import Prelude
 
+import Cardano.Ledger.Core qualified as L
+
 mkAlonzoTx
     :: TxParameters
-    -> AlonzoTx AlonzoEra
+    -> L.Tx AlonzoEra
 mkAlonzoTx TxParameters{txInputs, txOutputs} =
-    AlonzoTx (body txInputs txOutputs) wits valid aux
+    MkAlonzoTx $ AlonzoTx (body txInputs txOutputs) wits valid aux
 
 valid :: IsValid
 valid = IsValid True
@@ -104,7 +109,7 @@ aux = maybeToStrictMaybe Nothing
 body
     :: NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> AlonzoTxBody AlonzoEra
+    -> L.TxBody AlonzoEra
 body ins outs =
     AlonzoTxBody
         (txins ins)
@@ -147,5 +152,5 @@ collateralIns = mempty
 mint :: MultiAsset
 mint = mempty
 
-exampleAlonzoTx :: AlonzoTx AlonzoEra
+exampleAlonzoTx :: L.Tx AlonzoEra
 exampleAlonzoTx = mkAlonzoTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Conway.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Conway.hs
@@ -22,11 +22,8 @@ import Cardano.Ledger.Api
 import Cardano.Ledger.Api.Tx.In
     ( TxIn
     )
-import Cardano.Ledger.Babbage
-    ( BabbageTxOut
-    )
-import Cardano.Ledger.Babbage.TxBody
-    ( BabbageTxOut (..)
+import Cardano.Ledger.Babbage.TxOut
+    ( BabbageTxOut (BabbageTxOut)
     )
 import Cardano.Ledger.BaseTypes
     ( Network
@@ -43,9 +40,10 @@ import Cardano.Ledger.Conway.Governance
     )
 import Cardano.Ledger.Conway.Tx
     ( AlonzoTx (AlonzoTx)
+    , Tx (MkConwayTx)
     )
 import Cardano.Ledger.Conway.TxBody
-    ( ConwayTxBody (..)
+    ( TxBody (ConwayTxBody)
     )
 import Cardano.Ledger.Conway.TxCert
     ( ConwayTxCert
@@ -111,11 +109,13 @@ import Data.Set
     )
 import Prelude
 
+import Cardano.Ledger.Core qualified as L
+
 mkConwayTx
     :: TxParameters
-    -> AlonzoTx ConwayEra
+    -> L.Tx ConwayEra
 mkConwayTx TxParameters{txInputs, txOutputs} =
-    AlonzoTx (body txInputs txOutputs) wits valid aux
+    MkConwayTx $ AlonzoTx (body txInputs txOutputs) wits valid aux
 
 valid :: IsValid
 valid = IsValid True
@@ -129,7 +129,7 @@ aux = SNothing
 body
     :: NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> ConwayTxBody ConwayEra
+    -> TxBody ConwayEra
 body ins outs =
     ConwayTxBody
         (txins ins)
@@ -200,5 +200,5 @@ collateralIns = mempty
 mint :: MultiAsset
 mint = mempty
 
-exampleConwayTx :: AlonzoTx ConwayEra
+exampleConwayTx :: L.Tx ConwayEra
 exampleConwayTx = mkConwayTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Dijkstra.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Dijkstra.hs
@@ -2,62 +2,61 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Read.Tx.Gen.Babbage
-    ( mkBabbageTx
-    , exampleBabbageTx
-    , totalCollateral
-    , txouts
+module Cardano.Wallet.Read.Tx.Gen.Dijkstra
+    ( mkDijkstraTx
     )
 where
 
 import Cardano.Ledger.Alonzo
     ( AlonzoTxAuxData
     )
-import Cardano.Ledger.Api
-    ( Datum (NoDatum)
-    )
-import Cardano.Ledger.Api.Era
-    ( BabbageEra
-    )
-import Cardano.Ledger.Babbage.Tx
+import Cardano.Ledger.Alonzo.Tx
     ( AlonzoTx (AlonzoTx)
     , IsValid (..)
-    , Tx (MkBabbageTx)
+    , ScriptIntegrityHash
     )
-import Cardano.Ledger.Babbage.TxBody
-    ( ScriptIntegrityHash
-    , TxBody (BabbageTxBody)
+import Cardano.Ledger.Api
+    ( Datum (NoDatum)
+    , DijkstraEra
+    )
+import Cardano.Ledger.Api.Tx.In
+    ( TxIn
     )
 import Cardano.Ledger.Babbage.TxOut
     ( BabbageTxOut (BabbageTxOut)
-    )
-import Cardano.Ledger.Babbage.TxWits
-    ( AlonzoTxWits
     )
 import Cardano.Ledger.BaseTypes
     ( Network
     )
 import Cardano.Ledger.Binary
     ( Sized
-    , Version
     , mkSized
     , natVersion
     )
-import Cardano.Ledger.Coin
-    ( Coin
+import Cardano.Ledger.Conway.Governance
+    ( ProposalProcedure
+    , VotingProcedures (..)
+    )
+import Cardano.Ledger.Credential
+    ( Credential
+    )
+import Cardano.Ledger.Dijkstra.Tx
+    ( Tx (MkDijkstraTx)
+    )
+import Cardano.Ledger.Dijkstra.TxBody
+    ( TxBody (DijkstraTxBody)
+    )
+import Cardano.Ledger.Dijkstra.TxCert
+    ( DijkstraTxCert
     )
 import Cardano.Ledger.Hashes
     ( TxAuxDataHash
     )
 import Cardano.Ledger.Keys
-    ( KeyHash
-    , KeyRole (..)
+    ( KeyRole (..)
     )
 import Cardano.Ledger.Mary.Value
     ( MultiAsset
-    )
-import Cardano.Ledger.Shelley.API.Types
-    ( TxIn
     )
 import Cardano.Wallet.Read.Tx.Gen.Address
     ( decodeShelleyAddress
@@ -65,14 +64,15 @@ import Cardano.Wallet.Read.Tx.Gen.Address
 import Cardano.Wallet.Read.Tx.Gen.Allegra
     ( exampleValidity
     )
+import Cardano.Wallet.Read.Tx.Gen.Babbage
+    ( totalCollateral
+    )
 import Cardano.Wallet.Read.Tx.Gen.Mary
     ( mkMaryValue
     )
 import Cardano.Wallet.Read.Tx.Gen.Shelley
-    ( certs
-    , txfee
+    ( txfee
     , txins
-    , upd
     , wdrls
     )
 import Cardano.Wallet.Read.Tx.Gen.TxParameters
@@ -80,7 +80,6 @@ import Cardano.Wallet.Read.Tx.Gen.TxParameters
     , Index (..)
     , Lovelace (..)
     , TxParameters (..)
-    , exampleTxParameters
     )
 import Cardano.Wallet.Read.Tx.TxId
     ( TxId
@@ -93,7 +92,9 @@ import Data.List.NonEmpty
     )
 import Data.Maybe.Strict
     ( StrictMaybe (SNothing)
-    , maybeToStrictMaybe
+    )
+import Data.OSet.Strict
+    ( OSet
     )
 import Data.Sequence.Strict
     ( StrictSeq
@@ -106,62 +107,74 @@ import Prelude
 
 import Cardano.Ledger.Core qualified as L
 
-mkBabbageTx
+-- | Create a minimal Dijkstra era transaction from parameters.
+mkDijkstraTx
     :: TxParameters
-    -> L.Tx BabbageEra
-mkBabbageTx TxParameters{txInputs, txOutputs} =
-    MkBabbageTx $ AlonzoTx (body txInputs txOutputs) wits valid aux
+    -> L.Tx DijkstraEra
+mkDijkstraTx TxParameters{txInputs, txOutputs} =
+    MkDijkstraTx $ AlonzoTx (body txInputs txOutputs) wits valid aux
 
 valid :: IsValid
 valid = IsValid True
 
-wits :: AlonzoTxWits BabbageEra
+wits :: L.TxWits DijkstraEra
 wits = mempty
 
-aux :: StrictMaybe (AlonzoTxAuxData BabbageEra)
-aux = maybeToStrictMaybe Nothing
+aux :: StrictMaybe (AlonzoTxAuxData DijkstraEra)
+aux = SNothing
 
 body
     :: NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> TxBody BabbageEra
+    -> L.TxBody DijkstraEra
 body ins outs =
-    BabbageTxBody
+    DijkstraTxBody
         (txins ins)
         collateralIns
         referenceIns
-        (txouts (natVersion @7) outs)
+        (txouts outs)
         collateralReturn
         totalCollateral
         certs
         wdrls
         txfee
         exampleValidity
-        upd
-        whash
+        guards
         mint
         integrity
         auxhash
         network
-
-totalCollateral :: StrictMaybe Coin
-totalCollateral = SNothing
+        votingProcedures
+        proposalProcedures
+        mempty
+        mempty
 
 collateralReturn
-    :: StrictMaybe (Sized (BabbageTxOut BabbageEra))
+    :: StrictMaybe (Sized (BabbageTxOut DijkstraEra))
 collateralReturn = SNothing
+
+proposalProcedures :: OSet (ProposalProcedure DijkstraEra)
+proposalProcedures = mempty
+
+votingProcedures :: VotingProcedures DijkstraEra
+votingProcedures = VotingProcedures mempty
+
+guards :: OSet (Credential 'Guard)
+guards = mempty
+
+certs :: OSet (DijkstraTxCert DijkstraEra)
+certs = mempty
 
 referenceIns :: Set TxIn
 referenceIns = mempty
 
 txouts
-    :: Version
-    -> NonEmpty (Address, Lovelace)
-    -> StrictSeq (Sized (BabbageTxOut BabbageEra))
-txouts v xs = fromList $ do
+    :: NonEmpty (Address, Lovelace)
+    -> StrictSeq (Sized (BabbageTxOut DijkstraEra))
+txouts xs = fromList $ do
     (addr, Lovelace val) <- toList xs
     pure
-        $ mkSized v
+        $ mkSized (natVersion @12)
         $ BabbageTxOut
             (decodeShelleyAddress addr)
             (mkMaryValue val)
@@ -177,14 +190,8 @@ auxhash = SNothing
 integrity :: StrictMaybe ScriptIntegrityHash
 integrity = SNothing
 
-whash :: Set (KeyHash 'Witness)
-whash = mempty
-
 collateralIns :: Set TxIn
 collateralIns = mempty
 
 mint :: MultiAsset
 mint = mempty
-
-exampleBabbageTx :: L.Tx BabbageEra
-exampleBabbageTx = mkBabbageTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Mary.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Mary.hs
@@ -19,17 +19,22 @@ import Cardano.Ledger.Api
 import Cardano.Ledger.Coin
     ( Coin (..)
     )
+import Cardano.Ledger.Mary
+    ( Tx (MkMaryTx)
+    )
 import Cardano.Ledger.Mary.TxBody
-    ( MaryTxBody (..)
+    ( TxBody (MaryTxBody)
     )
 import Cardano.Ledger.Mary.Value
     ( MaryValue (..)
     , MultiAsset
     )
 import Cardano.Ledger.Shelley.API.Types
-    ( ShelleyTx (ShelleyTx)
-    , ShelleyTxOut (ShelleyTxOut)
+    ( ShelleyTxOut (ShelleyTxOut)
     , StrictMaybe (..)
+    )
+import Cardano.Ledger.Shelley.Tx
+    ( ShelleyTx (ShelleyTx)
     )
 import Cardano.Wallet.Read.Tx.Gen.Address
     ( decodeShelleyAddress
@@ -68,11 +73,13 @@ import Data.Sequence.Strict
     )
 import Prelude
 
+import Cardano.Ledger.Core qualified as L
+
 mkMaryTx
     :: TxParameters
-    -> ShelleyTx MaryEra
+    -> L.Tx MaryEra
 mkMaryTx TxParameters{txInputs, txOutputs} =
-    ShelleyTx (body txInputs txOutputs) wits aux
+    MkMaryTx $ ShelleyTx (body txInputs txOutputs) wits aux
 
 aux :: StrictMaybe (AllegraTxAuxData MaryEra)
 aux = maybeToStrictMaybe Nothing
@@ -80,7 +87,7 @@ aux = maybeToStrictMaybe Nothing
 body
     :: NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> MaryTxBody MaryEra
+    -> L.TxBody MaryEra
 body ins outs =
     MaryTxBody
         (txins ins)
@@ -109,5 +116,5 @@ mkMaryValue lovelace = MaryValue (Coin lovelace) mempty
 validity :: ValidityInterval
 validity = ValidityInterval SNothing SNothing
 
-exampleMaryTx :: ShelleyTx MaryEra
+exampleMaryTx :: L.Tx MaryEra
 exampleMaryTx = mkMaryTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Shelley.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Gen/Shelley.hs
@@ -48,16 +48,19 @@ import Cardano.Ledger.Keys
     ( KeyHash (..)
     )
 import Cardano.Ledger.Shelley.API.Types
-    ( ShelleyTx (ShelleyTx)
-    , ShelleyTxAuxData
-    , ShelleyTxBody (ShelleyTxBody)
+    ( ShelleyTxAuxData
     , ShelleyTxOut (ShelleyTxOut)
     , ShelleyTxWits
+    , TxBody (ShelleyTxBody)
     , TxIn (..)
     , Withdrawals (Withdrawals)
     )
 import Cardano.Ledger.Shelley.PParams
     ( Update
+    )
+import Cardano.Ledger.Shelley.Tx
+    ( ShelleyTx (ShelleyTx)
+    , Tx (MkShelleyTx)
     )
 import Cardano.Ledger.Shelley.TxCert
     ( ShelleyTxCert
@@ -109,9 +112,9 @@ import Data.Set qualified as Set
 
 mkShelleyTx
     :: TxParameters
-    -> ShelleyTx ShelleyEra
+    -> L.Tx ShelleyEra
 mkShelleyTx TxParameters{txInputs, txOutputs} =
-    ShelleyTx (body txInputs txOutputs) wits aux
+    MkShelleyTx $ ShelleyTx (body txInputs txOutputs) wits aux
 
 aux :: StrictMaybe (ShelleyTxAuxData ShelleyEra)
 aux = maybeToStrictMaybe Nothing
@@ -123,7 +126,7 @@ body
     :: HasCallStack
     => NonEmpty (Index, TxId)
     -> NonEmpty (Address, Lovelace)
-    -> ShelleyTxBody ShelleyEra
+    -> L.TxBody ShelleyEra
 body ins outs =
     ShelleyTxBody
         (txins ins)
@@ -187,5 +190,5 @@ mkShelleyInput (Index idx) txid =
         $ mkTxInPartial txid
         $ fromIntegral idx
 
-exampleShelleyTx :: ShelleyTx ShelleyEra
+exampleShelleyTx :: L.Tx ShelleyEra
 exampleShelleyTx = mkShelleyTx exampleTxParameters

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Inputs.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Inputs.hs
@@ -52,6 +52,7 @@ getInputs = case theEra :: Era era of
     Alonzo -> unInputs . L.getEraInputs
     Babbage -> unInputs . L.getEraInputs
     Conway -> unInputs . L.getEraInputs
+    Dijkstra -> unInputs . L.getEraInputs
 
 {-# INLINE byronInputs #-}
 byronInputs :: L.Inputs Byron -> Set TxIn

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/ScriptValidity.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/ScriptValidity.hs
@@ -43,6 +43,7 @@ getScriptValidity = case theEra :: Era era of
     Alonzo -> onScriptValidity id
     Babbage -> onScriptValidity id
     Conway -> onScriptValidity id
+    Dijkstra -> onScriptValidity id
   where
     trueValid = const (IsValid True)
 

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxId.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxId.hs
@@ -89,3 +89,4 @@ fromLedgerTxId = case theEra :: Era era of
     Alonzo -> L.unTxId
     Babbage -> L.unTxId
     Conway -> L.unTxId
+    Dijkstra -> L.unTxId

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxOut.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/TxOut.hs
@@ -155,6 +155,7 @@ upgradeTxOutToBabbageOrLater :: TxOut -> TxOut
 upgradeTxOutToBabbageOrLater x@(TxOutC (EraValue (txout :: Output era))) =
     case theEra :: Era era of
         Conway -> x
+        Dijkstra -> x
         Babbage -> x
         _ -> case upgradeToOutputBabbage txout of
             Just output -> TxOutC (EraValue output)
@@ -295,6 +296,7 @@ withFoldableOutputs f = case theEra :: Era era of
     Alonzo -> \(Outputs x) -> f x
     Babbage -> \(Outputs x) -> f x
     Conway -> \(Outputs x) -> f x
+    Dijkstra -> \(Outputs x) -> f x
 
 -- Helper function: Treat the 'CollateralOutputs' as a 'StrictMaybe'.
 withMaybeCollateralOutputs
@@ -311,3 +313,4 @@ withMaybeCollateralOutputs f = case theEra :: Era era of
     Alonzo -> \(CollateralOutputs _) -> f SNothing
     Babbage -> \(CollateralOutputs x) -> f x
     Conway -> \(CollateralOutputs x) -> f x
+    Dijkstra -> \(CollateralOutputs x) -> f x

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Validity.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Tx/Validity.hs
@@ -80,6 +80,7 @@ getValidityInterval = case theEra :: Era era of
     Alonzo -> onValidity id
     Babbage -> onValidity id
     Conway -> onValidity id
+    Dijkstra -> onValidity id
 
 -- Helper function for type inference.
 onValidity

--- a/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Value.hs
+++ b/lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Value.hs
@@ -118,6 +118,7 @@ fromEraValue =
         Alonzo -> onValue id
         Babbage -> onValue id
         Conway -> onValue id
+        Dijkstra -> onValue id
 
 -- Helper function for type inference.
 onValue :: (L.ValueType era -> t) -> L.Value era -> t

--- a/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
+++ b/lib/cardano-wallet-read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
@@ -117,6 +117,7 @@ mkBasicOutput addr value = case theEra :: Era era of
     Alonzo -> Output $ mkBasicTxOut addr (toMaryValue value)
     Babbage -> Output $ mkBasicTxOut addr (toMaryValue value)
     Conway -> Output $ mkBasicTxOut addr (toMaryValue value)
+    Dijkstra -> Output $ mkBasicTxOut addr (toMaryValue value)
 
 mkPaymentCred :: ByteString -> PaymentCredential
 mkPaymentCred =

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -45,7 +45,7 @@ library
     , delta-store
     , delta-types
     , io-classes
-    , Only           ==0.1
+    , Only
     , sqlite-simple
     , text
     , transformers

--- a/lib/delta-types/delta-types.cabal
+++ b/lib/delta-types/delta-types.cabal
@@ -64,9 +64,9 @@ library
   import:          language, opts-lib
   hs-source-dirs:  src
   build-depends:
-    , base           >=4.14  && <5
-    , containers     >=0.5   && <0.8
-    , semigroupoids  >=6.0.1 && <6.1
+    , base
+    , containers
+    , semigroupoids
 
   exposed-modules:
     Data.Delta
@@ -84,7 +84,7 @@ test-suite unit
   main-is:            Main.hs
   build-depends:
     , base
-    , hspec  >=2.11.0 && <2.12
+    , hspec
 
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:      Data.DeltaSpec

--- a/lib/faucet/faucet.cabal
+++ b/lib/faucet/faucet.cabal
@@ -58,7 +58,7 @@ library
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses          >=4.0.2 && <4.1
+    , cardano-addresses
     , containers
     , directory
     , extra

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -51,7 +51,7 @@ library framework
     , bech32
     , bech32-th
     , bytestring
-    , cardano-addresses                    >=4.0.2    && <4.1
+    , cardano-addresses
     , cardano-ledger-shelley
     , cardano-wallet
     , cardano-wallet-api
@@ -84,10 +84,10 @@ library framework
     , http-client
     , http-types
     , HUnit
-    , iohk-monitoring                      >=0.2.0.0  && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , lens
-    , lobemo-backend-ekg                   >=0.2.0.0  && <0.3
+    , lobemo-backend-ekg
     , local-cluster
     , local-cluster:local-cluster-process
     , memory
@@ -135,7 +135,7 @@ library scenarios
     , base
     , bech32-th
     , bytestring
-    , cardano-addresses                     >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-crypto
     , cardano-crypto-class
@@ -232,7 +232,7 @@ test-suite e2e
   build-depends:
     , aeson
     , bytestring
-    , cardano-addresses                     >=4.0.2 && <4.1
+    , cardano-addresses
     , cardano-wallet-api
     , cardano-wallet-application
     , cardano-wallet-application-extras

--- a/lib/integration/framework/Test/Integration/Plutus.hs
+++ b/lib/integration/framework/Test/Integration/Plutus.hs
@@ -68,6 +68,7 @@ import Data.String.Interpolate
 import Data.Text
     ( Text
     )
+import Flat.Instances.Base ()
 import Text.Microstache
     ( compileMustacheText
     , renderMustache

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
@@ -238,6 +238,7 @@ spec = describe "VOTING_TRANSACTIONS" $ do
 
     it "VOTING_01b - Can vote and revote after delegation" $ \ctx -> runResourceT $ do
         noBabbage ctx "voting supported in Conway onwards"
+        pendingWith "Node 10.6.2 ledger rule change: WithdrawalsNotInRewardsCERTS when delegation and voting are in separate transactions. See #5210"
         src <- fixtureWallet ctx
 
         pool1 : _pool2 : _ <- map (view #id) <$> notRetiringPools ctx

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
@@ -238,7 +238,7 @@ spec = describe "VOTING_TRANSACTIONS" $ do
 
     it "VOTING_01b - Can vote and revote after delegation" $ \ctx -> runResourceT $ do
         noBabbage ctx "voting supported in Conway onwards"
-        --pendingWith "Node 10.6.2 ledger rule change: WithdrawalsNotInRewardsCERTS when delegation and voting are in separate transactions. See #5210"
+        -- pendingWith "Node 10.6.2 ledger rule change: WithdrawalsNotInRewardsCERTS when delegation and voting are in separate transactions. See #5210"
         src <- fixtureWallet ctx
 
         pool1 : _pool2 : _ <- map (view #id) <$> notRetiringPools ctx

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
@@ -238,7 +238,7 @@ spec = describe "VOTING_TRANSACTIONS" $ do
 
     it "VOTING_01b - Can vote and revote after delegation" $ \ctx -> runResourceT $ do
         noBabbage ctx "voting supported in Conway onwards"
-        pendingWith "Node 10.6.2 ledger rule change: WithdrawalsNotInRewardsCERTS when delegation and voting are in separate transactions. See #5210"
+        --pendingWith "Node 10.6.2 ledger rule change: WithdrawalsNotInRewardsCERTS when delegation and voting are in separate transactions. See #5210"
         src <- fixtureWallet ctx
 
         pool1 : _pool2 : _ <- map (view #id) <$> notRetiringPools ctx

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -38,7 +38,7 @@ library
     , exceptions
     , filepath
     , fmt
-    , iohk-monitoring      >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , stm
     , text
     , text-class

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -27,20 +27,20 @@ library
     ghc-options: -Werror
 
   build-depends:
-      base             >=4.14      && <5
-    , bytestring       >=0.10.6    && <0.13
-    , contra-tracer    >=0.1       && <0.3
-    , directory        >=1.3.8     && <1.4
-    , filepath         >=1.4.300.1 && <1.6
-    , fmt              >=0.6.3.0   && <0.7
-    , http-conduit     >=2.3.9     && <2.4
-    , iohk-monitoring  >=0.2.0.0   && <0.3
-    , network          >=3.1.2.5   && <3.3
-    , process          >=1.6.19.0  && <1.7
-    , text             >=1.2       && <2.2
+      base
+    , bytestring
+    , contra-tracer
+    , directory
+    , filepath
+    , fmt
+    , http-conduit
+    , iohk-monitoring
+    , network
+    , process
+    , text
     , text-class
-    , unliftio         >=0.2.25    && <0.3
-    , unliftio-core    >=0.1.1     && <0.3
+    , unliftio
+    , unliftio-core
 
   hs-source-dirs:     src
   exposed-modules:
@@ -77,15 +77,15 @@ test-suite unit
     , cardano-wallet-launcher
     , cardano-wallet-test-utils
     , contra-tracer
-    , fmt                        >=0.6.3.0 && <0.7
-    , hspec                      >=2.11.0  && <2.12
+    , fmt
+    , hspec
     , hspec-core
-    , hspec-expectations         >=0.8.4   && <0.9
-    , iohk-monitoring            >=0.2.0.0 && <0.3
-    , retry                      >=0.9.3   && <0.10
+    , hspec-expectations
+    , iohk-monitoring
+    , retry
     , text
     , text-class
-    , time                       >=1.12.2  && <1.15
+    , time
     , unliftio
 
   build-tool-depends: hspec-discover:hspec-discover

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
@@ -24,11 +24,8 @@ import Cardano.Api
     , SerialiseAsBech32
     , SerialiseAsCBOR (..)
     , StakeKey
+    , StakePoolKey
     , VerificationKey
-    , runExceptT
-    )
-import Cardano.Api.Shelley
-    ( StakePoolKey
     , VrfKey
     )
 import Cardano.Binary
@@ -183,6 +180,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.ListMap as ListMap
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import qualified RIO
 
 -- | Represents the notion of a fully configured pool. All keys are known, but
 -- not necessarily exposed using this interface.
@@ -330,8 +328,7 @@ readFailVerificationKeyOrFile
     -> ClusterM (VerificationKey keyrole)
 readFailVerificationKeyOrFile (FileOf op) =
     liftIO
-        . fmap (either (error . show) id)
-        . runExceptT
+        $ RIO.runRIO ()
         $ readVerificationKeyOrFile
             (VerificationKeyFilePath $ File $ toFilePath op)
 

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Logging.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Logging.hs
@@ -264,7 +264,7 @@ testMinSeverityFromEnv :: IO Severity
 testMinSeverityFromEnv =
     minSeverityFromEnv Notice "TESTS_TRACING_MIN_SEVERITY"
 
--- | Directory for extra logging. CI will set this environment variable
+-- | Directory for extra logging. Buildkite will set this environment variable
 -- and upload logs in it automatically.
 testLogDirFromEnv
     :: Maybe (RelDirOf "log-subdir")

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -98,15 +98,15 @@ library
 
   build-depends:
     , address-derivation-discovery
-    , aeson                              >=2.2       && <2.3
-    , aeson-pretty                       >=0.8.10    && <0.9
-    , base                               >=4.14      && <5
-    , base58-bytestring                  >=0.1       && <0.2
-    , bytestring                         >=0.10.6    && <0.13
-    , cardano-addresses                  >=4.0.2     && <4.1
+    , aeson
+    , aeson-pretty
+    , base
+    , base58-bytestring
+    , bytestring
+    , cardano-addresses
     , cardano-api
     , cardano-binary
-    , cardano-cli                        >=10.11.0.0
+    , cardano-cli
     , cardano-data
     , cardano-ledger-api
     , cardano-ledger-core
@@ -115,52 +115,53 @@ library
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
-    , cborg                              >=0.2.1     && <0.3
-    , comonad                            >=4.0       && <6
-    , containers                         >=0.5       && <0.8
-    , contra-tracer                      >=0.1       && <0.3
+    , cborg
+    , comonad
+    , containers
+    , contra-tracer
     , crypto-primitives
-    , directory                          >=1.3.8     && <1.4
+    , directory
     , faucet
-    , filepath                           >=1.4.300.1 && <1.6
-    , foldl                              >=1.4.17    && <1.5
-    , generic-lens                       >=2.2.2.0   && <2.3
-    , hkd                                >=0.2.1     && <0.3
-    , http-client                        >=0.7.17    && <0.8
-    , http-media                         >=0.8.1.1   && <0.9
-    , insert-ordered-containers          >=0.2.3     && <0.3
-    , int-cast                           >=0.2.0.0   && <0.3
+    , filepath
+    , foldl
+    , generic-lens
+    , hkd
+    , http-client
+    , http-media
+    , insert-ordered-containers
+    , int-cast
     , io-classes
-    , iohk-monitoring                    >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
-    , lens                               >=5.2.3     && <5.4
-    , lens-aeson                         >=1.2.3     && <1.3
-    , machines                           >=0.7.3     && <0.8
-    , memory                             >=0.18.0    && <0.19
-    , mtl                                >=2.3.1     && <2.4
-    , network                            >=3.1.2.5   && <3.3
-    , OddWord                            >=1.0.1.1   && <1.1
-    , openapi3                           >=3.2.3     && <3.3
-    , optparse-applicative               >=0.18.1.0  && <0.19
+    , lens
+    , lens-aeson
+    , machines
+    , memory
+    , mtl
+    , network
+    , OddWord
+    , openapi3
+    , optparse-applicative
     , ouroboros-network
     , ouroboros-network-api
-    , pathtype                           >=0.8.1.3   && <0.9
-    , profunctors                        >=5.6.2     && <5.7
-    , QuickCheck                         >=2.14      && <2.16
-    , retry                              >=0.9.3     && <0.10
-    , servant                            >=0.20.2    && <0.21
-    , servant-client                     >=0.20.2    && <0.21
-    , servant-server                     >=0.20.2    && <0.21
-    , tagged                             >=0.8.8     && <0.9
-    , temporary                          >=1.3       && <1.4
+    , pathtype
+    , profunctors
+    , QuickCheck
+    , retry
+    , rio
+    , servant
+    , servant-client
+    , servant-server
+    , tagged
+    , temporary
     , temporary-extra
-    , text                               >=1.2       && <2.2
+    , text
     , text-class
-    , time                               >=1.12.2    && <1.15
-    , typed-process                      >=0.2.12.0  && <0.3
-    , unliftio                           >=0.2.25    && <0.3
-    , warp                               >=3.4       && <3.5
-    , yaml                               >=0.11.7    && <0.12
+    , time
+    , typed-process
+    , unliftio
+    , warp
+    , yaml
 
 -- insert-ordered-containers is used by openapi3
 -- openapi3 requires a fork https://github.com/paolino/openapi3
@@ -186,7 +187,7 @@ library local-cluster-process
     , cardano-wallet-primitive
     , contra-tracer
     , directory
-    , extra                              >=1.7.16 && <1.9
+    , extra
     , filepath
     , iohk-monitoring-extra
     , local-cluster
@@ -209,17 +210,17 @@ executable local-cluster
     , cardano-wallet-primitive
     , contra-tracer
     , directory
-    , extra                              >=1.7.16  && <1.9
+    , extra
     , iohk-monitoring-extra
     , lens
     , local-cluster
     , mtl
     , pathtype
-    , pretty-simple                      >=4.1.2.0 && <4.2
+    , pretty-simple
     , temporary-extra
     , text
     , unliftio
-    , with-utf8                          >=1.1.0   && <1.2
+    , with-utf8
 
 common test-common
   import:             language
@@ -228,10 +229,10 @@ common test-common
   build-depends:
     , aeson
     , aeson-pretty
-    , aeson-qq                             >=0.8.4    && <0.9
+    , aeson-qq
     , base
     , bytestring
-    , cardano-addresses                    >=4.0.2    && <4.1
+    , cardano-addresses
     , cardano-binary
     , cardano-ledger-alonzo
     , cardano-ledger-babbage
@@ -247,10 +248,10 @@ common test-common
     , cardano-wallet-test-utils
     , containers
     , contra-tracer
-    , extra                                >=1.7.16   && <1.9
+    , extra
     , foldl
-    , hspec                                >=2.11.0   && <2.12
-    , hspec-golden                         >=0.2.2    && <0.3
+    , hspec
+    , hspec-golden
     , iohk-monitoring-extra
     , local-cluster
     , local-cluster:local-cluster-process
@@ -260,10 +261,10 @@ common test-common
     , ouroboros-network
     , pathtype
     , QuickCheck
-    , streaming                            >=0.2.4    && <0.3
+    , streaming
     , time
     , unliftio
-    , with-utf8                            >=1.1.0    && <1.2
+    , with-utf8
 
   build-tool-depends: hspec-discover:hspec-discover
 

--- a/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Http/ServiceSpec.hs
+++ b/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Http/ServiceSpec.hs
@@ -460,6 +460,7 @@ txOutFromOutput = case theEra :: Era era of
     Alonzo -> \(Outputs os) -> fromAlonzoTxOut <$> toList os
     Babbage -> \(Outputs os) -> fromBabbageTxOut <$> toList os
     Conway -> \(Outputs os) -> fromConwayTxOut <$> toList os
+    Dijkstra -> error "txOutFromOutput: DijkstraEra not yet supported"
   where
     fromByronTxOut :: Byron.TxOut -> TxOut
     fromByronTxOut (Byron.TxOut addr amount) =

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -66,8 +66,8 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-    , base                           >=4.14      && <5
-    , bytestring                     >=0.10.6    && <0.13
+    , base
+    , bytestring
     , cardano-api
     , cardano-balance-tx
     , cardano-binary
@@ -83,17 +83,17 @@ library
     , cardano-slotting
     , cardano-wallet-launcher
     , cardano-wallet-primitive
-    , cardano-wallet-read            >=1.0.0.0   && <1.1
-    , cborg                          >=0.2.1     && <0.3
-    , containers                     >=0.5       && <0.8
-    , contra-tracer                  >=0.1       && <0.3
-    , exceptions                     >=0.10.7    && <0.11
-    , fmt                            >=0.6.3     && <0.7
+    , cardano-wallet-read
+    , cborg
+    , containers
+    , contra-tracer
+    , exceptions
+    , fmt
     , io-classes
-    , iohk-monitoring                >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
-    , network-mux                    >=0.6       && <0.10
-    , nothunks                       >=0.1.5     && <0.4
+    , network-mux
+    , nothunks
     , ouroboros-consensus
     , ouroboros-consensus-cardano
     , ouroboros-consensus-diffusion
@@ -102,20 +102,20 @@ library
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
-    , parallel                       >=3.2.2     && <3.3
-    , retry                          >=0.9.3     && <0.10
-    , safe                           >=0.3.19    && <0.4
+    , parallel
+    , retry
+    , safe
     , singletons
-    , streaming                      >=0.2.4     && <0.3
-    , strict-stm
-    , text                           >=1.2       && <2.2
+    , streaming
+    , io-classes:strict-stm
+    , text
     , text-class
-    , time                           >=1.12.2    && <1.15
-    , transformers                   >=0.6.1.0   && <0.7
-    , typed-protocols                >=0.3.0.0   && <1.1
+    , time
+    , transformers
+    , typed-protocols
     , typed-protocols-stateful
-    , unliftio                       >=0.2.25    && <0.3
-    , unliftio-core                  >=0.1.1     && <0.3
+    , unliftio
+    , unliftio-core
 
 test-suite unit
   import:             language, opts-exe
@@ -129,9 +129,9 @@ test-suite unit
     , cardano-wallet-read
     , containers
     , contra-tracer
-    , hspec                         >=2.11.0  && <2.12
+    , hspec
     , io-classes
-    , QuickCheck                    >=2.14    && <2.16
+    , QuickCheck
     , text
     , transformers
 

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -90,6 +90,7 @@ library
     , exceptions
     , fmt
     , io-classes
+    , io-classes:strict-stm
     , iohk-monitoring
     , iohk-monitoring-extra
     , network-mux
@@ -107,7 +108,6 @@ library
     , safe
     , singletons
     , streaming
-    , io-classes:strict-stm
     , text
     , text-class
     , time

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -38,9 +38,7 @@ import Cardano.Api
     , CardanoEra (..)
     , NodeToClientVersion (..)
     , SlotNo (..)
-    )
-import Cardano.Api.Shelley
-    ( toConsensusGenTx
+    , toConsensusGenTx
     )
 import Cardano.BM.Data.Severity
     ( Severity (..)
@@ -177,6 +175,8 @@ import Control.Monad.Class.MonadST
     )
 import Control.Monad.Class.MonadThrow
     ( MonadEvaluate
+    , MonadMask
+    , MonadThrow
     )
 import Control.Monad.Class.MonadTimer
     ( MonadTimer
@@ -267,6 +267,9 @@ import Network.Mux
     ( Error (..)
     , Mode (..)
     , WithBearer (..)
+    )
+import Network.Mux.Trace
+    ( nullTracers
     )
 import Ouroboros.Consensus.Cardano
     ( CardanoBlock
@@ -687,6 +690,8 @@ withNodeNetworkLayerBase
                     AnyCardanoEra AlonzoEra -> InNonRecentEraAlonzo
                     AnyCardanoEra BabbageEra -> InRecentEraBabbage mempty
                     AnyCardanoEra ConwayEra -> InRecentEraConway mempty
+                    AnyCardanoEra DijkstraEra ->
+                        error "_getUTxOByTxIn: DijkstraEra not yet supported"
             | otherwise =
                 bracketQuery "getUTxOByTxIn" tr
                     $ queue `send` SomeLSQ (LSQ.getUTxOByTxIn ins)
@@ -824,6 +829,7 @@ type WalletNodeToClientProtocols m =
 mkWalletClient
     :: forall m block
      . ( block ~ CardanoBlock (StandardCrypto)
+       , MonadThrow m
        , MonadEvaluate m
        , MonadST m
        , MonadTimer m
@@ -859,6 +865,7 @@ mkWalletClient tr pipeliningStrategy follower cfg nodeToClientVer =
 mkFetchBlockClient
     :: forall m block
      . ( block ~ CardanoBlock (StandardCrypto)
+       , MonadThrow m
        , MonadEvaluate m
        , MonadST m
        , MonadTimer m
@@ -894,6 +901,7 @@ mkDelegationRewardsClient
        , MonadTimer m
        , MonadIO m
        , MonadAsync m
+       , MonadMask m
        , MonadEvaluate m
        )
     => Tracer m Log
@@ -938,6 +946,7 @@ mkWalletToNodeProtocols
        , MonadST m
        , MonadTimer m
        , MonadAsync m
+       , MonadMask m
        , MonadEvaluate m
        )
     => Tracer m Log
@@ -1188,6 +1197,7 @@ codecConfig sp =
         ShelleyCodecConfig
         ShelleyCodecConfig
         ShelleyCodecConfig
+        ShelleyCodecConfig
 
 -- | A group of codecs which will deserialise block data.
 codecs
@@ -1244,7 +1254,7 @@ connectClient tr handlers client vData conn = withIOManager $ \manager ->
             ]
     tracers =
         NetworkConnectTracers
-            { nctMuxTracer = nullTracer
+            { nctMuxTracers = nullTracers
             , nctHandshakeTracer = contramap MsgHandshakeTracer tr
             }
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/Extra.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/Extra.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Api
     , AlonzoEra
     , BabbageEra
     , ConwayEra
+    , DijkstraEra
     , MaryEra
     , ShelleyEra
     )
@@ -36,6 +37,7 @@ import Cardano.Wallet.Read
     , Babbage
     , Byron
     , Conway
+    , Dijkstra
     , Mary
     , Shelley
     )
@@ -96,6 +98,7 @@ byronOrShelleyBased onByron onShelleyBased =
         onShelleyBased
         onShelleyBased
         onShelleyBased
+        onShelleyBased
 
 -- | Combine era-specific local state queries into an era-agnostic one.
 onAnyEra'
@@ -115,8 +118,12 @@ onAnyEra'
         m
         (f Babbage)
     -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) Conway) m (f Conway)
+    -> LSQ
+        (Shelley.ShelleyBlock (Praos StandardCrypto) Dijkstra)
+        m
+        (f Dijkstra)
     -> LSQ (CardanoBlock StandardCrypto) m (Read.EraValue f)
-onAnyEra' a b c d e f g =
+onAnyEra' a b c d e f g h =
     onAnyEra
         (Read.EraValue <$> a)
         (Read.EraValue <$> b)
@@ -125,6 +132,7 @@ onAnyEra' a b c d e f g =
         (Read.EraValue <$> e)
         (Read.EraValue <$> f)
         (Read.EraValue <$> g)
+        (Read.EraValue <$> h)
 
 -- | Create a local state query specific to the each era.
 --
@@ -143,8 +151,9 @@ onAnyEra
     -> LSQ (Shelley.ShelleyBlock (TPraos StandardCrypto) AlonzoEra) m a
     -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) BabbageEra) m a
     -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) ConwayEra) m a
+    -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) DijkstraEra) m a
     -> LSQ (CardanoBlock StandardCrypto) m a
-onAnyEra onByron onShelley onAllegra onMary onAlonzo onBabbage onConway =
+onAnyEra onByron onShelley onAllegra onMary onAlonzo onBabbage onConway onDijkstra =
     currentEra >>= \case
         AnyCardanoEra ByronEra -> mapQuery QueryIfCurrentByron onByron
         AnyCardanoEra ShelleyEra -> mapQuery QueryIfCurrentShelley onShelley
@@ -153,6 +162,7 @@ onAnyEra onByron onShelley onAllegra onMary onAlonzo onBabbage onConway =
         AnyCardanoEra AlonzoEra -> mapQuery QueryIfCurrentAlonzo onAlonzo
         AnyCardanoEra BabbageEra -> mapQuery QueryIfCurrentBabbage onBabbage
         AnyCardanoEra ConwayEra -> mapQuery QueryIfCurrentConway onConway
+        AnyCardanoEra DijkstraEra -> mapQuery QueryIfCurrentDijkstra onDijkstra
   where
     mapQuery
         :: ( forall footprint r
@@ -221,4 +231,5 @@ eraIndexToAnyCardanoEra index =
         4 -> AnyCardanoEra AlonzoEra
         5 -> AnyCardanoEra BabbageEra
         6 -> AnyCardanoEra ConwayEra
+        7 -> AnyCardanoEra DijkstraEra
         _ -> error "eraIndexToAnyCardanoEra: unknown era"

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
@@ -75,6 +75,7 @@ protocolParams =
         (Read.PParams <$> LSQry Shelley.GetCurrentPParams)
         (Read.PParams <$> LSQry Shelley.GetCurrentPParams)
         (Read.PParams <$> LSQry Shelley.GetCurrentPParams)
+        (Read.PParams <$> LSQry Shelley.GetCurrentPParams)
   where
     fromByron = Read.PParams . Byron.adoptedProtocolParameters
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/RewardAccount.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/RewardAccount.hs
@@ -67,6 +67,7 @@ fetchRewardAccounts accounts =
         shelleyQry
         shelleyQry
         shelleyQry
+        shelleyQry
   where
     byronValue :: Map W.RewardAccount W.Coin
     byronValue = Map.fromList . map (,W.Coin 0) $ Set.toList accounts
@@ -100,6 +101,7 @@ getStakeDelegDeposits
 getStakeDelegDeposits credentials =
     onAnyEra
         (pure byronValue)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
         (LSQry $ Shelley.GetStakeDelegDeposits credentials)
         (LSQry $ Shelley.GetStakeDelegDeposits credentials)
         (LSQry $ Shelley.GetStakeDelegDeposits credentials)

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/StakeDistribution.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/StakeDistribution.hs
@@ -76,12 +76,13 @@ stakeDistribution coin =
 stakeDistr :: LSQ' (Maybe (Map PoolId Percentage))
 stakeDistr =
     shelleyBased
-        (fromPoolDistr <$> LSQry Shelley.GetStakeDistribution)
+        (fromPoolDistr <$> LSQry Shelley.GetStakeDistribution2)
 
 getNOpt :: LSQ' (Maybe Int)
 getNOpt =
     onAnyEra
         (pure Nothing)
+        (Just . optimumNumberOfPools <$> LSQry Shelley.GetCurrentPParams)
         (Just . optimumNumberOfPools <$> LSQry Shelley.GetCurrentPParams)
         (Just . optimumNumberOfPools <$> LSQry Shelley.GetCurrentPParams)
         (Just . optimumNumberOfPools <$> LSQry Shelley.GetCurrentPParams)

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
@@ -54,3 +54,5 @@ getUTxOByTxIn ins =
         (pure InNonRecentEraAlonzo)
         (InRecentEraBabbage <$> LSQry (Shelley.GetUTxOByTxIn ins))
         (InRecentEraConway <$> LSQry (Shelley.GetUTxOByTxIn ins))
+        -- TODO: promote Dijkstra to a RecentEra
+        (error "getUTxOByTxIn: DijkstraEra not yet supported")

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -61,6 +61,7 @@ library
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-dijkstra
+    , cardano-ledger-read
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-ledger-shelley

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -45,7 +45,7 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses             >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-binary
     , cardano-crypto
@@ -60,6 +60,7 @@ library
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-dijkstra
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-ledger-shelley
@@ -85,7 +86,7 @@ library
     , generics-sop
     , hashable
     , int-cast
-    , iohk-monitoring               >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , lattices
     , lens
     , memory
@@ -229,10 +230,10 @@ test-suite test
     , base58-bytestring
     , binary
     , bytestring
-    , cardano-addresses               >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-crypto-class
-    , cardano-ledger-allegra:testlib  >=1.7.0.0   && <1.8
+    , cardano-ledger-allegra:testlib
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-core
@@ -253,7 +254,7 @@ test-suite test
     , generic-lens
     , hspec
     , hspec-core
-    , iohk-monitoring                 >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , lens
     , memory
     , ouroboros-consensus

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -61,7 +61,6 @@ library
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-dijkstra
-    , cardano-ledger-read
     , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-ledger-shelley

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -458,6 +458,7 @@ toWalletScript tokeyrole = \case
         ActiveUntilSlot $ fromIntegral slot
     Scripts.RequireTimeStart (SlotNo slot) ->
         ActiveFromSlot $ fromIntegral slot
+    _ -> error "toWalletScript: impossible"
 
 toWalletScriptFromShelley
     :: forall era
@@ -576,3 +577,4 @@ toPlutusScriptInfo script = case Alonzo.plutusScriptLanguage @era script of
     Ledger.PlutusV1 -> PlutusVersionV1
     Ledger.PlutusV2 -> PlutusVersionV2
     Ledger.PlutusV3 -> PlutusVersionV3
+    Ledger.PlutusV4 -> PlutusVersionV4

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
@@ -103,6 +103,7 @@ primitiveHash = case theEra @era of
     Alonzo -> mkHashShelley
     Babbage -> mkHashShelley
     Conway -> mkHashShelley
+    Dijkstra -> mkHashShelley
   where
     mkHashShelley
         :: HeaderHashT era ~ ShelleyHash
@@ -125,6 +126,7 @@ primitivePrevHash gp = case theEra @era of
     Alonzo -> mkPrevHashShelley
     Babbage -> mkPrevHashShelley
     Conway -> mkPrevHashShelley
+    Dijkstra -> mkPrevHashShelley
   where
     mkPrevHashShelley
         :: (SL.PrevHash ~ PrevHeaderHashT era)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Eras.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Eras.hs
@@ -14,6 +14,7 @@ import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
     )
+import Prelude
 
 import qualified Cardano.Wallet.Read as Read
 
@@ -28,3 +29,4 @@ fromAnyCardanoEra (AnyCardanoEra era) =
         AlonzoEra -> Read.EraValue Read.Alonzo
         BabbageEra -> Read.EraValue Read.Babbage
         ConwayEra -> Read.EraValue Read.Conway
+        _ -> error "fromAnyCardanoEra: era not yet supported"

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/PParams.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/PParams.hs
@@ -19,6 +19,7 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     , fromAlonzoPParams
     , fromBabbagePParams
     , fromConwayPParams
+    , fromDijkstraPParams
     , fromMaryPParams
     , fromShelleyPParams
     )
@@ -52,3 +53,4 @@ primitiveProtocolParameters eraBounds (Read.PParams pparams) =
         Read.Alonzo -> fromAlonzoPParams eraBounds pparams
         Read.Babbage -> fromBabbagePParams eraBounds pparams
         Read.Conway -> fromConwayPParams eraBounds pparams
+        Read.Dijkstra -> fromDijkstraPParams eraBounds pparams

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralInputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralInputs.hs
@@ -35,6 +35,7 @@ getCollateralInputs = case theEra @era of
     Alonzo -> mkShelleyTxCollateralInputsIns
     Babbage -> mkShelleyTxCollateralInputsIns
     Conway -> mkShelleyTxCollateralInputsIns
+    Dijkstra -> mkShelleyTxCollateralInputsIns
 
 mkShelleyTxCollateralInputsIns
     :: (Foldable t, CollateralInputsType era ~ t SH.TxIn)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralOutputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralOutputs.hs
@@ -13,6 +13,9 @@ import Cardano.Ledger.Babbage
 import Cardano.Ledger.Conway
     ( ConwayEra
     )
+import Cardano.Ledger.Dijkstra
+    ( DijkstraEra
+    )
 import Cardano.Read.Ledger.Tx.CollateralOutputs
     ( CollateralOutputs (..)
     )
@@ -51,6 +54,8 @@ getCollateralOutputs = case theEra @era of
         fromBabbageTxOut <$> strictMaybeToMaybe mo
     Conway -> \(CollateralOutputs mo) ->
         fromConwayTxOut <$> strictMaybeToMaybe mo
+    Dijkstra -> \(CollateralOutputs mo) ->
+        fromDijkstraTxOut <$> strictMaybeToMaybe mo
 
 fromBabbageTxOut
     :: Babbage.BabbageTxOut BabbageEra
@@ -62,4 +67,10 @@ fromConwayTxOut
     :: Babbage.BabbageTxOut ConwayEra
     -> W.TxOut
 fromConwayTxOut (Babbage.BabbageTxOut addr value _datum _refScript) =
+    W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
+
+fromDijkstraTxOut
+    :: Babbage.BabbageTxOut DijkstraEra
+    -> W.TxOut
+fromDijkstraTxOut (Babbage.BabbageTxOut addr value _datum _refScript) =
     W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ExtraSigs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ExtraSigs.hs
@@ -52,6 +52,7 @@ extraSigs = case theEra @era of
     Alonzo -> yesExtraSigs
     Babbage -> yesExtraSigs
     Conway -> yesExtraSigs
+    Dijkstra -> yesExtraSigs
   where
     noExtraSigs = const []
     yesExtraSigs (ExtraSigs es) = getExtraSigs es

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Fee.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Fee.hs
@@ -35,6 +35,7 @@ getFee = case theEra @era of
     Alonzo -> mkShelleyTxFee
     Babbage -> mkShelleyTxFee
     Conway -> mkShelleyTxFee
+    Dijkstra -> mkShelleyTxFee
 
 mkShelleyTxFee :: FeeType era ~ Coin => Fee era -> Maybe W.Coin
 mkShelleyTxFee (Fee c) = Just $ Ledger.toWalletCoin c

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
@@ -48,6 +48,7 @@ getInputs = case theEra @era of
     Alonzo -> mkShelleyTxInputsIns
     Babbage -> mkShelleyTxInputsIns
     Conway -> mkShelleyTxInputsIns
+    Dijkstra -> mkShelleyTxInputsIns
 
 fromShelleyTxIns :: Foldable t => t SH.TxIn -> [W.TxIn]
 fromShelleyTxIns ins = fromShelleyTxIn <$> toList ins

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
@@ -53,6 +53,7 @@ integrity = case theEra @era of
     Alonzo -> yesIntegrity
     Babbage -> yesIntegrity
     Conway -> yesIntegrity
+    Dijkstra -> yesIntegrity
   where
     noIntegrity = const Nothing
     yesIntegrity (Integrity es) = getIntegrity es

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Metadata
     , fromAlonzoMetadata
     , fromBabbageMetadata
     , fromConwayMetadata
+    , fromDijkstraMetadata
     )
 where
 
@@ -39,6 +40,9 @@ import Cardano.Ledger.BaseTypes
     )
 import Cardano.Ledger.Conway
     ( ConwayEra
+    )
+import Cardano.Ledger.Dijkstra
+    ( DijkstraEra
     )
 import Cardano.Ledger.Mary
     ( MaryEra
@@ -65,8 +69,7 @@ import Data.Word
     )
 import Prelude
 
-import qualified Cardano.Api.Shelley as Cardano
-import qualified Cardano.Api.Shelley as CardanoAPI
+import qualified Cardano.Api.Tx as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
 
 {-# INLINEABLE getMetadata #-}
@@ -80,6 +83,7 @@ getMetadata = case theEra @era of
     Alonzo -> yesMetadata fromAlonzoMetadata
     Babbage -> yesMetadata fromBabbageMetadata
     Conway -> yesMetadata fromConwayMetadata
+    Dijkstra -> yesMetadata fromDijkstraMetadata
   where
     noMetadatas _ = Nothing
     yesMetadata f (Metadata s) = f <$> strictMaybeToMaybe s
@@ -105,6 +109,9 @@ fromBabbageMetadata (AlonzoTxAuxData md _timelock _plutus) = fromMetadata md
 fromConwayMetadata :: AlonzoTxAuxData ConwayEra -> W.TxMetadata
 fromConwayMetadata (AlonzoTxAuxData md _timelock _plutus) = fromMetadata md
 
+fromDijkstraMetadata :: AlonzoTxAuxData DijkstraEra -> W.TxMetadata
+fromDijkstraMetadata (AlonzoTxAuxData md _timelock _plutus) = fromMetadata md
+
 fromMetadata :: Map Word64 Metadatum -> W.TxMetadata
 fromMetadata =
-    Cardano.makeTransactionMetadata . CardanoAPI.fromShelleyMetadata
+    Cardano.makeTransactionMetadata . Cardano.fromShelleyMetadata

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs
     , fromAlonzoTxOut
     , fromBabbageTxOut
     , fromConwayTxOut
+    , fromDijkstraTxOut
     , fromCardanoValue
     , fromShelleyAddress
     , fromByronTxOut
@@ -34,6 +35,9 @@ import Cardano.Ledger.Babbage
     )
 import Cardano.Ledger.Conway
     ( ConwayEra
+    )
+import Cardano.Ledger.Dijkstra
+    ( DijkstraEra
     )
 import Cardano.Ledger.Mary
     ( MaryEra
@@ -68,7 +72,7 @@ import GHC.Stack
     )
 import Prelude
 
-import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Api as Cardano
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Ledger.Address as SL
 import qualified Cardano.Ledger.Alonzo as Alonzo
@@ -102,6 +106,7 @@ getOutputs = case theEra @era of
     Alonzo -> \(Outputs os) -> fromAlonzoTxOut <$> toList os
     Babbage -> \(Outputs os) -> fst . fromBabbageTxOut <$> toList os
     Conway -> \(Outputs os) -> fst . fromConwayTxOut <$> toList os
+    Dijkstra -> \(Outputs os) -> fst . fromDijkstraTxOut <$> toList os
 
 fromShelleyAddress :: SL.Addr -> W.Address
 fromShelleyAddress = W.Address . SL.serialiseAddr
@@ -142,6 +147,16 @@ fromConwayTxOut
     :: Babbage.BabbageTxOut ConwayEra
     -> (W.TxOut, Maybe (AlonzoScript Conway.ConwayEra))
 fromConwayTxOut (Babbage.BabbageTxOut addr value _datum refScript) =
+    ( W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
+    , case refScript of
+        SJust s -> Just s
+        SNothing -> Nothing
+    )
+
+fromDijkstraTxOut
+    :: Babbage.BabbageTxOut DijkstraEra
+    -> (W.TxOut, Maybe (AlonzoScript DijkstraEra))
+fromDijkstraTxOut (Babbage.BabbageTxOut addr value _datum refScript) =
     ( W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
     , case refScript of
         SJust s -> Just s

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ScriptValidity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ScriptValidity.hs
@@ -38,6 +38,7 @@ getScriptValidity = case theEra @era of
     Alonzo -> yesScriptValidity
     Babbage -> yesScriptValidity
     Conway -> yesScriptValidity
+    Dijkstra -> yesScriptValidity
   where
     noScriptValidity _ = Nothing
     yesScriptValidity (ScriptValidity (IsValid b))

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Scripts
     ( alonzoAnyExplicitScript
     , babbageAnyExplicitScript
     , conwayAnyExplicitScript
+    , dijkstraAnyExplicitScript
     )
 where
 
@@ -25,6 +26,9 @@ import Cardano.Ledger.Babbage
     )
 import Cardano.Ledger.Conway
     ( ConwayEra
+    )
+import Cardano.Ledger.Dijkstra
+    ( DijkstraEra
     )
 import Cardano.Ledger.Mary.Value
     ( PolicyID (..)
@@ -58,7 +62,7 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 alonzoAnyExplicitScript
     :: WitnessCountCtx -> AlonzoScript AlonzoEra -> AnyExplicitScript
 alonzoAnyExplicitScript witCtx = \case
-    Alonzo.TimelockScript script ->
+    Alonzo.NativeScript script ->
         NativeExplicitScript
             (toWalletScript (toKeyRole witCtx) script)
             ViaSpending
@@ -81,7 +85,7 @@ babbageAnyExplicitScript witCtx (scriptRef, scriptH, script) =
     (toWalletTokenPolicyId (PolicyID scriptH), toAnyScript script)
   where
     toAnyScript = \case
-        Alonzo.TimelockScript timelockScript ->
+        Alonzo.NativeScript timelockScript ->
             NativeExplicitScript
                 (toWalletScript (toKeyRole witCtx) timelockScript)
                 scriptRef
@@ -104,7 +108,7 @@ conwayAnyExplicitScript witCtx (scriptRef, scriptH, script) =
     (toWalletTokenPolicyId (PolicyID scriptH), toAnyScript script)
   where
     toAnyScript = \case
-        Alonzo.TimelockScript timelockScript ->
+        Alonzo.NativeScript timelockScript ->
             NativeExplicitScript
                 (toWalletScript (toKeyRole witCtx) timelockScript)
                 scriptRef
@@ -113,5 +117,28 @@ conwayAnyExplicitScript witCtx (scriptRef, scriptH, script) =
                 ( PlutusScriptInfo
                     (toPlutusScriptInfo @ConwayEra s)
                     (fromLedgerScriptHash $ hashScript @ConwayEra script)
+                )
+                scriptRef
+
+dijkstraAnyExplicitScript
+    :: WitnessCountCtx
+    -> ( ScriptReference
+       , ScriptHash
+       , AlonzoScript DijkstraEra
+       )
+    -> (TokenPolicyId, AnyExplicitScript)
+dijkstraAnyExplicitScript witCtx (scriptRef, scriptH, script) =
+    (toWalletTokenPolicyId (PolicyID scriptH), toAnyScript script)
+  where
+    toAnyScript = \case
+        Alonzo.NativeScript timelockScript ->
+            NativeExplicitScript
+                (toWalletScript (toKeyRole witCtx) timelockScript)
+                scriptRef
+        Alonzo.PlutusScript s ->
+            PlutusExplicitScript
+                ( PlutusScriptInfo
+                    (toPlutusScriptInfo @DijkstraEra s)
+                    (fromLedgerScriptHash $ hashScript @DijkstraEra script)
                 )
                 scriptRef

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Validity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Validity.hs
@@ -50,6 +50,7 @@ getValidity = case theEra @era of
     Alonzo -> afterShelleyValidity
     Babbage -> afterShelleyValidity
     Conway -> afterShelleyValidity
+    Dijkstra -> afterShelleyValidity
   where
     afterShelleyValidity (Validity validity) =
         Just $ afterShelleyValidityInterval validity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Withdrawals.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Withdrawals.hs
@@ -50,6 +50,7 @@ getWithdrawals = case theEra @era of
     Alonzo -> eraFromWithdrawals
     Babbage -> eraFromWithdrawals
     Conway -> eraFromWithdrawals
+    Dijkstra -> eraFromWithdrawals
   where
     eraFromWithdrawals (Withdrawals withdrawals) =
         Just $ fromLedgerWithdrawals withdrawals

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
@@ -26,9 +26,9 @@ import Cardano.Wallet.Read.Eras
     , Mary
     , Shelley
     )
+import Prelude
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
 
 fromSealedTx :: W.SealedTx -> EraValue Tx
@@ -45,3 +45,4 @@ fromCardanoApiTx tx0 = case tx0 of
         Cardano.ShelleyBasedEraAlonzo -> EraValue (Tx tx :: Tx Alonzo)
         Cardano.ShelleyBasedEraBabbage -> EraValue (Tx tx :: Tx Babbage)
         Cardano.ShelleyBasedEraConway -> EraValue (Tx tx :: Tx Conway)
+        _ -> error "fromCardanoApiTx: era not yet supported"

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/TxExtended.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/TxExtended.hs
@@ -60,7 +60,6 @@ import Cardano.Wallet.Read
 import Prelude
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Api.Shelley as Cardano
 
 fromCardanoTx
     :: Cardano.Tx cera
@@ -73,6 +72,7 @@ fromCardanoTx = \case
         Cardano.ShelleyBasedEraAlonzo -> getTxExtended @Alonzo $ Tx tx
         Cardano.ShelleyBasedEraBabbage -> getTxExtended @Babbage $ Tx tx
         Cardano.ShelleyBasedEraConway -> getTxExtended @Conway $ Tx tx
+        _ -> error "fromCardanoTx: era not yet supported"
 
 getTxExtended :: forall era. IsEra era => Tx era -> TxExtended
 getTxExtended tx =

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -386,7 +386,7 @@ emptyGenesis gp =
 -- | The protocol client version. Distinct from the codecs version.
 nodeToClientVersions :: [NodeToClientVersion]
 nodeToClientVersions =
-    [NodeToClientV_16, NodeToClientV_17]
+    [NodeToClientV_16 .. NodeToClientV_22]
 
 --------------------------------------------------------------------------------
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
@@ -68,6 +68,7 @@ import qualified Data.Text as T
 --              addresses. Genesis file needs to be passed explicitly when
 --              starting the application.
 data NetworkDiscriminant = Mainnet | Testnet Nat
+    deriving ()
 
 class NetworkDiscriminantCheck k where
     networkDiscriminantCheck :: SNetworkId n -> Word8 -> Bool

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMapWithScripts.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMapWithScripts.hs
@@ -47,7 +47,11 @@ import Prelude
 
 import qualified Data.Map.Strict as Map
 
-data PlutusVersion = PlutusVersionV1 | PlutusVersionV2 | PlutusVersionV3
+data PlutusVersion
+    = PlutusVersionV1
+    | PlutusVersionV2
+    | PlutusVersionV3
+    | PlutusVersionV4
     deriving (Eq, Generic, Show)
     deriving anyclass (NFData)
 
@@ -55,19 +59,21 @@ instance ToText PlutusVersion where
     toText PlutusVersionV1 = "v1"
     toText PlutusVersionV2 = "v2"
     toText PlutusVersionV3 = "v3"
+    toText PlutusVersionV4 = "v4"
 
 instance FromText PlutusVersion where
     fromText txt = case txt of
         "v1" -> Right PlutusVersionV1
         "v2" -> Right PlutusVersionV2
         "v3" -> Right PlutusVersionV3
+        "v4" -> Right PlutusVersionV4
         _ ->
             Left
                 $ TextDecodingError
                 $ unwords
                     [ "I couldn't parse the given plutus version."
-                    , "I am expecting one of the words 'v1' or"
-                    , "'v2'."
+                    , "I am expecting one of the words 'v1', 'v2',"
+                    , "'v3' or 'v4'."
                     ]
 
 data PlutusScriptInfo = PlutusScriptInfo

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -44,7 +44,7 @@ import Cardano.Api
     , anyCardanoEra
     , deserialiseFromCBOR
     )
-import Cardano.Api.Shelley
+import Cardano.Api.Tx
     ( Tx (ShelleyTx)
     )
 import Cardano.Binary
@@ -314,6 +314,7 @@ withinEra = (>=) `on` numberEra
         AlonzoEra -> 5
         BabbageEra -> 6
         ConwayEra -> 7
+        _ -> 8
 
 -- | Deserialise a transaction to construct a 'SealedTx'.
 sealedTxFromBytes :: ByteString -> Either DecoderError SealedTx

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:    System.IO.Temp.Extra
   build-depends:
     , base
-    , iohk-monitoring        >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , temporary
     , text

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -45,7 +45,7 @@ library
     , http-api-data
     , HUnit
     , int-cast
-    , iohk-monitoring       >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , lattices
     , monoid-subclasses
     , optparse-applicative

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -250,7 +250,9 @@ data CaseStyle
 toTextFromBoundedEnum
     :: forall a
      . (Bounded a, Enum a, Show a)
-    => CaseStyle -> a -> Text
+    => CaseStyle
+    -> a
+    -> Text
 toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 
 -- | Parses the given text to a value, according to the specified 'CaseStyle'.
@@ -261,7 +263,9 @@ toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 fromTextToBoundedEnum
     :: forall a
      . (Bounded a, Enum a, Show a)
-    => CaseStyle -> Text -> Either TextDecodingError a
+    => CaseStyle
+    -> Text
+    -> Either TextDecodingError a
 fromTextToBoundedEnum cs t =
     case matchingValue of
         Just mv -> Right mv

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -70,7 +70,7 @@ library common
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses             >=4.0.2 && <4.1
+    , cardano-addresses
     , cardano-wallet-network-layer
     , containers
     , contra-tracer
@@ -119,7 +119,7 @@ library shelley
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses             >=4.0.2   && <4.1
+    , cardano-addresses
     , cardano-slotting
     , cardano-wallet
     , cardano-wallet-api

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -72,7 +72,7 @@ test-suite unit
     , bech32
     , bech32-th
     , bytestring
-    , cardano-addresses                   >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-api-extra
     , cardano-balance-tx
@@ -99,14 +99,14 @@ test-suite unit
     , containers
     , contra-tracer
     , crypto-primitives
-    , data-default                        >=0.8.0.0   && <0.9
+    , data-default
     , data-interval
     , deepseq
     , delta-store
     , delta-types
     , directory
     , either
-    , extra                               >=1.6.17
+    , extra
     , file-embed
     , filepath
     , fmt
@@ -115,8 +115,8 @@ test-suite unit
     , generic-lens
     , generics-sop
     , hedgehog-corpus
-    , hspec                               >=2.8.2
-    , hspec-core                          >=2.8.2
+    , hspec
+    , hspec-core
     , http-api-data
     , http-client
     , http-client-tls
@@ -125,7 +125,7 @@ test-suite unit
     , int-cast
     , io-classes
     , io-sim
-    , iohk-monitoring                     >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , lattices
     , lens
@@ -151,7 +151,7 @@ test-suite unit
     , QuickCheck
     , quickcheck-classes
     , quickcheck-instances
-    , quickcheck-state-machine            >=0.6.0
+    , quickcheck-state-machine
     , random
     , regex-pcre-builtin
     , resourcet
@@ -160,7 +160,7 @@ test-suite unit
     , servant
     , servant-openapi3
     , servant-server
-    , si-timers
+    , io-classes:si-timers
     , sop-extras
     , splitmix
     , string-interpolate

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -124,6 +124,7 @@ test-suite unit
     , http-types
     , int-cast
     , io-classes
+    , io-classes:si-timers
     , io-sim
     , iohk-monitoring
     , iohk-monitoring-extra
@@ -160,7 +161,6 @@ test-suite unit
     , servant
     , servant-openapi3
     , servant-server
-    , io-classes:si-timers
     , sop-extras
     , splitmix
     , string-interpolate

--- a/lib/unit/test/data/Cardano/CLISpec/recovery-phrase --help
+++ b/lib/unit/test/data/Cardano/CLISpec/recovery-phrase --help
@@ -6,5 +6,4 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  generate                 Generate a recovery phrase for a
-                           specified mnemonic size and language.
+  generate                 Generate an English recovery phrase

--- a/lib/unit/test/data/Cardano/CLISpec/recovery-phrase --help
+++ b/lib/unit/test/data/Cardano/CLISpec/recovery-phrase --help
@@ -6,4 +6,5 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  generate                 Generate an English recovery phrase
+  generate                 Generate a recovery phrase for a
+                           specified mnemonic size and language.

--- a/lib/unit/test/data/Cardano/CLISpec/recovery-phrase generate --help
+++ b/lib/unit/test/data/Cardano/CLISpec/recovery-phrase generate --help
@@ -1,8 +1,12 @@
-Usage:  recovery-phrase generate [--size INT]
+Usage:  recovery-phrase generate [--size INT] [--language STR]
 
-  Generate an English recovery phrase
+  Generate a recovery phrase for a specified mnemonic size and
+  language.
 
 Available options:
   -h,--help                Show this help text
   --size INT               Number of mnemonic words to generate.
                            Must be a multiple of 3. (default: 24)
+  --language STR           Language of mnemonic words to
+                           generate. Must be one of: en, it, ja,
+                           fr, ko, es. (default: en)

--- a/lib/unit/test/data/Cardano/CLISpec/recovery-phrase generate --help
+++ b/lib/unit/test/data/Cardano/CLISpec/recovery-phrase generate --help
@@ -1,12 +1,8 @@
-Usage:  recovery-phrase generate [--size INT] [--language STR]
+Usage:  recovery-phrase generate [--size INT]
 
-  Generate a recovery phrase for a specified mnemonic size and
-  language.
+  Generate an English recovery phrase
 
 Available options:
   -h,--help                Show this help text
   --size INT               Number of mnemonic words to generate.
                            Must be a multiple of 3. (default: 24)
-  --language STR           Language of mnemonic words to
-                           generate. Must be one of: en, it, ja,
-                           fr, ko, es. (default: en)

--- a/lib/unit/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -389,7 +389,7 @@ instance Malformed (BodyParam ApiWalletSignData) where
             { "metadata": null
             , "passphrase": #{wPassphrase}
             }|]
-                    , "Error in $.metadata: TxMetadataJsonToplevelNotMap"
+                    , "Error in $.metadata: The JSON metadata top level must be a map (JSON object) from word to value."
                     )
                 ,
                     ( Aeson.encode
@@ -2140,7 +2140,7 @@ instance Malformed (BodyParam (ApiConstructTransactionData ('Testnet pm))) where
                            )
                        ,
                            ( [aesonQQ|{ "metadata": "hello" }|]
-                           , "Error in $.metadata: TxMetadataJsonToplevelNotMap"
+                           , "Error in $.metadata: The JSON metadata top level must be a map (JSON object) from word to value."
                            )
                        ,
                            ( [aesonQQ|{ "withdrawal": "slef" }|]

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -3442,7 +3442,6 @@ instance Typeable n => ToSchema (ApiDecodedTransaction n) where
         addDefinition
             =<< declareSchemaForDefinition "TransactionMetadataValueNoSchema"
         addDefinition =<< declareSchemaForDefinition "ScriptValue"
-        addDefinition =<< declareSchemaForDefinition "ScriptValueGeneral"
         declareSchemaForDefinition "ApiDecodedTransaction"
 
 instance ToSchema ApiBlockHeader where

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -45,6 +45,7 @@ import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
     , InAnyCardanoEra (..)
+    , ShelleyLedgerEra
     )
 import Cardano.Api.Gen
     ( genTx
@@ -1387,6 +1388,8 @@ unsafeWithShelleyBasedEra era a = case era of
         Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraBabbage a
     ConwayEra ->
         Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraConway a
+    DijkstraEra ->
+        error "unsafeWithShelleyBasedEra: DijkstraEra not yet supported"
 
 --------------------------------------------------------------------------------
 
@@ -1739,6 +1742,7 @@ withCardanoApiConstraints
 withCardanoApiConstraints e a = case e of
     Cardano.ConwayEra -> a
     Cardano.BabbageEra -> a
+    Cardano.DijkstraEra -> err
     Cardano.AlonzoEra -> err
     Cardano.MaryEra -> err
     Cardano.AllegraEra -> err

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -53,9 +53,6 @@ import Cardano.Api.Gen
     , genTxInEra
     , genWitnesses
     )
-import Cardano.Api.Shelley
-    ( ShelleyLedgerEra
-    )
 import Cardano.Balance.Tx.Balance
     ( ErrBalanceTx (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
@@ -346,7 +343,6 @@ import Prelude
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Ledger as L
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Balance.Tx.Eras as Write
     ( Babbage
     , CardanoApiEra

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -47,7 +47,7 @@ library
     , bytestring
     , contra-tracer
     , http-types
-    , iohk-monitoring       >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , servant-server
     , text
     , text-class
@@ -74,7 +74,7 @@ test-suite unit
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring            >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , network
     , QuickCheck
     , servant-server

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -66,7 +66,7 @@ benchmark memory
     , cardano-wallet-launcher
     , contra-tracer
     , filepath
-    , iohk-monitoring                     >=0.2.0.0 && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , mtl
     , optparse-applicative

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -48,7 +48,7 @@ library
     , async
     , base
     , bytestring
-    , cardano-addresses             >=4.0.2     && <4.1
+    , cardano-addresses
     , cardano-api
     , cardano-balance-tx
     , cardano-binary
@@ -92,7 +92,7 @@ library
     , http-types
     , int-cast
     , io-classes
-    , iohk-monitoring               >=0.2.0.0   && <0.3
+    , iohk-monitoring
     , iohk-monitoring-extra
     , lens
     , list-transformer

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -306,9 +306,9 @@ executable wallet-key-export
     , text
 
 test-suite wallet-key-export-test
-  import:        language, opts-exe
-  type:          exitcode-stdio-1.0
-  main-is:       exe/wallet-key-export-test.hs
+  import:             language, opts-exe
+  type:               exitcode-stdio-1.0
+  main-is:            exe/wallet-key-export-test.hs
   build-depends:
     , address-derivation-discovery
     , base
@@ -331,8 +331,7 @@ test-suite wallet-key-export-test
     , text-class
     , time
 
-  build-tool-depends:
-    cardano-wallet:wallet-key-export
+  build-tool-depends: cardano-wallet:wallet-key-export
 
 -- Triggers this https://github.com/haskell/cabal/issues/6470
 -- if moved to an external library

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2266,6 +2266,8 @@ pparamsInRecentEra (Read.PParams pparams) =
         Read.Alonzo -> Write.InNonRecentEraAlonzo
         Read.Babbage -> Write.InRecentEraBabbage pparams
         Read.Conway -> Write.InRecentEraConway pparams
+        Read.Dijkstra ->
+            error "pparamsInRecentEra: DijkstraEra not yet supported"
 
 -- | Wallet-specific wrapped version of 'Write.balanceTx', made for the new tx
 -- workflow with Shelley- and Shared- wallet flavors.

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -767,6 +767,8 @@ monitorStakePools tr (NetworkParameters gp sp _pp) genesisPools nl DBLayer{..} =
             BlockAlonzo blk -> forEachShelleyBlock b' (getProducer blk)
             BlockBabbage blk -> forEachShelleyBlock b' (getBabbageProducer blk)
             BlockConway blk -> forEachShelleyBlock b' (getConwayProducer blk)
+            BlockDijkstra _ ->
+                error "forAllBlocks: DijkstraEra not yet supported"
           where
             b' = fromCardanoBlock getGenesisBlockHash c
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -254,22 +254,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Certificate as ApiCert
 import qualified Cardano.Api.Experimental.Certificate as ExpCert
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Balance.Tx.Eras as Write
-import qualified Cardano.Crypto as CC
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Crypto.Wallet as Crypto.HD
-import qualified Cardano.Ledger.Api as Ledger
-import qualified Cardano.Ledger.Keys.Bootstrap as SL
-import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
-import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
-import qualified Cardano.Wallet.Primitive.Types.AssetId as AssetId
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-    ( CardanoApiEra
-    , IsRecentEra (recentEra)
-    , RecentEra (RecentEraBabbage, RecentEraConway)
-    , shelleyBasedEraFromRecentEra
-    )
 import qualified Cardano.Balance.Tx.Primitive as BT
 import qualified Cardano.Balance.Tx.Sign as Write
     ( estimateMaxWitnessRequiredPerInput

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -20,6 +20,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+-- TODO: Migrate from deprecated Cardano.Api.Certificate to
+-- Cardano.Api.Experimental.Certificate
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}
@@ -248,8 +252,19 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Byron
+import qualified Cardano.Api.Certificate as ApiCert
+import qualified Cardano.Api.Experimental.Certificate as ExpCert
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Balance.Tx.Eras as Write
+import qualified Cardano.Crypto as CC
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Crypto.Wallet as Crypto.HD
+import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Ledger.Keys.Bootstrap as SL
+import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
+import qualified Cardano.Wallet.Primitive.Types.AssetId as AssetId
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
     ( CardanoApiEra
     , IsRecentEra (recentEra)
     , RecentEra (RecentEraBabbage, RecentEraConway)
@@ -712,6 +727,8 @@ withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
         Nothing
     Cardano.ByronEra ->
         Nothing
+    Cardano.DijkstraEra ->
+        error "withRecentEraLedgerTx: DijkstraEra not yet supported"
 
 -- | Construct a standard unsigned transaction.
 --
@@ -974,7 +991,7 @@ mkUnsignedTx
                                 in
                                     Cardano.TxCertificates shelleyEra
                                         $ OMap.fromList
-                                        $ certs
+                                        $ map certToLedger certs
                                         <&> (,ctx)
                             Just stakingScript ->
                                 let
@@ -992,7 +1009,7 @@ mkUnsignedTx
                                 in
                                     Cardano.TxCertificates shelleyEra
                                         $ OMap.fromList
-                                        $ certs
+                                        $ map certToLedger certs
                                         <&> (,ctx)
                         , Cardano.txFee = Cardano.TxFeeExplicit shelleyEra fees
                         , Cardano.txValidityLowerBound =
@@ -1208,6 +1225,14 @@ mkShelleyWitness body key =
         Cardano.WitnessPaymentExtendedKey
             $ Cardano.PaymentExtendedSigningKey
             $ Crypto.HD.xPrvChangePass pwd BS.empty xprv
+
+certToLedger
+    :: Cardano.Certificate era
+    -> ExpCert.Certificate (Cardano.ShelleyLedgerEra era)
+certToLedger (ApiCert.ShelleyRelatedCertificate w txCert) =
+    Cardano.shelleyToBabbageEraConstraints w $ ExpCert.Certificate txCert
+certToLedger (ApiCert.ConwayCertificate w txCert) =
+    Cardano.conwayEraOnwardsConstraints w $ ExpCert.Certificate txCert
 
 mkByronWitness
     :: forall era

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+-- TODO: Migrate from deprecated Cardano.Api.Certificate to
+-- Cardano.Api.Experimental.Certificate
 
 -- |
 -- Copyright: © 2024 Cardano Foundation
@@ -53,7 +57,6 @@ import Prelude
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Ledger as Ledger
-import qualified Cardano.Api.Shelley as Cardano
 
 {-----------------------------------------------------------------------------
     Cardano.Certificate

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Voting.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Voting.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+-- TODO: Migrate from deprecated Cardano.Api.Certificate to
+-- Cardano.Api.Experimental.Certificate
 
 -- |
 -- Copyright: © 2024 Cardano Foundation
@@ -50,7 +54,6 @@ import Prelude
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Ledger as Ledger
-import qualified Cardano.Api.Shelley as Cardano
 
 {-----------------------------------------------------------------------------
     Cardano.Certificate

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -191,8 +191,6 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               # Enable Haskell Program Coverage for all local libraries
               # and test suites.
               doCoverage = coverage;
-
-              ghcOptions = [];
             });
           }
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -293,8 +293,9 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             packages.crypton-x509-system.postPatch = ''
               sed -i 's/Crypt32/crypt32/g' crypton-x509-system.cabal
             '';
-            # haskell.nix patch for streaming-commons is already applied in 0.2.3.1
-            packages.streaming-commons.patches = lib.mkForce [];
+            # haskell.nix patches streaming-commons < 0.2.3.1 for Windows
+            # header file casing (Share.h). Don't clear the patch until
+            # index-state is new enough to resolve 0.2.3.1.
           })
 
           # Build fixes for library dependencies


### PR DESCRIPTION
## Summary

Bumps cardano-node runtime and all Haskell dependencies to 10.6.2, which introduces **DijkstraEra** (era 8, protocol version 12).

- Bump `cardano-node-runtime` flake input to 10.6.2
- Bump all Cardano ecosystem deps: cardano-api 10.23, ouroboros-consensus 0.30, plutus-core 1.57, io-classes 1.8, etc.
- Add DijkstraEra support across `cardano-wallet-read`, `cardano-wallet-primitive`, `cardano-balance-tx`, network layer
- Rewrite `addScriptIntegrityHash` for new ledger API (`ScriptIntegrity` record, `NativeScript` rename)
- Extend `nodeToClientVersions` to V22
- Add error stubs for DijkstraEra in API/wallet core (documented in `TODO.md` for future promotion to `RecentEra`)
- Consume `cardano-ledger-read` from external package
- Fix VOTING_01b test for babbage and conway

Key upstream breaking changes handled:
- Per-era `Tx` newtypes (`MkDijkstraTx`, etc.) — use `Core.Tx era`
- `TimelockScript` → `NativeScript`
- `hashScriptIntegrity` single-record API
- `nctMuxTracer` → `nctMuxTracers`
- `MonadThrow`/`MonadMask` constraints on network client functions

See `ERA-CHANGES.md` for full change documentation.

Closes #5187

## Test results

- All unit test shards pass
- All local cluster tests pass (Linux + macOS)
- Mainnet + Preview boot sync pass
- Docker image builds
- Formatting, hlint, cabal check all pass
- Conway Integration Tests: 8 flaky failures (stake pool metadata/rewards timeouts — not related to dep bump)