### PR TITLE
fix: pin oasdiff to v1.11.11

### DIFF
--- a/scripts/release/openapi-diff.sh
+++ b/scripts/release/openapi-diff.sh
@@ -8,7 +8,8 @@ GOPATH=$(mktemp -d)
 export GOPATH
 
 # go install is going to write unremovable stuff to the $GOPATH/bin directory
-go install github.com/oasdiff/oasdiff@latest
+# pinned: v1.12.4+ breaks on __origin__ duplicate keys injected by oasdiff/kin-openapi
+go install github.com/oasdiff/oasdiff@v1.11.11
 
 swagger_tmp=$(mktemp -d)
 swagger_file="specifications/api/swagger.yaml"


### PR DESCRIPTION
## Summary

- Pin `oasdiff` to v1.11.11 in `openapi-diff.sh` to fix the nightly release CI failure
- v1.12.4 switched from `getkin/kin-openapi` to `oasdiff/kin-openapi` which injects `__origin__` metadata during spec loading, then the new YAML library rejects them as duplicate keys

Failing run: https://github.com/cardano-foundation/cardano-wallet/actions/runs/23727354649/job/69113585809
Last green run: https://github.com/cardano-foundation/cardano-wallet/actions/runs/23079715863