### PR TITLE
Bump cardano-node runtime to 10.7.1

### DIFF
--- a/.github/workflows/local-cluster-stress.yml
+++ b/.github/workflows/local-cluster-stress.yml
@@ -1,7 +1,8 @@
 name: Local Cluster Stress Test
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [chore/bump-node-10.7.1]
 
 jobs:
   local-cluster:

--- a/.github/workflows/local-cluster-stress.yml
+++ b/.github/workflows/local-cluster-stress.yml
@@ -1,0 +1,35 @@
+name: Local Cluster Stress Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  local-cluster:
+    name: "Local Cluster Run ${{ matrix.run }}"
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        env:
+          LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
+          CLUSTER_LOGS_DIR_PATH: local-cluster-logs
+        run: |
+          mkdir -p local-cluster-logs
+          nix shell --quiet .#local-cluster .#test-local-cluster-exe .#cardano-cli .#cardano-node .#cardano-wallet \
+            -c test-local-cluster-exe
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: local-cluster-logs-run-${{ matrix.run }}
+          path: local-cluster-logs/

--- a/flake.lock
+++ b/flake.lock
@@ -231,16 +231,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1774379192,
-        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.0",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -556,11 +556,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1771502057,
-        "narHash": "sha256-XwoLg6wftnU50KPn5jY4jtuGulyNPyspB4lSDSrmR1g=",
+        "lastModified": 1774557316,
+        "narHash": "sha256-AErDLAypo/a4gNSKjExpNUM7xdlsTdTf68cWnbr1bOA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e6bb05af1f45a616f534798263a5a13f2299e3bc",
+        "rev": "06fa3e96f4d7ced3496ec984c8016aad5282db67",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.7.0";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.7.1";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Closes #5256

Runtime-only bump from 10.7.0 to 10.7.1, no code changes.

Local cluster stress test (10 runs): all green.