### PR TITLE
Update stale flake inputs and bump ruby 3.1 → 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-logs
           path: integration-test-dir/
@@ -330,7 +330,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: local-cluster-logs
           path: local-cluster-logs/
@@ -381,7 +381,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: boot-sync-logs-${{ strategy.job-index }}
           path: ${{ matrix.dir }}/logs/
@@ -404,7 +404,7 @@ jobs:
           rm -rf ./result/*
           nix build --quiet -o result/linux .#ci.artifacts.linux64.release
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-release-package
           path: result/linux/
@@ -423,7 +423,7 @@ jobs:
           rm -rf ./result/*
           nix build --quiet -o result/wallet-key-export .#ci.artifacts.wallet-key-export-static
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wallet-key-export-linux-static
           path: result/wallet-key-export/bin/wallet-key-export
@@ -467,7 +467,7 @@ jobs:
           echo "Docker image tag: $tag"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-image
           path: artifacts/docker-image.tgz
@@ -574,7 +574,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-local-cluster-logs
           path: local-cluster-logs/
@@ -591,7 +591,7 @@ jobs:
       - name: Build macOS Intel package
         run: nix build --quiet -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-intel-package
           path: result/macos-intel/
@@ -608,7 +608,7 @@ jobs:
       - name: Build macOS Silicon package
         run: nix build --quiet -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-silicon-package
           path: result/macos-silicon/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,7 +636,7 @@ jobs:
 
   attic-cache:
     name: "Attic Cache"
-    needs: build-gate-quality
+    needs: [build-gate-quality, build-gate-artifacts]
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     timeout-minutes: 180
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,33 @@ jobs:
           .#ci.artifacts.wallet-key-export-static
 
 
+  build-gate-windows:
+    name: "Build Gate (Windows)"
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build Windows cross-compiled artifacts
+        run: >-
+          nix build --quiet
+          .#ci.artifacts.win64.release
+          .#ci.artifacts.win64.tests.wallet-unit
+          .#ci.artifacts.win64.tests.wallet-primitive
+          .#ci.artifacts.win64.tests.wallet-secrets
+          .#ci.artifacts.win64.tests.wallet-network-layer
+          .#ci.artifacts.win64.tests.wallet-test-utils
+          .#ci.artifacts.win64.tests.wallet-launcher
+          .#ci.artifacts.win64.tests.cardano-numeric
+          .#ci.artifacts.win64.tests.wallet-blackbox-benchmarks
+          .#ci.artifacts.win64.tests.delta-chain
+          .#ci.artifacts.win64.tests.delta-store
+          .#ci.artifacts.win64.tests.delta-table
+          .#ci.artifacts.win64.tests.delta-types
+          .#ci.artifacts.win64.tests.std-gen-seed
+          .#ci.artifacts.win64.tests.wai-middleware-logging
+
   build-gate-quality:
     name: "Build Gate (Dev Shell)"
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
@@ -636,7 +663,7 @@ jobs:
 
   attic-cache:
     name: "Attic Cache"
-    needs: [build-gate-quality, build-gate-artifacts]
+    needs: [build-gate-quality, build-gate-artifacts, build-gate-windows]
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     timeout-minutes: 180
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build test and runtime derivations
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build release artifacts (musl static)
@@ -64,7 +64,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build Windows cross-compiled artifacts
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build dev shell
@@ -107,7 +107,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check nix version
@@ -260,7 +260,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -284,7 +284,7 @@ jobs:
       TESTS_RETRY_FAILED: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -315,7 +315,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -368,7 +368,7 @@ jobs:
       NETWORK: ${{ matrix.network }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -396,7 +396,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build release package
@@ -415,7 +415,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build static binary
@@ -434,7 +434,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Evaluate shell
@@ -452,7 +452,7 @@ jobs:
       image-tag: ${{ steps.build.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -496,7 +496,7 @@ jobs:
       USE_LOCAL_IMAGE: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -518,7 +518,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build all macOS derivations
@@ -544,7 +544,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check nix version
@@ -559,7 +559,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -585,7 +585,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build macOS Intel package
@@ -602,7 +602,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build macOS Silicon package
@@ -654,7 +654,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -669,7 +669,7 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Push derivations to Attic

--- a/flake.lock
+++ b/flake.lock
@@ -458,11 +458,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1775046858,
-        "narHash": "sha256-2fbFM+6E90+bBr6idTwCgrlVs1zdatMrZKHSvdZqx40=",
+        "lastModified": 1775058616,
+        "narHash": "sha256-G9mCZaFhxBJ4CCSW+YSHUy5myBLpr3CSgRe+oADrs1M=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6169b07a9589e7669c3e21575ce64e5dee6b4586",
+        "rev": "4b790b1ce019e32680d584f7cf30d88889bc954b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -117,23 +117,6 @@
         "type": "github"
       }
     },
-    "cabal-32_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -296,11 +279,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1759893430,
-        "narHash": "sha256-yAy4otLYm9iZ+NtQwTMEbqHwswSFUbhn7x826RR6djw=",
+        "lastModified": 1767744144,
+        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1979a2524cb8c801520bd94c38bb3d5692419d93",
+        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
         "type": "github"
       },
       "original": {
@@ -426,11 +409,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -475,11 +458,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1771029998,
-        "narHash": "sha256-n2OPFR7msGuDHi03FsSSTkw5uyO6/odXCH42033/Yjs=",
+        "lastModified": 1775046858,
+        "narHash": "sha256-2fbFM+6E90+bBr6idTwCgrlVs1zdatMrZKHSvdZqx40=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "26b99ff043af013c9c1c929976ce7dcd8f04d3d7",
+        "rev": "6169b07a9589e7669c3e21575ce64e5dee6b4586",
         "type": "github"
       },
       "original": {
@@ -508,11 +491,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762302430,
-        "narHash": "sha256-thtGuIGrodKEfZPh+Sv22m1BR2zxNQY8RCsGlBWroj4=",
+        "lastModified": 1775004062,
+        "narHash": "sha256-VSxoJD5zb3BlDpvQieWBB44AKM8FSr7MT0GCzOlzhXE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c5dc9e01d45948892915b5394f23986277fb0ccb",
+        "rev": "5da730e51c6b8130320d83da0740e66e4bdfd7ea",
         "type": "github"
       },
       "original": {
@@ -645,7 +628,6 @@
     "haskellNix_2": {
       "inputs": {
         "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
@@ -660,6 +642,7 @@
         "hls-2.0": "hls-2.0_2",
         "hls-2.10": "hls-2.10_2",
         "hls-2.11": "hls-2.11_2",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2_2",
         "hls-2.3": "hls-2.3_2",
         "hls-2.4": "hls-2.4_2",
@@ -680,16 +663,17 @@
         "nixpkgs-2405": "nixpkgs-2405_2",
         "nixpkgs-2411": "nixpkgs-2411_2",
         "nixpkgs-2505": "nixpkgs-2505_2",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1762315551,
-        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
+        "lastModified": 1775005722,
+        "narHash": "sha256-2ucRXQobMiOfA22I8R0b36Zfmd7OkWXCvKLxwMwioo4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
+        "rev": "9373f20d7b8c6edd73000854401912e0a91f82b9",
         "type": "github"
       },
       "original": {
@@ -846,6 +830,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -1222,17 +1223,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1741648051,
-        "narHash": "sha256-Wl1nQ2dak4b3fXA7+9rB2ntiKUS+yAzR2kOIUoAF0u8=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "911835056d2b48a9ae65b4e3a2925c88a320a6ab",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "911835056d2b48a9ae65b4e3a2925c88a320a6ab",
         "type": "github"
       }
     },
@@ -1280,16 +1280,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1762531402,
-        "narHash": "sha256-c+0i3/P3xMvmLx8kfYPifraKxp9ySmuJSCQiUd26P04=",
+        "lastModified": 1769104967,
+        "narHash": "sha256-0amlnplGcwe8KkwdsTCVStfS88bv2+5cOyzVTaFfEhk=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "5d5571ef3421ae3d4af567a7a06a1fc553c592b7",
+        "rev": "567a8e8e63a449c9da70c8c3ddb09f8fab174e18",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2543.1-hotfix",
+        "ref": "2603.1",
         "repo": "mithril",
         "type": "github"
       }
@@ -1423,11 +1423,11 @@
     },
     "nixpkgs-2411_2": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -1455,11 +1455,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
@@ -1469,13 +1469,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -1502,11 +1518,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1759070547,
-        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -1674,11 +1690,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1762301584,
-        "narHash": "sha256-yLihKEbngbLV1EhuLJSencMCtrDM2sYGsVZkX8xlSK8=",
+        "lastModified": 1775003016,
+        "narHash": "sha256-s9+yhzF1MoX0+BsJFykizAXoSmQwotwKxbFWvD1P9X8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "ce12bd44df0b5488bdbbe8762d79379e2bc76d62",
+        "rev": "551d2e4a33de0c7fd938e78f24a68014dac5aec2",
         "type": "github"
       },
       "original": {
@@ -1725,11 +1741,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760120816,
-        "narHash": "sha256-gq9rdocpmRZCwLS5vsHozwB6b5nrOBDNc2kkEaTXHfg=",
+        "lastModified": 1768158989,
+        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "761ae7aff00907b607125b2f57338b74177697ed",
+        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -221,6 +221,7 @@
               (import ./nix/overlays/common-lib.nix)
               (import ./nix/overlays/basement.nix)
               (import ./nix/overlays/ghc-lib-parser.nix)
+              (import ./nix/overlays/mdbook-mermaid.nix)
               fix-crypton-x509
               overlay
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     iohkNix = {
-      url = "github:input-output-hk/iohk-nix?rev=911835056d2b48a9ae65b4e3a2925c88a320a6ab";
+      url = "github:input-output-hk/iohk-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-compat = {
@@ -124,7 +124,7 @@
     customConfig.url = "github:input-output-hk/empty-flake";
     cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.6.2";
     mithril = {
-      url = "github:input-output-hk/mithril?ref=2543.1-hotfix";
+      url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       };
   };

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/History.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/History.hs
@@ -245,7 +245,7 @@ parseDays hm =
             return (d, v')
 
 parseHistory :: BL8.ByteString -> Either String History
-parseHistory r = foldMap rowToHarmonizedRow . toList . snd <$> decodeByName r
+parseHistory r = foldMap rowToHarmonizedRow . snd <$> decodeByName r
 
 -- | Render a harmonized history as a CSV file.
 renderHarmonizedHistoryCsv :: HarmonizedHistory -> (Header, [Row])

--- a/lib/delta-chain/src/Data/Chain.hs
+++ b/lib/delta-chain/src/Data/Chain.hs
@@ -148,7 +148,7 @@ fromEdge Edge{from, to, via} =
 -- appear in the list.
 fromEdges :: Ord node => [Edge node edge] -> Maybe (Chain node [edge])
 fromEdges [] = Nothing
-fromEdges (e : es) = ($ fromEdge' e) . foldr (<=<) Just $ map addEdge es
+fromEdges (e : es) = flip (foldr (<=<) Just) (fromEdge' e) $ map addEdge es
   where
     fromEdge' = fmap (: []) . fromEdge
 

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -802,7 +802,7 @@ expectListSize
     -> m ()
 expectListSize l (_, res) = liftIO $ case res of
     Left e -> wantedSuccessButError e
-    Right xs -> length (toList xs) `shouldBe` l
+    Right xs -> length xs `shouldBe` l
 
 -- | Expects data list returned by the API to be of certain length
 expectListSizeSatisfy
@@ -812,7 +812,7 @@ expectListSizeSatisfy
     -> m ()
 expectListSizeSatisfy cond (_, res) = liftIO $ case res of
     Left e -> wantedSuccessButError e
-    Right xs -> length (toList xs) `shouldSatisfy` cond
+    Right xs -> length xs `shouldSatisfy` cond
 
 -- | Expects wallet UTxO statistics from the request to be equal to
 -- pre-calculated statistics.

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -489,9 +489,6 @@ import Data.Either.Combinators
 import Data.Either.Extra
     ( eitherToMaybe
     )
-import Data.Foldable
-    ( toList
-    )
 import Data.Function
     ( (&)
     )

--- a/lib/ui/src/common/Cardano/Wallet/UI/Lib/ListOf.hs
+++ b/lib/ui/src/common/Cardano/Wallet/UI/Lib/ListOf.hs
@@ -17,7 +17,7 @@ data Cons e a where
 type ListOf e = Program (Cons e) ()
 
 listOf :: ListOf a -> [a]
-listOf = reverse . ($ []) . interpret
+listOf = reverse . flip interpret []
 
 interpret :: forall e. ListOf e -> [e] -> [e]
 interpret = eval . view

--- a/lib/unit/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/unit/test/unit/Cardano/Pool/DB/Properties.hs
@@ -833,9 +833,7 @@ prop_readPoolLifeCycleStatus
             :: (PoolCertificate -> Maybe certificate)
             -> Maybe (CertificatePublicationTime, certificate)
         lookupFinalCertificateMatching match =
-            certificatePublications
-                & reverse
-                & mapMaybe (traverse match)
+            reverse (mapMaybe (traverse match) certificatePublications)
                 & listToMaybe
 
         certificatePublications

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
@@ -745,8 +745,7 @@ applyBlockEventsToUTxO BlockEvents{slot, blockHeight, transactions, delegations}
             , delegations = filter (ours s . dlgCertAccount) $ toList delegations
             }
     (rtxs1, du1, u1) =
-        L.foldl' applyOurTx (mempty, mempty, u0)
-            $ toList transactions
+        foldl' applyOurTx (mempty, mempty, u0) transactions
 
     applyOurTx
         :: ([(Tx, TxMeta)], DeltaUTxO, UTxO)

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -152,8 +152,8 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           just
           pkg-config
           nixpkgs-recent.python3Packages.openapi-spec-validator
-          (ruby_3_1.withPackages (ps: [ ps.rake ps.thor ]))
-          rubyPackages_3_1.rubocop
+          (ruby_3_3.withPackages (ps: [ ps.rake ps.thor ]))
+          rubyPackages_3_3.rubocop
           sqlite-interactive
           curlFull
           jq

--- a/nix/overlays/mdbook-mermaid.nix
+++ b/nix/overlays/mdbook-mermaid.nix
@@ -1,0 +1,18 @@
+# Pin mdbook-mermaid to 0.16.x from an older nixpkgs.
+#
+# haskell.nix's nixpkgs ships mdbook-mermaid 0.17 which requires
+# mdbook 0.5, but still ships mdbook 0.4.52. The 0.17 preprocessor
+# can't parse the 0.4.52 JSON context and crashes with
+# "Unable to parse the input".
+#
+# Until haskell.nix bumps mdbook to 0.5, pin mdbook-mermaid from
+# a nixpkgs revision where it was still 0.16.x.
+let
+  oldNixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/647e5c14cbd5067f44ac86b74f014962df460840.tar.gz";
+    sha256 = "0m30xfi18dgxi5lx9zgqpq1kxwdwrdg9wdbzzgs8cicmsvq6ami5";
+  };
+in
+final: prev: {
+  mdbook-mermaid = (import oldNixpkgs { inherit (final) system; }).mdbook-mermaid;
+}

--- a/nix/release-package.nix
+++ b/nix/release-package.nix
@@ -46,7 +46,7 @@ in
         ++ lib.optionals makeZip [zip];
       checkInputs = with pkgs.buildPackages;
         [
-          ruby_3_1
+          ruby_3_3
           gnugrep
           gnused
         ]


### PR DESCRIPTION
## Summary

### Flake input updates
- **iohk-nix**: Remove hardcoded `?rev=` pin to personal branch `hkm/update-blst` — blst v0.3.14 is already on master
- **mithril**: Update from `2543.1-hotfix` to latest stable release `2603.1`
- **haskell.nix + hackage.nix**: Update to latest master

### Nix fixes
- **ruby 3.1 → 3.3**: `ruby_3_1` removed in newer nixpkgs pulled by haskell.nix update
- **mdbook-mermaid overlay**: Pin to 0.16.x — haskell.nix's nixpkgs ships mdbook-mermaid 0.17 (requires mdbook 0.5) but still has mdbook 0.4.52

### CI improvements
- **Build Gate (Windows)**: Extract Windows cross-compilation into its own visible build gate
- **Attic Cache dependencies**: Now waits for all three gates (quality, artifacts, windows) before pushing — no more redundant rebuilds
- **actions/checkout v4 → v6**: Fix Node.js 20 deprecation warnings
- **actions/upload-artifact v4 → v7**: Fix Node.js 20 deprecation warnings

### HLint fixes
- Resolve 7 new warnings from updated HLint version (redundant toList, use flip, move reverse out)

## Test plan

- [x] All unit tests pass
- [x] Conway integration tests pass
- [x] Local cluster tests pass
- [x] Docs build passes (mdbook-mermaid overlay verified)
- [x] HLint passes
- [x] Build Gate (Linux, macOS, Dev Shell, Artifacts) pass
- [x] Build Gate (Windows) visible as separate check

Closes #5218, closes #5219, closes #5220