### PR TITLE
Fix release script idempotency and bump all workflow actions

### DIFF
--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build all benchmark derivations
@@ -87,7 +87,7 @@ jobs:
       BENCHMARK_CSV_FILE: ${{ github.workspace }}/${{ matrix.csv_file }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.artifacts }}
@@ -113,7 +113,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -128,7 +128,7 @@ jobs:
             bash scripts/gha/benchmark-history.sh
 
       - name: Upload Benchmark History
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Benchmark History
           path: |

--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -34,7 +34,7 @@ jobs:
       NETWORK: mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-sync-logs
           path: run/mainnet/nix/logs/

--- a/.github/workflows/macos-boot-sync.yml
+++ b/.github/workflows/macos-boot-sync.yml
@@ -41,7 +41,7 @@ jobs:
       NETWORK: ${{ matrix.network }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-boot-sync-logs-${{ strategy.job-index }}
           path: ${{ matrix.dir }}/logs/

--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -35,7 +35,7 @@ jobs:
       TESTS_RETRY_FAILED: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-integration-test-logs
           path: integration-test-dir/

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build all test derivations
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       last-release-date: ${{ steps.rc.outputs.last-release-date }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
             artifact-name: docker-image
     steps:
       - name: Checkout release candidate
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
         run: nix build --quiet -o result .#${{ matrix.output }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: result
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
         run: nix develop --quiet path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/openapi-diff.sh
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes
           path: artifacts/
@@ -126,7 +126,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -273,7 +273,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           fetch-depth: 0

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build benchmark derivations
@@ -54,7 +54,7 @@ jobs:
       TO_TIP_TIMEOUT: ${{ inputs.to-tip-timeout }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: restore-${{ matrix.bench }}
           path: |

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
         run: nix build --quiet .#ci.artifacts.win64.e2e -o result
 
       - name: Upload E2E bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: win-e2e
           path: result/
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           nix build --quiet -o result/windows .#ci.artifacts.win64.release
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-release-package
           path: result/windows/
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
           - name: wai-middleware-logging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
         run: nix build --quiet .#ci.artifacts.win64.tests.${{ matrix.name }} -o result
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: win-test-${{ matrix.name }}
           path: result/

--- a/scripts/release/release-candidate.sh
+++ b/scripts/release/release-candidate.sh
@@ -68,15 +68,15 @@ git branch -D "$RELEASE_CANDIDATE_BRANCH" || true
 git checkout -b "$RELEASE_CANDIDATE_BRANCH" || true
 
 sed -i "s|version: .*|version: $NEW_GIT_TAG|g" specifications/api/swagger.yaml
-git commit -m "Update wallet version in swagger.yaml" specifications/api/swagger.yaml
+git diff --quiet || git commit -m "Update wallet version in swagger.yaml" specifications/api/swagger.yaml
 
 git ls-files '*.cabal' | xargs sed -i "s|$OLD_CABAL_VERSION|$NEW_CABAL_VERSION|g"
-git commit -am "Update cardano-wallet version in *.cabal files"
+git diff --quiet || git commit -am "Update cardano-wallet version in *.cabal files"
 
 sed -i "s|NODE_TAG=.*|NODE_TAG=$CARDANO_NODE_TAG|g" README.md
 sed -i "s|WALLET_TAG=.*|WALLET_TAG=$NEW_CABAL_VERSION|g" README.md
 sed -i "s|WALLET_VERSION=.*|WALLET_VERSION=$NEW_GIT_TAG|g" README.md
-git commit -am "Update cardano-wallet version in README.md"
+git diff --quiet || git commit -am "Update cardano-wallet version in README.md"
 
 sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/ci/ruby-e2e.sh
 git diff --quiet || git commit -am "Update cardano-wallet version in ruby-e2e.sh"


### PR DESCRIPTION
## Summary

- **release-candidate.sh**: Guard all version bump commits with `git diff --quiet ||` so the nightly release doesn't fail when re-run on the same day (the swagger/cabal/README sed replacements are no-ops, `git commit` finds nothing to commit and exits 1)
- **All workflows**: Bump `actions/checkout` v4 → v6 and `actions/upload-artifact` v4 → v7 to fix Node.js 20 deprecation warnings

Fixes the nightly release failure: https://github.com/cardano-foundation/cardano-wallet/actions/runs/23882995758/job/69639871045

## Test plan

- [ ] Nightly release workflow succeeds
- [x] CI passes