### PR TITLE
fix: scope test temp dirs to RUNNER_TEMP instead of globbing shared /tmp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,12 @@ jobs:
           fetch-depth: 0
 
       - name: Run integration tests
+        # Scope test-cluster temp dirs to the job-private RUNNER_TEMP
+        # (auto-cleaned by the runner between jobs). Shared /tmp on the build
+        # host is a tmpfs visible to every sibling runner, so a sibling's
+        # cleanup glob would unlink VolatileDB files of a live cluster.
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
@@ -323,6 +329,7 @@ jobs:
         env:
           LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
           CLUSTER_LOGS_DIR_PATH: local-cluster-logs
+          TMPDIR: ${{ runner.temp }}
         run: |
           mkdir -p local-cluster-logs
           nix shell --quiet .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -83,7 +83,6 @@ jobs:
 
     env:
       LC_ALL: C.UTF-8
-      TMPDIR: /tmp/gha-bench
       BENCHMARK_CSV_FILE: ${{ github.workspace }}/${{ matrix.csv_file }}
     steps:
       - name: Checkout
@@ -92,9 +91,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run benchmark
-        run: |
-          mkdir -p "$TMPDIR"
-          ${{ matrix.command }}
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: ${{ matrix.command }}
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -31,10 +31,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run E2E tests
+        # RUNNER_TEMP is per-job and auto-cleaned by the runner. Globbing
+        # /tmp/e2e-* /tmp/test-cluster* would wipe sibling runners' live
+        # clusters since /tmp is one shared tmpfs on the build host.
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+          TMPDIR: ${{ runner.temp }}
         run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
-
-      - name: Cleanup temp directories
-        if: always()
-        run: rm -rf /tmp/e2e-* /tmp/test-cluster*

--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -40,6 +40,8 @@ jobs:
           fetch-depth: 0
 
       - name: Run integration tests
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -200,4 +200,5 @@ jobs:
       - name: Run E2E tests
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+          TMPDIR: ${{ runner.temp }}
         run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,11 +196,8 @@ jobs:
       - name: Run E2E tests
         env:
           HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
+          TMPDIR: ${{ runner.temp }}
         run: nix shell --quiet .#cardano-node .#cardano-wallet .#e2e 'nixpkgs#gnutar' 'nixpkgs#p7zip' -c e2e
-
-      - name: Cleanup
-        if: always()
-        run: rm -rf /tmp/e2e-* /tmp/test-cluster*
 
   build-e2e-windows:
     name: "Build E2E Bundle (Windows)"

--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -50,7 +50,6 @@ jobs:
             node-db: mainnet-4
     env:
       LC_ALL: C.UTF-8
-      TMPDIR: /tmp/gha-bench
       TO_TIP_TIMEOUT: ${{ inputs.to-tip-timeout }}
     steps:
       - name: Checkout
@@ -59,8 +58,9 @@ jobs:
           fetch-depth: 0
 
       - name: Run restore benchmark
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
-          mkdir -p "$TMPDIR"
           nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
             bash scripts/ci/bench-restore.sh \
               mainnet ${{ matrix.bench }} $HOME/databases/node/${{ matrix.node-db }}


### PR DESCRIPTION
## Problem

The CI build host (`zur1-s-d-029`) runs ~28 GHA self-hosted runners
as a single user against **one shared tmpfs `/tmp`**. Any job running
`rm -rf /tmp/e2e-* /tmp/test-cluster*` on `if: always()` will wipe
sibling runners' **live** VolatileDB files.

Under UTxO-HD (cardano-node >= 10.7.0) the consensus layer re-opens
VolatileDB files by path through `fs-api`, so an unlinked
`blocks-*.dat` now crashes the node with
`ApiMisuse (ClosedDBError (UnexpectedFailure (FileSystemError FsResourceDoesNotExist …)))`
instead of tolerating the unlink via open fd's.

This reproduced on master (`253d290bfd`) — Conway Integration Tests
crashed at 15:46:43 UTC on 2026-04-20 with two pool nodes failing
simultaneously on `/tmp/test-cluster436150/pool-*/db/volatile/blocks-0.dat`.
See also upstream ouroboros-consensus#1991.

## Fix

- Set `TMPDIR: ${{ runner.temp }}` on every job that launches a local
  test cluster or E2E run. `$RUNNER_TEMP` is per-job, per-runner, and
  auto-cleaned by the runner service between jobs, so clusters live
  in a private directory that sibling runners cannot touch.
- Drop the pre-existing dangerous cleanup in
  `.github/workflows/linux-e2e.yml` and `.github/workflows/release.yml`
  — `$RUNNER_TEMP` makes them redundant.
- Replace the shared fixed path `TMPDIR: /tmp/gha-bench` in
  `linux-benchmarks.yml` and `restoration-benchmarks.yml` for the
  same reason.

No new cleanup steps are introduced.