### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/approve-docs.yml
+++ b/.github/workflows/approve-docs.yml
@@ -6,7 +6,7 @@ jobs:
     if: '${{ github.ref_protected }}'
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
-      - uses: actions/checkout@v6.2.0
+      - uses: actions/checkout@v6
 
       - name: 'Check scope of PR'
         run: './scripts/gh/check-scope.sh scope'

--- a/.github/workflows/approve-docs.yml
+++ b/.github/workflows/approve-docs.yml
@@ -6,7 +6,7 @@ jobs:
     if: '${{ github.ref_protected }}'
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v6.2.0
 
       - name: 'Check scope of PR'
         run: './scripts/gh/check-scope.sh scope'

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: '📥 Checkout repository'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: ✏️ Set up Lean
       run: |

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build all benchmark derivations
@@ -87,7 +87,7 @@ jobs:
       BENCHMARK_CSV_FILE: ${{ github.workspace }}/${{ matrix.csv_file }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.artifacts }}
@@ -113,12 +113,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download current run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: current-run-artifacts
 
@@ -128,7 +128,7 @@ jobs:
             bash scripts/gha/benchmark-history.sh
 
       - name: Upload Benchmark History
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Benchmark History
           path: |

--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -34,7 +34,7 @@ jobs:
       NETWORK: mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mithril-sync-logs
           path: run/mainnet/nix/logs/

--- a/.github/workflows/macos-boot-sync.yml
+++ b/.github/workflows/macos-boot-sync.yml
@@ -41,7 +41,7 @@ jobs:
       NETWORK: ${{ matrix.network }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macos-boot-sync-logs-${{ strategy.job-index }}
           path: ${{ matrix.dir }}/logs/

--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build derivations
@@ -35,7 +35,7 @@ jobs:
       TESTS_RETRY_FAILED: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macos-integration-test-logs
           path: integration-test-dir/

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build all test derivations
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6.2.0
+        uses: actions/checkout@v6
 
       - name: "❄ Install Nix"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v6.2.0
 
       - name: "❄ Install Nix"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       last-release-date: ${{ steps.rc.outputs.last-release-date }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
             artifact-name: docker-image
     steps:
       - name: Checkout release candidate
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -80,7 +80,7 @@ jobs:
         run: nix build --quiet -o result .#${{ matrix.output }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: result
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
         run: nix develop --quiet path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/openapi-diff.sh
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-notes
           path: artifacts/
@@ -126,7 +126,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
           git push origin -f "$TAG"
 
       - name: Download release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: release-notes
           path: artifacts/
@@ -191,7 +191,7 @@ jobs:
             "${{ steps.tag.outputs.tag }}"
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: build-artifacts/
 
@@ -227,7 +227,7 @@ jobs:
       IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: docker-image
           path: docker-image/
@@ -273,7 +273,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           fetch-depth: 0

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Build benchmark derivations
@@ -54,7 +54,7 @@ jobs:
       TO_TIP_TIMEOUT: ${{ inputs.to-tip-timeout }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: restore-${{ matrix.bench }}
           path: |

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
         run: nix build --quiet .#ci.artifacts.win64.e2e -o result
 
       - name: Upload E2E bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: win-e2e
           path: result/
@@ -33,12 +33,12 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download E2E bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: win-e2e
           path: e2e-bundle

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           nix build --quiet -o result/windows .#ci.artifacts.win64.release
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-release-package
           path: result/windows/
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
           - name: wai-middleware-logging
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
         run: nix build --quiet .#ci.artifacts.win64.tests.${{ matrix.name }} -o result
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: win-test-${{ matrix.name }}
           path: result/
@@ -243,7 +243,7 @@ jobs:
 
     steps:
       - name: Download test artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ matrix.artifact }}
           path: test-bundle


### PR DESCRIPTION
Bump GitHub Actions to Node.js 24 compatible versions. Node.js 20 is deprecated June 2026.