### PR TITLE
docs: Update CI documentation and benchmark history

### DIFF
--- a/docs/site/src/contributor/how/continuous-integration.md
+++ b/docs/site/src/contributor/how/continuous-integration.md
@@ -47,6 +47,35 @@ All CI for `cardano-wallet` runs on [GitHub Actions](https://github.com/cardano-
 | [`approve-docs.yml`](https://github.com/cardano-foundation/cardano-wallet/actions/workflows/approve-docs.yml) | PR target | Auto-approves docs-only PRs |
 | [`lean.yml`](https://github.com/cardano-foundation/cardano-wallet/actions/workflows/lean.yml) | push, PR | Lean specification checks (path-filtered to `specifications/`) |
 
+## Benchmark History
+
+The benchmark history pipeline (`benchmark-history.sh`) automatically aggregates performance data from recent CI runs to track regressions over time. It produces CSV data and SVG charts that are uploaded as workflow artifacts.
+
+### Data collection
+
+The pipeline follows these steps to gather data:
+1. **Discovery**: Uses `gh run list` to find the last 6 months of successful `Linux Benchmarks` runs on the `master` branch.
+2. **Download**: For each unique day with a successful run, it downloads the CSV artifacts from the following benchmark jobs:
+   - API Benchmark
+   - Latency Benchmark
+   - DB Benchmark
+   - Read-blocks Benchmark
+   - Memory Benchmark
+3. **Aggregation**: Combines the downloaded CSVs with the results from the current run.
+
+### Checkpoint mechanism
+
+To avoid downloading hundreds of historical runs in every CI session, the pipeline uses a **checkpoint** system:
+- It attempts to download the `Benchmark History` artifact from the *most recent* successful run of the same workflow.
+- If found, it uses the `benchmark-history.csv` from that artifact as a starting point (`--checkpoint`).
+- Only runs newer than the checkpoint are downloaded and merged.
+
+### Artifact retention
+
+- **Historical data**: The aggregated `benchmark-history.csv` is the source of truth for all historical data.
+- **Charts**: SVG charts are regenerated on every successful `master` run, providing a visual representation of performance trends for each benchmark category.
+- **Retention**: GitHub Actions retains these artifacts according to the repository's retention policy (typically 90 days). The checkpoint mechanism ensures that data is preserved in the *latest* artifact even if the original individual run artifacts have expired.
+
 ## Nix verbosity
 
 All `nix` commands in CI workflows must include the `--quiet` flag. This suppresses verbose build logs and warnings that clutter GitHub Actions output, making it easier to spot actual failures.

--- a/docs/site/src/contributor/how/release-process.md
+++ b/docs/site/src/contributor/how/release-process.md
@@ -10,7 +10,7 @@ Even though the act of making a release frequently reveals **problems** in our *
 
 Unfortunately, releasing directly from the `master` branch is not quite practical for two reasons: a) secondary CI and b) administrative commits.
 
-Our [Continuous Integration](../decisions/2023-01-27-continuous-integration.md) can be grouped into two categories:
+Our [Continuous Integration](../decisions/2026-02-10-migrate-ci-to-github-actions.md) can be grouped into two categories:
 
 * Primary CI — gatekeeper for accepting pull requests to the `master` branch.
 * Secondary CI — gatekeeper for making releases.
@@ -64,7 +64,7 @@ The changelog is distilled from a sequence of pull requests as follows:
 
 ## **Release checklist**
 
-We use a **release checklist** in order to ensure that we do not miss creating, testing, or publishing any artifact. The focus of the checklist is for a human to **verify** that nothing has been missed — creating and testing the artifacts should be automated as much as possible by [Continuous Integration](../decisions/2023-01-27-continuous-integration.md).
+We use a **release checklist** in order to ensure that we do not miss creating, testing, or publishing any artifact. The focus of the checklist is for a human to **verify** that nothing has been missed — creating and testing the artifacts should be automated as much as possible by [Continuous Integration](../decisions/2026-02-10-migrate-ci-to-github-actions.md).
 
 (The work required to perform the release checklist, resulting in the publication of the release artifacts, is tracked in a ticketing system decided in our [HAL Workflow Review](../decisions/2023-07-28-workflow-review.md).)
 
@@ -102,7 +102,7 @@ We use the following **tools** to help automate the release process:
 
 ## **Trunk-based development**
 
-Experience, both by us ([Continuous Integration](../decisions/2023-01-27-continuous-integration.md)) and by others _Phoenix2013_[^2], _Google2020_[^3], indicates that trunk-based development is the way to go — the ability to release at any time ensures the ability to release in the first place. Even though problems with testing and dependency management frequently resurface, they do not grow so bad that they become intractable.
+Experience, both by us ([Continuous Integration](../decisions/2026-02-10-migrate-ci-to-github-actions.md)) and by others _Phoenix2013_[^2], _Google2020_[^3], indicates that trunk-based development is the way to go — the ability to release at any time ensures the ability to release in the first place. Even though problems with testing and dependency management frequently resurface, they do not grow so bad that they become intractable.
 
 ## **Bundling dependent executables**
 


### PR DESCRIPTION
Audit docs for stale Buildkite references, document the benchmark history pipeline, and update contributor guides following the GHA migration.