### PR TITLE
feat: bump cardano-balance-transaction, remove Babbage from RecentEra

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -141,8 +141,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/cardano-foundation/cardano-balance-transaction
-  tag: 98e7f4155451e357410e266dd6c754d58ead3b7f
-  --sha256: 1p8xhf4ly37lqs45663vk786k1mv8dzgji6wiz2s2ysn9zqq3kda
+  tag: 964e8a232f492ce52a157e0b678af6881c35d184
+  --sha256: 0ndsj3q7v7qdiq2y24ily2hpyrmhzjmqgk49vsbncii7vyh7vy9v
 
 -- END cardano-balance-tx
 --------------------------------------------------------------------------------

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -617,6 +617,23 @@ instance IsServerError ErrWriteTxEra where
             eraNameToApiEra x =
                 error
                     $ "eraNameToApiEra: unknown era " <> x
+        ErrEraNotYetSupported eraName ->
+            apiError err403 (NodeNotYetInRecentEra info)
+                $ T.unwords
+                    [ "The node is in the"
+                    , T.pack eraName
+                    , "era, which is not yet supported by this"
+                    , "wallet version. Please upgrade the wallet."
+                    ]
+          where
+            info =
+                ApiErrorNodeNotYetInRecentEra
+                    { nodeEra = eraNameToApiEra eraName
+                    , supportedRecentEras = ApiEra.allRecentEras
+                    }
+            eraNameToApiEra :: String -> ApiEra.ApiEra
+            eraNameToApiEra "Dijkstra" = ApiEra.ApiConway
+            eraNameToApiEra _ = ApiEra.ApiConway
         ErrPartialTxNotInNodeEra nodeEra ->
             apiError err403 TxNotInNodeEra
                 $ T.unwords
@@ -1422,5 +1439,5 @@ instance IsServerError WriteTx.ErrInvalidTxOutInEra where
         WriteTx.InlinePlutusV4ScriptNotSupportedInConway ->
             apiError
                 err400
-                BalanceTxInlinePlutusV3ScriptNotSupportedInBabbage
+                BalanceTxInlinePlutusV4ScriptNotSupportedInConway
                 "Plutus V4 scripts are not supported in the Conway era."

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -215,7 +215,6 @@ import Servant.Server
     )
 import Prelude
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Balance.Tx.Eras as Write
     ( IsRecentEra (..)
     )
@@ -593,21 +592,31 @@ instance IsServerError ErrGetPolicyId where
 
 instance IsServerError ErrWriteTxEra where
     toServerError = \case
-        ErrNodeNotYetInRecentEra (Cardano.AnyCardanoEra era) ->
+        ErrNodeNotYetInRecentEra eraName ->
             apiError err403 (NodeNotYetInRecentEra info)
                 $ T.unwords
                     [ "This operation requires the node to be synchronised to a"
                     , "recent era, but the node is currently only synchronised to the"
-                    , showT era
+                    , T.pack eraName
                     , "era. Please wait until the node is fully synchronised and"
                     , "try again."
                     ]
           where
             info =
                 ApiErrorNodeNotYetInRecentEra
-                    { nodeEra = ApiEra.fromAnyCardanoEra $ Cardano.AnyCardanoEra era
+                    { nodeEra = eraNameToApiEra eraName
                     , supportedRecentEras = ApiEra.allRecentEras
                     }
+            eraNameToApiEra :: String -> ApiEra.ApiEra
+            eraNameToApiEra "Byron" = ApiEra.ApiByron
+            eraNameToApiEra "Shelley" = ApiEra.ApiShelley
+            eraNameToApiEra "Allegra" = ApiEra.ApiAllegra
+            eraNameToApiEra "Mary" = ApiEra.ApiMary
+            eraNameToApiEra "Alonzo" = ApiEra.ApiAlonzo
+            eraNameToApiEra "Babbage" = ApiEra.ApiBabbage
+            eraNameToApiEra x =
+                error
+                    $ "eraNameToApiEra: unknown era " <> x
         ErrPartialTxNotInNodeEra nodeEra ->
             apiError err403 TxNotInNodeEra
                 $ T.unwords
@@ -1410,8 +1419,8 @@ instance IsServerError (Request, ServerError) where
 
 instance IsServerError WriteTx.ErrInvalidTxOutInEra where
     toServerError = \case
-        WriteTx.InlinePlutusV3ScriptNotSupportedInBabbage ->
+        WriteTx.InlinePlutusV4ScriptNotSupportedInConway ->
             apiError
                 err400
                 BalanceTxInlinePlutusV3ScriptNotSupportedInBabbage
-                "Plutus V3 scripts are not supported in the Babbage era."
+                "Plutus V4 scripts are not supported in the Conway era."

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -149,10 +149,6 @@ import Cardano.Api
     ( SerialiseAsCBOR (..)
     , StakeAddress (..)
     )
-import Cardano.BM.Tracing
-    ( HasPrivacyAnnotation (..)
-    , HasSeverityAnnotation (..)
-    )
 -- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
 --     ( getNetworkInformation
 --     , makeApiBlockReference
@@ -160,6 +156,23 @@ import Cardano.BM.Tracing
 --     , makeApiSlotReference
 --     )
 
+-- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
+--     ( getNetworkInformation
+--     , makeApiBlockReference
+--     , makeApiBlockReferenceFromHeader
+--     , makeApiSlotReference
+--     )
+
+import Cardano.Api.Extra
+    ( cardanoApiEraConstraints
+    , cardanoEraFromRecentEra
+    , fromCardanoApiTx
+    , toCardanoApiTx
+    )
+import Cardano.BM.Tracing
+    ( HasPrivacyAnnotation (..)
+    , HasSeverityAnnotation (..)
+    )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
     )
@@ -319,13 +332,6 @@ import Cardano.Wallet.Api.Http.Server.Handlers.MintBurn
     ( convertApiAssetMintBurn
     , getTxApiAssetMintBurn
     )
--- import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
---     ( getNetworkInformation
---     , makeApiBlockReference
---     , makeApiBlockReferenceFromHeader
---     , makeApiSlotReference
---     )
-
 import Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
 import Cardano.Wallet.Api.Http.Server.Handlers.TxCBOR
     ( ParsedTxCBOR (..)
@@ -854,7 +860,6 @@ import qualified Cardano.Balance.Tx.Balance as Write
 import qualified Cardano.Balance.Tx.Eras as Write
     ( IsRecentEra (recentEra)
     , RecentEra
-    , cardanoEraFromRecentEra
     )
 import qualified Cardano.Balance.Tx.Sign as Write
     ( TimelockKeyWitnessCounts (..)
@@ -866,9 +871,7 @@ import qualified Cardano.Balance.Tx.Tx as Write
     , Tx
     , TxIn
     , TxOutInRecentEra (TxOutInRecentEra)
-    , fromCardanoApiTx
     , getFeePerByte
-    , toCardanoApiTx
     , utxoFromTxOutsInRecentEra
     , pattern PolicyId
     )
@@ -3079,7 +3082,7 @@ constructTransaction api knownPools poolStatus apiWalletId body = do
                     pp
                     timeTranslation
                     Write.PartialTx
-                        { tx = Write.fromCardanoApiTx $ Cardano.Tx unbalancedTx []
+                        { tx = fromCardanoApiTx $ Cardano.Tx unbalancedTx []
                         , extraUTxO = mempty
                         , redeemers = mempty
                         , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
@@ -3552,7 +3555,7 @@ constructSharedTransaction
                                 timeTranslation
                                 Write.PartialTx
                                     { tx =
-                                        Write.fromCardanoApiTx
+                                        fromCardanoApiTx
                                             $ Cardano.Tx unbalancedTx []
                                     , extraUTxO = mempty
                                     , redeemers = mempty
@@ -3773,7 +3776,7 @@ balanceTransaction ctx (ApiT wid) body = do
         :: Write.IsRecentEra era
         => Write.RecentEra era
         -> Handler (Write.PartialTx era)
-    parsePartialTx era = do
+    parsePartialTx era = cardanoApiEraConstraints era $ do
         let mExternalUTxO =
                 Write.utxoFromTxOutsInRecentEra
                     $ map fromExternalInput
@@ -3787,7 +3790,7 @@ balanceTransaction ctx (ApiT wid) body = do
                     $ AnyRecentEra era
                 )
                 pure
-                . cardanoTxInExactEra (Write.cardanoEraFromRecentEra era)
+                . cardanoTxInExactEra (cardanoEraFromRecentEra era)
                 . getApiT
                 $ body ^. #transaction
 
@@ -3795,7 +3798,7 @@ balanceTransaction ctx (ApiT wid) body = do
             Right externalUTxO ->
                 pure
                     $ Write.PartialTx
-                        (Write.fromCardanoApiTx tx)
+                        (fromCardanoApiTx tx)
                         externalUTxO
                         (fromApiRedeemer <$> body ^. #redeemers)
                         (Write.StakeKeyDepositMap mempty)
@@ -5491,12 +5494,13 @@ fromApiRedeemer = \case
 sealWriteTx
     :: forall era. Write.IsRecentEra era => Write.Tx era -> W.SealedTx
 sealWriteTx =
-    W.sealedTxFromCardano
-        . Cardano.InAnyCardanoEra cardanoEra
-        . Write.toCardanoApiTx
+    cardanoApiEraConstraints era'
+        $ W.sealedTxFromCardano
+            . Cardano.InAnyCardanoEra cardanoEra
+            . toCardanoApiTx
   where
-    cardanoEra =
-        Write.cardanoEraFromRecentEra (Write.recentEra :: Write.RecentEra era)
+    era' = Write.recentEra :: Write.RecentEra era
+    cardanoEra = cardanoEraFromRecentEra era'
 
 toApiSerialisedTransaction
     :: Write.IsRecentEra era

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -50,6 +50,9 @@ import Data.Function
 import Data.List
     ( drop
     )
+import Data.Maybe
+    ( Maybe (..)
+    )
 import Data.Ord
     ( Ord
     )
@@ -135,9 +138,14 @@ toAnyCardanoEra = \case
 -- | The complete set of recent eras.
 allRecentEras :: Set ApiEra
 allRecentEras =
-    Set.map fromAnyRecentEra Write.allRecentEras
+    Set.fromList
+        [ era
+        | x <- Set.toList Write.allRecentEras
+        , Just era <- [fromAnyRecentEra x]
+        ]
 
-fromAnyRecentEra :: Write.AnyRecentEra -> ApiEra
+fromAnyRecentEra :: Write.AnyRecentEra -> Maybe ApiEra
 fromAnyRecentEra = \case
-    Write.AnyRecentEra Write.RecentEraBabbage -> ApiBabbage
-    Write.AnyRecentEra Write.RecentEraConway -> ApiConway
+    Write.AnyRecentEra Write.RecentEraConway -> Just ApiConway
+    -- TODO: add ApiDijkstra once DijkstraEra is fully supported
+    Write.AnyRecentEra Write.RecentEraDijkstra -> Nothing

--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -255,6 +255,7 @@ data ApiErrorInfo
     | BlockHeaderNotFound
     | TranslationByronTxOutInContext
     | BalanceTxInlinePlutusV3ScriptNotSupportedInBabbage
+    | BalanceTxInlinePlutusV4ScriptNotSupportedInConway
     | UnsupportedEra !ApiErrorUnsupportedEra
     deriving (Eq, Generic, Show, Data)
     deriving anyclass (NFData)

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -707,7 +707,7 @@ mockNetworkLayer =
             pure
                 $ Read.EraValue
                     ( Read.PParams dummyLedgerProtocolParameters
-                        :: Read.PParams Read.Babbage
+                        :: Read.PParams Read.Conway
                     )
         , currentProtocolParameters = pure dummyProtocolParameters
         , currentNodeEra = pure $ Cardano.anyCardanoEra Cardano.BabbageEra

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -3970,7 +3970,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 UnsupportedEra
                     ( ApiErrorUnsupportedEra
                         { unsupportedEra = ApiMary
-                        , supportedEras = fromList [ApiBabbage, ApiConway]
+                        , supportedEras = fromList [ApiConway]
                         }
                     )
         decodeErrorInfo submittedMaryTxExternal `shouldBe` errInfo

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -688,10 +688,10 @@ withNodeNetworkLayerBase
                     AnyCardanoEra AllegraEra -> InNonRecentEraAllegra
                     AnyCardanoEra MaryEra -> InNonRecentEraMary
                     AnyCardanoEra AlonzoEra -> InNonRecentEraAlonzo
-                    AnyCardanoEra BabbageEra -> InRecentEraBabbage mempty
+                    AnyCardanoEra BabbageEra -> InNonRecentEraBabbage
                     AnyCardanoEra ConwayEra -> InRecentEraConway mempty
                     AnyCardanoEra DijkstraEra ->
-                        error "_getUTxOByTxIn: DijkstraEra not yet supported"
+                        InRecentEraDijkstra mempty
             | otherwise =
                 bracketQuery "getUTxOByTxIn" tr
                     $ queue `send` SomeLSQ (LSQ.getUTxOByTxIn ins)

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
@@ -52,7 +52,6 @@ getUTxOByTxIn ins =
         (pure InNonRecentEraAllegra)
         (pure InNonRecentEraMary)
         (pure InNonRecentEraAlonzo)
-        (InRecentEraBabbage <$> LSQry (Shelley.GetUTxOByTxIn ins))
+        (pure InNonRecentEraBabbage)
         (InRecentEraConway <$> LSQry (Shelley.GetUTxOByTxIn ins))
-        -- TODO: promote Dijkstra to a RecentEra
-        (error "getUTxOByTxIn: DijkstraEra not yet supported")
+        (InRecentEraDijkstra <$> LSQry (Shelley.GetUTxOByTxIn ins))

--- a/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -114,26 +114,12 @@ import qualified Data.Set as Set
 spec :: Spec
 spec = describe "Cardano.Wallet.DelegationSpec" $ do
     describe "Join/Quit Stake pool properties" $ do
-        it "You can quit if you cannot join Babbage" $ do
-            property (prop_guardJoinQuit guardJoinBabbage)
         it "You can quit if you cannot join Conway" $ do
             property (prop_guardJoinQuit guardJoinConway)
-        it "You can join if you cannot quit Babbage" $ do
-            property (prop_guardQuitJoin guardJoinBabbage)
         it "You can join if you cannot quit Conway" $ do
             property (prop_guardQuitJoin guardJoinConway)
 
     describe "Join/Quit Stake pool unit mockEventSource" $ do
-        it "Cannot join A, when active = A in Babbage" $ do
-            let dlg = WalletDelegation{active = Delegating pidA, next = []}
-            WD.guardJoin
-                Write.RecentEraBabbage
-                knownPools
-                dlg
-                pidA
-                noRetirementPlanned
-                NotVotedYet
-                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
         it "Can rejoin A, when active = A in Conway" $ do
             let dlg = WalletDelegation{active = Delegating pidA, next = []}
             WD.guardJoin
@@ -154,17 +140,6 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                 noRetirementPlanned
                 VotedSameAsBefore
                 `shouldBe` Left (W.ErrAlreadyDelegatingVoting pidA)
-        it "Cannot join A, when next = [A] in Babbage" $ do
-            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidA)
-            let dlg = WalletDelegation{active = NotDelegating, next = [next1]}
-            WD.guardJoin
-                Write.RecentEraBabbage
-                knownPools
-                dlg
-                pidA
-                noRetirementPlanned
-                NotVotedYet
-                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
         it "Can join A, when next = [A] in Conway" $ do
             let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidA)
             let dlg = WalletDelegation{active = NotDelegating, next = [next1]}
@@ -195,14 +170,6 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                         , next = [next1]
                         }
             WD.guardJoin
-                Write.RecentEraBabbage
-                knownPools
-                dlg
-                pidA
-                noRetirementPlanned
-                NotVotedYet
-                `shouldBe` Right ()
-            WD.guardJoin
                 Write.RecentEraConway
                 knownPools
                 dlg
@@ -218,22 +185,6 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                 noRetirementPlanned
                 VotedSameAsBefore
                 `shouldBe` Right ()
-        it "Cannot join A, when active = A, next = [B, A] in Babbage" $ do
-            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidB)
-            let next2 = WalletDelegationNext (EpochNo 2) (Delegating pidA)
-            let dlg =
-                    WalletDelegation
-                        { active = Delegating pidA
-                        , next = [next1, next2]
-                        }
-            WD.guardJoin
-                Write.RecentEraBabbage
-                knownPools
-                dlg
-                pidA
-                noRetirementPlanned
-                NotVotedYet
-                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
         it "Can join A, when active = A, next = [B, A] in Conway" $ do
             let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidB)
             let next2 = WalletDelegationNext (EpochNo 2) (Delegating pidA)
@@ -268,14 +219,6 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                 `shouldBe` Left (W.ErrAlreadyDelegatingVoting pidA)
         it "Cannot join when pool is unknown in any era" $ do
             let dlg = WalletDelegation{active = NotDelegating, next = []}
-            WD.guardJoin
-                Write.RecentEraBabbage
-                knownPools
-                dlg
-                pidUnknown
-                noRetirementPlanned
-                NotVotedYet
-                `shouldBe` Left (W.ErrNoSuchPool pidUnknown)
             WD.guardJoin
                 Write.RecentEraConway
                 knownPools
@@ -419,9 +362,6 @@ type GuardJoinFun =
     -> Maybe PoolRetirementEpochInfo
     -> VoteRequest
     -> Either ErrCannotJoin ()
-
-guardJoinBabbage :: GuardJoinFun
-guardJoinBabbage = WD.guardJoin Write.RecentEraBabbage
 
 guardJoinConway :: GuardJoinFun
 guardJoinConway = WD.guardJoin Write.RecentEraConway

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -45,7 +45,12 @@ import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
     , InAnyCardanoEra (..)
-    , ShelleyLedgerEra
+    )
+import Cardano.Api.Extra
+    ( CardanoApiEra
+    , cardanoApiEraConstraints
+    , cardanoEraFromRecentEra
+    , shelleyBasedEraFromRecentEra
     )
 import Cardano.Api.Gen
     ( genTx
@@ -59,10 +64,7 @@ import Cardano.Balance.Tx.Balance
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
-    , CardanoApiEra
-    , IsRecentEra
     , RecentEra (..)
-    , cardanoEraFromRecentEra
     )
 import Cardano.Balance.Tx.Gen
     ( mockPParams
@@ -311,7 +313,6 @@ import Test.QuickCheck
     , conjoin
     , counterexample
     , cover
-    , elements
     , forAll
     , forAllShow
     , frequency
@@ -344,12 +345,9 @@ import Prelude
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Balance.Tx.Eras as Write
-    ( Babbage
-    , CardanoApiEra
+    ( Conway
     , IsRecentEra
-    , RecentEra (RecentEraBabbage, RecentEraConway)
-    , cardanoEraFromRecentEra
-    , shelleyBasedEraFromRecentEra
+    , RecentEra (RecentEraConway, RecentEraDijkstra)
     )
 import qualified Cardano.Balance.Tx.Primitive as BT
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
@@ -408,31 +406,31 @@ spec_forAllRecentErasPendingConway description p =
         $ forAllRecentEras
         $ \(AnyRecentEra recentEra) ->
             case recentEra of
-                Write.RecentEraBabbage ->
-                    it (show recentEra) $ property $ p (AnyRecentEra recentEra)
                 Write.RecentEraConway ->
-                    it (show recentEra) $ pendingWith "TODO: Conway"
+                    it (show recentEra) $ property $ p (AnyRecentEra recentEra)
+                Write.RecentEraDijkstra ->
+                    it (show recentEra) $ pendingWith "TODO: Dijkstra"
 
 instance Arbitrary SealedTx where
     arbitrary = sealedTxFromCardano <$> genTx
 
 showTransactionBody
     :: RecentEra era
-    -> Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
+    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
     -> String
 showTransactionBody recentEra =
     either show show
         . Cardano.createTransactionBody
-            (Write.shelleyBasedEraFromRecentEra recentEra)
+            (shelleyBasedEraFromRecentEra recentEra)
 
 unsafeMakeTransactionBody
     :: RecentEra era
-    -> Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
-    -> Cardano.TxBody (Write.CardanoApiEra era)
+    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+    -> Cardano.TxBody (CardanoApiEra era)
 unsafeMakeTransactionBody recentEra =
     either (error . show) id
         . Cardano.createTransactionBody
-            (Write.shelleyBasedEraFromRecentEra recentEra)
+            (shelleyBasedEraFromRecentEra recentEra)
 
 stakeAddressForKey
     :: SL.Network
@@ -483,12 +481,12 @@ prop_signTransaction_addsRewardAccountKey
     rootXPrv
     utxo
     wdrlAmt =
-        withMaxSuccess 10 $ do
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
             let
-                shelleyEra :: Cardano.ShelleyBasedEra (Write.CardanoApiEra era)
-                shelleyEra = Write.shelleyBasedEraFromRecentEra recentEra
+                shelleyEra :: Cardano.ShelleyBasedEra (CardanoApiEra era)
+                shelleyEra = shelleyBasedEraFromRecentEra recentEra
 
-                era = Write.cardanoEraFromRecentEra recentEra
+                era = cardanoEraFromRecentEra recentEra
 
                 creds@(RootCredentials pk hpwd) = mkCredentials rootXPrv
 
@@ -510,8 +508,8 @@ prop_signTransaction_addsRewardAccountKey
                     ]
 
                 addWithdrawals
-                    :: Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
-                    -> Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
+                    :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
                 addWithdrawals txBodyContent =
                     txBodyContent
                         { Cardano.txWithdrawals =
@@ -543,10 +541,9 @@ prop_signTransaction_addsRewardAccountKey
 
                     expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                     expectedWits =
-                        withCardanoApiConstraints era
-                            $ InAnyCardanoEra era
-                                <$> [ mkShelleyWitness txBody rawRewardK
-                                    ]
+                        InAnyCardanoEra era
+                            <$> [ mkShelleyWitness txBody rawRewardK
+                                ]
 
                 expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
@@ -583,14 +580,15 @@ prop_signTransaction_addsExtraKeyWitnesses
     rootK
     utxo
     extraKeys =
-        withMaxSuccess 10 $ do
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
             let
-                alonzoOnwards :: Cardano.AlonzoEraOnwards (Write.CardanoApiEra era)
+                alonzoOnwards :: Cardano.AlonzoEraOnwards (CardanoApiEra era)
                 alonzoOnwards = case recentEra of
-                    Write.RecentEraBabbage -> Cardano.AlonzoEraOnwardsBabbage
                     Write.RecentEraConway -> Cardano.AlonzoEraOnwardsConway
+                    Write.RecentEraDijkstra ->
+                        error "alonzoOnwards: Dijkstra not yet supported"
 
-                era = Write.cardanoEraFromRecentEra recentEra
+                era = cardanoEraFromRecentEra recentEra
 
                 keys
                     :: (XPrv, Passphrase "encryption")
@@ -607,8 +605,8 @@ prop_signTransaction_addsExtraKeyWitnesses
                         <$> extraKeys
 
                 addExtraWits
-                    :: Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
-                    -> Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
+                    :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
                 addExtraWits txBodyContent =
                     txBodyContent
                         { Cardano.txExtraKeyWits =
@@ -635,10 +633,9 @@ prop_signTransaction_addsExtraKeyWitnesses
 
                     expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                     expectedWits =
-                        withCardanoApiConstraints era
-                            $ InAnyCardanoEra era
-                                . mkShelleyWitness txBody
-                                <$> extraKeys
+                        InAnyCardanoEra era
+                            . mkShelleyWitness txBody
+                            <$> extraKeys
 
                 expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
@@ -691,7 +688,7 @@ lookupFnFromKeys keys addr =
         Map.lookup addr addrMap
 
 withBodyContent
-    :: era ~ Write.CardanoApiEra era'
+    :: era ~ CardanoApiEra era'
     => RecentEra era'
     -> ( Cardano.TxBodyContent Cardano.BuildTx era
          -> Cardano.TxBodyContent Cardano.BuildTx era
@@ -707,7 +704,7 @@ withBodyContent recentEra modTxBody cont =
 
             forAll (genWitnesses era txBody) $ \wits -> cont (txBody, wits)
   where
-    era = Write.cardanoEraFromRecentEra recentEra
+    era = cardanoEraFromRecentEra recentEra
 
 checkSubsetOf :: (Eq a, Show a) => [a] -> [a] -> Property
 checkSubsetOf as bs =
@@ -742,12 +739,12 @@ prop_signTransaction_addsTxInWitnesses
     (AnyRecentEra recentEra)
     rootK
     extraKeysNE =
-        withMaxSuccess 10 $ do
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
             let extraKeys = NE.toList extraKeysNE
 
             utxoFromKeys extraKeys $ \utxo -> do
                 let
-                    era = Write.cardanoEraFromRecentEra recentEra
+                    era = cardanoEraFromRecentEra recentEra
 
                     txIns :: [TxIn]
                     txIns = Map.keys $ unUTxO utxo
@@ -773,7 +770,7 @@ prop_signTransaction_addsTxInWitnesses
                             signTransaction
                                 ShelleyKeyS
                                 tl
-                                (AnyCardanoEra $ Write.cardanoEraFromRecentEra recentEra)
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
                                 AnyWitnessCountCtx
                                 (lookupFnFromKeys extraKeys)
                                 Nothing
@@ -784,10 +781,9 @@ prop_signTransaction_addsTxInWitnesses
 
                         expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                         expectedWits =
-                            withCardanoApiConstraints era
-                                $ InAnyCardanoEra era
-                                    . mkShelleyWitness txBody
-                                    <$> extraKeys
+                            InAnyCardanoEra era
+                                . mkShelleyWitness txBody
+                                <$> extraKeys
 
                     expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
@@ -803,14 +799,15 @@ prop_signTransaction_addsTxInCollateralWitnesses
     (AnyRecentEra (recentEra :: RecentEra era))
     rootK
     extraKeysNE =
-        withMaxSuccess 10 $ do
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
             let
-                alonzoOnwards :: Cardano.AlonzoEraOnwards (Write.CardanoApiEra era)
+                alonzoOnwards :: Cardano.AlonzoEraOnwards (CardanoApiEra era)
                 alonzoOnwards = case recentEra of
-                    Write.RecentEraBabbage -> Cardano.AlonzoEraOnwardsBabbage
                     Write.RecentEraConway -> Cardano.AlonzoEraOnwardsConway
+                    Write.RecentEraDijkstra ->
+                        error "alonzoOnwards: Dijkstra not yet supported"
 
-                era = Write.cardanoEraFromRecentEra recentEra
+                era = cardanoEraFromRecentEra recentEra
 
                 extraKeys = NE.toList extraKeysNE
 
@@ -820,8 +817,8 @@ prop_signTransaction_addsTxInCollateralWitnesses
                     txIns = Map.keys $ unUTxO utxo
 
                     addTxCollateralIns
-                        :: Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
-                        -> Cardano.TxBodyContent Cardano.BuildTx (Write.CardanoApiEra era)
+                        :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                        -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
                     addTxCollateralIns txBodyContent =
                         txBodyContent
                             { Cardano.txInsCollateral =
@@ -850,10 +847,9 @@ prop_signTransaction_addsTxInCollateralWitnesses
 
                         expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                         expectedWits =
-                            withCardanoApiConstraints era
-                                $ InAnyCardanoEra era
-                                    . mkShelleyWitness txBody
-                                    <$> extraKeys
+                            InAnyCardanoEra era
+                                . mkShelleyWitness txBody
+                                <$> extraKeys
 
                     expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
@@ -872,8 +868,9 @@ prop_signTransaction_neverRemovesWitnesses
     rootK
     utxo
     extraKeys =
-        withMaxSuccess 10
-            $ forAll (genTxInEra $ Write.cardanoEraFromRecentEra recentEra)
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
             $ \tx -> do
                 let
                     tl = testTxLayer
@@ -883,7 +880,7 @@ prop_signTransaction_neverRemovesWitnesses
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ Write.cardanoEraFromRecentEra recentEra)
+                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
                             AnyWitnessCountCtx
                             (lookupFnFromKeys extraKeys)
                             Nothing
@@ -914,11 +911,12 @@ prop_signTransaction_neverChangesTxBody
     rootK
     utxo
     extraKeys =
-        withMaxSuccess 10
-            $ forAll (genTxInEra $ Write.cardanoEraFromRecentEra recentEra)
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
             $ \tx -> do
                 let
-                    era = Write.cardanoEraFromRecentEra recentEra
+                    era = cardanoEraFromRecentEra recentEra
                     tl = testTxLayer
 
                     sealedTx = sealedTxFromCardano' tx
@@ -970,8 +968,9 @@ prop_signTransaction_preservesScriptIntegrity
     (AnyRecentEra recentEra)
     rootK
     utxo =
-        withMaxSuccess 10
-            $ forAll (genTxInEra $ Write.cardanoEraFromRecentEra recentEra)
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
             $ \tx -> do
                 let
                     tl = testTxLayer
@@ -981,7 +980,7 @@ prop_signTransaction_preservesScriptIntegrity
                         signTransaction
                             ShelleyKeyS
                             tl
-                            (AnyCardanoEra $ Write.cardanoEraFromRecentEra recentEra)
+                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
                             AnyWitnessCountCtx
                             (const Nothing)
                             Nothing
@@ -1018,7 +1017,6 @@ prop_signTransaction_preservesScriptIntegrity
 
 forAllRecentEras :: (AnyRecentEra -> Spec) -> Spec
 forAllRecentEras eraSpec = do
-    eraSpec (AnyRecentEra RecentEraBabbage)
     eraSpec (AnyRecentEra RecentEraConway)
 
 allEras :: [(Int, AnyCardanoEra)]
@@ -1039,7 +1037,9 @@ eraNum e = case filter ((== e) . snd) allEras of
 
 shelleyEraNum :: AnyRecentEra -> Int
 shelleyEraNum (AnyRecentEra era) =
-    eraNum . AnyCardanoEra $ cardanoEraFromRecentEra era
+    cardanoApiEraConstraints era
+        $ eraNum . AnyCardanoEra
+        $ cardanoEraFromRecentEra era
 
 instance Arbitrary AnyCardanoEra where
     arbitrary = frequency $ zip [1 ..] $ map (pure . snd) allEras
@@ -1092,7 +1092,10 @@ binaryCalculationsSpec :: AnyRecentEra -> Spec
 binaryCalculationsSpec (AnyRecentEra era) =
     case era of
         RecentEraConway -> binaryCalculationsSpec' era
-        RecentEraBabbage -> binaryCalculationsSpec' era
+        RecentEraDijkstra ->
+            describe "binaryCalculationsSpec"
+                $ it "Dijkstra"
+                $ pendingWith "TODO: Dijkstra"
 
 -- Up till Mary era we have the following structure of transaction
 --   transaction =
@@ -1144,8 +1147,8 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
-                    RecentEraBabbage ->
-                        "84a4008182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a1028184582001000000000000000000000000000000000000000000000000000000000000005840d7af60ae33d2af351411c1445c79590526990bfa73cbb3732b54ef322daa142e6884023410f8be3c16e9bd52076f2bb36bf38dfe034a9f04658e9f56197ab80f5820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
         it "2 inputs, 3 outputs" $ do
@@ -1176,8 +1179,8 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000041a0845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010141a0f5f6"
-                    RecentEraBabbage ->
-                        "84a4008282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a1028284582001000000000000000000000000000000000000000000000000000000000000005840e8e769ecd0f3c538f0a5a574a1c881775f086d6f4c845b81be9b78955728bffa7efa54297c6a5d73337bd6280205b1759c13f79d4c93f29871fc51b78aeba80e5820000000000000000000000000000000000000000000000000000000000000000041a0845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f5158405835ff78c6fc5e4466a179ca659fa85c99b8a3fba083f3f3f42ba360d479c64ef169914b52ade49b19a7208fd63a6e67a19c406b4826608fdc5307025506c3075820010101010101010101010101010101010101010101010101010101010101010141a0f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
     describe "Byron witnesses - testnet" $ do
@@ -1205,8 +1208,8 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
-                    RecentEraBabbage ->
-                        "84a4008182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a1028184582001000000000000000000000000000000000000000000000000000000000000005840d7af60ae33d2af351411c1445c79590526990bfa73cbb3732b54ef322daa142e6884023410f8be3c16e9bd52076f2bb36bf38dfe034a9f04658e9f56197ab80f5820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
         it "2 inputs, 3 outputs" $ do
@@ -1237,15 +1240,14 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010144a1024100845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
-                    RecentEraBabbage ->
-                        "84a4008282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a10282845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f5158405835ff78c6fc5e4466a179ca659fa85c99b8a3fba083f3f3f42ba360d479c64ef169914b52ade49b19a7208fd63a6e67a19c406b4826608fdc5307025506c3075820010101010101010101010101010101010101010101010101010101010101010144a102410084582001000000000000000000000000000000000000000000000000000000000000005840e8e769ecd0f3c538f0a5a574a1c881775f086d6f4c845b81be9b78955728bffa7efa54297c6a5d73337bd6280205b1759c13f79d4c93f29871fc51b78aeba80e5820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
-
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
   where
     slotNo = SlotNo 7_750
     md = Nothing
     calculateBinary net utxo outs chgs pairs =
-        hex (Cardano.serialiseToCBOR ledgerTx)
+        cardanoApiEraConstraints era $ hex (Cardano.serialiseToCBOR ledgerTx)
       where
         ledgerTx :: Cardano.Tx (CardanoApiEra era)
         ledgerTx = Cardano.makeSignedTransaction addrWits unsigned
@@ -1299,60 +1301,60 @@ prop_sealedTxRecentEraRoundtrip
     txEra@(AnyRecentEra era)
     currentEra
     (Pretty tc) =
-        conjoin
-            [ txBytes ==== serialisedTx sealedTxC
-            , either
-                (\e -> counterexample (show e) False)
-                (compareOnCBOR tx)
-                sealedTxB
-            ]
-            .||. encodingFromTheFuture (txEra) currentEra
-      where
-        tx = makeShelleyTx era tc
-        txBytes = Cardano.serialiseToCBOR tx
-        sealedTxC = sealedTxFromCardano' tx
-        sealedTxB = sealedTxFromBytes' currentEra txBytes
+        cardanoApiEraConstraints era
+            $ let tx = makeShelleyTx era tc
+                  txBytes = Cardano.serialiseToCBOR tx
+                  sealedTxC = sealedTxFromCardano' tx
+                  sealedTxB = sealedTxFromBytes' currentEra txBytes
+              in  conjoin
+                    [ txBytes ==== serialisedTx sealedTxC
+                    , either
+                        (\e -> counterexample (show e) False)
+                        (compareOnCBOR tx)
+                        sealedTxB
+                    ]
+                    .||. encodingFromTheFuture (txEra) currentEra
 
 makeShelleyTx
     :: Write.IsRecentEra era
     => RecentEra era
     -> DecodeSetup
     -> Cardano.Tx (CardanoApiEra era)
-makeShelleyTx _era testCase =
-    Cardano.makeSignedTransaction addrWits unsigned
-  where
-    DecodeSetup utxo outs md slotNo pairs _netwk = testCase
-    inps = Map.toList $ unUTxO utxo
-    fee = toLedgerCoin $ selectionDelta cs
-    unsigned =
-        either (error . show) id
-            $ mkUnsignedTx
-                (Nothing, slotNo)
-                (Right cs)
-                md
-                mempty
-                []
-                fee
-                TokenMap.empty
-                TokenMap.empty
-                Map.empty
-                Map.empty
-                Nothing
-                Nothing
-    addrWits =
-        map (mkShelleyWitness unsigned) pairs
-    cs =
-        Selection
-            { inputs = NE.fromList inps
-            , collateral = []
-            , extraCoinSource = Coin 0
-            , extraCoinSink = Coin 0
-            , outputs = []
-            , change = outs
-            , -- TODO: [ADP-346]
-              assetsToMint = TokenMap.empty
-            , assetsToBurn = TokenMap.empty
-            }
+makeShelleyTx era' testCase =
+    cardanoApiEraConstraints era'
+        $ let DecodeSetup utxo outs md slotNo pairs _netwk = testCase
+              inps = Map.toList $ unUTxO utxo
+              fee = toLedgerCoin $ selectionDelta cs
+              unsigned =
+                either (error . show) id
+                    $ mkUnsignedTx
+                        (Nothing, slotNo)
+                        (Right cs)
+                        md
+                        mempty
+                        []
+                        fee
+                        TokenMap.empty
+                        TokenMap.empty
+                        Map.empty
+                        Map.empty
+                        Nothing
+                        Nothing
+              addrWits =
+                map (mkShelleyWitness unsigned) pairs
+              cs =
+                Selection
+                    { inputs = NE.fromList inps
+                    , collateral = []
+                    , extraCoinSource = Coin 0
+                    , extraCoinSink = Coin 0
+                    , outputs = []
+                    , change = outs
+                    , -- TODO: [ADP-346]
+                      assetsToMint = TokenMap.empty
+                    , assetsToBurn = TokenMap.empty
+                    }
+          in  Cardano.makeSignedTransaction addrWits unsigned
 
 encodingFromTheFuture :: AnyRecentEra -> AnyCardanoEra -> Bool
 encodingFromTheFuture tx current = shelleyEraNum tx > eraNum current
@@ -1511,7 +1513,7 @@ emptyTxSkeleton =
 mockTxConstraints :: TxConstraints
 mockTxConstraints =
     txConstraints
-        (mockPParams @Write.Babbage)
+        (mockPParams @Write.Conway)
         TxWitnessShelleyUTxO
 data MockSelection = MockSelection
     { txInputCount :: Int
@@ -1625,11 +1627,7 @@ instance Arbitrary (Large TokenBundle) where
     arbitrary = fmap Large . genTxOutTokenBundle =<< choose (1, 128)
 
 instance Arbitrary AnyRecentEra where
-    arbitrary =
-        elements
-            [ AnyRecentEra RecentEraBabbage
-            , AnyRecentEra RecentEraConway
-            ]
+    arbitrary = return (AnyRecentEra RecentEraConway)
 
 instance Arbitrary AssetId where
     arbitrary =
@@ -1724,25 +1722,3 @@ newtype ShowOrd a = ShowOrd {unShowOrd :: a}
 
 instance (Eq a, Show a) => Ord (ShowOrd a) where
     compare = comparing show
-
--- | Hack until signTransaction and properties are converted to ledger types
-withCardanoApiConstraints
-    :: forall era a
-     . CardanoEra era
-    -> ( ( CardanoApiEra (ShelleyLedgerEra era) ~ era
-         , IsRecentEra (ShelleyLedgerEra era)
-         )
-         => a
-       )
-    -> a
-withCardanoApiConstraints e a = case e of
-    Cardano.ConwayEra -> a
-    Cardano.BabbageEra -> a
-    Cardano.DijkstraEra -> err
-    Cardano.AlonzoEra -> err
-    Cardano.MaryEra -> err
-    Cardano.AllegraEra -> err
-    Cardano.ShelleyEra -> err
-    Cardano.ByronEra -> err
-  where
-    err = error "withCardanoApiConstraints: unsupported era"

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -400,7 +400,7 @@ import Prelude
 
 import qualified Cardano.Balance.Tx.Eras as Write
     ( AnyRecentEra (AnyRecentEra)
-    , RecentEra (RecentEraBabbage, RecentEraConway)
+    , RecentEra (RecentEraConway, RecentEraDijkstra)
     )
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
@@ -889,8 +889,8 @@ prop_calculateFeePercentiles
 instance Arbitrary Write.AnyRecentEra where
     arbitrary =
         elements
-            [ Write.AnyRecentEra Write.RecentEraBabbage
-            , Write.AnyRecentEra Write.RecentEraConway
+            [ Write.AnyRecentEra Write.RecentEraConway
+            , Write.AnyRecentEra Write.RecentEraDijkstra
             ]
 
 {-------------------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Api/Extra.hs
+++ b/lib/wallet/src/Cardano/Api/Extra.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -8,15 +12,94 @@
 -- Module containing extra 'Cardano.Api' functionality needed by the wallet.
 module Cardano.Api.Extra
     ( inAnyCardanoEra
+    , CardanoApiEra
+    , cardanoApiEraConstraints
+    , shelleyBasedEraFromRecentEra
+    , cardanoEraFromRecentEra
+    , toCardanoApiTx
+    , fromCardanoApiTx
     ) where
 
-import Cardano.Api
-    ( InAnyCardanoEra (..)
-    , IsCardanoEra (cardanoEra)
-    , Tx
+import Cardano.Balance.Tx.Eras
+    ( Conway
+    , IsRecentEra (recentEra)
+    , RecentEra (..)
     )
+import Data.Typeable
+    ( Typeable
+    )
+import Prelude
+
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Balance.Tx.Tx as Write
 
 -- | Helper function for more easily creating an existential
 -- @InAnyCardanoEra Tx@.
-inAnyCardanoEra :: IsCardanoEra era => Tx era -> InAnyCardanoEra Tx
-inAnyCardanoEra = InAnyCardanoEra cardanoEra
+inAnyCardanoEra
+    :: Cardano.IsCardanoEra era
+    => Cardano.Tx era
+    -> Cardano.InAnyCardanoEra Cardano.Tx
+inAnyCardanoEra = Cardano.InAnyCardanoEra Cardano.cardanoEra
+
+-- | Temporary shim: maps balance-tx RecentEra types to Cardano.Api era types.
+-- Will be removed when cardano-api dependency is fully eliminated.
+type family CardanoApiEra era = cardanoApiEra | cardanoApiEra -> era
+
+type instance CardanoApiEra Conway = Cardano.ConwayEra
+
+-- | Bring Cardano.Api era constraints into scope for a 'RecentEra'.
+cardanoApiEraConstraints
+    :: RecentEra era
+    -> ( ( Cardano.IsCardanoEra (CardanoApiEra era)
+         , Cardano.IsShelleyBasedEra (CardanoApiEra era)
+         , Cardano.ShelleyLedgerEra (CardanoApiEra era) ~ era
+         , Typeable (CardanoApiEra era)
+         )
+         => a
+       )
+    -> a
+cardanoApiEraConstraints RecentEraConway f = f
+cardanoApiEraConstraints RecentEraDijkstra _ =
+    error "cardanoApiEraConstraints: Dijkstra era not yet supported"
+
+-- | Temporary shim for 'shelleyBasedEraFromRecentEra'.
+shelleyBasedEraFromRecentEra
+    :: RecentEra era
+    -> Cardano.ShelleyBasedEra (CardanoApiEra era)
+shelleyBasedEraFromRecentEra RecentEraConway =
+    Cardano.ShelleyBasedEraConway
+shelleyBasedEraFromRecentEra RecentEraDijkstra =
+    error "shelleyBasedEraFromRecentEra: Dijkstra era not yet supported"
+
+-- | Temporary shim for 'cardanoEraFromRecentEra'.
+cardanoEraFromRecentEra
+    :: RecentEra era
+    -> Cardano.CardanoEra (CardanoApiEra era)
+cardanoEraFromRecentEra RecentEraConway =
+    Cardano.ConwayEra
+cardanoEraFromRecentEra RecentEraDijkstra =
+    error "cardanoEraFromRecentEra: Dijkstra era not yet supported"
+
+-- | Convert a ledger-era transaction to a Cardano.Api transaction.
+toCardanoApiTx
+    :: forall era
+     . IsRecentEra era
+    => Write.Tx era
+    -> Cardano.Tx (CardanoApiEra era)
+toCardanoApiTx tx = case recentEra :: RecentEra era of
+    RecentEraConway ->
+        Cardano.ShelleyTx Cardano.ShelleyBasedEraConway tx
+    RecentEraDijkstra ->
+        error "toCardanoApiTx: Dijkstra era not yet supported"
+
+-- | Convert a Cardano.Api transaction to a ledger-era transaction.
+fromCardanoApiTx
+    :: forall era
+     . IsRecentEra era
+    => Cardano.Tx (CardanoApiEra era)
+    -> Write.Tx era
+fromCardanoApiTx tx = case recentEra :: RecentEra era of
+    RecentEraConway -> case tx of
+        Cardano.ShelleyTx _ ledgerTx -> ledgerTx
+    RecentEraDijkstra ->
+        error "fromCardanoApiTx: Dijkstra era not yet supported"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2230,6 +2230,8 @@ type MakeRewardAccountBuilder k =
 data ErrWriteTxEra
     = -- | Node is not synced enough or on an unsupported testnet in an older era.
       ErrNodeNotYetInRecentEra String
+    | -- | The node is in a recent era that the wallet does not yet support.
+      ErrEraNotYetSupported String
     | -- | The provided partial tx is not deserialisable as a tx in the era of the
       -- node.
       --
@@ -2252,7 +2254,13 @@ readNodeTipStateForTxWrite netLayer = do
             throwIO
                 $ ExceptionWriteTxEra
                 $ ErrNodeNotYetInRecentEra nopp
-        Right pp -> pure (pp, timeTranslation)
+        Right pp@(Write.PParamsInAnyRecentEra era _) ->
+            case era of
+                Write.RecentEraDijkstra ->
+                    throwIO
+                        $ ExceptionWriteTxEra
+                        $ ErrEraNotYetSupported "Dijkstra"
+                _ -> pure (pp, timeTranslation)
 
 -- | Filter protocol parameters for recent eras.
 pparamsInRecentEra
@@ -2343,7 +2351,10 @@ balanceTx wrk pp timeTranslation partialTx = do
         -> IO (Write.UTxO era)
     forceUTxOToEra = \case
         InRecentEraConway utxo -> hoist $ Write.forceUTxOToEra utxo
-        InRecentEraDijkstra utxo -> hoist $ Write.forceUTxOToEra utxo
+        InRecentEraDijkstra _ ->
+            throwIO
+                $ ExceptionWriteTxEra
+                $ ErrEraNotYetSupported "Dijkstra"
         InNonRecentEraBabbage -> impossibleRollback
         InNonRecentEraAlonzo -> impossibleRollback
         InNonRecentEraMary -> impossibleRollback

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -255,7 +255,12 @@ import Cardano.Api
     ( serialiseToCBOR
     )
 import Cardano.Api.Extra
-    ( inAnyCardanoEra
+    ( CardanoApiEra
+    , cardanoApiEraConstraints
+    , cardanoEraFromRecentEra
+    , fromCardanoApiTx
+    , inAnyCardanoEra
+    , toCardanoApiTx
     )
 import Cardano.BM.Data.Severity
     ( Severity (..)
@@ -857,11 +862,9 @@ import qualified Cardano.Balance.Tx.Balance as Write
     )
 import qualified Cardano.Balance.Tx.Eras as Write
     ( AnyRecentEra
-    , CardanoApiEra
     , IsRecentEra (..)
     , MaybeInRecentEra (..)
     , RecentEra (..)
-    , cardanoEraFromRecentEra
     )
 import qualified Cardano.Balance.Tx.Tx as Write
     ( ErrInvalidTxOutInEra
@@ -872,10 +875,8 @@ import qualified Cardano.Balance.Tx.Tx as Write
     , UTxO (UTxO)
     , feeOfBytes
     , forceUTxOToEra
-    , fromCardanoApiTx
     , getFeePerByte
     , stakeKeyDeposit
-    , toCardanoApiTx
     )
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Ledger.Core as Ledger
@@ -2047,44 +2048,46 @@ buildCoinSelectionForTransaction
     depositRefund
     delegationAction
     tx =
-        CoinSelection
-            { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
-            , outputs = paymentOutputs
-            , change = do
-                out <-
-                    -- NOTE: We assume that the change outputs are always
-                    -- at the end of the list. This is true for the current
-                    -- 'balanceTx' implementation, but may not
-                    -- be true for other implementations.
-                    drop (length paymentOutputs) $ fromCardanoTxOut <$> txOuts
-                let address = out ^. #address
-                derivationPath <-
-                    maybeToList $ fst $ isOurs address (getState wallet)
-                pure
-                    TxChange
-                        { address
-                        , amount = out ^. #tokens . #coin
-                        , assets = out ^. #tokens . #tokens
-                        , derivationPath
-                        }
-            , collateral =
-                resolveInput . fromCardanoTxIn
-                    =<< case txInsCollateral of
-                        Cardano.TxInsCollateralNone -> []
-                        Cardano.TxInsCollateral _supported is -> is
-            , withdrawals =
-                fromCardanoWdrls txWithdrawals
-                    <&> \(acct, coin) -> (acct, coin, rewardAcctPath)
-            , delegationAction = (,rewardAcctPath) <$> delegationAction
-            , deposit =
-                case delegationAction of
-                    Just (JoinRegisteringKey _poolId) -> Just depositRefund
-                    _ -> Nothing
-            , refund =
-                case delegationAction of
-                    Just Quit -> Just depositRefund
-                    _ -> Nothing
-            }
+        cardanoApiEraConstraints
+            (Write.recentEra @era)
+            CoinSelection
+                { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
+                , outputs = paymentOutputs
+                , change = do
+                    out <-
+                        -- NOTE: We assume that the change outputs are always
+                        -- at the end of the list. This is true for the current
+                        -- 'balanceTx' implementation, but may not
+                        -- be true for other implementations.
+                        drop (length paymentOutputs) $ fromCardanoTxOut <$> txOuts
+                    let address = out ^. #address
+                    derivationPath <-
+                        maybeToList $ fst $ isOurs address (getState wallet)
+                    pure
+                        TxChange
+                            { address
+                            , amount = out ^. #tokens . #coin
+                            , assets = out ^. #tokens . #tokens
+                            , derivationPath
+                            }
+                , collateral =
+                    resolveInput . fromCardanoTxIn
+                        =<< case txInsCollateral of
+                            Cardano.TxInsCollateralNone -> []
+                            Cardano.TxInsCollateral _supported is -> is
+                , withdrawals =
+                    fromCardanoWdrls txWithdrawals
+                        <&> \(acct, coin) -> (acct, coin, rewardAcctPath)
+                , delegationAction = (,rewardAcctPath) <$> delegationAction
+                , deposit =
+                    case delegationAction of
+                        Just (JoinRegisteringKey _poolId) -> Just depositRefund
+                        _ -> Nothing
+                , refund =
+                    case delegationAction of
+                        Just Quit -> Just depositRefund
+                        _ -> Nothing
+                }
       where
         Cardano.TxBodyContent
             { txIns
@@ -2094,7 +2097,7 @@ buildCoinSelectionForTransaction
             } =
                 Cardano.getTxBodyContent
                     $ Cardano.getTxBody
-                    $ Write.toCardanoApiTx tx
+                    $ toCardanoApiTx tx
 
         resolveInput txIn = do
             (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)
@@ -2226,7 +2229,7 @@ type MakeRewardAccountBuilder k =
 
 data ErrWriteTxEra
     = -- | Node is not synced enough or on an unsupported testnet in an older era.
-      ErrNodeNotYetInRecentEra Cardano.AnyCardanoEra
+      ErrNodeNotYetInRecentEra String
     | -- | The provided partial tx is not deserialisable as a tx in the era of the
       -- node.
       --
@@ -2264,10 +2267,9 @@ pparamsInRecentEra (Read.PParams pparams) =
         Read.Allegra -> Write.InNonRecentEraAllegra
         Read.Mary -> Write.InNonRecentEraMary
         Read.Alonzo -> Write.InNonRecentEraAlonzo
-        Read.Babbage -> Write.InRecentEraBabbage pparams
+        Read.Babbage -> Write.InNonRecentEraBabbage
         Read.Conway -> Write.InRecentEraConway pparams
-        Read.Dijkstra ->
-            error "pparamsInRecentEra: DijkstraEra not yet supported"
+        Read.Dijkstra -> Write.InRecentEraDijkstra pparams
 
 -- | Wallet-specific wrapped version of 'Write.balanceTx', made for the new tx
 -- workflow with Shelley- and Shared- wallet flavors.
@@ -2341,7 +2343,8 @@ balanceTx wrk pp timeTranslation partialTx = do
         -> IO (Write.UTxO era)
     forceUTxOToEra = \case
         InRecentEraConway utxo -> hoist $ Write.forceUTxOToEra utxo
-        InRecentEraBabbage utxo -> hoist $ Write.forceUTxOToEra utxo
+        InRecentEraDijkstra utxo -> hoist $ Write.forceUTxOToEra utxo
+        InNonRecentEraBabbage -> impossibleRollback
         InNonRecentEraAlonzo -> impossibleRollback
         InNonRecentEraMary -> impossibleRollback
         InNonRecentEraAllegra -> impossibleRollback
@@ -2518,11 +2521,11 @@ buildAndSignTransactionPure
     txLayer
     changeAddrGen
     preSelection
-    txCtx = do
+    txCtx = cardanoApiEraConstraints (Write.recentEra @era) $ do
         wallet <- get
         (unsignedBalancedTx, updatedWalletState) <-
             lift
-                $ first Write.toCardanoApiTx
+                $ first toCardanoApiTx
                     <$> buildTransactionPure @s
                         wallet
                         timeTranslation
@@ -2599,7 +2602,10 @@ buildAndSignTransactionPure
       where
         era = recentEra @era
         wF = walletFlavor @s
-        anyCardanoEra = Cardano.AnyCardanoEra $ Write.cardanoEraFromRecentEra era
+        anyCardanoEra =
+            cardanoApiEraConstraints era
+                $ Cardano.AnyCardanoEra
+                $ cardanoEraFromRecentEra era
 
 buildTransaction
     :: forall s era
@@ -2702,7 +2708,7 @@ buildTransactionPure
                     changeAddrGen
                     (getState wallet)
                     Write.PartialTx
-                        { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                        { tx = fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                         , extraUTxO = Write.UTxO mempty
                         , redeemers = []
                         , timelockKeyWitnessCounts = mempty
@@ -2815,7 +2821,7 @@ constructTransaction
     -> DBLayer IO (SeqState n ShelleyKey)
     -> TransactionCtx
     -> PreSelection
-    -> ExceptT ErrConstructTx IO (Cardano.TxBody (Write.CardanoApiEra era))
+    -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))
 constructTransaction era db txCtx preSel = do
     (_, xpub, _) <- lift $ readRewardAccount db
     when (containsSelfWithdrawal (txCtx ^. #txWithdrawal))
@@ -2834,7 +2840,7 @@ constructUnbalancedSharedTransaction
     -> DBLayer IO (SharedState n SharedKey)
     -> TransactionCtx
     -> PreSelection
-    -> ExceptT ErrConstructTx IO (Cardano.TxBody (Write.CardanoApiEra era))
+    -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))
 constructUnbalancedSharedTransaction era db txCtx sel =
     db & \DBLayer{..} -> do
         cp <- lift $ atomically readCheckpoint
@@ -3477,7 +3483,7 @@ transactionFee
         let ptx :: Write.PartialTx era
             ptx =
                 Write.PartialTx
-                    { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                    { tx = fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                     , extraUTxO = Write.UTxO mempty
                     , redeemers = []
                     , timelockKeyWitnessCounts = mempty
@@ -3970,8 +3976,9 @@ utxoIndexFromWalletUTxO
 utxoIndexFromWalletUTxO utxo =
     Write.constructUTxOIndex
         $ case Write.recentEra :: Write.RecentEra era of
-            Write.RecentEraBabbage -> Convert.toLedgerUTxOBabbage utxo
             Write.RecentEraConway -> Convert.toLedgerUTxOConway utxo
+            Write.RecentEraDijkstra ->
+                error "utxoIndexFromWalletUTxO: Dijkstra era not yet supported"
 
 {-------------------------------------------------------------------------------
                                    Errors

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -129,7 +129,6 @@ joinStakePoolDelegationAction
                         then Tx.Join poolId
                         else Tx.JoinRegisteringKey poolId
                     , case era of
-                        Write.RecentEraBabbage -> Nothing
                         Write.RecentEraConway ->
                             if not stakeKeyIsRegistered
                                 then
@@ -140,6 +139,10 @@ joinStakePoolDelegationAction
                                             Just $ Tx.Vote Abstain
                                         else
                                             Nothing
+                        Write.RecentEraDijkstra ->
+                            error
+                                "joinStakePoolDelegationAction: \
+                                \Dijkstra era not yet supported"
                     )
       where
         stakeKeyIsRegistered =
@@ -178,8 +181,6 @@ guardJoin era knownPools delegation pid mRetirementEpochInfo votedTheSameM = do
   where
     WalletDelegation{active, next} = delegation
     eraVotingLogic = case (era, votedTheSameM) of
-        (Write.RecentEraBabbage, _) ->
-            Left (ErrAlreadyDelegating pid)
         (Write.RecentEraConway, NotVotedYet) ->
             pure ()
         (Write.RecentEraConway, NotVotedThisTime) ->
@@ -188,6 +189,8 @@ guardJoin era knownPools delegation pid mRetirementEpochInfo votedTheSameM = do
             Left (ErrAlreadyDelegatingVoting pid)
         (Write.RecentEraConway, VotedDifferently) ->
             pure ()
+        (Write.RecentEraDijkstra, _) ->
+            error "guardJoin: Dijkstra era not yet supported"
 
 {-----------------------------------------------------------------------------
     Quit stake pool
@@ -272,10 +275,10 @@ joinDRepVotingAction era targetDRep dlg stakeKeyIsRegistered = do
         :: Write.IsRecentEra era
         => Write.RecentEra era
         -> Either ErrCannotVote ()
-    guardEraIsConway Write.RecentEraBabbage =
-        Left ErrWrongEra
     guardEraIsConway Write.RecentEraConway =
         Right ()
+    guardEraIsConway Write.RecentEraDijkstra =
+        error "guardEraIsConway: Dijkstra era not yet supported"
 
     votingAction =
         if stakeKeyIsRegistered

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -74,9 +74,15 @@ import Cardano.Api
     )
 -- Removed: Cardano.Api.Error no longer exists, using show instead
 
-import Cardano.Balance.Tx.Eras
+import Cardano.Api.Extra
     ( CardanoApiEra
-    , RecentEra (..)
+    , cardanoApiEraConstraints
+    , fromCardanoApiTx
+    , shelleyBasedEraFromRecentEra
+    , toCardanoApiTx
+    )
+import Cardano.Balance.Tx.Eras
+    ( RecentEra (..)
     )
 import Cardano.Balance.Tx.SizeEstimation
     ( TxSkeleton (..)
@@ -276,10 +282,8 @@ import qualified Cardano.Balance.Tx.Tx as Write
     , TxOut
     , computeMinimumCoinForTxOut
     , feeOfBytes
-    , fromCardanoApiTx
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
-    , toCardanoApiTx
     )
 import qualified Cardano.Crypto as CC
 import qualified Cardano.Crypto.Hash.Class as Crypto
@@ -338,7 +342,7 @@ constructUnsignedTx
     -- ^ Delegation script
     -> Maybe (Script KeyHash)
     -- ^ Reference script
-    -> Either ErrMkTransaction (Cardano.TxBody (Write.CardanoApiEra era))
+    -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))
 constructUnsignedTx
     networkId
     (md, certs)
@@ -412,7 +416,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
             Nothing
     let signed :: Cardano.Tx (CardanoApiEra era)
         signed =
-            Write.toCardanoApiTx
+            toCardanoApiTx
                 $ signTransaction
                     keyF
                     networkId
@@ -423,13 +427,14 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
                     (const Nothing)
                     addrResolver
                     inputResolver
-                    (Write.fromCardanoApiTx $ Cardano.Tx unsigned [])
+                    (fromCardanoApiTx $ Cardano.Tx unsigned [])
     let withResolvedInputs tx =
             tx{resolvedInputs = second Just <$> F.toList (view #inputs cs)}
-    Right
-        ( withResolvedInputs $ walletTx $ fromCardanoTx signed
-        , sealedTxFromCardano' signed
-        )
+    cardanoApiEraConstraints era
+        $ Right
+            ( withResolvedInputs $ walletTx $ fromCardanoTx signed
+            , sealedTxFromCardano' signed
+            )
   where
     inputResolver :: TxIn -> Maybe Address
     inputResolver i =
@@ -482,9 +487,9 @@ signTransaction
     resolveAddress
     resolveInput
     txToSign =
-        Write.fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
+        fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
       where
-        Cardano.Tx body wits = Write.toCardanoApiTx txToSign
+        Cardano.Tx body wits = toCardanoApiTx txToSign
 
         wits' =
             mconcat
@@ -691,17 +696,12 @@ withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
     Cardano.ConwayEra ->
         Just
             . InAnyCardanoEra era
-            . Write.toCardanoApiTx
+            . toCardanoApiTx
             . f
-            . Write.fromCardanoApiTx
+            . fromCardanoApiTx
             $ tx
     Cardano.BabbageEra ->
-        Just
-            . InAnyCardanoEra era
-            . Write.toCardanoApiTx
-            . f
-            . Write.fromCardanoApiTx
-            $ tx
+        Nothing
     Cardano.AlonzoEra ->
         Nothing
     Cardano.MaryEra ->
@@ -891,7 +891,7 @@ mkUnsignedTx
     -> Map TxIn (Script KeyHash)
     -> Maybe (Script KeyHash)
     -> Maybe (Script KeyHash)
-    -> Either ErrMkTransaction (Cardano.TxBody (Write.CardanoApiEra era))
+    -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))
 mkUnsignedTx
     ttl
     cs
@@ -1101,14 +1101,15 @@ mkUnsignedTx
         scriptWitsSupported
             :: Cardano.ScriptLanguageInEra
                 Cardano.SimpleScript'
-                (Write.CardanoApiEra era)
+                (CardanoApiEra era)
         scriptWitsSupported = case era of
-            RecentEraBabbage -> Cardano.SimpleScriptInBabbage
             RecentEraConway -> Cardano.SimpleScriptInConway
+            RecentEraDijkstra ->
+                error "scriptWitsSupported: Dijkstra era not yet supported"
 
         toScriptWitness
             :: Script KeyHash
-            -> Cardano.ScriptWitness witctx (Write.CardanoApiEra era)
+            -> Cardano.ScriptWitness witctx (CardanoApiEra era)
         toScriptWitness script =
             Cardano.SimpleScriptWitness
                 scriptWitsSupported
@@ -1145,22 +1146,25 @@ mkUnsignedTx
                 Cardano.BuildTxWith
                     $ Cardano.KeyWitness Cardano.KeyWitnessForSpending
 
-        shelleyEra = Write.shelleyBasedEraFromRecentEra era
+        shelleyEra = shelleyBasedEraFromRecentEra era
 
         allegraOnwards :: Cardano.AllegraEraOnwards (CardanoApiEra era)
         allegraOnwards = case era of
-            RecentEraBabbage -> Cardano.AllegraEraOnwardsBabbage
             RecentEraConway -> Cardano.AllegraEraOnwardsConway
+            RecentEraDijkstra ->
+                error "allegraOnwards: Dijkstra era not yet supported"
 
         maryOnwards :: Cardano.MaryEraOnwards (CardanoApiEra era)
         maryOnwards = case era of
-            RecentEraBabbage -> Cardano.MaryEraOnwardsBabbage
             RecentEraConway -> Cardano.MaryEraOnwardsConway
+            RecentEraDijkstra ->
+                error "maryOnwards: Dijkstra era not yet supported"
 
         babbageOnwards :: Cardano.BabbageEraOnwards (CardanoApiEra era)
         babbageOnwards = case era of
-            RecentEraBabbage -> Cardano.BabbageEraOnwardsBabbage
             RecentEraConway -> Cardano.BabbageEraOnwardsConway
+            RecentEraDijkstra ->
+                error "babbageOnwards: Dijkstra era not yet supported"
 
 -- TODO: ADP-2257
 -- cardano-node does not allow to construct tx without inputs at this moment.
@@ -1169,18 +1173,22 @@ dummyInput :: TxIn
 dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
 removeDummyInput
-    :: Write.IsRecentEra era
+    :: forall era
+     . Write.IsRecentEra era
     => Cardano.TxBody (CardanoApiEra era)
     -> Cardano.TxBody (CardanoApiEra era)
-removeDummyInput = \case
-    Cardano.ShelleyTxBody era body scripts scriptData aux val ->
-        Cardano.ShelleyTxBody
-            era
-            (over inputsTxBodyL (Set.delete (toLedger dummyInput)) body)
-            scripts
-            scriptData
-            aux
-            val
+removeDummyInput = case Write.recentEra @era of
+    RecentEraConway -> \case
+        Cardano.ShelleyTxBody sbe body scripts scriptData aux val ->
+            Cardano.ShelleyTxBody
+                sbe
+                (over inputsTxBodyL (Set.delete (toLedger dummyInput)) body)
+                scripts
+                scriptData
+                aux
+                val
+    RecentEraDijkstra ->
+        error "removeDummyInput: Dijkstra era not yet supported"
 
 mkWithdrawals
     :: NetworkId
@@ -1205,7 +1213,7 @@ mkShelleyWitness body key =
     Cardano.makeShelleyKeyWitness shelleyBasedEra body (unencrypt key)
   where
     shelleyBasedEra =
-        Write.shelleyBasedEraFromRecentEra (Write.recentEra @era)
+        shelleyBasedEraFromRecentEra (Write.recentEra @era)
     unencrypt (xprv, pwd) =
         Cardano.WitnessPaymentExtendedKey
             $ Cardano.PaymentExtendedSigningKey
@@ -1244,8 +1252,9 @@ mkByronWitness
       where
         era = Write.recentEra @era
         txHash = case era of
-            RecentEraBabbage -> Crypto.castHash $ Crypto.hashWith serialize' body
             RecentEraConway -> Crypto.castHash $ Crypto.hashWith serialize' body
+            RecentEraDijkstra ->
+                error "mkByronWitness: Dijkstra era not yet supported"
 
         unencrypt (xprv, pwd) =
             CC.SigningKey
@@ -1415,8 +1424,9 @@ txConstraints protocolParams witnessTag =
         -> Write.TxOut era
     mkLedgerTxOut address bundle =
         case era of
-            Write.RecentEraBabbage -> Convert.toBabbageTxOut txOut
             Write.RecentEraConway -> Convert.toConwayTxOut txOut
+            Write.RecentEraDijkstra ->
+                error "mkLedgerTxOut: Dijkstra era not yet supported"
       where
         txOut = TxOut address bundle
 

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -24,9 +24,11 @@ import Cardano.Address.KeyHash
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Balance.Tx.Eras
+import Cardano.Api.Extra
     ( CardanoApiEra
-    , RecentEra (..)
+    )
+import Cardano.Balance.Tx.Eras
+    ( RecentEra (..)
     )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash)
@@ -40,9 +42,6 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin
-    )
-import Cardano.Wallet.Primitive.Types.Pool
-    ( PoolId (..)
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -72,33 +71,6 @@ certificateFromDelegationAction
     -- ^ Delegation action that we plan to take
     -> [Cardano.Certificate (CardanoApiEra era)]
     -- ^ Certificates representing the action
-certificateFromDelegationAction RecentEraBabbage cred _ da = case da of
-    Join poolId ->
-        [ Cardano.makeStakeAddressDelegationCertificate
-            $ Cardano.StakeDelegationRequirementsPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-                (toCardanoPoolId poolId)
-        ]
-    JoinRegisteringKey poolId ->
-        [ Cardano.makeStakeAddressRegistrationCertificate
-            $ Cardano.StakeAddrRegistrationPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-        , Cardano.makeStakeAddressDelegationCertificate
-            $ Cardano.StakeDelegationRequirementsPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-                (toCardanoPoolId poolId)
-        ]
-    Quit ->
-        [ Cardano.makeStakeAddressUnregistrationCertificate
-            $ Cardano.StakeAddrRegistrationPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-        ]
-  where
-    babbageWitness = Cardano.ShelleyToBabbageEraBabbage
 certificateFromDelegationAction RecentEraConway cred depositM da =
     case (da, depositM) of
         (Join poolId, _) ->
@@ -137,6 +109,9 @@ certificateFromDelegationAction RecentEraConway cred depositM da =
                 \Conway era when registration is carried out (quitting)"
   where
     conwayWitness = Cardano.ConwayEraOnwardsConway
+certificateFromDelegationAction RecentEraDijkstra _cred _depositM _da =
+    error
+        "certificateFromDelegationAction: Dijkstra era not yet supported"
 
 {-----------------------------------------------------------------------------
     Cardano.StakeCredential
@@ -154,10 +129,6 @@ toCardanoStakeCredential = \case
             . Cardano.hashScript
             . Cardano.SimpleScript
             $ toCardanoSimpleScript script
-
-toCardanoPoolId :: PoolId -> Cardano.PoolId
-toCardanoPoolId (PoolId pid) =
-    Cardano.StakePoolKeyHash . Ledger.KeyHash . UnsafeHash $ toShort pid
 
 toHashStakeKey :: XPub -> Cardano.Hash Cardano.StakeKey
 toHashStakeKey =

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Voting.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Voting.hs
@@ -24,9 +24,11 @@ import Cardano.Address.KeyHash
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Balance.Tx.Eras
+import Cardano.Api.Extra
     ( CardanoApiEra
-    , RecentEra (..)
+    )
+import Cardano.Balance.Tx.Eras
+    ( RecentEra (..)
     )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash)
@@ -69,8 +71,6 @@ certificateFromVotingAction
     -- ^ Voting action in Conway era onwards
     -> [Cardano.Certificate (CardanoApiEra era)]
     -- ^ Certificates representing the voting action
-certificateFromVotingAction RecentEraBabbage _cred _depositM _va =
-    []
 certificateFromVotingAction RecentEraConway cred depositM va =
     case (va, depositM) of
         (Vote action, _) ->
@@ -98,6 +98,8 @@ certificateFromVotingAction RecentEraConway cred depositM va =
                 \Conway era when registration is carried out"
   where
     conwayWitness = Cardano.ConwayEraOnwardsConway
+certificateFromVotingAction RecentEraDijkstra _cred _depositM _va =
+    error "certificateFromVotingAction: Dijkstra era not yet supported"
 
 {-----------------------------------------------------------------------------
     Cardano.StakeCredential


### PR DESCRIPTION
## Summary

Bump `cardano-balance-transaction` pin from `98e7f41` to `964e8a2`. The upstream library removed its cardano-api dependency (cardano-foundation/cardano-balance-transaction#32, #33).

## Breaking changes from upstream

- `CardanoApiEra` type family removed
- `RecentEraBabbage` removed (Babbage demoted to non-recent)
- `RecentEraDijkstra` added
- `toCardanoApiTx`/`fromCardanoApiTx` removed
- `cardanoEraFromRecentEra`/`shelleyBasedEraFromRecentEra` removed

## Wallet-side compatibility

A `Cardano.Api.Extra` shim module provides the removed functions locally so the wallet can continue using cardano-api types at the balance-tx boundary:

- `CardanoApiEra` type family (Conway only)
- `cardanoApiEraConstraints` to bring era constraints into scope
- `toCardanoApiTx`/`fromCardanoApiTx` for ledger↔cardano-api conversion
- `cardanoEraFromRecentEra`/`shelleyBasedEraFromRecentEra`

All `RecentEraBabbage` pattern matches replaced with `InNonRecentEraBabbage`. `RecentEraDijkstra` branches added as error stubs.

Depends on #5244 (TLS certs).

Related: #5237, #5243