### PR TITLE
fix: update local cluster configs for cardano-node 10.7.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -49,11 +49,11 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
-index-state: 2026-01-29T00:00:00Z
+index-state: 2026-02-17T10:15:41Z
 
 index-state:
-  , hackage.haskell.org 2026-01-29T00:00:00Z
-  , cardano-haskell-packages 2026-03-28T09:44:46Z
+  , hackage.haskell.org 2026-02-17T10:15:41Z
+  , cardano-haskell-packages 2026-03-23T18:21:55Z
 
 packages:
   lib/address-derivation-discovery

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1774695208,
-        "narHash": "sha256-4GaPRLb1S9pvQnSXBYdKz2xCZzu0m1UgWsItFu9poOk=",
+        "lastModified": 1774292745,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2d51f381c901c7f1a799d65d2de4f2387d07a9e5",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1774695208,
-        "narHash": "sha256-4GaPRLb1S9pvQnSXBYdKz2xCZzu0m1UgWsItFu9poOk=",
+        "lastModified": 1776203472,
+        "narHash": "sha256-husRfOULFemi5q+JpO7deykZxTKSIz0E4fCR387aO3Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2d51f381c901c7f1a799d65d2de4f2387d07a9e5",
+        "rev": "3831817e4131b3ef5fe262e3f853b87bec8a24a0",
         "type": "github"
       },
       "original": {
@@ -231,16 +231,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1774886169,
-        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
+        "lastModified": 1774379192,
+        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
+        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.3",
+        "ref": "10.7.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -556,11 +556,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1768311066,
-        "narHash": "sha256-g2WdhScDFQNkJs2GBjWIGG49upIQuBshgaeAxddujrE=",
+        "lastModified": 1771502057,
+        "narHash": "sha256-XwoLg6wftnU50KPn5jY4jtuGulyNPyspB4lSDSrmR1g=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "adbb09d536f3a2797f9bd0762a0577a30672b8b1",
+        "rev": "e6bb05af1f45a616f534798263a5a13f2299e3bc",
         "type": "github"
       },
       "original": {
@@ -1200,11 +1200,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1770069549,
-        "narHash": "sha256-jHgw8KL0/TFGY2aVwxhD0DeDq7sl5Ti7jAp8T3RLNb0=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0ce7cc21b9a4cfde41871ef486d01a8fafbf9627",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.6.3";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.7.0";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenNodeConfig.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenNodeConfig.hs
@@ -123,7 +123,8 @@ genNodeConfig nodeSegment name genesisFiles clusterEra logCfg = do
 
     let LogFileConfig severity mExtraLogFile extraSev = logCfg
 
-        GenesisRecord byronFile shelleyFile alonzoFile conwayFile = genesisFiles
+        GenesisRecord byronFile shelleyFile alonzoFile conwayFile dijkstraFile =
+            genesisFiles
 
         scribes =
             let
@@ -151,6 +152,7 @@ genNodeConfig nodeSegment name genesisFiles clusterEra logCfg = do
                 & setFilePath "ShelleyGenesisFile" shelleyFile
                 & setFilePath "AlonzoGenesisFile" alonzoFile
                 & setFilePath "ConwayGenesisFile" conwayFile
+                & setFilePath "DijkstraGenesisFile" dijkstraFile
                 & removeGenesisHashes
                 & setHardFork "ShelleyHardFork"
                 & setHardFork "AllegraHardFork"
@@ -186,7 +188,7 @@ genNodeConfig nodeSegment name genesisFiles clusterEra logCfg = do
 
 controlExperimental :: ClusterEra -> ChangeValue
 controlExperimental = \case
-    _ -> setExperimental False
+    _ -> setExperimental True
 
 setExperimental :: Bool -> ChangeValue
 setExperimental enabled value =
@@ -232,3 +234,4 @@ removeGenesisHashes value =
         & atKey "ShelleyGenesisHash" .~ Nothing
         & atKey "AlonzoGenesisHash" .~ Nothing
         & atKey "ConwayGenesisHash" .~ Nothing
+        & atKey "DijkstraGenesisHash" .~ Nothing

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenesisFiles.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenesisFiles.hs
@@ -139,18 +139,19 @@ data GenesisRecord f = GenesisRecord
     , shelleyGenesis :: f "genesis-shelley"
     , alonzoGenesis :: f "genesis-alonzo"
     , conwayGenesis :: f "genesis-conway"
+    , dijkstraGenesis :: f "genesis-dijkstra"
     }
     deriving stock (Generic)
 
 instance FFunctor GenesisRecord where ffmap = ffmapDefault
 instance FFoldable GenesisRecord where ffoldMap = ffoldMapDefault
 instance FTraversable GenesisRecord where
-    ftraverse f (GenesisRecord a b c d) =
-        GenesisRecord <$> f a <*> f b <*> f c <*> f d
+    ftraverse f (GenesisRecord a b c d e) =
+        GenesisRecord <$> f a <*> f b <*> f c <*> f d <*> f e
 
 instance FZip GenesisRecord where
-    fzipWith f (GenesisRecord a b c d) (GenesisRecord a' b' c' d') =
-        GenesisRecord (f a a') (f b b') (f c c') (f d d')
+    fzipWith f (GenesisRecord a b c d e) (GenesisRecord a' b' c' d' e') =
+        GenesisRecord (f a a') (f b b') (f c c') (f d d') (f e e')
 
 deriving stock instance Show (GenesisRecord FileOf)
 
@@ -189,6 +190,7 @@ mkGenesisFiles (DirOf d) =
         , shelleyGenesis = mkFile "shelley"
         , alonzoGenesis = mkFile "alonzo"
         , conwayGenesis = mkFile "conway"
+        , dijkstraGenesis = mkFile "dijkstra"
         }
   where
     mkFile :: String -> FileOf x
@@ -261,7 +263,7 @@ generateGenesis initialFunds genesisMods = do
                     -- based on the protocol version rather than just the era,
                     -- so we need to set it to a realisitic value.
                     & ppProtocolVersionL
-                        .~ Ledger.ProtVer (natVersion @8) 0
+                        .~ Ledger.ProtVer (natVersion @10) 0
                     -- Sensible pool & reward parameters:
                     & ppNOptL
                         .~ 3
@@ -325,4 +327,5 @@ generateGenesis initialFunds genesisMods = do
                     $ \_ -> toJSON shelleyGenesisData
                 , alonzoGenesis = Const id
                 , conwayGenesis = Const id
+                , dijkstraGenesis = Const id
                 }

--- a/lib/local-cluster/test/data/cluster-configs/dijkstra-genesis.json
+++ b/lib/local-cluster/test/data/cluster-configs/dijkstra-genesis.json
@@ -1,0 +1,6 @@
+{
+    "maxRefScriptSizePerBlock": 1048576,
+    "maxRefScriptSizePerTx": 204800,
+    "refScriptCostStride": 25600,
+    "refScriptCostMultiplier": 1.2
+}

--- a/lib/local-cluster/test/data/cluster-configs/node-config.json
+++ b/lib/local-cluster/test/data/cluster-configs/node-config.json
@@ -4,6 +4,7 @@
   "ApplicationVersion": 0,
     "ByronGenesisFile": "byron-genesis.json",
     "ConwayGenesisFile": "conway-genesis.json",
+    "DijkstraGenesisFile": "dijkstra-genesis.json",
   "EnableP2P": true,
   "ExperimentalHardForksEnabled": false,
   "ExperimentalProtocolsEnabled": false,

--- a/specs/002-bump-node-10-7-0/checklists/requirements.md
+++ b/specs/002-bump-node-10-7-0/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Bump dependencies to cardano-node 10.7.0
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a dependency version bump, not a feature — the spec is necessarily close to implementation concerns (package names, versions). The "what" is "all versions match node 10.7.0" and the "why" is "van Rossem hard fork compatibility".

--- a/specs/002-bump-node-10-7-0/plan.md
+++ b/specs/002-bump-node-10-7-0/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: Bump dependencies to cardano-node 10.7.0
+
+**Branch**: `002-bump-node-10-7-0` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-bump-node-10-7-0/spec.md`
+
+## Summary
+
+Update all Cardano dependency version constraints and `.cabal` bounds to match cardano-node 10.7.0, following the process in `docs/site/src/contributor/notes/updating-dependencies.md`. The freeze file from cardano-node 10.7.0 is the source of truth. The `.cabal` files are updated in topological order using `bump-constraints.sh`.
+
+## Technical Context
+
+**Language/Version**: Haskell, GHC 9.12 (unchanged)
+**Primary Dependencies**: cardano-node 10.7.0, ouroboros-consensus 1.0.0.0, ouroboros-network 1.1.0.0, cardano-ledger-core 1.19.0.0, cardano-api 10.25.0.0, plutus-core 1.59.0.0
+**Storage**: N/A (no storage changes)
+**Testing**: cabal test, just e2e, just integration-tests-cabal-options
+**Target Platform**: Linux (primary), macOS, Windows (cross-compiled)
+**Project Type**: Library/application monorepo
+**Constraints**: Must build on all three platforms. E2E must pass on preprod.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Maintenance-First Stability | PASS | Node upgrade is core maintenance activity |
+| II. Era-Aware Design | PASS | No era logic changes in this PR, just version bumps |
+| III. Type Safety as Security | PASS | No type changes in this PR |
+| IV. Formal Specification | N/A | No spec changes needed for dependency bump |
+| V. Reproducible Builds | PASS | CHaP aligned with node 10.7.0, flake.lock updated, SHA256 pins maintained |
+| VI. Comprehensive Testing | PASS | E2E already running against 10.7.0 in probe PR #5248 |
+| VII. Code Quality Gates | PASS | Will run full CI after bump |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-bump-node-10-7-0/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Version delta analysis
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+No new files. Changes touch:
+
+```text
+cabal.project                    # Constraints, index-state
+flake.nix                        # cardano-node-runtime input
+flake.lock                       # CHaP, cardano-node-runtime
+lib/*/cardano-*.cabal            # Version bounds (via bump-constraints.sh)
+```
+
+## Process
+
+Following `updating-dependencies.md` steps:
+
+### Step 1: Choose target version
+cardano-node 10.7.0 (van Rossem hard fork, protocol version 11)
+
+### Step 2: Freeze from node
+Freeze file: `/tmp/cardano-node-10.7.0/cabal.project.freeze`
+
+### Step 3: Align CHaP
+CHaP rev `887d73ce434831e3a67df48e070f4f979b3ac5a6` (same as node 10.7.0)
+Index-state: `hackage.haskell.org 2026-02-17T10:15:41Z`, `cardano-haskell-packages 2026-03-23T18:21:55Z`
+
+### Step 4: Update cabal.project constraints
+Replace the `-- Cardano Node 10.6.3 dependencies:` block with versions from freeze file.
+
+Key version changes:
+
+| Package | 10.6.3 | 10.7.0 |
+|---------|--------|--------|
+| cardano-api | 10.23.0.0 | 10.25.0.0 |
+| cardano-binary | 1.7.2.0 | 1.8.0.0 |
+| cardano-crypto-class | 2.2.3.2 | 2.3.1.0 |
+| cardano-crypto-praos | 2.2.1.1 | 2.2.2.0 |
+| cardano-crypto-wrapper | 1.6.1.0 | 1.7.0.0 |
+| cardano-data | 1.2.4.1 | 1.3.0.0 |
+| cardano-ledger-allegra | 1.8.0.0 | 1.9.0.0 |
+| cardano-ledger-alonzo | 1.14.0.0 | 1.15.0.0 |
+| cardano-ledger-api | 1.12.1.0 | 1.13.0.0 |
+| cardano-ledger-babbage | 1.12.0.0 | 1.13.0.0 |
+| cardano-ledger-binary | 1.7.1.0 | 1.8.0.0 |
+| cardano-ledger-byron | 1.2.0.0 | 1.3.0.0 |
+| cardano-ledger-conway | 1.20.0.0 | 1.21.0.0 |
+| cardano-ledger-core | 1.18.0.0 | 1.19.0.0 |
+| cardano-ledger-mary | 1.9.0.0 | 1.10.0.0 |
+| cardano-ledger-shelley | 1.17.0.0 | 1.18.0.0 |
+| cardano-prelude | 0.2.1.0 | 0.2.1.0 (unchanged) |
+| cardano-protocol-tpraos | 1.4.1.0 | 1.5.0.0 |
+| cardano-slotting | 0.2.0.1 | 0.2.1.0 |
+| cardano-strict-containers | 0.1.6.0 | 0.1.6.0 (unchanged) |
+| io-classes | 1.8.0.1 | 1.8.0.1 (unchanged) |
+| ouroboros-consensus | 0.30.0.1 | 1.0.0.0 |
+| ouroboros-consensus-cardano | 0.26.0.3 | REMOVED (absorbed) |
+| ouroboros-consensus-diffusion | 0.26.0.0 | REMOVED (absorbed) |
+| ouroboros-consensus-protocol | 0.13.0.0 | REMOVED (absorbed) |
+| ouroboros-network | 0.22.6.0 | 1.1.0.0 |
+| ouroboros-network-api | 0.16.0.0 | REMOVED (absorbed) |
+| ouroboros-network-framework | 0.19.3.0 | REMOVED (absorbed) |
+| ouroboros-network-protocols | 0.15.2.0 | REMOVED (absorbed) |
+| plutus-core | 1.57.0.0 | 1.59.0.0 |
+| plutus-ledger-api | 1.57.0.0 | 1.59.0.0 |
+| plutus-tx | 1.57.0.0 | 1.59.0.0 |
+
+### Step 5: Run bump-constraints.sh
+
+Feed the freeze file to `scripts/bump-constraints.sh` to update all `.cabal` files. The script handles packages it knows about; removed packages need manual cleanup.
+
+### Step 6: Update .cabal files in topological order
+
+One commit per sublibrary, bottom-up (leaves first):
+
+1. `cardano-numeric` (`lib/numeric`)
+2. `text-class` (`lib/text-class`)
+3. `cardano-wallet-launcher` (`lib/launcher`)
+4. `cardano-wallet-read` (`lib/cardano-wallet-read`)
+5. `cardano-wallet-test-utils` (`lib/test-utils`)
+6. `crypto-primitives` (`lib/crypto-primitives`)
+7. `delta-types` (`lib/delta-types`)
+8. `cardano-wallet-primitive` (`lib/primitive`)
+9. `cardano-wallet-secrets` (`lib/secrets`)
+10. `address-derivation-discovery` (`lib/address-derivation-discovery`)
+11. `cardano-api-extra` (`lib/cardano-api-extra`)
+12. `iohk-monitoring-extra` (`lib/iohk-monitoring-extra`)
+13. `cardano-wallet-network-layer` (`lib/network-layer`)
+14. `delta-store` (`lib/delta-store`)
+15. `cardano-wallet` (`lib/wallet`)
+16. `cardano-wallet-api` (`lib/api`)
+17. `wai-middleware-logging` (`lib/wai-middleware-logging`)
+18. `cardano-wallet-application` (`lib/application`)
+19. `cardano-wallet-ui` (`lib/ui`)
+20. `cardano-wallet-application-extras` (`lib/application-extras`)
+21. `cardano-wallet-application-tls` (`lib/application-tls`)
+22. `faucet` (`lib/faucet`)
+23. `temporary-extra` (`lib/temporary-extra`)
+24. `local-cluster` (`lib/local-cluster`)
+25. `cardano-wallet-benchmarks` (`lib/benchmarks`)
+26. `cardano-wallet-unit` (`lib/unit`)
+27. `cardano-wallet-blackbox-benchmarks` (`lib/wallet-benchmarks`)
+28. `cardano-wallet-integration` (`lib/integration`)
+29. `flaky-tests` (`lib/flaky-tests`)
+30. `delta-chain` (`lib/delta-chain`)
+31. `delta-table` (`lib/delta-table`)
+
+### Step 7: Manual cleanup
+
+- Remove constraints for absorbed ouroboros packages from `cabal.project`
+- Remove absorbed ouroboros packages from `bump-constraints.sh` updates list
+- Update `allow-newer` section if any entries reference removed packages
+- Check source-repository-package pins (cardano-ledger-read, cardano-balance-tx) for compatibility with new ledger versions
+
+### Step 8: Update flake.nix
+Already done: `cardano-node-runtime.url` → 10.7.0
+
+### Step 9: Validate
+- `cabal build all -O0`
+- `just ci`
+- `just e2e`

--- a/specs/002-bump-node-10-7-0/research.md
+++ b/specs/002-bump-node-10-7-0/research.md
@@ -1,0 +1,48 @@
+# Research: Bump dependencies to cardano-node 10.7.0
+
+## Freeze File Analysis
+
+**Source**: `/tmp/cardano-node-10.7.0/cabal.project.freeze`
+**Method**: `nix develop -c cabal freeze` in cloned cardano-node 10.7.0
+
+## Key Breaking Change: Ouroboros Package Consolidation
+
+**Decision**: Replace all references to absorbed packages with their new homes.
+
+**Details**: ouroboros-consensus 1.0.0.0 absorbs:
+- ouroboros-consensus-diffusion
+- ouroboros-consensus-protocol
+- ouroboros-consensus-cardano
+- lsm, lmdb sublibraries
+
+ouroboros-network 1.1.0.0 absorbs:
+- ouroboros-network-api
+- ouroboros-network-framework
+- ouroboros-network-protocols
+
+**Impact on wallet**: All `.cabal` files referencing these packages need deps updated. Import paths may change but that's a code change, not a bounds change.
+
+**Rationale**: Upstream consolidation, no alternative.
+
+## CHaP Alignment
+
+**Decision**: Use CHaP rev `887d73ce434831e3a67df48e070f4f979b3ac5a6` and index-state `2026-03-23T18:21:55Z`.
+
+**Rationale**: Must match cardano-node 10.7.0 exactly to avoid Windows cross-compilation failures (wine/iserv socket errors from transitive dependency mismatches).
+
+## E2E Probe Results
+
+E2E probe (PR #5248) with only flake.nix bump (no cabal changes):
+- Node 10.7.0 built and synced preprod successfully
+- Wallet API responded 200 OK
+- Test failure was missing `HAL_E2E_PREPROD_MNEMONICS` env var, not a compatibility issue
+- Runtime compatibility confirmed
+
+## Source Repository Packages
+
+Need to verify compatibility of pinned source-repository-packages with new ledger versions:
+- `cardano-ledger-read` (pin: `0ce0e7a`)
+- `cardano-balance-tx` (pin: `98e7f41`)
+- `cardano-coin-selection` (pin: `1766110`)
+
+These may need tag bumps if they depend on ledger packages that changed.

--- a/specs/002-bump-node-10-7-0/spec.md
+++ b/specs/002-bump-node-10-7-0/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Bump dependencies to cardano-node 10.7.0
+
+**Feature Branch**: `002-bump-node-10-7-0`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: Bump all Cardano dependency constraints and .cabal version bounds to match cardano-node 10.7.0
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Wallet builds against node 10.7.0 dependencies (Priority: P1)
+
+A developer checks out the wallet repo and runs `cabal build all`. The build succeeds with all dependency versions aligned to cardano-node 10.7.0.
+
+**Why this priority**: Without a successful build, no other work is possible.
+
+**Independent Test**: Run `cabal build all -O0` in nix develop shell. Build succeeds with no version conflicts.
+
+**Acceptance Scenarios**:
+
+1. **Given** updated cabal.project constraints and .cabal bounds, **When** `cabal build all -O0` is run, **Then** the build resolves and compiles successfully
+2. **Given** the ouroboros package consolidation (consensus-cardano/diffusion/protocol absorbed into ouroboros-consensus 1.0.0.0, network-api/framework/protocols absorbed into ouroboros-network 1.1.0.0), **When** building, **Then** no references to removed packages remain
+
+---
+
+### User Story 2 - E2E tests pass against node 10.7.0 (Priority: P2)
+
+The E2E test suite runs against a cardano-node 10.7.0 binary on preprod and passes.
+
+**Why this priority**: Confirms runtime compatibility beyond just compilation.
+
+**Independent Test**: Run `just e2e` with the bumped flake input. Tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** cardano-node-runtime flake input set to 10.7.0, **When** `just e2e` runs, **Then** all E2E tests pass
+2. **Given** the new NodeToClientV_23 protocol version, **When** wallet connects to node, **Then** protocol negotiation succeeds
+
+---
+
+### Edge Cases
+
+- Ouroboros packages that were standalone are now sublibraries — imports and cabal deps must be rewritten, not just version-bumped
+- `bump-constraints.sh` may not handle removed packages (ouroboros-consensus-cardano, etc.) — manual cleanup needed
+- `cardano-ledger-read` and `cardano-balance-tx` (source-repository-package pins) may need their own bumps if they depend on the new ledger versions
+- `Tx Size` type changed from `Integer` to `Word32` — any wallet code using this type needs updating
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `cabal.project` constraints MUST be updated to match cardano-node 10.7.0 freeze file versions
+- **FR-002**: `cabal.project` index-state MUST align with cardano-node 10.7.0's CHaP revision
+- **FR-003**: All `.cabal` files MUST have version bounds updated via `bump-constraints.sh` using the node 10.7.0 freeze file
+- **FR-004**: References to absorbed ouroboros packages (ouroboros-consensus-cardano, ouroboros-consensus-diffusion, ouroboros-consensus-protocol, ouroboros-network-api, ouroboros-network-framework, ouroboros-network-protocols) MUST be removed or replaced
+- **FR-005**: `flake.nix` cardano-node-runtime input MUST point to 10.7.0
+- **FR-006**: `flake.lock` CHaP input MUST match cardano-node 10.7.0's CHaP rev (887d73ce)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `cabal build all -O0` succeeds with zero version conflicts
+- **SC-002**: `just e2e` passes against node 10.7.0
+- **SC-003**: Zero references to removed ouroboros packages remain in .cabal files or cabal.project
+
+## Assumptions
+
+- The freeze file at `/tmp/cardano-node-10.7.0/cabal.project.freeze` is the source of truth for target versions
+- `bump-constraints.sh` handles version bound updates for packages that still exist; removed packages need manual handling
+- Source-repository-package pins (cardano-ledger-read, cardano-balance-tx, cardano-coin-selection) may need separate bumps
+- The `updating-dependencies.md` doc defines the canonical process: freeze, topo order, bump-constraints.sh, manual fixes
+- Code changes to adapt to API breakages (LedgerDB V2, submitTxToNodeLocal, WrapTx removal, etc.) are out of scope for the dependency bump itself — they will be addressed in follow-up commits


### PR DESCRIPTION
Part of #5247

Node 10.7.0 sets `cardanoProtocolVersion = ProtVer 10 8`, which exceeds the Conway-era maximum derived from the shelley genesis `ProtVer 8 0`. Every forged block in the local cluster was rejected with `HeaderProtVerTooHigh`.

## Changes

- Bump shelley genesis protocol version from 8.0 to 10.0
- Enable `ExperimentalHardForksEnabled`
- Add `dijkstra-genesis.json` and wire through `GenesisFiles`/`GenNodeConfig`
- Bump `cardano-node-runtime` flake input to 10.7.0
- Align CHaP and index-state with node 10.7.0

## Verification

`WALLETS_CREATE_01` passes with node 10.7.0 (was timing out before this fix).