### PR TITLE
ci: migrate Windows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -89,7 +89,7 @@ jobs:
 
   verify-windows:
     name: "Verify Windows"
-    runs-on: [self-hosted, Windows, x64, cardano-wallet-win]
+    runs-on: windows-latest
     steps:
       - name: Download and verify
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Download and verify
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           TAG="${{ inputs.tag }}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT
@@ -52,10 +53,11 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Download and verify
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           TAG="${{ inputs.tag }}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT
@@ -135,10 +137,11 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Download and verify
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           TAG="${{ inputs.tag }}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -29,7 +29,7 @@ jobs:
   e2e-tests:
     name: "Windows E2E Tests"
     needs: build-e2e
-    runs-on: [self-hosted, Windows, x64, cardano-wallet-win]
+    runs-on: windows-latest
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
   unit-tests:
     name: ${{ matrix.name }}
     needs: upload-win-test
-    runs-on: [self-hosted, Windows, x64, cardano-wallet-win]
+    runs-on: windows-latest
     env:
       LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
     strategy:


### PR DESCRIPTION
- Use `nix shell nixpkgs#gh` in verify-release workflow (self-hosted runners lack `gh` on PATH)
- Migrate all Windows jobs to `windows-latest`: verify-release, unit tests (`windows.yml`), E2E tests (`windows-e2e.yml`)

Validated on this branch:
- verify-release: 4/4 passed (Linux, macOS, Windows, Docker)
- windows.yml unit tests: 38/38 passed
- windows-e2e.yml: passed (preprod sync + full E2E suite)