### PR TITLE
feat: drop cardano-api dependency (additive migration, 47/75 files)

### DIFF
--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -45,6 +45,7 @@ library
     , cardano-binary
     , cardano-crypto
     , cardano-ledger-api
+    , cardano-ledger-binary
     , cardano-ledger-core
     , cardano-ledger-read
     , cardano-wallet

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/NetworkInformation.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/NetworkInformation.hs
@@ -118,7 +118,7 @@ getNetworkInformation
                 , Api.nextEpoch = snd <$> nowInfo
                 , Api.nodeTip = apiNodeTip
                 , Api.networkTip = fst <$> nowInfo
-                , Api.nodeEra = ApiEra.fromAnyCardanoEra nodeEra
+                , Api.nodeEra = ApiEra.fromReadEra nodeEra
                 , Api.networkInfo =
                     Api.ApiNetworkInfo
                         ( case nid of

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -145,9 +145,6 @@ import Cardano.Address.Script
     , foldScript
     , validateScriptOfTemplate
     )
-import Cardano.Api
-    ( SerialiseAsCBOR (..)
-    )
 -- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
 --     ( getNetworkInformation
 --     , makeApiBlockReference
@@ -174,6 +171,10 @@ import Cardano.BM.Tracing
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
+    )
+import Cardano.Ledger.Binary
+    ( serialize'
+    , shelleyProtVer
     )
 import Cardano.Mnemonic
     ( SomeMnemonic
@@ -644,6 +645,10 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( TxStatus (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( toShelleyMetadata
+    , unTxMetadata
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
@@ -2207,7 +2212,10 @@ selectCoins ctx@ApiLayer{..} argGenChange (ApiT walletId) body = do
                 , depositsTaken = maybeToList $ ApiAmount.fromCoin <$> deposit
                 , depositsReturned = maybeToList $ ApiAmount.fromCoin <$> refund
                 , metadata =
-                    ApiBytesT . serialiseToCBOR
+                    ApiBytesT
+                        . serialize' shelleyProtVer
+                        . toShelleyMetadata
+                        . unTxMetadata
                         <$> body ^? #metadata . traverse . #getApiT
                 }
 
@@ -5136,7 +5144,10 @@ mkApiCoinSelection deps refunds mDelCerts mVotingCerts metadata unsignedTx =
             ApiAmount.fromCoin
                 <$> refunds
         , metadata =
-            ApiBytesT . serialiseToCBOR
+            ApiBytesT
+                . serialize' shelleyProtVer
+                . toShelleyMetadata
+                . unTxMetadata
                 <$> metadata
         }
   where

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -147,7 +147,6 @@ import Cardano.Address.Script
     )
 import Cardano.Api
     ( SerialiseAsCBOR (..)
-    , StakeAddress (..)
     )
 -- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
 --     ( getNetworkInformation
@@ -537,6 +536,9 @@ import Cardano.Wallet.Primitive.Delegation.UTxO
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( toLedger
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( toLedgerStakeCredential
+    )
 import Cardano.Wallet.Primitive.Model
     ( Wallet
     , availableBalance
@@ -549,6 +551,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     , NetworkDiscriminantCheck
+    , networkIdToLedger
     )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
@@ -5482,16 +5485,18 @@ fromExternalInput
         in
             (inp, out)
 
-fromApiRedeemer :: ApiRedeemer n -> Write.Redeemer
+fromApiRedeemer
+    :: forall n. HasSNetworkId n => ApiRedeemer n -> Write.Redeemer
 fromApiRedeemer = \case
     ApiRedeemerSpending (ApiBytesT bytes) (ApiT i) ->
         Write.RedeemerSpending bytes (toLedger i)
     ApiRedeemerMinting (ApiBytesT bytes) (ApiT p) ->
         Write.RedeemerMinting bytes (toLedger p)
-    ApiRedeemerRewarding (ApiBytesT bytes) (StakeAddress x y) ->
-        Write.RedeemerRewarding
-            bytes
-            (Ledger.AccountAddress x (Ledger.AccountId y))
+    ApiRedeemerRewarding (ApiBytesT bytes) acct ->
+        Write.RedeemerRewarding bytes
+            $ Ledger.AccountAddress
+                (networkIdToLedger (sNetworkId @n))
+                (Ledger.AccountId (toLedgerStakeCredential acct))
 
 sealWriteTx
     :: forall era. Write.IsRecentEra era => Write.Tx era -> W.SealedTx

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -552,7 +552,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     , NetworkDiscriminantCheck
-    , networkIdToLedger
+    , sNetworkIdToLedger
     )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
@@ -5506,7 +5506,7 @@ fromApiRedeemer = \case
     ApiRedeemerRewarding (ApiBytesT bytes) acct ->
         Write.RedeemerRewarding bytes
             $ Ledger.AccountAddress
-                (networkIdToLedger (sNetworkId @n))
+                (sNetworkIdToLedger (sNetworkId @n))
                 (Ledger.AccountId (toLedgerStakeCredential acct))
 
 sealWriteTx

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -267,11 +267,6 @@ import Cardano.Address.Script
     , ScriptTemplate
     , ValidationLevel (..)
     )
-import Cardano.Api
-    ( StakeAddress
-    , deserialiseFromBech32
-    , serialiseToBech32
-    )
 import Cardano.Mnemonic
     ( MkSomeMnemonic (..)
     , MkSomeMnemonicError (..)
@@ -311,7 +306,9 @@ import Cardano.Wallet.Address.Discovery.Shared
     )
 import Cardano.Wallet.Address.Encoding
     ( decodeAddress
+    , decodeStakeAddress
     , encodeAddress
+    , encodeStakeAddress
     )
 import Cardano.Wallet.Api.Aeson
     ( eitherToParser
@@ -660,6 +657,7 @@ import qualified Cardano.Wallet.Address.Derivation as AD
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.AssetName as W
+import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMetadata as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
@@ -1434,7 +1432,7 @@ type ApiRedeemerData = ApiBytesT 'Base16 ByteString
 data ApiRedeemer (n :: NetworkDiscriminant)
     = ApiRedeemerSpending ApiRedeemerData (ApiT TxIn)
     | ApiRedeemerMinting ApiRedeemerData (ApiT W.TokenPolicyId)
-    | ApiRedeemerRewarding ApiRedeemerData StakeAddress
+    | ApiRedeemerRewarding ApiRedeemerData W.RewardAccount
     deriving (Eq, Generic, Show)
 
 data ApiFee = ApiFee
@@ -2822,7 +2820,7 @@ instance HasSNetworkId n => FromJSON (ApiRedeemer n) where
                 ApiRedeemerMinting bytes <$> (o .: "policy_id")
             "rewarding" -> do
                 text <- o .: "stake_address"
-                case deserialiseFromBech32 @StakeAddress text of
+                case decodeStakeAddress (sNetworkId @n) text of
                     Left e -> fail (show e)
                     Right addr -> pure $ ApiRedeemerRewarding bytes addr
             _ ->
@@ -2845,7 +2843,7 @@ instance HasSNetworkId n => ToJSON (ApiRedeemer n) where
             object
                 [ "purpose" .= ("rewarding" :: Text)
                 , "data" .= bytes
-                , "stake_address" .= serialiseToBech32 addr
+                , "stake_address" .= encodeStakeAddress (sNetworkId @n) addr
                 ]
 
 instance ToJSON ApiValidityBound where

--- a/lib/api/src/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Primitive.hs
@@ -14,12 +14,6 @@ module Cardano.Wallet.Api.Types.Primitive () where
 import Cardano.Address.Script
     ( ScriptHash (..)
     )
-import Cardano.Api
-    ( TxMetadataJsonSchema (..)
-    , metadataFromJson
-    , metadataToJson
-    )
--- Removed: Cardano.Api.Error no longer exists
 import Cardano.Pool.Metadata.Types
     ( StakePoolMetadataHash
     , StakePoolMetadataUrl
@@ -69,6 +63,11 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( TxMetadataJsonSchema (..)
+    , metadataFromJson
+    , metadataToJson
     )
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)

--- a/lib/api/src/Cardano/Wallet/Api/Types/SchemaMetadata.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/SchemaMetadata.hs
@@ -17,14 +17,13 @@
 -- see https://github.com/IntersectMBO/cardano-node/blob/master/cardano-api/src/Cardano/Api/TxMetadata.hs
 module Cardano.Wallet.Api.Types.SchemaMetadata where
 
-import Cardano.Api
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxMetadata (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
     ( TxMetadataJsonSchema (..)
     , metadataFromJson
     , metadataToJson
-    )
--- Removed: Cardano.Api.Error no longer exists
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxMetadata (..)
     )
 import Control.Applicative
     ( (<|>)

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -192,7 +192,6 @@ import System.IO
     )
 import Prelude
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB as DB
 import qualified Cardano.Wallet.DB.Layer as DB
@@ -710,7 +709,7 @@ mockNetworkLayer =
                         :: Read.PParams Read.Conway
                     )
         , currentProtocolParameters = pure dummyProtocolParameters
-        , currentNodeEra = pure $ Cardano.anyCardanoEra Cardano.BabbageEra
+        , currentNodeEra = pure $ Read.EraValue Read.Babbage
         , currentNodeTip =
             pure
                 Read.BlockTip

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -381,6 +381,10 @@ import qualified Cardano.Wallet.Api.Types.Era as ApiEra
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxMetadata as W
+    ( fromShelleyMetadata
+    , metadataValueToJsonNoSchema
+    )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BL
@@ -484,7 +488,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             Nothing -> error "Tx doesn't include metadata"
             Just m -> case Map.lookup 1 m of
                 Nothing -> error "Tx doesn't include metadata"
-                Just (Cardano.TxMetaText "hello") -> pure ()
+                Just (TxMetaText "hello") -> pure ()
                 Just _ -> error "Tx metadata incorrect"
 
         let decodePayload = Json (toJSON signedTx)
@@ -558,7 +562,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 Nothing -> error "Tx doesn't include metadata"
                 Just m -> case Map.lookup 1 m of
                     Nothing -> error "Tx doesn't include metadata"
-                    Just (Cardano.TxMetaText "hello") -> pure ()
+                    Just (TxMetaText "hello") -> pure ()
                     Just _ -> error "Tx metadata incorrect"
 
             let decodePayload = Json (toJSON signedTx)
@@ -714,7 +718,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     cardanoTxIdeallyNoLaterThan era
                         $ getApiT (signedTx ^. #serialisedTxSealed)
 
-            let extractTxt (Cardano.TxMetaText txt) = txt
+            let extractTxt (TxMetaText txt) = txt
                 extractTxt _ =
                     error "extractTxt is expected"
             let encryptedMsg = case getMetadataFromTx tx of
@@ -722,7 +726,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     Just m -> case Map.lookup 674 m of
                         Nothing -> error "Tx doesn't include metadata"
                         Just
-                            ( Cardano.TxMetaMap
+                            ( TxMetaMap
                                     [ (TxMetaText "msg", TxMetaList chunks1)
                                         , (TxMetaText "msg", TxMetaList chunks2)
                                         , (TxMetaText "enc", TxMetaText "basic")
@@ -746,13 +750,13 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     encrypt WithPadding key1 iv1 (Just salt1)
                         $ BL.toStrict
                         $ Aeson.encode
-                        $ Cardano.metadataValueToJsonNoSchema
+                        $ W.metadataValueToJsonNoSchema
                             toBeEncrypted1
             let (Right encryptedMsgRaw2) =
                     encrypt WithPadding key2 iv2 (Just salt2)
                         $ BL.toStrict
                         $ Aeson.encode
-                        $ Cardano.metadataValueToJsonNoSchema
+                        $ W.metadataValueToJsonNoSchema
                             toBeEncrypted2
 
             encryptedMsg
@@ -5525,8 +5529,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     , expectField
                         (#metadata . traverse . #txMetadataWithSchema_metadata)
                         ( `shouldBe`
-                            Cardano.TxMetadata
-                                (Map.fromList [(1, Cardano.TxMetaText "hello")])
+                            TxMetadata
+                                (Map.fromList [(1, TxMetaText "hello")])
                         )
                     ]
 
@@ -6735,7 +6739,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     Cardano.TxMetadataNone ->
                         Nothing
                     Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
-                        Just m
+                        Just (W.fromShelleyMetadata (Cardano.toShelleyMetadata m))
 
     -- Construct a JSON payment request for the given quantity of lovelace.
     mkTxPayload
@@ -7380,7 +7384,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 cardanoTxIdeallyNoLaterThan era
                     $ getApiT (signedTx ^. #serialisedTxSealed)
 
-        let extractTxt (Cardano.TxMetaText txt) = txt
+        let extractTxt (TxMetaText txt) = txt
             extractTxt _ =
                 error "extractTxt is expected"
         let encryptedMsg = case getMetadataFromTx tx of
@@ -7388,7 +7392,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 Just m -> case Map.lookup 674 m of
                     Nothing -> error "Tx doesn't include metadata"
                     Just
-                        ( Cardano.TxMetaMap
+                        ( TxMetaMap
                                 [ (TxMetaText "msg", TxMetaList chunks)
                                     , (TxMetaText "enc", TxMetaText "basic")
                                     ]
@@ -7404,7 +7408,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 encrypt WithPadding key iv (Just salt)
                     $ BL.toStrict
                     $ Aeson.encode
-                    $ Cardano.metadataValueToJsonNoSchema
+                    $ W.metadataValueToJsonNoSchema
                         toBeEncrypted
 
         encryptedMsg `shouldBe` toBase64 encryptedMsgRaw

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -26,9 +26,6 @@ module Cardano.Wallet.Network
     , updateStats
     ) where
 
-import Cardano.Api
-    ( AnyCardanoEra
-    )
 import Cardano.Balance.Tx.Eras
     ( MaybeInRecentEra
     )
@@ -127,7 +124,7 @@ data NetworkLayer m block = NetworkLayer
         :: m Read.ChainTip
     -- ^ Get the current tip from the chain producer
     , currentNodeEra
-        :: m AnyCardanoEra
+        :: m (Read.EraValue Read.Era)
     -- ^ Get the era the node is currently in.
     , currentPParams
         :: m (Read.EraValue Read.PParams)

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -554,7 +554,7 @@ withNodeNetworkLayerBase
                 ( STM IO (Tip (CardanoBlock StandardCrypto))
                 , TMVar IO NetworkParams
                 , TMVar IO (CardanoInterpreter StandardCrypto)
-                , TMVar IO AnyCardanoEra
+                , TMVar IO (Read.EraValue Read.Era)
                 , TQueue
                     IO
                     ( LocalTxSubmissionCmd
@@ -653,7 +653,7 @@ withNodeNetworkLayerBase
             preferredEra <- liftIO readCurrentEra
             case unsealShelleyTx preferredEra tx of
                 Left (UnsealedTxInUnsupportedEra era) ->
-                    throwE $ ErrPostTxEraUnsupported (fromAnyCardanoEra era)
+                    throwE $ ErrPostTxEraUnsupported era
                 Right tx' -> do
                     let cmd = CmdSubmitTx . toConsensusGenTx $ tx'
                     liftIO (send txSubmissionQueue cmd) >>= \case
@@ -683,14 +683,14 @@ withNodeNetworkLayerBase
         _getUTxOByTxIn queue readCachedEra ins
             | ins == mempty =
                 readCachedEra <&> \case
-                    AnyCardanoEra ByronEra -> InNonRecentEraByron
-                    AnyCardanoEra ShelleyEra -> InNonRecentEraShelley
-                    AnyCardanoEra AllegraEra -> InNonRecentEraAllegra
-                    AnyCardanoEra MaryEra -> InNonRecentEraMary
-                    AnyCardanoEra AlonzoEra -> InNonRecentEraAlonzo
-                    AnyCardanoEra BabbageEra -> InNonRecentEraBabbage
-                    AnyCardanoEra ConwayEra -> InRecentEraConway mempty
-                    AnyCardanoEra DijkstraEra ->
+                    Read.EraValue Read.Byron -> InNonRecentEraByron
+                    Read.EraValue Read.Shelley -> InNonRecentEraShelley
+                    Read.EraValue Read.Allegra -> InNonRecentEraAllegra
+                    Read.EraValue Read.Mary -> InNonRecentEraMary
+                    Read.EraValue Read.Alonzo -> InNonRecentEraAlonzo
+                    Read.EraValue Read.Babbage -> InNonRecentEraBabbage
+                    Read.EraValue Read.Conway -> InRecentEraConway mempty
+                    Read.EraValue Read.Dijkstra ->
                         InRecentEraDijkstra mempty
             | otherwise =
                 bracketQuery "getUTxOByTxIn" tr
@@ -957,7 +957,7 @@ mkWalletToNodeProtocols
     -- ^ Notifier callback for when parameters for tip change.
     -> (CardanoInterpreter StandardCrypto -> m ())
     -- ^ Notifier callback for when time interpreter is updated.
-    -> (AnyCardanoEra -> m ())
+    -> (Read.EraValue Read.Era -> m ())
     -- ^ Notifier callback for when the era is updated
     -> TQueue
         m
@@ -1015,7 +1015,7 @@ mkWalletToNodeProtocols
                 (pparams, int, e) <- localStateQueryQ `send` (SomeLSQ qry)
                 onPParamsUpdate' pparams
                 onInterpreterUpdate int
-                onEraUpdate e
+                onEraUpdate (fromAnyCardanoEra e)
 
         link =<< async (observeForever (readTVar tipVar) onTipUpdate)
 

--- a/lib/primitive/lib/Cardano/Wallet/Orphans.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Orphans.hs
@@ -9,12 +9,12 @@
 -- Module for orphans which would be too inconvenient to avoid.
 module Cardano.Wallet.Orphans where
 
-import Cardano.Api
-    ( TxMetadata (..)
-    , TxMetadataValue (..)
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( TxMetadata (..)
+    , TxMetadataValue (..)
     )
 import Control.DeepSeq
     ( NFData (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Eras.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Eras.hs
@@ -7,6 +7,7 @@
 -- Convert from Cardano.Api to Cardano.Wallet.Read.
 module Cardano.Wallet.Primitive.Ledger.Read.Eras
     ( fromAnyCardanoEra
+    , toAnyCardanoEra
     )
 where
 
@@ -14,7 +15,6 @@ import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
     )
-import Prelude
 
 import qualified Cardano.Wallet.Read as Read
 
@@ -29,4 +29,17 @@ fromAnyCardanoEra (AnyCardanoEra era) =
         AlonzoEra -> Read.EraValue Read.Alonzo
         BabbageEra -> Read.EraValue Read.Babbage
         ConwayEra -> Read.EraValue Read.Conway
-        _ -> error "fromAnyCardanoEra: era not yet supported"
+        DijkstraEra -> Read.EraValue Read.Dijkstra
+
+-- | Convert an era from 'Read' to 'Cardano.Api'.
+toAnyCardanoEra :: Read.EraValue Read.Era -> AnyCardanoEra
+toAnyCardanoEra (Read.EraValue era) =
+    case era of
+        Read.Byron -> AnyCardanoEra ByronEra
+        Read.Shelley -> AnyCardanoEra ShelleyEra
+        Read.Allegra -> AnyCardanoEra AllegraEra
+        Read.Mary -> AnyCardanoEra MaryEra
+        Read.Alonzo -> AnyCardanoEra AlonzoEra
+        Read.Babbage -> AnyCardanoEra BabbageEra
+        Read.Conway -> AnyCardanoEra ConwayEra
+        Read.Dijkstra -> AnyCardanoEra DijkstraEra

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
@@ -69,8 +69,8 @@ import Data.Word
     )
 import Prelude
 
-import qualified Cardano.Api.Tx as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxMetadata as W
 
 {-# INLINEABLE getMetadata #-}
 getMetadata
@@ -114,4 +114,4 @@ fromDijkstraMetadata (AlonzoTxAuxData md _timelock _plutus) = fromMetadata md
 
 fromMetadata :: Map Word64 Metadatum -> W.TxMetadata
 fromMetadata =
-    Cardano.makeTransactionMetadata . Cardano.fromShelleyMetadata
+    W.makeTransactionMetadata . W.fromShelleyMetadata

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -304,6 +304,7 @@ import qualified Cardano.Ledger.State as Ledger
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.AssetId as W
@@ -1118,22 +1119,27 @@ rewardAccountFromAddress (W.Address bytes) = refToAccount . ref =<< parseAddr by
     refToAccount (SL.StakeRefPtr _) = Nothing
     refToAccount SL.StakeRefNull = Nothing
 
-newtype UnsealException = UnsealedTxInUnsupportedEra AnyCardanoEra
+newtype UnsealException
+    = UnsealedTxInUnsupportedEra (Read.EraValue Read.Era)
 
 -- | Converts 'SealedTx' to something that can be submitted with the
 -- 'Cardano.Api' local tx submission client.
 unsealShelleyTx
-    :: AnyCardanoEra
+    :: Read.EraValue Read.Era
     -- ^ Preferred latest era (see 'ideallyNoLaterThan')
     -> W.SealedTx
     -> Either UnsealException TxInMode
-unsealShelleyTx era wtx = case W.cardanoTxIdeallyNoLaterThan era wtx of
-    Cardano.InAnyCardanoEra BabbageEra tx ->
-        Right $ TxInMode ShelleyBasedEraBabbage tx
-    Cardano.InAnyCardanoEra ConwayEra tx ->
-        Right $ TxInMode ShelleyBasedEraConway tx
-    Cardano.InAnyCardanoEra unsupportedEra _ ->
-        Left $ UnsealedTxInUnsupportedEra $ AnyCardanoEra unsupportedEra
+unsealShelleyTx era wtx =
+    case W.cardanoTxIdeallyNoLaterThan (Eras.toAnyCardanoEra era) wtx of
+        Cardano.InAnyCardanoEra BabbageEra tx ->
+            Right $ TxInMode ShelleyBasedEraBabbage tx
+        Cardano.InAnyCardanoEra ConwayEra tx ->
+            Right $ TxInMode ShelleyBasedEraConway tx
+        Cardano.InAnyCardanoEra unsupportedEra _ ->
+            Left
+                $ UnsealedTxInUnsupportedEra
+                $ Eras.fromAnyCardanoEra
+                $ AnyCardanoEra unsupportedEra
 
 instance
     (forall era. IsCardanoEra era => Show (thing era))

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/MetadataEncryption.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/MetadataEncryption.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Primitive.Types.MetadataEncryption
     )
 where
 
-import Cardano.Api
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
     ( TxMetadata (..)
     , TxMetadataValue (..)
     , metadataValueFromJsonNoSchema

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Metadata/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Metadata/Gen.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Primitive.Types.Tx.Metadata.Gen
     )
 where
 
-import Cardano.Api
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
     ( TxMetadata (..)
     , TxMetadataJsonSchema (..)
     , TxMetadataValue (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -39,8 +39,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Tx
 
 import Cardano.Api
     ( ScriptWitnessIndex (..)
-    , TxMetadata (..)
-    , TxMetadataValue (..)
     )
 import Cardano.Wallet.Orphans
     (
@@ -57,6 +55,10 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxId
     , TxIn (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( TxMetadata (..)
+    , TxMetadataValue (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/MetadataEncryptionSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/MetadataEncryptionSpec.hs
@@ -57,7 +57,7 @@ import Test.QuickCheck
     )
 import Prelude
 
-import qualified Cardano.Api as Cardano
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxMetadata as Cardano
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List as L

--- a/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -8,10 +8,6 @@
 
 module Cardano.Wallet.Api.ServerSpec (spec) where
 
-import Cardano.Api
-    ( AnyCardanoEra (..)
-    , CardanoEra (..)
-    )
 import Cardano.BM.Trace
     ( nullTracer
     )
@@ -268,7 +264,7 @@ networkInfoSpec = describe "getNetworkInformation" $ do
         -> NetworkLayer IO Block
     mockNetworkLayer sl ti relativeTime =
         dummyNetworkLayer
-            { currentNodeEra = pure $ AnyCardanoEra MaryEra
+            { currentNodeEra = pure $ Read.EraValue Read.Mary
             , currentNodeTip =
                 pure
                     $ Read.BlockTip

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -44,11 +44,6 @@ import Cardano.Address.Script
     , ScriptTemplate (..)
     , ValidationLevel (..)
     )
-import Cardano.Api
-    ( StakeAddress
-    , deserialiseFromRawBytes
-    , proxyToAsType
-    )
 import Cardano.Api.Gen
     ( genAddressAnyWithNetworkId
     )
@@ -523,9 +518,6 @@ import Data.Data
     )
 import Data.Either
     ( lefts
-    )
-import Data.Either.Combinators
-    ( fromRight'
     )
 import Data.FileEmbed
     ( embedFile
@@ -2422,16 +2414,6 @@ instance HasSNetworkId n => Arbitrary (ApiDecodedTransaction n) where
             <*> arbitrary
             <*> arbitrary
             <*> arbitrary
-
-instance Arbitrary StakeAddress where
-    arbitrary = do
-        header <- elements [BS.singleton 241, BS.singleton 224]
-        payload <- BS.pack <$> vector 28
-        pure
-            $ fromRight'
-            $ deserialiseFromRawBytes
-                (proxyToAsType Proxy)
-                (header <> payload)
 
 instance Arbitrary ApiSealedTxEncoding where
     arbitrary = elements [HexEncoded, Base64Encoded]

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -389,6 +389,7 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -565,7 +566,7 @@ prop_signTransaction_addsRewardAccountKey
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (const Nothing)
                             Nothing
@@ -657,7 +658,7 @@ prop_signTransaction_addsExtraKeyWitnesses
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -805,7 +806,9 @@ prop_signTransaction_addsTxInWitnesses
                             signTransaction
                                 ShelleyKeyS
                                 tl
-                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                                ( Eras.fromAnyCardanoEra
+                                    (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                                )
                                 AnyWitnessCountCtx
                                 (lookupFnFromKeys extraKeys)
                                 Nothing
@@ -871,7 +874,7 @@ prop_signTransaction_addsTxInCollateralWitnesses
                             signTransaction
                                 ShelleyKeyS
                                 tl
-                                (AnyCardanoEra era)
+                                (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                                 AnyWitnessCountCtx
                                 (lookupFnFromKeys extraKeys)
                                 Nothing
@@ -915,7 +918,9 @@ prop_signTransaction_neverRemovesWitnesses
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            ( Eras.fromAnyCardanoEra
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            )
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -959,7 +964,7 @@ prop_signTransaction_neverChangesTxBody
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -1015,7 +1020,9 @@ prop_signTransaction_preservesScriptIntegrity
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            ( Eras.fromAnyCardanoEra
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            )
                             AnyWitnessCountCtx
                             (const Nothing)
                             Nothing

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -209,6 +209,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( toShelleyMetadata
+    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -1385,7 +1388,7 @@ makeShelleyTx era' testCase = case era' of
                   metadata = case md of
                     Nothing -> Map.empty
                     Just (TxMetadata m) ->
-                        Cardano.toShelleyMetadata m
+                        toShelleyMetadata m
                   baseTx =
                     mkLedgerTx
                         era''

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -355,6 +355,7 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -530,7 +531,7 @@ prop_signTransaction_addsRewardAccountKey
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (const Nothing)
                             Nothing
@@ -622,7 +623,7 @@ prop_signTransaction_addsExtraKeyWitnesses
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -770,7 +771,9 @@ prop_signTransaction_addsTxInWitnesses
                             signTransaction
                                 ShelleyKeyS
                                 tl
-                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                                ( Eras.fromAnyCardanoEra
+                                    (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                                )
                                 AnyWitnessCountCtx
                                 (lookupFnFromKeys extraKeys)
                                 Nothing
@@ -836,7 +839,7 @@ prop_signTransaction_addsTxInCollateralWitnesses
                             signTransaction
                                 ShelleyKeyS
                                 tl
-                                (AnyCardanoEra era)
+                                (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                                 AnyWitnessCountCtx
                                 (lookupFnFromKeys extraKeys)
                                 Nothing
@@ -880,7 +883,9 @@ prop_signTransaction_neverRemovesWitnesses
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            ( Eras.fromAnyCardanoEra
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            )
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -924,7 +929,7 @@ prop_signTransaction_neverChangesTxBody
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra era)
+                            (Eras.fromAnyCardanoEra (AnyCardanoEra era))
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -980,7 +985,9 @@ prop_signTransaction_preservesScriptIntegrity
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            ( Eras.fromAnyCardanoEra
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            )
                             AnyWitnessCountCtx
                             (const Nothing)
                             Nothing

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -25,10 +25,6 @@ module Cardano.WalletSpec
 import Cardano.Address.Derivation
     ( XPrv
     )
-import Cardano.Api
-    ( AnyCardanoEra (..)
-    , CardanoEra (..)
-    )
 import Cardano.Balance.Tx.Balance
     ( ErrBalanceTx (..)
     , ErrBalanceTxAssetsInsufficientError (..)
@@ -1586,7 +1582,7 @@ mockNetworkLayer =
         { currentNodeTip =
             pure dummyTip
         , currentNodeEra =
-            pure (AnyCardanoEra AllegraEra)
+            pure (Read.EraValue Read.Allegra)
         , currentProtocolParameters =
             pure (protocolParameters dummyNetworkParameters)
         , timeInterpreter = dummyTimeInterpreter

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -58,6 +58,7 @@ library
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
+    , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -494,8 +494,8 @@ import Cardano.Wallet.Primitive.Model
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
-    , networkIdToLedger
     , networkIdVal
+    , sNetworkIdToLedger
     )
 import Cardano.Wallet.Primitive.Passphrase
     ( ErrWrongPassphrase (..)
@@ -2710,7 +2710,7 @@ buildTransactionPure
         do
             let era = Write.recentEra @era
                 network =
-                    networkIdToLedger
+                    sNetworkIdToLedger
                         (sNetworkId @(NetworkOf s))
                 stakeXPub =
                     case walletFlavor @s of
@@ -3514,7 +3514,7 @@ transactionFee
                 $ availableUTxO mempty wallet
         let era = Write.recentEra @era
             network =
-                networkIdToLedger
+                sNetworkIdToLedger
                     (sNetworkId @(NetworkOf s))
             stakeXPub =
                 case walletFlavor @s of

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -258,7 +258,6 @@ import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
     , cardanoEraFromRecentEra
-    , fromCardanoApiTx
     , inAnyCardanoEra
     , toCardanoApiTx
     )
@@ -495,6 +494,7 @@ import Cardano.Wallet.Primitive.Model
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
+    , networkIdToLedger
     , networkIdVal
     )
 import Cardano.Wallet.Primitive.Passphrase
@@ -632,6 +632,9 @@ import Cardano.Wallet.Shelley.Transaction
     , txConstraints
     , txWitnessTagForKey
     , _txRewardWithdrawalCost
+    )
+import Cardano.Wallet.Shelley.Transaction.Ledger
+    ( constructUnsignedTxLedger
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -2701,13 +2704,16 @@ buildTransactionPure
     preSelection
     txCtx =
         do
-            unsignedTxBody <-
+            unsignedTx <-
                 withExceptT (Right . ErrConstructTxBody) . except
-                    $ mkUnsignedTransaction
-                        (networkIdVal $ sNetworkId @(NetworkOf s))
-                        (Left $ unsafeShelleyOnlyGetRewardXPub @s (getState wallet))
-                        txCtx
+                    $ constructUnsignedTxLedger
+                        (Write.recentEra @era)
+                        (networkIdToLedger (sNetworkId @(NetworkOf s)))
+                        (view #txMetadata txCtx, [])
+                        (txValidityInterval txCtx)
+                        (view #txWithdrawal txCtx)
                         (Left preSelection)
+                        (Coin 0)
             let utxoIndex :: Write.UTxOIndex era
                 utxoIndex = utxoIndexFromWalletUTxO utxo
             withExceptT Left
@@ -2719,7 +2725,7 @@ buildTransactionPure
                     changeAddrGen
                     (getState wallet)
                     Write.PartialTx
-                        { tx = fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                        { tx = unsignedTx
                         , extraUTxO = Write.UTxO mempty
                         , redeemers = []
                         , timelockKeyWitnessCounts = mempty
@@ -2735,22 +2741,6 @@ buildTransactionPure
 -- make 'buildAndSignTransactionPure' partial instead.
 --
 -- https://cardanofoundation.atlassian.net/browse/ADP-2933
-
-unsafeShelleyOnlyGetRewardXPub
-    :: forall s
-     . WalletFlavor s
-    => s -> XPub
-unsafeShelleyOnlyGetRewardXPub walletState =
-    case walletFlavor @s of
-        ShelleyWallet ->
-            getRawKey (keyFlavorFromState @s)
-                $ Seq.rewardAccountKey walletState
-        _ ->
-            error
-                $ unwords
-                    [ "buildAndSignTransactionPure:"
-                    , "can't delegate using non-shelley wallet"
-                    ]
 
 -- | Produce witnesses and construct a transaction from a given selection.
 --
@@ -3483,18 +3473,21 @@ transactionFee
             evaluate
                 $ utxoIndexFromWalletUTxO
                 $ availableUTxO mempty wallet
-        unsignedTxBody <-
+        unsignedTx <-
             wrapErrMkTransaction
-                $ mkUnsignedTransaction
-                    (networkIdVal $ sNetworkId @(NetworkOf s))
-                    (Left $ unsafeShelleyOnlyGetRewardXPub @s (getState wallet))
-                    txCtx
+                $ constructUnsignedTxLedger
+                    (Write.recentEra @era)
+                    (networkIdToLedger (sNetworkId @(NetworkOf s)))
+                    (view #txMetadata txCtx, [])
+                    (txValidityInterval txCtx)
+                    (view #txWithdrawal txCtx)
                     (Left preSelection)
+                    (Coin 0)
 
         let ptx :: Write.PartialTx era
             ptx =
                 Write.PartialTx
-                    { tx = fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                    { tx = unsignedTx
                     , extraUTxO = Write.UTxO mempty
                     , redeemers = []
                     , timelockKeyWitnessCounts = mempty

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -633,7 +633,9 @@ import Cardano.Wallet.Shelley.Transaction
     , _txRewardWithdrawalCost
     )
 import Cardano.Wallet.Shelley.Transaction.Ledger
-    ( constructUnsignedTxLedger
+    ( certificateFromDelegationActionLedger
+    , certificateFromVotingActionLedger
+    , constructUnsignedTxLedger
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -2702,12 +2704,47 @@ buildTransactionPure
     preSelection
     txCtx =
         do
+            let era = Write.recentEra @era
+                network =
+                    networkIdToLedger
+                        (sNetworkId @(NetworkOf s))
+                stakeXPub =
+                    case walletFlavor @s of
+                        ShelleyWallet ->
+                            getRawKey
+                                (keyFlavorFromState @s)
+                                $ Seq.rewardAccountKey
+                                    (getState wallet)
+                        _ ->
+                            error
+                                "buildTransactionPure: \
+                                \non-shelley wallet"
+                depositM = view #txDeposit txCtx
+                delegCerts =
+                    case view #txDelegationAction txCtx of
+                        Nothing -> []
+                        Just action ->
+                            certificateFromDelegationActionLedger
+                                era
+                                (Left stakeXPub)
+                                depositM
+                                action
+                votingCerts =
+                    case view #txVotingAction txCtx of
+                        Nothing -> []
+                        Just action ->
+                            certificateFromVotingActionLedger
+                                era
+                                (Left stakeXPub)
+                                depositM
+                                action
+                allCerts = L.nub $ delegCerts <> votingCerts
             unsignedTx <-
                 withExceptT (Right . ErrConstructTxBody) . except
                     $ constructUnsignedTxLedger
-                        (Write.recentEra @era)
-                        (networkIdToLedger (sNetworkId @(NetworkOf s)))
-                        (view #txMetadata txCtx, [])
+                        era
+                        network
+                        (view #txMetadata txCtx, allCerts)
                         (txValidityInterval txCtx)
                         (view #txWithdrawal txCtx)
                         (Left preSelection)
@@ -3471,12 +3508,47 @@ transactionFee
             evaluate
                 $ utxoIndexFromWalletUTxO
                 $ availableUTxO mempty wallet
+        let era = Write.recentEra @era
+            network =
+                networkIdToLedger
+                    (sNetworkId @(NetworkOf s))
+            stakeXPub =
+                case walletFlavor @s of
+                    ShelleyWallet ->
+                        getRawKey
+                            (keyFlavorFromState @s)
+                            $ Seq.rewardAccountKey
+                                (getState wallet)
+                    _ ->
+                        error
+                            "transactionFee: \
+                            \non-shelley wallet"
+            depositM = view #txDeposit txCtx
+            delegCerts =
+                case view #txDelegationAction txCtx of
+                    Nothing -> []
+                    Just action ->
+                        certificateFromDelegationActionLedger
+                            era
+                            (Left stakeXPub)
+                            depositM
+                            action
+            votingCerts =
+                case view #txVotingAction txCtx of
+                    Nothing -> []
+                    Just action ->
+                        certificateFromVotingActionLedger
+                            era
+                            (Left stakeXPub)
+                            depositM
+                            action
+            allCerts = L.nub $ delegCerts <> votingCerts
         unsignedTx <-
             wrapErrMkTransaction
                 $ constructUnsignedTxLedger
-                    (Write.recentEra @era)
-                    (networkIdToLedger (sNetworkId @(NetworkOf s)))
-                    (view #txMetadata txCtx, [])
+                    era
+                    network
+                    (view #txMetadata txCtx, allCerts)
                     (txValidityInterval txCtx)
                     (view #txWithdrawal txCtx)
                     (Left preSelection)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -251,9 +251,6 @@ import Cardano.Address.KeyHash
 import Cardano.Address.Script
     ( Cosigner (..)
     )
-import Cardano.Api
-    ( serialiseToCBOR
-    )
 import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
@@ -301,6 +298,10 @@ import Cardano.Ledger.Api
     ( EraTxBody (allInputsTxBodyF)
     , bodyTxL
     , feeTxBodyL
+    )
+import Cardano.Ledger.Binary
+    ( serialize'
+    , shelleyProtVer
     )
 import Cardano.Mnemonic
     ( SomeMnemonic
@@ -611,6 +612,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..)
     , TxMeta (..)
     , TxStatus (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( toShelleyMetadata
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
@@ -3809,7 +3813,9 @@ signMetadataWith ctx wid pwd (role_, ix) metadata =
                 $ BA.convert
                 $ CC.sign encPwd (getRawKey (keyFlavorFromState @s) addrK)
                 $ hash @ByteString @Blake2b_256
-                $ serialiseToCBOR metadata
+                $ serialize' shelleyProtVer
+                $ toShelleyMetadata
+                $ unTxMetadata metadata
   where
     db = ctx ^. dbLayer
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -257,7 +257,6 @@ import Cardano.Api
 import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
-    , cardanoEraFromRecentEra
     , inAnyCardanoEra
     , toCardanoApiTx
     )
@@ -2140,7 +2139,7 @@ signTransaction
     => KeyFlavorS k
     -> TransactionLayer k ktype SealedTx
     -- ^ The way to interact with the wallet backend
-    -> Cardano.AnyCardanoEra
+    -> Read.EraValue Read.Era
     -- ^ Preferred latest era
     -> WitnessCountCtx
     -> (Address -> Maybe (k ktype XPrv, Passphrase "encryption"))
@@ -2616,10 +2615,9 @@ buildAndSignTransactionPure
       where
         era = recentEra @era
         wF = walletFlavor @s
-        anyCardanoEra =
-            cardanoApiEraConstraints era
-                $ Cardano.AnyCardanoEra
-                $ cardanoEraFromRecentEra era
+        anyCardanoEra = case era of
+            Write.RecentEraConway -> Read.EraValue Read.Conway
+            Write.RecentEraDijkstra -> Read.EraValue Read.Dijkstra
 
 buildTransaction
     :: forall s era

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -25,11 +25,6 @@ import Cardano.Address.Script
     , Script
     , ScriptHash (..)
     )
-import Cardano.Api
-    ( TxMetadataJsonSchema (..)
-    , metadataFromJson
-    , metadataToJson
-    )
 import Cardano.Pool.Types
     ( PoolId
     )
@@ -107,6 +102,11 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..)
     , TxStatus (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( TxMetadataJsonSchema (..)
+    , metadataFromJson
+    , metadataToJson
     )
 import Control.Arrow
     ( left

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -183,6 +183,10 @@ import Cardano.Wallet.Primitive.Types.Tx.TxExtended
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( TxMetadata (..)
+    , toShelleyMetadata
+    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -326,7 +330,7 @@ constructUnsignedTx
     :: forall era
      . Write.IsRecentEra era
     => Cardano.NetworkId
-    -> (Maybe Cardano.TxMetadata, [Cardano.Certificate (CardanoApiEra era)])
+    -> (Maybe TxMetadata, [Cardano.Certificate (CardanoApiEra era)])
     -> (Maybe SlotNo, SlotNo)
     -- ^ Slot at which the transaction will optionally start and expire.
     -> Withdrawal
@@ -885,7 +889,7 @@ mkUnsignedTx
      . Write.IsRecentEra era
     => (Maybe SlotNo, SlotNo)
     -> Either PreSelection (SelectionOf TxOut)
-    -> Maybe Cardano.TxMetadata
+    -> Maybe TxMetadata
     -> [(Cardano.StakeAddress, Write.Coin)]
     -> [Cardano.Certificate (CardanoApiEra era)]
     -> Write.Coin
@@ -1012,7 +1016,11 @@ mkUnsignedTx
                         , Cardano.txMetadata =
                             case md of
                                 Nothing -> Cardano.TxMetadataNone
-                                Just d -> Cardano.TxMetadataInEra shelleyEra d
+                                Just (TxMetadata d) ->
+                                    Cardano.TxMetadataInEra shelleyEra
+                                        $ Cardano.makeTransactionMetadata
+                                        $ Cardano.fromShelleyMetadata
+                                        $ toShelleyMetadata d
                         , Cardano.txAuxScripts =
                             Cardano.TxAuxScriptsNone
                         , Cardano.txUpdateProposal =

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -69,8 +69,7 @@ import Cardano.Address.Script
     , toScriptHash
     )
 import Cardano.Api
-    ( AnyCardanoEra (..)
-    , InAnyCardanoEra (..)
+    ( InAnyCardanoEra (..)
     , NetworkId
     )
 -- Removed: Cardano.Api.Error no longer exists, using show instead
@@ -292,9 +291,11 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
 import qualified Cardano.Wallet.Primitive.Types.AssetId as AssetId
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -672,7 +673,7 @@ newTransactionLayer keyF networkId =
                     sealedTxFromCardano
                         $ fromMaybe errNonRecentEra
                         $ withRecentEraLedgerTx
-                            (cardanoTxIdeallyNoLaterThan era sealedTx)
+                            (cardanoTxIdeallyNoLaterThan (Eras.toAnyCardanoEra era) sealedTx)
                         $ \ledgerTx ->
                             signTransaction
                                 keyF
@@ -860,11 +861,13 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
                 refScriptM
 
 _decodeSealedTx
-    :: AnyCardanoEra
+    :: Read.EraValue Read.Era
     -> SealedTx
     -> TxExtended
 _decodeSealedTx preferredLatestEra sealedTx =
-    case cardanoTxIdeallyNoLaterThan preferredLatestEra sealedTx of
+    case cardanoTxIdeallyNoLaterThan
+        (Eras.toAnyCardanoEra preferredLatestEra)
+        sealedTx of
         Cardano.InAnyCardanoEra _ tx ->
             fromCardanoTx tx
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -159,6 +159,10 @@ import Cardano.Wallet.Primitive.Types.Tx.TxExtended
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( toShelleyMetadata
+    , unTxMetadata
+    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -453,7 +457,7 @@ buildLedgerTx era ttl network wdrl fee md certs outs cs =
     metadata :: Map Word64 Metadatum
     metadata = case md of
         Nothing -> Map.empty
-        Just m -> Cardano.toShelleyMetadata (Cardano.unTxMetadata m)
+        Just m -> toShelleyMetadata (unTxMetadata m)
 
 -- | Lower-level builder that takes already-converted
 -- types.
@@ -519,7 +523,7 @@ buildLedgerTxRaw
         metadata :: Map Word64 Metadatum
         metadata = case md of
             Nothing -> Map.empty
-            Just m -> Cardano.toShelleyMetadata (Cardano.unTxMetadata m)
+            Just m -> toShelleyMetadata (unTxMetadata m)
 
 -- | Convert a wallet 'TxOut' to a ledger 'TxOut'.
 toLedgerTxOut

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -59,8 +59,7 @@ import Cardano.Address.Script
     ( Script (..)
     )
 import Cardano.Api.Extra
-    ( CardanoApiEra
-    , cardanoApiEraConstraints
+    ( cardanoApiEraConstraints
     , toCardanoApiTx
     )
 import Cardano.Balance.Tx.Eras
@@ -217,8 +216,6 @@ import Prelude
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Byron
-import qualified Cardano.Api.Certificate as ApiCert
-import qualified Cardano.Api.Experimental.Certificate as ExpCert
 import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Tx as Write
 import qualified Cardano.Crypto as CC
@@ -377,9 +374,8 @@ constructUnsignedTxLedger
     => RecentEra era
     -> Network
     -> ( Maybe TxMetadata
-       , [Cardano.Certificate (CardanoApiEra era)]
+       , [TxCert era]
        )
-    -- TODO: replace Cardano.Certificate with ledger TxCert
     -> (Maybe SlotNo, SlotNo)
     -> Withdrawal
     -> Either PreSelection (SelectionOf TxOut)
@@ -388,13 +384,12 @@ constructUnsignedTxLedger
 constructUnsignedTxLedger
     era
     network
-    (md, certs)
+    (md, lCerts)
     ttl
     wdrl
     cs
     fee = do
         outs <- extractValidatedOutputs cs
-        let lCerts = ledgerCertsFromApi era certs
         Right
             $ buildLedgerTxRaw
                 era
@@ -406,19 +401,6 @@ constructUnsignedTxLedger
                 lCerts
                 outs
                 cs
-
--- | Convert cardano-api certificates to ledger 'TxCert',
--- pattern-matching on the era to prove the type equality
--- @ShelleyLedgerEra (CardanoApiEra era) ~ era@.
-ledgerCertsFromApi
-    :: RecentEra era
-    -> [Cardano.Certificate (CardanoApiEra era)]
-    -> [TxCert era]
-ledgerCertsFromApi RecentEraConway certs =
-    map (unCert . certToLedger) certs
-ledgerCertsFromApi RecentEraDijkstra _ =
-    error
-        "ledgerCertsFromApi: Dijkstra not yet supported"
 
 -- | Convert wallet/context types and call 'mkLedgerTx'.
 buildLedgerTx
@@ -590,25 +572,6 @@ mkRewardAccount network acct =
         (Ledger.AccountId (toLedgerStakeCredential acct))
 
 -- | Convert a cardano-api 'Certificate' to the underlying
--- ledger certificate newtype.
---
--- Temporary bridge until certificate construction itself
--- produces ledger certs directly.
-certToLedger
-    :: Cardano.Certificate era
-    -> ExpCert.Certificate (Cardano.ShelleyLedgerEra era)
-certToLedger (ApiCert.ShelleyRelatedCertificate w c) =
-    Cardano.shelleyToBabbageEraConstraints w
-        $ ExpCert.Certificate c
-certToLedger (ApiCert.ConwayCertificate w c) =
-    Cardano.conwayEraOnwardsConstraints w
-        $ ExpCert.Certificate c
-
--- | Unwrap a 'Certificate' newtype to get the underlying
--- 'TxCert'.
-unCert :: ExpCert.Certificate era -> TxCert era
-unCert (ExpCert.Certificate c) = c
-
 -- | Seal a ledger 'Tx' into a 'SealedTx' by going through
 -- cardano-api serialisation.
 --

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -68,9 +68,6 @@ import Cardano.Address.Script
     ( Script (..)
     , ScriptTemplate
     )
-import Cardano.Api
-    ( AnyCardanoEra
-    )
 import Cardano.Api.Extra
     (
     )
@@ -177,12 +174,13 @@ import Prelude
 
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 
 data TransactionLayer (k :: Depth -> Type -> Type) ktype tx = TransactionLayer
     { addVkWitnesses
-        :: AnyCardanoEra
+        :: Read.EraValue Read.Era
         -- Preferred latest era
         -> WitnessCountCtx
         -> [(XPrv, Passphrase "encryption")]
@@ -203,7 +201,7 @@ data TransactionLayer (k :: Depth -> Type -> Type) ktype tx = TransactionLayer
     -- If inputs can't be resolved, they are simply skipped, hence why this
     -- function cannot fail.
     , decodeTx
-        :: AnyCardanoEra
+        :: Read.EraValue Read.Era
         -> tx
         -> TxExtended
     -- ^ Decode an externally-created transaction.
@@ -371,7 +369,7 @@ data ErrMkTransaction
         ErrMkTransactionOutputTokenQuantityExceedsLimitError
     | -- | Should never happen, means that that we have programmatically provided
       -- an invalid era.
-      ErrMkTransactionInvalidEra AnyCardanoEra
+      ErrMkTransactionInvalidEra (Read.EraValue Read.Era)
     | ErrMkTransactionJoinStakePool ErrCannotJoin
     | ErrMkTransactionQuitStakePool ErrCannotQuit
     | ErrMkTransactionIncorrectTTL PastHorizonException


### PR DESCRIPTION
## Summary

Remaining call-site migration after #5270 merged. This branch is rebased directly onto current `master` and contains the commits that switch existing wallet call sites onto the ledger-native surfaces introduced by #5270.

Base branch: `master`.
Follow-ups: #5271, then #5272.

## What is in this PR

| # | SHA | Purpose |
|---|---|---|
| 1 | `84bd668` | Use `constructUnsignedTxLedger` in `balanceTx` paths |
| 2 | `4c8b61b` | Replace `AnyCardanoEra` with `Read.EraValue` in NetworkLayer |
| 3 | `55097e6` | Build delegation and voting certificates in `balanceTx` paths |
| 4 | `f5b8ed2` | Replace `StakeAddress` with wallet-owned `RewardAccount` |
| 5 | `26bad3e` | Migrate `TxMetadata` end-to-end to wallet-owned types |
| 6 | `d543a6b` | Adapt singleton network conversions to #5270's `sNetworkIdToLedger` helper |

The foundation work previously described here landed in #5270. In particular, the wallet-owned `NetworkId`, `TxMetadata`, `SealedTx`, ledger-native transaction builders, certificate helpers, and witness helpers are now part of `master`.

## What this PR does not do

- It does not delete the remaining cardano-api bridges.
- It does not remove `cardano-api` from cabal files.
- It does not delete `lib/cardano-api-extra/`.
- It does not finish the `SealedTx` decommission; that remains split across #5271 and #5272.

## Test plan

- [x] Rebased cleanly onto `origin/master` after #5270 merged (2026-04-25).
- [x] `nix develop --command cabal build cardano-wallet cardano-wallet-api cardano-wallet-unit:unit --enable-benchmarks --enable-tests --minimize-conflict-set -O0 -v0`
- [ ] CI green on the rebased tip.

Note: `just build 'cardano-wallet cardano-wallet-unit:unit'` reaches unrelated `cardano-wallet-read` deprecation/unused warnings promoted by `-Werror` on this branch; the same target without `-Werror` passes.
