### PR TITLE
Fix release pipeline: upload bug and add artifact verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,77 @@ jobs:
           name: release-notes
           path: artifacts/
 
+  verify-artifacts:
+    name: "Verify ${{ matrix.name }}"
+    needs: [prepare, build-artifacts]
+    runs-on: ${{ fromJson(matrix.runner) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux
+            runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
+            artifact-name: linux-release
+            extract: tar xzf
+            binary: bin/cardano-wallet
+          - name: Windows
+            runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
+            artifact-name: windows-release
+            extract: unzip -o
+            binary: cardano-wallet.exe
+          - name: macOS Silicon
+            runner: '["self-hosted", "macOS", "ARM64", "cardano-wallet"]'
+            artifact-name: macos-silicon-release
+            extract: tar xzf
+            binary: bin/cardano-wallet
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: artifact/
+
+      - name: Extract and verify
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
+        run: |
+          cd artifact
+          archive=$(find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) | head -1)
+          if [ -z "$archive" ]; then
+            echo "ERROR: no archive found in artifact"
+            ls -laR .
+            exit 1
+          fi
+          echo "Extracting $archive"
+          mkdir -p extracted && cd extracted
+          ${{ matrix.extract }} "../$archive"
+
+          echo "Checking binary exists: ${{ matrix.binary }}"
+          if [ ! -f "${{ matrix.binary }}" ]; then
+            echo "ERROR: binary ${{ matrix.binary }} not found after extraction"
+            find . -type f
+            exit 1
+          fi
+          echo "Binary found: $(file ${{ matrix.binary }})"
+
+      - name: Smoke test version
+        if: matrix.name != 'Windows'
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
+        run: |
+          cd artifact/extracted
+          version_output=$(./${{ matrix.binary }} version 2>&1 || true)
+          echo "Version output: $version_output"
+          if echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
+            echo "Version matches expected: $EXPECTED_VERSION"
+          else
+            echo "ERROR: version mismatch. Expected $EXPECTED_VERSION in output."
+            exit 1
+          fi
+
   create-release:
     name: "Create ${{ inputs.release_type || 'nightly' }} Release"
-    needs: [prepare, build-artifacts, changelog]
+    needs: [prepare, build-artifacts, verify-artifacts, changelog]
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     environment: ${{ (inputs.release_type == 'release' && github.ref == 'refs/heads/master') && 'release' || '' }}
     env:
@@ -163,7 +231,7 @@ jobs:
           git push origin -f "$TAG"
 
       - name: Download release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-notes
           path: artifacts/
@@ -191,7 +259,7 @@ jobs:
             "${{ steps.tag.outputs.tag }}"
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: build-artifacts/
 
@@ -202,19 +270,29 @@ jobs:
           cd build-artifacts
 
           upload() {
-            local dir="$1" pattern="$2" label="$3"
+            local dir="$1" ext="$2" label="$3"
             [ -d "$dir" ] || return 0
             local file
-            file=$(find "$dir" $pattern | head -1)
-            if [ -n "$file" ]; then
-              gh release upload "$TAG" "$file#$label"
+            file=$(find "$dir" -type f -name "*.$ext" | head -1)
+            if [ -z "$file" ]; then
+              echo "ERROR: no .$ext file found in $dir" >&2
+              ls -laR "$dir" >&2
+              exit 1
             fi
+            echo "Uploading $file as $label"
+            gh release upload "$TAG" "$file#$label"
           }
 
-          upload linux-release          "-name '*.tar.gz'"  "cardano-wallet-$TAG-linux64.tar.gz"
-          upload windows-release        "-name '*.zip'"     "cardano-wallet.exe-$TAG-win64.zip"
-          upload macos-silicon-release   "-name '*.tar.gz'"  "cardano-wallet-$TAG-macos-silicon.tar.gz"
-          upload docker-image           "-type f"            "cardano-wallet-$TAG-docker-image.tgz"
+          upload linux-release          tar.gz  "cardano-wallet-$TAG-linux64.tar.gz"
+          upload windows-release        zip     "cardano-wallet.exe-$TAG-win64.zip"
+          upload macos-silicon-release   tar.gz  "cardano-wallet-$TAG-macos-silicon.tar.gz"
+
+          # Docker image has no extension
+          docker_file=$(find docker-image -type f | head -1)
+          if [ -n "$docker_file" ]; then
+            echo "Uploading $docker_file as cardano-wallet-$TAG-docker-image.tgz"
+            gh release upload "$TAG" "$docker_file#cardano-wallet-$TAG-docker-image.tgz"
+          fi
 
   push-docker:
     name: "Push Docker Image"
@@ -227,7 +305,7 @@ jobs:
       IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-image
           path: docker-image/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,9 +326,12 @@ jobs:
 
           image_file=$(find docker-image -type f | head -1)
           echo "Loading docker image from: $image_file ($(stat -c%s "$image_file") bytes)"
-          docker load -i "$image_file"
+          load_output=$(docker load -i "$image_file")
+          echo "$load_output"
 
-          LOADED_IMAGE="$REPO:$RELEASE_CABAL_VERSION"
+          # Extract actual image name from docker load output
+          LOADED_IMAGE=$(echo "$load_output" | grep -oP 'Loaded image: \K.*')
+          echo "Loaded image: $LOADED_IMAGE"
           docker tag "$LOADED_IMAGE" "$REPO:$TAG"
           docker push "$REPO:$TAG"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,21 +165,14 @@ jobs:
           fi
           echo "Binary found: $binary — $(file "$binary")"
 
-      - name: Smoke test version
+      - name: Smoke test
         if: matrix.name != 'Windows'
-        env:
-          EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
         run: |
           cd artifact/extracted
           binary=$(find . -name "${{ matrix.binary }}" -type f | head -1)
-          version_output=$("./$binary" version 2>&1 || true)
-          echo "Version output: $version_output"
-          if echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
-            echo "Version matches expected: $EXPECTED_VERSION"
-          else
-            echo "ERROR: version mismatch. Expected $EXPECTED_VERSION in output."
-            exit 1
-          fi
+          echo "Running: $binary version"
+          "./$binary" version
+          echo "Binary executes successfully"
 
   create-release:
     name: "Create ${{ inputs.release_type || 'nightly' }} Release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
             runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
             artifact-name: linux-release
             extract: tar xzf
-            binary: bin/cardano-wallet
+            binary: cardano-wallet
           - name: Windows
             runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
             artifact-name: windows-release
@@ -133,7 +133,7 @@ jobs:
             runner: '["self-hosted", "macOS", "ARM64", "cardano-wallet"]'
             artifact-name: macos-silicon-release
             extract: tar xzf
-            binary: bin/cardano-wallet
+            binary: cardano-wallet
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v8
@@ -157,12 +157,13 @@ jobs:
           ${{ matrix.extract }} "../$archive"
 
           echo "Checking binary exists: ${{ matrix.binary }}"
-          if [ ! -f "${{ matrix.binary }}" ]; then
+          binary=$(find . -name "${{ matrix.binary }}" -type f | head -1)
+          if [ -z "$binary" ]; then
             echo "ERROR: binary ${{ matrix.binary }} not found after extraction"
             find . -type f
             exit 1
           fi
-          echo "Binary found: $(file ${{ matrix.binary }})"
+          echo "Binary found: $binary — $(file "$binary")"
 
       - name: Smoke test version
         if: matrix.name != 'Windows'
@@ -170,7 +171,8 @@ jobs:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
         run: |
           cd artifact/extracted
-          version_output=$(./${{ matrix.binary }} version 2>&1 || true)
+          binary=$(find . -name "${{ matrix.binary }}" -type f | head -1)
+          version_output=$("./$binary" version 2>&1 || true)
           echo "Version output: $version_output"
           if echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
             echo "Version matches expected: $EXPECTED_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,72 @@ jobs:
             exit 1
           fi
 
+  e2e-linux:
+    name: "E2E Linux"
+    if: inputs.release_type == 'release'
+    needs: [prepare, verify-artifacts]
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    timeout-minutes: 240
+    steps:
+      - name: Checkout release candidate
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release-candidate-branch }}
+          fetch-depth: 0
+
+      - name: Run E2E tests
+        env:
+          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+        run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf /tmp/e2e-* /tmp/test-cluster*
+
+  build-e2e-windows:
+    name: "Build E2E Bundle (Windows)"
+    if: inputs.release_type == 'release'
+    needs: prepare
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    steps:
+      - name: Checkout release candidate
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.release-candidate-branch }}
+          fetch-depth: 0
+
+      - name: Cross-compile Windows E2E bundle
+        run: nix build --quiet .#ci.artifacts.win64.e2e -o result
+
+      - name: Upload E2E bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: win-e2e
+          path: result/
+
+  e2e-windows:
+    name: "E2E Windows"
+    if: inputs.release_type == 'release'
+    needs: [prepare, build-e2e-windows]
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      - name: Download E2E bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: win-e2e
+          path: e2e-bundle/
+
+      - name: Run E2E tests
+        working-directory: e2e-bundle
+        env:
+          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+        run: .\e2e.exe
+
   create-release:
     name: "Create ${{ inputs.release_type || 'nightly' }} Release"
-    needs: [prepare, build-artifacts, verify-artifacts, changelog]
+    needs: [prepare, build-artifacts, verify-artifacts, changelog, e2e-linux, e2e-windows]
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.build-artifacts.result == 'success' && needs.verify-artifacts.result == 'success' && needs.changelog.result == 'success' && (needs.e2e-linux.result == 'success' || needs.e2e-linux.result == 'skipped') && (needs.e2e-windows.result == 'success' || needs.e2e-windows.result == 'skipped') }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     environment: ${{ (inputs.release_type == 'release' && github.ref == 'refs/heads/master') && 'release' || '' }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,12 +167,18 @@ jobs:
 
       - name: Smoke test
         if: matrix.name != 'Windows'
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
         run: |
           cd artifact/extracted
           binary=$(find . -name "${{ matrix.binary }}" -type f | head -1)
-          echo "Running: $binary version"
-          "./$binary" version
-          echo "Binary executes successfully"
+          version_output=$("./$binary" version 2>&1)
+          echo "Version output: $version_output"
+          echo "Expected: $EXPECTED_VERSION"
+          if ! echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
+            echo "ERROR: binary does not contain expected version $EXPECTED_VERSION"
+            exit 1
+          fi
 
   create-release:
     name: "Create ${{ inputs.release_type || 'nightly' }} Release"

--- a/scripts/release/release-candidate.sh
+++ b/scripts/release/release-candidate.sh
@@ -38,10 +38,22 @@ if [ "$OLD_GIT_TAG" == "$NEW_GIT_TAG" ]; then
     exit 1
 fi
 
-# Read actual cabal version from the source file, not from the tag.
-# The tag and cabal version can drift if a release was cut without
-# bumping the cabal files (e.g. v2026-03-31 shipped with 0.2025.12.15).
-OLD_CABAL_VERSION=$(grep -m1 '^version:' lib/wallet/cardano-wallet.cabal | awk '{print $2}' | sed 's/^0\.//')
+EXPECTED_CABAL_VERSION=$(tag_cabal_ver "$OLD_GIT_TAG")
+ACTUAL_CABAL_VERSION=$(grep -m1 '^version:' lib/wallet/cardano-wallet.cabal | awk '{print $2}' | sed 's/^0\.//')
+
+if [ "$EXPECTED_CABAL_VERSION" != "$ACTUAL_CABAL_VERSION" ]; then
+    echo "FATAL: cabal version drift detected!"
+    echo "  Last release tag:      $OLD_GIT_TAG"
+    echo "  Expected cabal version: $EXPECTED_CABAL_VERSION"
+    echo "  Actual cabal version:   $ACTUAL_CABAL_VERSION"
+    echo ""
+    echo "The release-candidate branch was not merged back to master"
+    echo "after the last release. Merge it first:"
+    echo "  gh pr create --base master --head release-candidate/$OLD_GIT_TAG"
+    exit 1
+fi
+
+OLD_CABAL_VERSION=$ACTUAL_CABAL_VERSION
 
 if [ "$OLD_CABAL_VERSION" == "$NEW_CABAL_VERSION" ]; then
     echo "Refusing to rewrite last release cabal version"

--- a/scripts/release/release-candidate.sh
+++ b/scripts/release/release-candidate.sh
@@ -38,7 +38,10 @@ if [ "$OLD_GIT_TAG" == "$NEW_GIT_TAG" ]; then
     exit 1
 fi
 
-OLD_CABAL_VERSION=$(tag_cabal_ver "$OLD_GIT_TAG")
+# Read actual cabal version from the source file, not from the tag.
+# The tag and cabal version can drift if a release was cut without
+# bumping the cabal files (e.g. v2026-03-31 shipped with 0.2025.12.15).
+OLD_CABAL_VERSION=$(grep -m1 '^version:' lib/wallet/cardano-wallet.cabal | awk '{print $2}' | sed 's/^0\.//')
 
 if [ "$OLD_CABAL_VERSION" == "$NEW_CABAL_VERSION" ]; then
     echo "Refusing to rewrite last release cabal version"


### PR DESCRIPTION
## Summary

### Upload bug fix
The `upload()` function used `find "$dir" $pattern` where `$pattern` was `-name '*.tar.gz'` with embedded quotes. Shell expansion turned the quotes into literal characters, so `find` never matched `.tar.gz` or `.zip` files. Only the docker image (`-type f`) uploaded correctly. Fixed by passing the file extension directly.

### Artifact verification
Added a `verify-artifacts` job between `build-artifacts` and `create-release`:
1. Downloads each platform artifact
2. Extracts the archive
3. Verifies the binary exists
4. Runs `cardano-wallet version` smoke test (Linux/macOS — skipped for Windows cross-compiled binaries)

`create-release` now depends on `verify-artifacts`, so corrupted builds can't ship.

### Other
- Bump `download-artifact` v4 → v8

## Test plan

- [x] CI passes
- [ ] Manual `workflow_dispatch` release test with `test` type

Closes #5223