### PR TITLE
fix: E2E release runner and timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
     name: "E2E Linux"
     if: inputs.release_type == 'release'
     needs: [prepare, verify-artifacts]
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet, high-memory]
     timeout-minutes: 240
     steps:
       - name: Checkout release candidate
@@ -228,7 +228,7 @@ jobs:
     if: inputs.release_type == 'release'
     needs: [prepare, build-e2e-windows]
     runs-on: windows-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Download E2E bundle
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- E2E Linux: add `high-memory` label to `runs-on` — was landing on 8GB runners and getting OOM-killed
- E2E Windows: bump timeout from 120 to 240 min — preprod sync needs ~215 min on `windows-latest`

Fixes failures in [release run 24522719407](https://github.com/cardano-foundation/cardano-wallet/actions/runs/24522719407).