### PR TITLE
chore: bump wallet nix compiler pins to ghc9123

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -99,7 +99,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc9122";
+      compiler-nix-name = "ghc9123";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";
@@ -146,7 +146,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             version = "latest";
           };
         };
-        withHoogle = false;
+        withHoogle = true;
         nativeBuildInputs = (with buildProject.hsPkgs; [
           # Wrap cardano-cli/node to only expose binaries, not Haskell libraries
           # This prevents GHC package database pollution with conflicting versions

--- a/nix/rewrite-libs/nix/project.nix
+++ b/nix/rewrite-libs/nix/project.nix
@@ -30,7 +30,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9122";
+    compiler-nix-name = "ghc9123";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];

--- a/nix/set-git-rev/nix/project.nix
+++ b/nix/set-git-rev/nix/project.nix
@@ -30,7 +30,7 @@
     ...
   }: {
     name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9122";
+    compiler-nix-name = "ghc9123";
     inherit src;
     shell = shell {inherit pkgs;};
     modules = [];


### PR DESCRIPTION
Closes #5253

## Summary

Bump the wallet Nix Haskell projects from `ghc9122` to `ghc9123` and re-enable `withHoogle` in the dev shell.

The original blocker was a `ghc-9.12.2` panic in the Hoogle/Haddock path used by the wallet dev shell. Haddock crashed while building docs for ledger packages (first observed in `cardano-ledger-mary-1.10.0.0`):

- `GHC version 9.12.2: tyConStupidTheta`
- symbol: `SubTx`

`SubTx` comes from ledger's `type data TxLevel = TopTx | SubTx`, so the failure is a GHC/Haddock bug triggered by promoted/type-level data constructors during documentation generation.

GHC `9.12.3` release notes include a directly relevant fix:

- `Fixed tyConStupidTheta to handle PromotedDataCon` (`#25739`)

On current `master` the shell workaround for that panic was `withHoogle = false` in `nix/haskell.nix` (see commit `28a9e5f96a`). This PR bumps the compiler to `ghc9123` and flips `withHoogle` back to `true`, restoring in-shell Hoogle.

## What Changed

- `nix/haskell.nix` — `compiler-nix-name = "ghc9123"`, `withHoogle = true`
- `nix/rewrite-libs/nix/project.nix` — `compiler-nix-name = "ghc9123"`
- `nix/set-git-rev/nix/project.nix` — `compiler-nix-name = "ghc9123"`

Total diff is four lines across three files. No application logic changed.

## Why These Files

`nix/haskell.nix` controls the main `cardano-wallet` Haskell project and the default dev shell. The `rewrite-libs` and `set-git-rev` helper projects also carry their own `compiler-nix-name` pins; leaving them on `ghc9122` would make the trial internally inconsistent and could hide unrelated failures.

## Verification

Confirmed locally on the rebased branch (head on top of current `master`, which already contains the `cardano-node 10.7.1` bump):

- `nix develop` completed with `ghc-9.12.3-env`.
- `withHoogle = true` rebuild produced `hoogle-with-packages.drv` and `cardano-wallet-shell-env` with no `tyConStupidTheta` panic.
- `hoogle` in the shell resolves to `…ghc-shell-for-packages-ghc-9.12.3-env/bin/hoogle` (the `withHoogle` wrapper, not the bare binary).
- `hoogle search --count=3 "Text -> ByteString"` returned live project-indexed results (`Cardano.Prelude`, `RIO.Prelude`, `RIO.Text`).

That verifies the Hoogle-enabled `nix develop` path that was previously blocked by the `ghc9122` panic.

## Reviewer Guide

1. Root-cause evidence points upstream to GHC/Haddock, not to ledger or wallet logic.
2. `9.12.3` has an upstream fix matching the observed panic.
3. Code change is deliberately minimal — four lines, nix-only.
4. Bumping the compiler and flipping `withHoogle` back on are one logical change: bumping ghc without flipping is dead code in the shell, and flipping without bumping reintroduces the panic. They ship as a single commit.

## Follow-up

This PR does not claim Windows validation. If Windows-specific fallout exists, it should be tracked separately from this narrow shell/Hoogle unblocker.