### PR TITLE
Bump cardano-node to 10.6.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ index-state: 2026-01-29T00:00:00Z
 
 index-state:
   , hackage.haskell.org 2026-01-29T00:00:00Z
-  , cardano-haskell-packages 2026-02-09T17:36:58Z
+  , cardano-haskell-packages 2026-03-28T09:44:46Z
 
 packages:
   lib/address-derivation-discovery
@@ -179,10 +179,10 @@ constraints:
   , katip >= 0.8.7.4
 
 
-  -- Cardano Node 10.6.2 dependencies:
+  -- Cardano Node 10.6.3 dependencies:
   , cardano-api ==10.23.0.0
   , cardano-binary ==1.7.2.0
-  , cardano-crypto ==1.2.0
+  , cardano-crypto ==1.3.0
   , cardano-crypto-class ==2.2.3.2
   , cardano-crypto-praos ==2.2.1.1
   , cardano-crypto-wrapper ==1.6.1.0

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1770667523,
-        "narHash": "sha256-NTZeJP2ETCS/9hAUottupnhI7b5RmYKiB4jJqhyvHhs=",
+        "lastModified": 1774695208,
+        "narHash": "sha256-4GaPRLb1S9pvQnSXBYdKz2xCZzu0m1UgWsItFu9poOk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "da32b7c7513f0f5383d233a0f97e03538b0c7726",
+        "rev": "2d51f381c901c7f1a799d65d2de4f2387d07a9e5",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1770667523,
-        "narHash": "sha256-NTZeJP2ETCS/9hAUottupnhI7b5RmYKiB4jJqhyvHhs=",
+        "lastModified": 1774695208,
+        "narHash": "sha256-4GaPRLb1S9pvQnSXBYdKz2xCZzu0m1UgWsItFu9poOk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "da32b7c7513f0f5383d233a0f97e03538b0c7726",
+        "rev": "2d51f381c901c7f1a799d65d2de4f2387d07a9e5",
         "type": "github"
       },
       "original": {
@@ -231,16 +231,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1770822424,
-        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
+        "lastModified": 1774886169,
+        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
+        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.2",
+        "ref": "10.6.3",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.6.2";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.6.3";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
## Summary

- Bump cardano-node runtime from 10.6.2 to 10.6.3
- cardano-crypto 1.2.0 → 1.3.0 (bounds relaxation only, no API changes)
- CHaP index-state 2026-02-09 → 2026-03-28 (target HSEC-2025-0002)
- All other Cardano dependency versions unchanged

Closes #5230