### PR TITLE
chore(fmt): pin formatters, enforce in CI, ban drive-by reformatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,5 +21,16 @@ When creating a pull request, please make sure that your code adheres
 to our [coding
 standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
 
+**Formatting.** Haskell, Cabal and Nix files have canonical formatters
+(`fourmolu`, `cabal-fmt`, `nixfmt`) pinned in the dev shell and
+enforced by CI. Run `just fmt` before every push.
+
+**No drive-by reformatting.** A style change and a semantic change
+must not share a commit, and typically must not share a PR. Pull
+requests that reformat files beyond what they meaningfully change —
+or that switch formatters — will be rejected. See the [coding
+standards](https://cardano-foundation.github.io/cardano-wallet/contributor/what/coding-standards)
+for details.
+
 For more information, please consult our [Contributor
 Manual](https://cardano-foundation.github.io/cardano-wallet/contributor).

--- a/docs/site/src/contributor/what/coding-standards.md
+++ b/docs/site/src/contributor/what/coding-standards.md
@@ -24,6 +24,9 @@ Each proposal should start with a section justifying the standard with rational 
     - [Use only a single blank line between top-level definitions](#use-only-a-single-blank-line-between-top-level-definitions)
     - [Avoid Variable-Length Indentation](#avoid-variable-length-indentation)
     - [Fourmolu is used for code formatting](#fourmolu-is-used-for-code-formatting)
+    - [Nixfmt is used for \*.nix formatting](#nixfmt-is-used-for-nix-formatting)
+    - [No drive-by reformatting](#no-drive-by-reformatting)
+    - [Run every formatter with `just fmt`](#run-every-formatter-with-just-fmt)
   - [Haskell Practices](#haskell-practices)
     - [Favor `newtype` and tagged type over type-aliases](#favor-newtype-and-tagged-type-over-type-aliases)
     - [Language extensions are specified on top of each module](#language-extensions-are-specified-on-top-of-each-module)
@@ -356,6 +359,44 @@ single-constraint-parens: auto
 column-limit: 70
 ```
 </details>
+
+### Nixfmt is used for \*.nix formatting
+
+All `*.nix` files in this repository are formatted with
+[`nixfmt`](https://github.com/NixOS/nixfmt) (RFC style). The binary is
+pinned via `nix/haskell.nix` so every contributor and every CI job use
+the exact same version. The format is checked in CI by
+`scripts/ci/check-code-format.sh`.
+
+There is no secondary formatter. Do not introduce
+[`alejandra`](https://github.com/kamadorueda/alejandra),
+`nixpkgs-fmt`, or any other tool.
+
+### No drive-by reformatting
+
+Pull requests that reformat files unrelated to their stated purpose
+will be rejected. A semantic change and a style change must never
+share a commit — and typically must not share a PR.
+
+> **Why**
+>
+> Mixed diffs destroy reviewability, pollute `git blame`, and make
+> reverts unsafe. When the whole tree is already formatted to a
+> canonical style, a drive-by reformat is pure noise.
+
+If you believe the canonical formatter itself should change, open an
+issue first. Do not change formatters as part of a feature or fix PR.
+
+### Run every formatter with `just fmt`
+
+```
+just fmt        # format *.hs, *.cabal and *.nix in place
+just check-fmt  # run the exact CI format check locally
+```
+
+Both recipes rely on tools pinned in the dev shell (`nix develop`);
+running them outside the shell will use whatever happens to be on your
+`$PATH` and is not guaranteed to match CI.
 
 <details>
     <summary>See import grouping example</summary>

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
     mithril = {
       url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
-      };
+    };
   };
 
   outputs =
@@ -169,16 +169,23 @@
             {
               packages =
                 { }
-                // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc && options.packages ? crypton-x509-system) {
-                  # Workaround for broken nixpkgs darwin.security_tool in
-                  # Mojave. This mirrors the workaround in nixpkgs
-                  # haskellPackages.
-                  #
-                  # ref:
-                  # https://github.com/NixOS/nixpkgs/pull/47676
-                  # https://github.com/NixOS/nixpkgs/issues/45042
-                  crypton-x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
-                };
+                //
+                  pkgs.lib.optionalAttrs
+                    (
+                      pkgs.stdenv.hostPlatform.isDarwin
+                      && !pkgs.stdenv.cc.nativeLibc
+                      && options.packages ? crypton-x509-system
+                    )
+                    {
+                      # Workaround for broken nixpkgs darwin.security_tool in
+                      # Mojave. This mirrors the workaround in nixpkgs
+                      # haskellPackages.
+                      #
+                      # ref:
+                      # https://github.com/NixOS/nixpkgs/pull/47676
+                      # https://github.com/NixOS/nixpkgs/issues/45042
+                      crypton-x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
+                    };
             };
         in
         {
@@ -281,7 +288,10 @@
                   backend = self.cardano-node;
                 };
                 # Local test cluster and mock metadata server
-                inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server wallet-key-export;
+                inherit (project.hsPkgs.cardano-wallet.components.exes)
+                  mock-token-metadata-server
+                  wallet-key-export
+                  ;
                 inherit (project.hsPkgs.cardano-wallet-benchmarks.components.exes) benchmark-history;
                 inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
                 integration-exe = project.hsPkgs.cardano-wallet-integration.components.exes.integration-exe;
@@ -306,19 +316,23 @@
                 unit-cardano-wallet-unit = project.hsPkgs.cardano-wallet-unit.components.tests.unit;
                 unit-cardano-wallet-primitive = project.hsPkgs.cardano-wallet-primitive.components.tests.test;
                 unit-cardano-wallet-secrets = project.hsPkgs.cardano-wallet-secrets.components.tests.test;
-                unit-cardano-wallet-network-layer = project.hsPkgs.cardano-wallet-network-layer.components.tests.unit;
+                unit-cardano-wallet-network-layer =
+                  project.hsPkgs.cardano-wallet-network-layer.components.tests.unit;
                 unit-cardano-wallet-test-utils = project.hsPkgs.cardano-wallet-test-utils.components.tests.unit;
                 unit-cardano-wallet-launcher = project.hsPkgs.cardano-wallet-launcher.components.tests.unit;
-                unit-cardano-wallet-application-tls = project.hsPkgs.cardano-wallet-application-tls.components.tests.unit;
+                unit-cardano-wallet-application-tls =
+                  project.hsPkgs.cardano-wallet-application-tls.components.tests.unit;
                 unit-cardano-numeric = project.hsPkgs.cardano-numeric.components.tests.unit;
-                unit-cardano-wallet-blackbox-benchmarks = project.hsPkgs.cardano-wallet-blackbox-benchmarks.components.tests.unit;
+                unit-cardano-wallet-blackbox-benchmarks =
+                  project.hsPkgs.cardano-wallet-blackbox-benchmarks.components.tests.unit;
                 unit-delta-chain = project.hsPkgs.delta-chain.components.tests.unit;
                 unit-delta-store = project.hsPkgs.delta-store.components.tests.unit;
                 unit-delta-table = project.hsPkgs.delta-table.components.tests.unit;
                 unit-delta-types = project.hsPkgs.delta-types.components.tests.unit;
                 unit-std-gen-seed = project.hsPkgs.std-gen-seed.components.tests.unit;
                 unit-wai-middleware-logging = project.hsPkgs.wai-middleware-logging.components.tests.unit;
-                unit-benchmark-history = project.hsPkgs.cardano-wallet-benchmarks.components.tests.benchmark-history-test;
+                unit-benchmark-history =
+                  project.hsPkgs.cardano-wallet-benchmarks.components.tests.benchmark-history-test;
                 wallet-key-export-test = project.hsPkgs.cardano-wallet.components.tests.wallet-key-export-test;
 
                 # Combined project coverage report
@@ -446,47 +460,50 @@
                     format = "zip";
                   };
                   # Per-test-exe bundles for Windows CI.
-                  tests = let
-                    mkTest = name: test:
-                      import ./nix/windows-test-exe.nix {
-                        inherit pkgs test name;
+                  tests =
+                    let
+                      mkTest =
+                        name: test:
+                        import ./nix/windows-test-exe.nix {
+                          inherit pkgs test name;
+                        };
+                    in
+                    {
+                      wallet-unit = import ./nix/windows-test-exe.nix {
+                        inherit pkgs;
+                        name = "wallet-unit";
+                        test = windowsPackages.unit-cardano-wallet-unit;
+                        extraPkgs = [ windowsPackages.cardano-cli ];
+                        testDataDirs = [
+                          ./lib/unit/test/data
+                          ./lib/local-cluster/test/data
+                        ];
                       };
-                  in {
-                    wallet-unit = import ./nix/windows-test-exe.nix {
-                      inherit pkgs;
-                      name = "wallet-unit";
-                      test = windowsPackages.unit-cardano-wallet-unit;
-                      extraPkgs = [windowsPackages.cardano-cli];
-                      testDataDirs = [
-                        ./lib/unit/test/data
-                        ./lib/local-cluster/test/data
-                      ];
+                      wallet-primitive = import ./nix/windows-test-exe.nix {
+                        inherit pkgs;
+                        name = "wallet-primitive";
+                        test = windowsPackages.unit-cardano-wallet-primitive;
+                        testDataDirs = [ ./lib/primitive/test/data ];
+                      };
+                      wallet-secrets = mkTest "wallet-secrets" windowsPackages.unit-cardano-wallet-secrets;
+                      wallet-network-layer = mkTest "wallet-network-layer" windowsPackages.unit-cardano-wallet-network-layer;
+                      wallet-test-utils = mkTest "wallet-test-utils" windowsPackages.unit-cardano-wallet-test-utils;
+                      wallet-launcher = mkTest "wallet-launcher" windowsPackages.unit-cardano-wallet-launcher;
+                      wallet-application-tls = mkTest "wallet-application-tls" windowsPackages.unit-cardano-wallet-application-tls;
+                      cardano-numeric = mkTest "cardano-numeric" windowsPackages.unit-cardano-numeric;
+                      wallet-blackbox-benchmarks = import ./nix/windows-test-exe.nix {
+                        inherit pkgs;
+                        name = "wallet-blackbox-benchmarks";
+                        test = windowsPackages.unit-cardano-wallet-blackbox-benchmarks;
+                        testDataDirs = [ ./lib/wallet-benchmarks/test/data ];
+                      };
+                      delta-chain = mkTest "delta-chain" windowsPackages.unit-delta-chain;
+                      delta-store = mkTest "delta-store" windowsPackages.unit-delta-store;
+                      delta-table = mkTest "delta-table" windowsPackages.unit-delta-table;
+                      delta-types = mkTest "delta-types" windowsPackages.unit-delta-types;
+                      std-gen-seed = mkTest "std-gen-seed" windowsPackages.unit-std-gen-seed;
+                      wai-middleware-logging = mkTest "wai-middleware-logging" windowsPackages.unit-wai-middleware-logging;
                     };
-                    wallet-primitive = import ./nix/windows-test-exe.nix {
-                      inherit pkgs;
-                      name = "wallet-primitive";
-                      test = windowsPackages.unit-cardano-wallet-primitive;
-                      testDataDirs = [./lib/primitive/test/data];
-                    };
-                    wallet-secrets = mkTest "wallet-secrets" windowsPackages.unit-cardano-wallet-secrets;
-                    wallet-network-layer = mkTest "wallet-network-layer" windowsPackages.unit-cardano-wallet-network-layer;
-                    wallet-test-utils = mkTest "wallet-test-utils" windowsPackages.unit-cardano-wallet-test-utils;
-                    wallet-launcher = mkTest "wallet-launcher" windowsPackages.unit-cardano-wallet-launcher;
-                    wallet-application-tls = mkTest "wallet-application-tls" windowsPackages.unit-cardano-wallet-application-tls;
-                    cardano-numeric = mkTest "cardano-numeric" windowsPackages.unit-cardano-numeric;
-                    wallet-blackbox-benchmarks = import ./nix/windows-test-exe.nix {
-                      inherit pkgs;
-                      name = "wallet-blackbox-benchmarks";
-                      test = windowsPackages.unit-cardano-wallet-blackbox-benchmarks;
-                      testDataDirs = [./lib/wallet-benchmarks/test/data];
-                    };
-                    delta-chain = mkTest "delta-chain" windowsPackages.unit-delta-chain;
-                    delta-store = mkTest "delta-store" windowsPackages.unit-delta-store;
-                    delta-table = mkTest "delta-table" windowsPackages.unit-delta-table;
-                    delta-types = mkTest "delta-types" windowsPackages.unit-delta-types;
-                    std-gen-seed = mkTest "std-gen-seed" windowsPackages.unit-std-gen-seed;
-                    wai-middleware-logging = mkTest "wai-middleware-logging" windowsPackages.unit-wai-middleware-logging;
-                  };
                   e2e = import ./nix/windows-test-exe.nix {
                     inherit pkgs;
                     name = "e2e";

--- a/justfile
+++ b/justfile
@@ -9,6 +9,21 @@ default:
 syntax:
   scripts/ci/check-code-format.sh
 
+# format every Haskell, Cabal and Nix file the CI format check covers
+fmt:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "+++ fourmolu"
+  fourmolu --mode inplace $(git ls-files -- '*.hs')
+  echo "+++ cabal-fmt"
+  find lib -name '*.cabal' -exec cabal-fmt -i {} \;
+  echo "+++ nixfmt"
+  nixfmt $(git ls-files -- '*.nix')
+
+# verify formatting matches CI (runs the exact CI script)
+check-fmt:
+  scripts/ci/check-code-format.sh
+
 hlint:
   nix develop --command bash -c 'hlint lib'
 

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -1,28 +1,32 @@
-lib: customConfig: let
-  config =
-    lib.recursiveUpdate {
-      platform = "all";
-      # The systems that the jobset will be built for.
-      supportedSystems = import ./nix/supported-systems.nix;
+lib: customConfig:
+let
+  config = lib.recursiveUpdate {
+    platform = "all";
+    # The systems that the jobset will be built for.
+    supportedSystems = import ./nix/supported-systems.nix;
 
-      # Enable debug tracing
-      debug = false;
+    # Enable debug tracing
+    debug = false;
 
-      # Use this git revision for stamping executables
-      gitrev = null;
+    # Use this git revision for stamping executables
+    gitrev = null;
 
-      # Enable building the cabal-cache util - only needed under CI
-      withCabalCache = false;
+    # Enable building the cabal-cache util - only needed under CI
+    withCabalCache = false;
 
-      # optional extra haskell.nix module
-      haskellNix = {};
+    # optional extra haskell.nix module
+    haskellNix = { };
 
-      # optional string argument to override compiler, in cabal shell.
-      ghcVersion = null;
+    # optional string argument to override compiler, in cabal shell.
+    ghcVersion = null;
 
-      dockerHubRepoName = null;
-    }
-    customConfig;
+    dockerHubRepoName = null;
+  } customConfig;
 in
-  assert lib.asserts.assertOneOf "platform" config.platform
-  ["all" "linux" "macos" "windows"]; config
+assert lib.asserts.assertOneOf "platform" config.platform [
+  "all"
+  "linux"
+  "macos"
+  "windows"
+];
+config

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,3 +1,3 @@
-{...} @ args:
+{ ... }@args:
 with (import ./flake-compat.nix args);
-  defaultNix.legacyPackages.${builtins.currentSystem}.pkgs
+defaultNix.legacyPackages.${builtins.currentSystem}.pkgs

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -18,7 +18,7 @@
   # The main contents of the image: cardano-wallet executables
   exes,
   # Executables to include in the image as a base layer: node and utilities
-  base ? [],
+  base ? [ ],
   # Other things to include in the image.
   iana-etc,
   cacert,
@@ -30,7 +30,8 @@
   # Used to generate the docker image names
   repoName ? "cardanofoundation/cardano-wallet",
   tag,
-}: let
+}:
+let
   defaultPort = "8090";
   dataDir = "/data";
 
@@ -50,10 +51,7 @@
     exec /bin/cardano-wallet "$@"
   '';
 
-  haveGlibcLocales =
-    glibcLocales
-    != null
-    && stdenv.hostPlatform.libc == "glibc";
+  haveGlibcLocales = glibcLocales != null && stdenv.hostPlatform.libc == "glibc";
 
   # Config file needed for container/host resolution.
   nsswitch-conf = writeTextFile {
@@ -68,17 +66,16 @@
     name = "${repoName}-env";
     copyToRoot = buildEnv {
       name = "${repoName}-env-packages";
-      paths =
-        [
-          iana-etc
-          cacert
-          nsswitch-conf
-          bashInteractive
-          coreutils
-          gnugrep
-          findutils
-        ]
-        ++ lib.optional haveGlibcLocales glibcLocales;
+      paths = [
+        iana-etc
+        cacert
+        nsswitch-conf
+        bashInteractive
+        coreutils
+        gnugrep
+        findutils
+      ]
+      ++ lib.optional haveGlibcLocales glibcLocales;
     };
     # set up /tmp (override with TMPDIR variable)
     extraCommands = "mkdir -m 0777 tmp";
@@ -96,7 +93,7 @@
     fromImage = envImage;
     copyToRoot = buildEnv {
       name = "${repoName}-base-packages";
-      paths = base ++ [nodeConfigs];
+      paths = base ++ [ nodeConfigs ];
     };
   };
 
@@ -108,18 +105,18 @@
     fromImage = baseImage;
     copyToRoot = buildEnv {
       name = "${repoName}-main-packages";
-      paths = exes ++ [startScript];
+      paths = exes ++ [ startScript ];
     };
     config = {
-      EntryPoint = ["start-cardano-wallet"];
+      EntryPoint = [ "start-cardano-wallet" ];
       ExposedPorts = {
-        "${defaultPort}/tcp" = {}; # wallet api
+        "${defaultPort}/tcp" = { }; # wallet api
       };
-      Volume = [dataDir];
+      Volume = [ dataDir ];
     };
   };
 in
-  mainImage
-  // {
-    inherit tag;
-  }
+mainImage
+// {
+  inherit tag;
+}

--- a/nix/flake-compat.nix
+++ b/nix/flake-compat.nix
@@ -1,23 +1,27 @@
-{...} @ args: let
+{ ... }@args:
+let
   src = args.src or ../.;
   lock = builtins.fromJSON (builtins.readFile (src + "/flake.lock"));
   flake-compate-input = lock.nodes.root.inputs.flake-compat;
   nixpkgs-input = lock.nodes.haskellNix.inputs.${builtins.elemAt lock.nodes.root.inputs.nixpkgs 1};
-  flake-compat = import (builtins.fetchTarball {
-    url = "https://api.github.com/repos/input-output-hk/flake-compat/tarball/${lock.nodes.${flake-compate-input}.locked.rev}";
-    sha256 = lock.nodes.${flake-compate-input}.locked.narHash;
-  });
-  pkgs =
-    import
-    (builtins.fetchTarball {
-      url = "https://api.github.com/repos/NixOS/nixpkgs/tarball/${lock.nodes.${nixpkgs-input}.locked.rev}";
-      sha256 = lock.nodes.${nixpkgs-input}.locked.narHash;
-    })
-    {};
+  flake-compat = import (
+    builtins.fetchTarball {
+      url = "https://api.github.com/repos/input-output-hk/flake-compat/tarball/${
+        lock.nodes.${flake-compate-input}.locked.rev
+      }";
+      sha256 = lock.nodes.${flake-compate-input}.locked.narHash;
+    }
+  );
+  pkgs = import (builtins.fetchTarball {
+    url = "https://api.github.com/repos/NixOS/nixpkgs/tarball/${
+      lock.nodes.${nixpkgs-input}.locked.rev
+    }";
+    sha256 = lock.nodes.${nixpkgs-input}.locked.narHash;
+  }) { };
 in
-  flake-compat {
-    inherit src pkgs;
-    override-inputs = {
-      customConfig = args;
-    };
-  }
+flake-compat {
+  inherit src pkgs;
+  override-inputs = {
+    customConfig = args;
+  };
+}

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,38 +1,49 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-libs: haskell-nix.cabalProject' [
-  ({ lib, pkgs, buildProject, ... }: {
-    options = {
-      gitrev = lib.mkOption {
-        type = lib.types.str;
-        description = "Git revision of sources";
-        default = "0000000000000000000000000000000000000000";
-      };
-      profiling = lib.mkOption {
-        type = lib.types.bool;
-        description = "Enable profiling";
-        default = false;
-      };
-      coverage = lib.mkOption {
-        type = lib.types.bool;
-        description = "Enable Haskell Program Coverage for cardano-wallet libraries and test suites.";
-        default = false;
-      };
-      cacheTestFailures = lib.mkOption {
-        type = lib.types.bool;
-        description = ''If false, prevent check results from being cached on `nix build`'';
-        default = true;
-      };
+CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-libs:
+haskell-nix.cabalProject' [
+  (
+    {
+      lib,
+      pkgs,
+      buildProject,
+      ...
+    }:
+    {
+      options = {
+        gitrev = lib.mkOption {
+          type = lib.types.str;
+          description = "Git revision of sources";
+          default = "0000000000000000000000000000000000000000";
+        };
+        profiling = lib.mkOption {
+          type = lib.types.bool;
+          description = "Enable profiling";
+          default = false;
+        };
+        coverage = lib.mkOption {
+          type = lib.types.bool;
+          description = "Enable Haskell Program Coverage for cardano-wallet libraries and test suites.";
+          default = false;
+        };
+        cacheTestFailures = lib.mkOption {
+          type = lib.types.bool;
+          description = "If false, prevent check results from being cached on `nix build`";
+          default = true;
+        };
 
-    };
-  })
-  ({ pkgs
-   , lib
-   , config
-   , buildProject
-   , ...
-   }:
+      };
+    }
+  )
+  (
+    {
+      pkgs,
+      lib,
+      config,
+      buildProject,
+      ...
+    }:
 
     let
       inherit (pkgs) stdenv;
@@ -54,11 +65,19 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
       # setGitRev is a postInstall script to stamp executables with
       # version info. It uses the "gitrev" option.
       setGitRevPostInstall = ''
-         ${set-git-rev}/bin/set-git-rev "${config.gitrev}" $out/bin/*
-        '';
+        ${set-git-rev}/bin/set-git-rev "${config.gitrev}" $out/bin/*
+      '';
 
       rewriteLibsPostInstall = lib.optionalString (pkgs.stdenv.hostPlatform.isDarwin) ''
-        export PATH=$PATH:${lib.makeBinPath (with pkgs.buildPackages; [ binutils nix ])}
+        export PATH=$PATH:${
+          lib.makeBinPath (
+            with pkgs.buildPackages;
+            [
+              binutils
+              nix
+            ]
+          )
+        }
         ${rewrite-libs}/bin/rewrite-libs $out/bin $out/bin/*
       '';
 
@@ -97,7 +116,8 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
 
       localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;
 
-    in {
+    in
+    {
       name = "cardano-wallet";
       compiler-nix-name = "ghc9123";
 
@@ -113,17 +133,20 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
         # haskell.nix does not register sublibraries in the shell's
         # GHC package database (issue #1662). Add them explicitly so
         # that cabal build inside nix develop can resolve them.
-        additional = hsPkgs: with hsPkgs; [
-          ouroboros-consensus.components.sublibs.cardano
-          ouroboros-consensus.components.sublibs.protocol
-          ouroboros-consensus.components.sublibs.diffusion
-          ouroboros-network.components.sublibs.api
-          ouroboros-network.components.sublibs.framework
-          ouroboros-network.components.sublibs.protocols
-          cardano-diffusion.components.sublibs.api
-        ];
+        additional =
+          hsPkgs: with hsPkgs; [
+            ouroboros-consensus.components.sublibs.cardano
+            ouroboros-consensus.components.sublibs.protocol
+            ouroboros-consensus.components.sublibs.diffusion
+            ouroboros-network.components.sublibs.api
+            ouroboros-network.components.sublibs.framework
+            ouroboros-network.components.sublibs.protocols
+            cardano-diffusion.components.sublibs.api
+          ];
         tools = {
-          cabal = { index-state = indexState; };
+          cabal = {
+            index-state = indexState;
+          };
           # cabal-fmt doesn't support base-4.20 (GHC 9.10) yet
           # cabal-fmt = { index-state = indexState; };
           haskell-language-server = {
@@ -131,15 +154,17 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             version = "latest";
             # Patch ghc-lib-parser genSym.c: atomic_inc64 → atomic_inc
             # (upstream bug in 9.8.5.20250214)
-            modules = [{
-              packages.ghc-lib-parser.postPatch = ''
-                if [ -f compiler/cbits/genSym.c ] \
-                    && grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
-                  substituteInPlace compiler/cbits/genSym.c \
-                    --replace-fail 'atomic_inc64' 'atomic_inc'
-                fi
-              '';
-            }];
+            modules = [
+              {
+                packages.ghc-lib-parser.postPatch = ''
+                  if [ -f compiler/cbits/genSym.c ] \
+                      && grep -q 'atomic_inc64' compiler/cbits/genSym.c; then
+                    substituteInPlace compiler/cbits/genSym.c \
+                      --replace-fail 'atomic_inc64' 'atomic_inc'
+                  fi
+                '';
+              }
+            ];
           };
           hoogle = {
             index-state = indexState;
@@ -147,85 +172,95 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           };
         };
         withHoogle = true;
-        nativeBuildInputs = (with buildProject.hsPkgs; [
-          # Wrap cardano-cli/node to only expose binaries, not Haskell libraries
-          # This prevents GHC package database pollution with conflicting versions
-          (pkgs.runCommand "cardano-cli-bin" {} ''
-            mkdir -p $out/bin
-            ln -s ${nodePkgs.cardano-cli}/bin/cardano-cli $out/bin/
-          '')
-          (pkgs.runCommand "cardano-node-bin" {} ''
-            mkdir -p $out/bin
-            ln -s ${nodePkgs.cardano-node}/bin/cardano-node $out/bin/
-          '')
-          cardano-addresses.components.exes.cardano-address
-          bech32.components.exes.bech32
-        ]) ++ (with pkgs.buildPackages.buildPackages; [
-          just
-          pkg-config
-          # ouroboros-consensus 1.0.0.0 consolidated all sublibraries
-          # (lmdb, lsm, cardano, protocol, diffusion) into one package.
-          # haskell.nix resolves ALL sublibraries even though the wallet
-          # only uses {cardano} and {protocol}. The lmdb and lsm
-          # sublibraries require these system C libraries for plan
-          # resolution — they are NOT linked into the wallet binary.
-          lmdb
-          liburing
-          nixpkgs-recent.python3Packages.openapi-spec-validator
-          (ruby_3_3.withPackages (ps: [ ps.rake ps.thor ]))
-          rubyPackages_3_3.rubocop
-          sqlite-interactive
-          curlFull
-          jq
-          yq
-          mdbook
-          haskellPackages.ghcid
-          haskellPackages.hp2pretty
-          haskellPackages.lentil
-          haskellPackages.markdown-unlit
-          haskellPackages.pretty-simple
-          haskellPackages.weeder
-          mithrilPkgs.mithril-client-cli
-        ]) ++ [
-          # fourmolu from nixpkgs-recent (>= 0.17) for import-grouping support.
-          nixpkgs-recent.haskellPackages.fourmolu
-          # hlint depends on ghc-lib-parser which needs patching.
-          # Pull from top-level pkgs where the ghc-lib-parser overlay applies,
-          # rather than buildPackages.buildPackages where it doesn't propagate.
-          pkgs.haskellPackages.hlint
-        ];
+        nativeBuildInputs =
+          (with buildProject.hsPkgs; [
+            # Wrap cardano-cli/node to only expose binaries, not Haskell libraries
+            # This prevents GHC package database pollution with conflicting versions
+            (pkgs.runCommand "cardano-cli-bin" { } ''
+              mkdir -p $out/bin
+              ln -s ${nodePkgs.cardano-cli}/bin/cardano-cli $out/bin/
+            '')
+            (pkgs.runCommand "cardano-node-bin" { } ''
+              mkdir -p $out/bin
+              ln -s ${nodePkgs.cardano-node}/bin/cardano-node $out/bin/
+            '')
+            cardano-addresses.components.exes.cardano-address
+            bech32.components.exes.bech32
+          ])
+          ++ (with pkgs.buildPackages.buildPackages; [
+            just
+            pkg-config
+            # ouroboros-consensus 1.0.0.0 consolidated all sublibraries
+            # (lmdb, lsm, cardano, protocol, diffusion) into one package.
+            # haskell.nix resolves ALL sublibraries even though the wallet
+            # only uses {cardano} and {protocol}. The lmdb and lsm
+            # sublibraries require these system C libraries for plan
+            # resolution — they are NOT linked into the wallet binary.
+            lmdb
+            liburing
+            nixpkgs-recent.python3Packages.openapi-spec-validator
+            (ruby_3_3.withPackages (ps: [
+              ps.rake
+              ps.thor
+            ]))
+            rubyPackages_3_3.rubocop
+            sqlite-interactive
+            curlFull
+            jq
+            yq
+            mdbook
+            haskellPackages.ghcid
+            haskellPackages.hp2pretty
+            haskellPackages.lentil
+            haskellPackages.markdown-unlit
+            haskellPackages.pretty-simple
+            haskellPackages.weeder
+            mithrilPkgs.mithril-client-cli
+          ])
+          ++ [
+            # fourmolu from nixpkgs-recent (>= 0.17) for import-grouping support.
+            nixpkgs-recent.haskellPackages.fourmolu
+            # hlint depends on ghc-lib-parser which needs patching.
+            # Pull from top-level pkgs where the ghc-lib-parser overlay applies,
+            # rather than buildPackages.buildPackages where it doesn't propagate.
+            pkgs.haskellPackages.hlint
+          ];
         shellHook =
           let
             localCHaPRepo = pkgs.haskell-nix.mkLocalHackageRepo {
               name = "cardano-haskell-packages";
               index = CHaP + "/01-index.tar.gz";
             };
-          in ''
-          export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}
+          in
+          ''
+            export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}
 
-          # Work around haskell.nix issue #1662: sublibraries are not
-          # registered correctly in the shell's GHC package database.
-          # Override active-repositories so cabal resolves packages from
-          # the local CHaP repo instead of from the installed package db.
-          # Clear stale cache to prevent cabal from trying to download
-          # packages from the local repo (it only has the index, not tarballs)
-          rm -rf ~/.cache/cabal/packages/cardano-haskell-packages-local
-          if [ ! -f cabal.project.local ] || ! grep -q cardano-haskell-packages-local cabal.project.local 2>/dev/null; then
-            mkdir -p ~/.cache/cabal/packages/cardano-haskell-packages-local
-            cat > cabal.project.local << 'EOF'
-          repository cardano-haskell-packages-local
-            url: file://${localCHaPRepo}
-            secure: False
-          EOF
-            cabal update cardano-haskell-packages-local 2>/dev/null || true
-          fi
-        '';
+            # Work around haskell.nix issue #1662: sublibraries are not
+            # registered correctly in the shell's GHC package database.
+            # Override active-repositories so cabal resolves packages from
+            # the local CHaP repo instead of from the installed package db.
+            # Clear stale cache to prevent cabal from trying to download
+            # packages from the local repo (it only has the index, not tarballs)
+            rm -rf ~/.cache/cabal/packages/cardano-haskell-packages-local
+            if [ ! -f cabal.project.local ] || ! grep -q cardano-haskell-packages-local cabal.project.local 2>/dev/null; then
+              mkdir -p ~/.cache/cabal/packages/cardano-haskell-packages-local
+              cat > cabal.project.local << 'EOF'
+            repository cardano-haskell-packages-local
+              url: file://${localCHaPRepo}
+              secure: False
+            EOF
+              cabal update cardano-haskell-packages-local 2>/dev/null || true
+            fi
+          '';
       };
 
-      inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
+      inputMap = {
+        "https://chap.intersectmbo.org/" = CHaP;
+      };
 
       modules =
-        let inherit (config) src coverage profiling;
+        let
+          inherit (config) src coverage profiling;
         in
         [
           {
@@ -240,24 +275,29 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           }
 
           # Provide configuration and dependencies to cardano-wallet components
-          ({ config, pkgs, ... }:
+          (
+            { config, pkgs, ... }:
             let
-              cardanoNodeExes = [ nodePkgs.cardano-cli nodePkgs.cardano-node ];
+              cardanoNodeExes = [
+                nodePkgs.cardano-cli
+                nodePkgs.cardano-node
+              ];
             in
             {
               reinstallableLibGhc = true;
 
-
-
               packages.cardano-wallet-unit.components.tests = {
                 unit.build-tools = cardanoNodeExes;
-                unit.preCheck = noCacheTestFailuresCookie + ''
+                unit.preCheck =
+                  noCacheTestFailuresCookie
+                  + ''
                     export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}
-                  '' + lib.optionalString stdenv.isDarwin ''
+                  ''
+                  + lib.optionalString stdenv.isDarwin ''
                     # cardano-node socket path becomes too long otherwise
                     export TMPDIR=/tmp
                   '';
-                  };
+              };
 
               packages.cardano-wallet-integration.components.tests = {
                 # NOTE:
@@ -272,42 +312,47 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
               # Add node backend to the PATH of the latency benchmarks, and
               # set the source tree as its working directory.
               packages.cardano-wallet-benchmarks.components.benchmarks.latency =
-                lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/* \
-                      --run "cd ${srcAll}/lib/wallet" \
-                      --add-flags --cluster-configs="${localClusterConfigs}" \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
+                lib.optionalAttrs (!stdenv.hostPlatform.isWindows)
+                  {
+                    build-tools = [ pkgs.buildPackages.makeWrapper ];
+                    postInstall = ''
+                      wrapProgram $out/bin/* \
+                        --run "cd ${srcAll}/lib/wallet" \
+                        --add-flags --cluster-configs="${localClusterConfigs}" \
+                        --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+                    '';
+                  };
 
               # Add cardano-node to the PATH of the byroon restore benchmark.
               # cardano-node will want to write logs to a subdirectory of the working directory.
               # We don't `cd $src` because of that.
               packages.cardano-wallet-benchmarks.components.benchmarks.restore =
-                lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/restore \
-                      --set CARDANO_NODE_CONFIGS ${pkgs.cardano-node-deployments} \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
+                lib.optionalAttrs (!stdenv.hostPlatform.isWindows)
+                  {
+                    build-tools = [ pkgs.buildPackages.makeWrapper ];
+                    postInstall = ''
+                      wrapProgram $out/bin/restore \
+                        --set CARDANO_NODE_CONFIGS ${pkgs.cardano-node-deployments} \
+                        --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+                    '';
+                  };
 
               packages.cardano-wallet.components.exes.local-cluster = {
-                  build-tools = [ pkgs.buildPackages.makeWrapper ];
-                  postInstall = ''
-                    wrapProgram $out/bin/* \
-                      --add-flags --cluster-configs="${localClusterConfigs}" \
-                      --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
-                  '';
-                };
+                build-tools = [ pkgs.buildPackages.makeWrapper ];
+                postInstall = ''
+                  wrapProgram $out/bin/* \
+                    --add-flags --cluster-configs="${localClusterConfigs}" \
+                    --prefix PATH : ${lib.makeBinPath cardanoNodeExes}
+                '';
+              };
 
               # Add shell completions for main executables.
-              packages.cardano-wallet-application.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
-              packages.cardano-wallet.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
-            })
+              packages.cardano-wallet-application.components.exes.cardano-wallet.postInstall =
+                optparseCompletionPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
+              packages.cardano-wallet.components.exes.cardano-wallet.postInstall =
+                optparseCompletionPostInstall + rewriteLibsPostInstall + stripBinariesPostInstall;
+            }
+          )
 
           # Provide the swagger file in an environment variable for
           # tests because it is located outside of the Cabal package
@@ -318,32 +363,59 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
             '';
           }
 
-          ({ lib, pkgs, ... }: {
-            # Use our forked libsodium from iohk-nix crypto overlay.
-            packages.plutus-tx.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.byron-spec-ledger.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-            packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ] ];
-          })
+          (
+            { lib, pkgs, ... }:
+            {
+              # Use our forked libsodium from iohk-nix crypto overlay.
+              packages.plutus-tx.components.library.pkgconfig = lib.mkForce [
+                [
+                  pkgs.libsodium-vrf
+                  pkgs.secp256k1
+                ]
+              ];
+              packages.byron-spec-ledger.components.library.pkgconfig = lib.mkForce [
+                [
+                  pkgs.libsodium-vrf
+                  pkgs.secp256k1
+                ]
+              ];
+              packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [
+                [
+                  pkgs.libsodium-vrf
+                  pkgs.secp256k1
+                ]
+              ];
+              packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [
+                [
+                  pkgs.libsodium-vrf
+                  pkgs.secp256k1
+                  pkgs.libblst
+                ]
+              ];
+            }
+          )
 
           # Windows cross-compilation fixes (from cardano-node)
-          ({ lib, pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
-            packages.unix-compat.postPatch = ''
-              sed -i 's/msvcrt//g' unix-compat.cabal
-            '';
-            packages.unix-time.postPatch = ''
-              sed -i 's/mingwex//g' unix-time.cabal
-            '';
-            # haskell.nix patch for crypton-x509-system is outdated for 1.8.0
-            # Clear their patch and apply the fix via postPatch
-            packages.crypton-x509-system.patches = lib.mkForce [];
-            packages.crypton-x509-system.postPatch = ''
-              sed -i 's/Crypt32/crypt32/g' crypton-x509-system.cabal
-            '';
-            # haskell.nix patches streaming-commons < 0.2.3.1 for Windows
-            # header file casing (Share.h). Don't clear the patch until
-            # index-state is new enough to resolve 0.2.3.1.
-          })
+          (
+            { lib, pkgs, ... }:
+            lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
+              packages.unix-compat.postPatch = ''
+                sed -i 's/msvcrt//g' unix-compat.cabal
+              '';
+              packages.unix-time.postPatch = ''
+                sed -i 's/mingwex//g' unix-time.cabal
+              '';
+              # haskell.nix patch for crypton-x509-system is outdated for 1.8.0
+              # Clear their patch and apply the fix via postPatch
+              packages.crypton-x509-system.patches = lib.mkForce [ ];
+              packages.crypton-x509-system.postPatch = ''
+                sed -i 's/Crypt32/crypt32/g' crypton-x509-system.cabal
+              '';
+              # haskell.nix patches streaming-commons < 0.2.3.1 for Windows
+              # header file casing (Share.h). Don't clear the patch until
+              # index-state is new enough to resolve 0.2.3.1.
+            }
+          )
 
           # Build fixes for library dependencies
           {
@@ -367,7 +439,13 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           # Musl libc fully static build
           (lib.optionalAttrs stdenv.hostPlatform.isMusl (
             let
-              staticLibs = with pkgs; [ zlib openssl libffi gmp6 pkgs.secp256k1 ];
+              staticLibs = with pkgs; [
+                zlib
+                openssl
+                libffi
+                gmp6
+                pkgs.secp256k1
+              ];
 
               # Module options which add GHC flags and libraries for a fully static build
               fullyStaticOptions = {
@@ -399,5 +477,6 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           }
 
         ];
-    })
+    }
+  )
 ]

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -224,6 +224,12 @@ haskell-nix.cabalProject' [
             # Pull from top-level pkgs where the ghc-lib-parser overlay applies,
             # rather than buildPackages.buildPackages where it doesn't propagate.
             pkgs.haskellPackages.hlint
+            # Canonical formatters pinned for both devs and CI.
+            pkgs.nixfmt-rfc-style
+            # cabal-fmt can't live under `shell.tools` because it doesn't
+            # support base-4.20 (GHC 9.10) yet. The binary itself builds
+            # fine against nixpkgs' default base.
+            pkgs.haskellPackages.cabal-fmt
           ];
         shellHook =
           let

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,10 +1,8 @@
 # Library of Nix functions used for cardano-wallet
 # nixpkgs.lib  library to import from.
-lib
-: rec {
+lib: rec {
   # Imports from nixpkgs.lib
-  inherit
-    (lib)
+  inherit (lib)
     filterAttrsRecursive
     recursiveUpdate
     collect
@@ -16,75 +14,68 @@ lib
     ;
 
   /*
-  Convert versions string from Cabal (YYYY.M.D)
-  to git tag format (vYYYY-MM-DD).
+    Convert versions string from Cabal (YYYY.M.D)
+    to git tag format (vYYYY-MM-DD).
   */
   gitTagFromCabalVersion =
     # Version number in cabal format as string (YYYY.M.D)
-    cabalName: let
+    cabalName:
+    let
       versionRegExp = "(^.*)([[:digit:]]{4})\.([[:digit:]]{1,2})\.([[:digit:]]{1,2})(.*$)";
       parts = builtins.match versionRegExp cabalName;
       name = lib.head parts;
       cabalVer = lib.take 3 (lib.drop 1 parts);
       rest = lib.drop 4 parts;
-      leading0 = str:
-        if lib.stringLength str == 1
-        then "0" + str
-        else str;
+      leading0 = str: if lib.stringLength str == 1 then "0" + str else str;
       tag = "v" + lib.concatMapStringsSep "-" leading0 cabalVer;
     in
-      assert lib.assertMsg (parts != null)
-      "gitTagFromCabalVersion: \"${cabalName}\" does not have a version in YYYY.M.D format"; (name + tag + lib.concatStrings rest);
+    assert lib.assertMsg (
+      parts != null
+    ) "gitTagFromCabalVersion: \"${cabalName}\" does not have a version in YYYY.M.D format";
+    (name + tag + lib.concatStrings rest);
 
   /*
-  Recursively set all attributes whose path satisfies
-  a given condition to the empty set {}.
+    Recursively set all attributes whose path satisfies
+    a given condition to the empty set {}.
   */
   setEmptyAttrsWithCondition =
     # cond :: [string] -> bool
     cond:
-      lib.mapAttrsRecursiveCond
-      (value: !(lib.isDerivation value)) # do not modify attributes of derivations
-      
-      (path: value:
-        if cond path
-        then {}
-        else value);
+    lib.mapAttrsRecursiveCond (value: !(lib.isDerivation value)) # do not modify attributes of derivations
+
+      (path: value: if cond path then { } else value);
 
   /*
-  Keep all attributes whose path contains a name starting
-  with "integration".
+    Keep all attributes whose path contains a name starting
+    with "integration".
   */
-  keepIntegrationChecks =
-    setEmptyAttrsWithCondition
-    (path: !lib.any (lib.hasPrefix "integration") path);
+  keepIntegrationChecks = setEmptyAttrsWithCondition (
+    path: !lib.any (lib.hasPrefix "integration") path
+  );
+
+  # Keep all attributes whose path contain a name that is "unit" or "test".
+  keepUnitChecks = setEmptyAttrsWithCondition (
+    path: !lib.any (name: name == "unit" || name == "test" || name == "scenario") path
+  );
+
+  # Recursively remove all attributes named `recurseForDerivations`.
+  removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
 
   /*
-  Keep all attributes whose path contain a name that is "unit" or "test".
+    Recursively traces an attrset as it's evaluated.
+    This is helpful for debugging large attribute sets.
   */
-  keepUnitChecks =
-    setEmptyAttrsWithCondition
-    (path: !lib.any (name: name == "unit" || name == "test" || name == "scenario") path);
-
-  /*
-  Recursively remove all attributes named `recurseForDerivations`.
-  */
-  removeRecurse =
-    lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
-
-  /*
-  Recursively traces an attrset as it's evaluated.
-  This is helpful for debugging large attribute sets.
-  */
-  traceNames = let
-    go = prefix:
-      builtins.mapAttrs (n: v:
-        if builtins.isAttrs v
-        then
-          if v ? type && v.type == "derivation"
-          then __trace (prefix + n) v
-          else go (prefix + n + ".") v
-        else v);
-  in
+  traceNames =
+    let
+      go =
+        prefix:
+        builtins.mapAttrs (
+          n: v:
+          if builtins.isAttrs v then
+            if v ? type && v.type == "derivation" then __trace (prefix + n) v else go (prefix + n + ".") v
+          else
+            v
+        );
+    in
     go;
 }

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -26,10 +26,11 @@
 {
   system ? builtins.currentSystem,
   crossSystem ? null,
-  config ? {},
-  pkgs ? import ./default.nix {},
+  config ? { },
+  pkgs ? import ./default.nix { },
 }:
-with pkgs.lib; let
+with pkgs.lib;
+let
   # List of git revisions to test against.
   # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.4.8:
   # nix-prefetch-url --unpack https://github.com/cardano-foundation/cardano-wallet/archive/v2021-11-11.zip
@@ -77,7 +78,8 @@ with pkgs.lib; let
   ];
 
   # Download the sources for a release.
-  fetchRelease = rel:
+  fetchRelease =
+    rel:
     pkgs.fetchFromGitHub {
       owner = "input-output-hk";
       repo = "cardano-wallet";
@@ -87,12 +89,14 @@ with pkgs.lib; let
 
   # Gets a package set for a specific release. If the argument is null
   # it returns the current working tree version.
-  importRelease = rel:
-    if rel == null
-    then import ../default.nix {inherit system crossSystem config;}
-    else let
-      src = fetchRelease rel;
-    in
+  importRelease =
+    rel:
+    if rel == null then
+      import ../default.nix { inherit system crossSystem config; }
+    else
+      let
+        src = fetchRelease rel;
+      in
       import src {
         inherit system crossSystem config;
         gitrev = src.rev;
@@ -102,79 +106,86 @@ with pkgs.lib; let
   migrationTest = (importRelease null).haskellPackages.cardano-wallet.components.exes.migration-test;
 
   # Generate attribute name/filename for a release.
-  releaseName = rel:
-    if rel == null
-    then "head"
-    else builtins.replaceStrings ["."] ["-"] rel.rev;
+  releaseName = rel: if rel == null then "head" else builtins.replaceStrings [ "." ] [ "-" ] rel.rev;
 
   ############################################################################
   # Generate a directory of wallet versions under test, with bash test
   # harness scripts for running under Linux and macOS.
 
-  mkTestsBash = let
-    # Create a script that runs the migration test against the server of
-    # a certain release.
-    testRelease = rel: let
-      targetRelease = importRelease rel;
-      # Use the genesis block from the latest release only.
-      # Having different genesis block (hash) across releases will basically
-      # make all wallets incompatible with each others. Prior to v2020-01-20,
-      # workers would simply loop ad-infinitum trying to rollback to (0, 0).
-      latestRelease = importRelease null;
+  mkTestsBash =
+    let
+      # Create a script that runs the migration test against the server of
+      # a certain release.
+      testRelease =
+        rel:
+        let
+          targetRelease = importRelease rel;
+          # Use the genesis block from the latest release only.
+          # Having different genesis block (hash) across releases will basically
+          # make all wallets incompatible with each others. Prior to v2020-01-20,
+          # workers would simply loop ad-infinitum trying to rollback to (0, 0).
+          latestRelease = importRelease null;
+        in
+        pkgs.writeScript "launch-migration-test-${releaseName rel}.sh" ''
+          #!${pkgs.runtimeShell}
+
+          export PATH=${
+            makeBinPath [
+              targetRelease.cardano-wallet
+              targetRelease.cardano-node
+              migrationTest
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.python3
+            ]
+          }
+          # fixme: ADP-549 port to shelley
+          export genesisDataDir=${latestRelease.src}/lib/jormungandr/test/data/jormungandr
+          export configFile=${targetRelease.src}/lib/jormungandr/test/data/jormungandr/config.yaml
+
+          exec ${./launch-migration-test.sh} "$@"
+        ''
+        // {
+          inherit (latestRelease) cardano-wallet;
+        };
+
+      # Create a test runner script for the given release.
+      # The test scenario is quite simple at present.
+      # It just starts with the given version then migrates to the current
+      # version.
+      mkTestRunner = rel: rec {
+        name = releaseName rel;
+        test = testRelease rel;
+        testStep2 = testRelease null;
+        allowFail = rel.allowFail or false;
+        runner = pkgs.writeScript "run-${test.name}" ''
+          #!${pkgs.runtimeShell}
+          set -euo pipefail
+
+          export stateDir=./state-migration-test-${name}
+
+          rm -rf "$stateDir"
+
+          # Setup database on server running chosen release.
+          ${test} step1
+          # Start up a server of the current version, and check the migration.
+          ${testStep2} step2 ${optionalString allowFail " || echo 'This test is allowed to fail.'"}
+        '';
+      };
     in
-      pkgs.writeScript "launch-migration-test-${releaseName rel}.sh" ''
-        #!${pkgs.runtimeShell}
-
-        export PATH=${makeBinPath [
-          targetRelease.cardano-wallet
-          targetRelease.cardano-node
-          migrationTest
-          pkgs.bash
-          pkgs.coreutils
-          pkgs.python3
-        ]}
-        # fixme: ADP-549 port to shelley
-        export genesisDataDir=${latestRelease.src}/lib/jormungandr/test/data/jormungandr
-        export configFile=${targetRelease.src}/lib/jormungandr/test/data/jormungandr/config.yaml
-
-        exec ${./launch-migration-test.sh} "$@"
-      ''
-      // {inherit (latestRelease) cardano-wallet;};
-
-    # Create a test runner script for the given release.
-    # The test scenario is quite simple at present.
-    # It just starts with the given version then migrates to the current
-    # version.
-    mkTestRunner = rel: rec {
-      name = releaseName rel;
-      test = testRelease rel;
-      testStep2 = testRelease null;
-      allowFail = rel.allowFail or false;
-      runner = pkgs.writeScript "run-${test.name}" ''
-        #!${pkgs.runtimeShell}
-        set -euo pipefail
-
-        export stateDir=./state-migration-test-${name}
-
-        rm -rf "$stateDir"
-
-        # Setup database on server running chosen release.
-        ${test} step1
-        # Start up a server of the current version, and check the migration.
-        ${testStep2} step2 ${optionalString allowFail
-          " || echo 'This test is allowed to fail.'"}
-      '';
-    };
-  in
     # Create a directory with migration test scripts for each release version.
     # At the top level is a script that runs all tests.
-    rels: let
+    rels:
+    let
       tests = map mkTestRunner rels;
     in
-      pkgs.runCommand "migration-tests" {
+    pkgs.runCommand "migration-tests"
+      {
         # provide individual tests as attributes of this derivation
         passthru = listToAttrs (map (test: nameValuePair test.name test.runner) tests);
-      } (''
+      }
+      (
+        ''
           mkdir -p $out
           echo "#!${pkgs.runtimeShell}" >> $out/runall.sh
           echo "set -euo pipefail" >> $out/runall.sh
@@ -187,77 +198,80 @@ with pkgs.lib; let
           ln -s ${test.runner} $out/${test.name}/${test.runner.name}
           echo 'printf "\n\n *** Migrating from ${test.name} ***\n\n"' >> $out/runall.sh
           echo "$out/${test.name}/${test.runner.name}" >> $out/runall.sh
-        '')
-        tests);
+        '') tests
+      );
 
   ############################################################################
   # Generate a folder of wallet versions under test, with batch files
   # for running the tests on Windows.
 
-  mkTestsWindows = let
-    # Create a test runner script for the given release.
-    # The test scenario is quite simple at present.
-    # It just starts with the given version then migrates to the current
-    # version.
-    mkTestRunner = rel: rec {
-      name = releaseName rel;
-      walletPackages = importRelease rel;
-      inherit (walletPackages) cardano-wallet src;
-      allowFail = rel.allowFail or false;
-      runner = let
-        stateDir = "state-migration-test-${name}";
-        args = "launch --state-dir ${stateDir} --genesis-block ${name}/data/block0.bin -- --secret ${name}/data/secret.yaml --config ${name}/data/config.yaml";
-      in
-        pkgs.writeScript "run.bat" ''
-          SETLOCAL
+  mkTestsWindows =
+    let
+      # Create a test runner script for the given release.
+      # The test scenario is quite simple at present.
+      # It just starts with the given version then migrates to the current
+      # version.
+      mkTestRunner = rel: rec {
+        name = releaseName rel;
+        walletPackages = importRelease rel;
+        inherit (walletPackages) cardano-wallet src;
+        allowFail = rel.allowFail or false;
+        runner =
+          let
+            stateDir = "state-migration-test-${name}";
+            args = "launch --state-dir ${stateDir} --genesis-block ${name}/data/block0.bin -- --secret ${name}/data/secret.yaml --config ${name}/data/config.yaml";
+          in
+          pkgs.writeScript "run.bat" ''
+            SETLOCAL
 
-          SET PATH=%~dp0;%PATH%
+            SET PATH=%~dp0;%PATH%
 
-          rmdir /s /q ${stateDir}
+            rmdir /s /q ${stateDir}
 
-          migration-test.exe step1 ${args}
-          if %errorlevel% neq 0 exit /b %errorlevel%
+            migration-test.exe step1 ${args}
+            if %errorlevel% neq 0 exit /b %errorlevel%
 
-          migration-test.exe step2 ${args}
-          if %errorlevel% neq 0 ${
-            if allowFail
-            then ''
-              echo This test is allowed to fail.
-            ''
-            else ''
-              exit /b %errorlevel%
-            ''
-          }
-        '';
-    };
-    latest = importRelease null;
-  in
+            migration-test.exe step2 ${args}
+            if %errorlevel% neq 0 ${
+              if allowFail then
+                ''
+                  echo This test is allowed to fail.
+                ''
+              else
+                ''
+                  exit /b %errorlevel%
+                ''
+            }
+          '';
+      };
+      latest = importRelease null;
+    in
     # Create a directory with migration test scripts for each release version.
     # At the top level is a script that runs all tests.
     rels:
-      pkgs.runCommand "migration-tests" {} (''
-          mkdir $out
-          cp ${migrationTest}/bin/* $out
-        ''
-        + concatMapStringsSep "\n" (test: ''
-          mkdir -p $out/${test.name}/data
-          cp ${test.cardano-wallet}/bin/* $out/${test.name}
-          cp ${test.runner} $out/${test.name}/${test.runner.name}
-          # fixme: ADP-549 port to shelley
-          cp ${latest.src}/lib/jormungandr/test/data/jormungandr/{block0.bin,config.yaml,secret.yaml} $out/${test.name}/data
+    pkgs.runCommand "migration-tests" { } (
+      ''
+        mkdir $out
+        cp ${migrationTest}/bin/* $out
+      ''
+      + concatMapStringsSep "\n" (test: ''
+        mkdir -p $out/${test.name}/data
+        cp ${test.cardano-wallet}/bin/* $out/${test.name}
+        cp ${test.runner} $out/${test.name}/${test.runner.name}
+        # fixme: ADP-549 port to shelley
+        cp ${latest.src}/lib/jormungandr/test/data/jormungandr/{block0.bin,config.yaml,secret.yaml} $out/${test.name}/data
 
-          # append test to the run all script
-          echo "${test.name}\${test.runner.name}" >> $out/runall.bat
-          echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> $out/runall.bat
-        '') (map mkTestRunner rels));
+        # append test to the run all script
+        echo "${test.name}\${test.runner.name}" >> $out/runall.bat
+        echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> $out/runall.bat
+      '') (map mkTestRunner rels)
+    );
 
   ############################################################################
 
-  mkTests =
-    if pkgs.stdenv.hostPlatform.isWindows
-    then mkTestsWindows
-    else mkTestsBash;
+  mkTests = if pkgs.stdenv.hostPlatform.isWindows then mkTestsWindows else mkTestsBash;
 in
-  if pkgs.stdenv.hostPlatform.isMusl
-  then pkgs.runCommand "migration-tests-disabled" {} "touch $out"
-  else mkTests releases
+if pkgs.stdenv.hostPlatform.isMusl then
+  pkgs.runCommand "migration-tests-disabled" { } "touch $out"
+else
+  mkTests releases

--- a/nix/nixos/cardano-wallet-service.nix
+++ b/nix/nixos/cardano-wallet-service.nix
@@ -3,11 +3,27 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.services.cardano-wallet;
-  inherit (lib) mkIf mkEnableOption mkOption types;
-  logLevels = ["DEBUG" "INFO" "NOTICE" "WARNING" "ERROR" "CRITICAL" "ALERT" "EMERGENCY"];
-in {
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+  logLevels = [
+    "DEBUG"
+    "INFO"
+    "NOTICE"
+    "WARNING"
+    "ERROR"
+    "CRITICAL"
+    "ALERT"
+    "EMERGENCY"
+  ];
+in
+{
   options.services.cardano-wallet = {
     enable = mkEnableOption "Cardano Wallet service";
 
@@ -37,43 +53,48 @@ in {
           "\"$CARDANO_NODE_SOCKET_PATH\""
           "--pool-metadata-fetching"
           (
-            if (cfg.poolMetadataFetching.enable)
-            then
-              (
-                if cfg.poolMetadataFetching.smashUrl != null
-                then cfg.poolMetadataFetching.smashUrl
-                else "direct"
-              )
-            else "none"
+            if (cfg.poolMetadataFetching.enable) then
+              (if cfg.poolMetadataFetching.smashUrl != null then cfg.poolMetadataFetching.smashUrl else "direct")
+            else
+              "none"
           )
           "--${cfg.walletMode}"
         ]
-        ++ lib.optional (cfg.walletMode != "mainnet")
-        (lib.escapeShellArg cfg.genesisFile)
-        ++ lib.optionals (cfg.tokenMetadataServer != null)
-        ["--token-metadata-server" cfg.tokenMetadataServer]
-        ++ lib.optionals (cfg.database != null)
-        ["--database" "\"$STATE_DIRECTORY\""]
-        ++ lib.mapAttrsToList
-        (name: level: "--trace-${name}=${level}")
-        cfg.trace
+        ++ lib.optional (cfg.walletMode != "mainnet") (lib.escapeShellArg cfg.genesisFile)
+        ++ lib.optionals (cfg.tokenMetadataServer != null) [
+          "--token-metadata-server"
+          cfg.tokenMetadataServer
+        ]
+        ++ lib.optionals (cfg.database != null) [
+          "--database"
+          "\"$STATE_DIRECTORY\""
+        ]
+        ++ lib.mapAttrsToList (name: level: "--trace-${name}=${level}") cfg.trace
       );
     };
 
     command = mkOption {
       type = types.str;
       internal = true;
-      default = lib.concatStringsSep " " ([
+      default = lib.concatStringsSep " " (
+        [
           "${cfg.package}/bin/${cfg.package.exeName}"
           "serve"
           cfg.serverArgs
         ]
-        ++ lib.optionals (cfg.rtsOpts != "") ["+RTS" cfg.rtsOpts "-RTS"]);
+        ++ lib.optionals (cfg.rtsOpts != "") [
+          "+RTS"
+          cfg.rtsOpts
+          "-RTS"
+        ]
+      );
     };
 
     package = mkOption {
       type = types.package;
-      default = ((import ../.. {}).legacyPackages.${pkgs.system}).hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
+      default =
+        ((import ../.. { }).legacyPackages.${pkgs.system})
+        .hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
       description = "Package for the cardano wallet executable.";
     };
 
@@ -98,11 +119,14 @@ in {
     nodeSocket = mkOption {
       type = types.str;
       default = "/run/cardano-node/node.socket";
-      description = ''Cardano-Node local communication socket path.'';
+      description = "Cardano-Node local communication socket path.";
     };
 
     walletMode = mkOption {
-      type = types.enum ["mainnet" "testnet"];
+      type = types.enum [
+        "mainnet"
+        "testnet"
+      ];
       default = "mainnet";
       description = "Which mode to start wallet in: --mainnet or --testnet";
     };
@@ -110,7 +134,8 @@ in {
     database = mkOption {
       type = types.nullOr types.str;
       default = "cardano-wallet";
-      description = ''        Directory (under /var/lib/) for storing wallets.
+      description = ''
+        Directory (under /var/lib/) for storing wallets.
                 Run in-memory if null.
                 Default to 'cardano-wallet'.
       '';
@@ -137,7 +162,9 @@ in {
           };
         };
       };
-      default = {enable = false;};
+      default = {
+        enable = false;
+      };
       example = {
         enable = true;
         smashUrl = "https://smash.cardano-mainnet.iohk.io";
@@ -163,8 +190,8 @@ in {
     };
 
     trace = mkOption {
-      type = types.attrsOf (types.enum (logLevels ++ ["off"]));
-      default = {};
+      type = types.attrsOf (types.enum (logLevels ++ [ "off" ]));
+      default = { };
       description = ''
         For each tracer, minimum severity for a message to be logged, or
         "off" to disable the tracer".
@@ -186,7 +213,8 @@ in {
     assertions = [
       {
         assertion = (cfg.walletMode == "mainnet") == (cfg.genesisFile == null);
-        message = ''          The option services.cardano-wallet.genesisFile must be set
+        message = ''
+          The option services.cardano-wallet.genesisFile must be set
                   if, and only if, services.cardano-wallet.walletMode is not \"mainnet\".
         '';
       }
@@ -198,7 +226,7 @@ in {
 
     systemd.services.cardano-wallet = {
       description = "cardano-wallet daemon";
-      wantedBy = ["multi-user.target"];
+      wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
         DynamicUser = true;

--- a/nix/nixos/default.nix
+++ b/nix/nixos/default.nix
@@ -1,1 +1,1 @@
-{imports = import ./module-list.nix;}
+{ imports = import ./module-list.nix; }

--- a/nix/nixos/tests/default.nix
+++ b/nix/nixos/tests/default.nix
@@ -1,17 +1,23 @@
 {
   pkgs,
   project,
-}: let
-  importTest = fn: args: let
-    imported = import fn;
-    test = import (pkgs.path + "/nixos/tests/make-test-python.nix") imported;
-  in
-    test ({
+}:
+let
+  importTest =
+    fn: args:
+    let
+      imported = import fn;
+      test = import (pkgs.path + "/nixos/tests/make-test-python.nix") imported;
+    in
+    test (
+      {
         inherit pkgs project;
         inherit (pkgs) system config;
       }
-      // args);
-in {
+      // args
+    );
+in
+{
   # TODO: @jbgi Python dependencies of NixOS tests are broken
   # basicTest = importTest ./service-basic-test.nix { };
 }

--- a/nix/nixos/tests/service-basic-test.nix
+++ b/nix/nixos/tests/service-basic-test.nix
@@ -4,50 +4,56 @@
   lib,
   ...
 }:
-with pkgs; let
+with pkgs;
+let
   inherit (project.hsPkgs.cardano-wallet.components.exes) cardano-wallet;
   inherit (pkgs) cardanoLib;
-in {
+in
+{
   name = "wallet-nixos-test";
   nodes = {
-    machine = {config, ...}: {
-      nixpkgs.pkgs = pkgs;
-      imports = [
-        ../.
-        (project.pkg-set.config.packages.cardano-node.src + "/nix/nixos")
-      ];
-      services.cardano-wallet = {
-        enable = true;
-        package = cardano-wallet;
-        walletMode = "mainnet";
-        nodeSocket = config.services.cardano-node.socketPath;
-        poolMetadataFetching = {
+    machine =
+      { config, ... }:
+      {
+        nixpkgs.pkgs = pkgs;
+        imports = [
+          ../.
+          (project.pkg-set.config.packages.cardano-node.src + "/nix/nixos")
+        ];
+        services.cardano-wallet = {
           enable = true;
-          smashUrl = cardanoLib.environments.mainnet.smashUrl;
+          package = cardano-wallet;
+          walletMode = "mainnet";
+          nodeSocket = config.services.cardano-node.socketPath;
+          poolMetadataFetching = {
+            enable = true;
+            smashUrl = cardanoLib.environments.mainnet.smashUrl;
+          };
+          tokenMetadataServer = cardanoLib.environments.mainnet.metadataUrl;
         };
-        tokenMetadataServer = cardanoLib.environments.mainnet.metadataUrl;
-      };
-      services.cardano-node = {
-        enable = true;
-        environment = "mainnet";
-        environments = {mainnet = {};};
-        package = project.hsPkgs.cardano-node.components.exes.cardano-node;
-        inherit (cardanoLib.environments.mainnet) nodeConfig;
-        topology = cardanoLib.mkEdgeTopology {
-          port = 3001;
-          edgeNodes = ["127.0.0.1"];
+        services.cardano-node = {
+          enable = true;
+          environment = "mainnet";
+          environments = {
+            mainnet = { };
+          };
+          package = project.hsPkgs.cardano-node.components.exes.cardano-node;
+          inherit (cardanoLib.environments.mainnet) nodeConfig;
+          topology = cardanoLib.mkEdgeTopology {
+            port = 3001;
+            edgeNodes = [ "127.0.0.1" ];
+          };
+          systemdSocketActivation = true;
         };
-        systemdSocketActivation = true;
-      };
-      systemd.services.cardano-node.serviceConfig.Restart = lib.mkForce "no";
-      systemd.services.cardano-wallet = {
-        after = ["cardano-node.service"];
-        serviceConfig = {
-          Restart = "no";
-          SupplementaryGroups = "cardano-node";
+        systemd.services.cardano-node.serviceConfig.Restart = lib.mkForce "no";
+        systemd.services.cardano-wallet = {
+          after = [ "cardano-node.service" ];
+          serviceConfig = {
+            Restart = "no";
+            SupplementaryGroups = "cardano-node";
+          };
         };
       };
-    };
   };
   testScript = ''
     start_all()

--- a/nix/overlays/basement.nix
+++ b/nix/overlays/basement.nix
@@ -1,15 +1,22 @@
-final: prev: let
+final: prev:
+let
   old = prev.haskell-nix;
-  fix = {
-    pkgs,
-    buildModules,
-    config,
-    lib,
-    ...
-  }:
+  fix =
+    {
+      pkgs,
+      buildModules,
+      config,
+      lib,
+      ...
+    }:
     prev.haskell-nix.haskellLib.addPackageKeys {
-      packages.basement.components.library.configureFlags = ["--hsc2hs-option=--cflag=-Wno-int-conversion"];
+      packages.basement.components.library.configureFlags = [
+        "--hsc2hs-option=--cflag=-Wno-int-conversion"
+      ];
     };
-in {
-  haskell-nix = old // {defaultModules = old.defaultModules ++ [fix];};
+in
+{
+  haskell-nix = old // {
+    defaultModules = old.defaultModules ++ [ fix ];
+  };
 }

--- a/nix/overlays/cardano-deployments.nix
+++ b/nix/overlays/cardano-deployments.nix
@@ -1,58 +1,66 @@
 pkgs: _: {
   # Provide real deployment configurations for use in dev/tests/benchmarks.
   # https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/index.html
-  cardano-node-deployments = let
-    environments = {
-      inherit
-        (pkgs.cardanoLib.environments)
-        mainnet
-        preview
-        preprod
-        ;
-    };
-    updateConfig = env:
-      env.nodeConfig
-      // {
-        minSeverity = "Notice";
-      }
-      // (
-        if (env.consensusProtocol == "Cardano")
-        then {
-          ByronGenesisFile = "genesis-byron.json";
-          ShelleyGenesisFile = "genesis-shelley.json";
-          AlonzoGenesisFile = "genesis-alonzo.json";
-        }
-        else {
-          GenesisFile = "genesis.json";
-        }
-      );
-    mkTopology = env:
-      pkgs.cardanoLib.mkEdgeTopology {
-        edgeNodes = [env.relaysNew];
-        valency = 2;
+  cardano-node-deployments =
+    let
+      environments = {
+        inherit (pkgs.cardanoLib.environments)
+          mainnet
+          preview
+          preprod
+          ;
       };
-    mapAttrsToString = f: attrs:
-      pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList f attrs);
-  in
-    pkgs.runCommand "cardano-node-deployments" {
-      nativeBuildInputs = [pkgs.buildPackages.jq];
-    } (mapAttrsToString (name: env:
-      ''
-        cfg=$out/${name}
-        mkdir -p $cfg
-        jq . < ${mkTopology env} > $cfg/topology.json
-        jq . < ${__toFile "${name}-config.json" (__toJSON (updateConfig env))} > $cfg/configuration.json
-      ''
-      + (
-        if env.consensusProtocol == "Cardano"
-        then ''
-          jq . < ${env.nodeConfig.ByronGenesisFile} > $cfg/genesis-byron.json
-          cp ${env.nodeConfig.ShelleyGenesisFile} $cfg/genesis-shelley.json
-          cp ${env.nodeConfig.AlonzoGenesisFile} $cfg/genesis-alonzo.json
-        ''
-        else ''
-          jq . < ${env.genesisFile} > $cfg/genesis.json
-        ''
-      ))
-    environments);
+      updateConfig =
+        env:
+        env.nodeConfig
+        // {
+          minSeverity = "Notice";
+        }
+        // (
+          if (env.consensusProtocol == "Cardano") then
+            {
+              ByronGenesisFile = "genesis-byron.json";
+              ShelleyGenesisFile = "genesis-shelley.json";
+              AlonzoGenesisFile = "genesis-alonzo.json";
+            }
+          else
+            {
+              GenesisFile = "genesis.json";
+            }
+        );
+      mkTopology =
+        env:
+        pkgs.cardanoLib.mkEdgeTopology {
+          edgeNodes = [ env.relaysNew ];
+          valency = 2;
+        };
+      mapAttrsToString = f: attrs: pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList f attrs);
+    in
+    pkgs.runCommand "cardano-node-deployments"
+      {
+        nativeBuildInputs = [ pkgs.buildPackages.jq ];
+      }
+      (
+        mapAttrsToString (
+          name: env:
+          ''
+            cfg=$out/${name}
+            mkdir -p $cfg
+            jq . < ${mkTopology env} > $cfg/topology.json
+            jq . < ${__toFile "${name}-config.json" (__toJSON (updateConfig env))} > $cfg/configuration.json
+          ''
+          + (
+            if env.consensusProtocol == "Cardano" then
+              ''
+                jq . < ${env.nodeConfig.ByronGenesisFile} > $cfg/genesis-byron.json
+                cp ${env.nodeConfig.ShelleyGenesisFile} $cfg/genesis-shelley.json
+                cp ${env.nodeConfig.AlonzoGenesisFile} $cfg/genesis-alonzo.json
+              ''
+            else
+              ''
+                jq . < ${env.genesisFile} > $cfg/genesis.json
+              ''
+          )
+        ) environments
+      );
 }

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -1,14 +1,17 @@
-self: super: let
+self: super:
+let
   inherit (self) lib cardanoWalletHaskellProject;
   inherit (self.haskell-nix) haskellLib;
-in {
+in
+{
   cardanoWalletLib = {
     # Retrieve the list of local project packages by
     # using the haskell.nix selectProjectPackages function.
-    projectPackageList = let
-      project = haskellLib.selectProjectPackages cardanoWalletHaskellProject.hsPkgs;
-      names = map (key: (builtins.getAttr key project).identifier.name) (builtins.attrNames project);
-    in
+    projectPackageList =
+      let
+        project = haskellLib.selectProjectPackages cardanoWalletHaskellProject.hsPkgs;
+        names = map (key: (builtins.getAttr key project).identifier.name) (builtins.attrNames project);
+      in
       lib.lists.unique names;
   };
 }

--- a/nix/overlays/ghc-lib-parser.nix
+++ b/nix/overlays/ghc-lib-parser.nix
@@ -9,9 +9,8 @@
 # because overlays don't propagate through buildPackages chains.
 final: prev: {
   haskell = prev.haskell // {
-    packageOverrides = final.lib.composeExtensions
-      (prev.haskell.packageOverrides or (_: _: {}))
-      (hfinal: hprev: {
+    packageOverrides = final.lib.composeExtensions (prev.haskell.packageOverrides or (_: _: { })) (
+      hfinal: hprev: {
         ghc-lib-parser = final.haskell.lib.compose.overrideCabal (drv: {
           postPatch = (drv.postPatch or "") + ''
             if [ -f compiler/cbits/genSym.c ] \
@@ -21,6 +20,7 @@ final: prev: {
             fi
           '';
         }) hprev.ghc-lib-parser;
-      });
+      }
+    );
   };
 }

--- a/nix/release-build.nix
+++ b/nix/release-build.nix
@@ -13,29 +13,28 @@
   set-git-rev ? null, # set-git-rev tool derivation
   gitrev ? null, # git revision string to stamp into binaries
 }:
-with pkgs.lib; let
+with pkgs.lib;
+let
   drv = pkgs.stdenv.mkDerivation rec {
     name = "${exe.exeName}-${version}";
     version = exe.identifier.version;
-    phases = ["installPhase"];
-    installPhase =
-      ''
-        cp -RL ${exe} $out
-      ''
-      + (optionalString (set-git-rev != null && gitrev != null) ''
-        chmod +w $out/bin/*
-        ${set-git-rev}/bin/set-git-rev "${gitrev}" $out/bin/*
-      '')
-      + (optionalString (pkgs.stdenv.hostPlatform.isWindows && backend != null) ''
-        # fixme: remove this
-        cp -RvL ${backend.deployments} $out/deployments
-      '');
+    phases = [ "installPhase" ];
+    installPhase = ''
+      cp -RL ${exe} $out
+    ''
+    + (optionalString (set-git-rev != null && gitrev != null) ''
+      chmod +w $out/bin/*
+      ${set-git-rev}/bin/set-git-rev "${gitrev}" $out/bin/*
+    '')
+    + (optionalString (pkgs.stdenv.hostPlatform.isWindows && backend != null) ''
+      # fixme: remove this
+      cp -RvL ${backend.deployments} $out/deployments
+    '');
     meta.platforms = platforms.all;
-    passthru =
-      {
-        exePath = drv + "/bin/cardano-wallet";
-      }
-      // (optionalAttrs (backend != null) {inherit backend;});
+    passthru = {
+      exePath = drv + "/bin/cardano-wallet";
+    }
+    // (optionalAttrs (backend != null) { inherit backend; });
   };
 in
-  drv
+drv

--- a/nix/release-package.nix
+++ b/nix/release-package.nix
@@ -13,10 +13,12 @@
   nodeConfigs,
   format,
   rewrite-libs ? null,
-}: let
+}:
+let
   inherit (pkgs) lib;
 
-  exe = assert lib.assertMsg (lib.length exes > 0) "empty list of exes";
+  exe =
+    assert lib.assertMsg (lib.length exes > 0) "empty list of exes";
     lib.head exes;
   name = "${walletLib.gitTagFromCabalVersion exe.meta.name}-${platform}";
 
@@ -27,133 +29,136 @@
   isMacOS = platform == "macos-intel" || platform == "macos-silicon";
   isWindows = platform == "win64";
 in
-  assert lib.assertMsg (makeTarball || makeZip)
-  "format must be tar.gz or zip";
-  assert lib.assertMsg (isLinux || isMacOS || isWindows)
-  "wrong platform \"${platform}\"";
-    pkgs.stdenv.mkDerivation {
-      inherit name;
-      buildInputs = with pkgs.buildPackages;
-        [
-          nix
-        ]
-        ++ (
-          if pkgs.stdenv.hostPlatform.isDarwin
-          then [darwin.binutils]
-          else [binutils]
-        )
-        ++ lib.optionals makeTarball [gnutar gzip]
-        ++ lib.optionals makeZip [zip];
-      checkInputs = with pkgs.buildPackages;
-        [
-          ruby_3_3
-          gnugrep
-          gnused
-        ]
-        ++ lib.optionals isMacOS [darwin.cctools]
-        ++ lib.optionals isWindows [unzip winePackages.minimal]
-        ++ lib.optional (stdenv.buildPlatform.libc == "glibc") glibcLocales;
+assert lib.assertMsg (makeTarball || makeZip) "format must be tar.gz or zip";
+assert lib.assertMsg (isLinux || isMacOS || isWindows) "wrong platform \"${platform}\"";
+pkgs.stdenv.mkDerivation {
+  inherit name;
+  buildInputs =
+    with pkgs.buildPackages;
+    [
+      nix
+    ]
+    ++ (if pkgs.stdenv.hostPlatform.isDarwin then [ darwin.binutils ] else [ binutils ])
+    ++ lib.optionals makeTarball [
+      gnutar
+      gzip
+    ]
+    ++ lib.optionals makeZip [ zip ];
+  checkInputs =
+    with pkgs.buildPackages;
+    [
+      ruby_3_3
+      gnugrep
+      gnused
+    ]
+    ++ lib.optionals isMacOS [ darwin.cctools ]
+    ++ lib.optionals isWindows [
+      unzip
+      winePackages.minimal
+    ]
+    ++ lib.optional (stdenv.buildPlatform.libc == "glibc") glibcLocales;
 
-      doCheck = true;
-      phases = ["buildPhase" "checkPhase"];
-      pkgname = "${name}.${format}";
-      exeName = lib.getName exe.name;
-      buildPhase =
-        ''
-          mkdir -p $out/nix-support $name
+  doCheck = true;
+  phases = [
+    "buildPhase"
+    "checkPhase"
+  ];
+  pkgname = "${name}.${format}";
+  exeName = lib.getName exe.name;
+  buildPhase = ''
+    mkdir -p $out/nix-support $name
 
-          # Note: On Windows, each output directory of a derivation in `exes`
-          # may contain a copy of the same DLLs — for example,
-          # the `cardano-wallet` and `bech32` derivations both contain `libffi-8.dll`.
-          # When copying all DLLs to the output directory,
-          # we silently discard duplicates, hoping that were equal anyway.
-          # If the duplicates are not equal, we may get subtle conflicts
-          # where two executables depend on slightly different DLLs with the same name.
-          # This should not happen, but this Note exists to remind us of the possibility.
-          #
-          cp --no-preserve=timestamps --update=none --recursive \
-            ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \
-            $name
+    # Note: On Windows, each output directory of a derivation in `exes`
+    # may contain a copy of the same DLLs — for example,
+    # the `cardano-wallet` and `bech32` derivations both contain `libffi-8.dll`.
+    # When copying all DLLs to the output directory,
+    # we silently discard duplicates, hoping that were equal anyway.
+    # If the duplicates are not equal, we may get subtle conflicts
+    # where two executables depend on slightly different DLLs with the same name.
+    # This should not happen, but this Note exists to remind us of the possibility.
+    #
+    cp --no-preserve=timestamps --update=none --recursive \
+      ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \
+      $name
 
-          chmod -R +w $name
+    chmod -R +w $name
 
-        ''
-        + lib.optionalString isMacOS ''
-          # Rewrite library paths to standard non-nix locations
-          ( cd $name; ${rewrite-libs}/bin/rewrite-libs . `ls -1 | grep -Fv .dylib`
-            for a in *; do /usr/bin/codesign -f -s - $a; done
-          )
+  ''
+  + lib.optionalString isMacOS ''
+    # Rewrite library paths to standard non-nix locations
+    ( cd $name; ${rewrite-libs}/bin/rewrite-libs . `ls -1 | grep -Fv .dylib`
+      for a in *; do /usr/bin/codesign -f -s - $a; done
+    )
 
-        ''
-        + ''
-          # Add configuration files
-          mkdir -p $name/configs
-          cp  --recursive ${nodeConfigs}/cardano/* $name/configs
-          chmod -R +w $name
+  ''
+  + ''
+    # Add configuration files
+    mkdir -p $name/configs
+    cp  --recursive ${nodeConfigs}/cardano/* $name/configs
+    chmod -R +w $name
 
-        ''
-        + lib.optionalString (isLinux || isMacOS) ''
-          mkdir -p $name/auto-completion/{bash,zsh,fish}
-          cp ${exe}/share/bash-completion/completions/* $name/auto-completion/bash/$exeName.sh
-          cp ${exe}/share/zsh/vendor-completions/* $name/auto-completion/zsh/_$exeName
-          cp ${exe}/share/fish/vendor_completions.d/* $name/auto-completion/fish/$exeName.fish
+  ''
+  + lib.optionalString (isLinux || isMacOS) ''
+    mkdir -p $name/auto-completion/{bash,zsh,fish}
+    cp ${exe}/share/bash-completion/completions/* $name/auto-completion/bash/$exeName.sh
+    cp ${exe}/share/zsh/vendor-completions/* $name/auto-completion/zsh/_$exeName
+    cp ${exe}/share/fish/vendor_completions.d/* $name/auto-completion/fish/$exeName.fish
 
-        ''
-        + lib.optionalString makeTarball ''
-          tar -czf $out/$pkgname $name
-        ''
-        + lib.optionalString makeZip ''
-          ( cd $name; zip -r $out/$pkgname . )
-        ''
-        + ''
-          echo "file binary-dist $out/$pkgname" > $out/nix-support/hydra-build-products
-        ''
-        + lib.optionalString isWindows ''
+  ''
+  + lib.optionalString makeTarball ''
+    tar -czf $out/$pkgname $name
+  ''
+  + lib.optionalString makeZip ''
+    ( cd $name; zip -r $out/$pkgname . )
+  ''
+  + ''
+    echo "file binary-dist $out/$pkgname" > $out/nix-support/hydra-build-products
+  ''
+  + lib.optionalString isWindows ''
 
-          # make a separate configuration package if needed
-          if [ -d ${exe}/configuration ]; then
-            cp --no-preserve=mode,timestamps -R ${exe}/configuration .
+    # make a separate configuration package if needed
+    if [ -d ${exe}/configuration ]; then
+      cp --no-preserve=mode,timestamps -R ${exe}/configuration .
 
-            ( cd configuration; zip -r $out/$name-configuration.zip . )
-            echo "file binary-dist $out/$name-configuration.zip" >> $out/nix-support/hydra-build-products
-          fi
+      ( cd configuration; zip -r $out/$name-configuration.zip . )
+      echo "file binary-dist $out/$name-configuration.zip" >> $out/nix-support/hydra-build-products
+    fi
 
-          # make a separate deployments configuration package if needed
-          if [ -d ${exe}/deployments ]; then
-            cp --no-preserve=mode,timestamps -R ${exe}/deployments .
+    # make a separate deployments configuration package if needed
+    if [ -d ${exe}/deployments ]; then
+      cp --no-preserve=mode,timestamps -R ${exe}/deployments .
 
-            ( cd deployments; zip -r $out/$name-deployments.zip . )
-            echo "file binary-dist $out/$name-deployments.zip" >> $out/nix-support/hydra-build-products
-          fi
-        '';
+      ( cd deployments; zip -r $out/$name-deployments.zip . )
+      echo "file binary-dist $out/$name-deployments.zip" >> $out/nix-support/hydra-build-products
+    fi
+  '';
 
-      # test that executables work
-      exeRunner = lib.optionalString isWindows "wine64";
-      checkPhase =
-        ''
-          cd `mktemp -d`
-          echo " - extracting $pkgname"
-          ${lib.optionalString makeTarball "tar -xzvf $out/$pkgname"}
-          ${lib.optionalString makeZip "unzip $out/$pkgname"}
+  # test that executables work
+  exeRunner = lib.optionalString isWindows "wine64";
+  checkPhase = ''
+    cd `mktemp -d`
+    echo " - extracting $pkgname"
+    ${lib.optionalString makeTarball "tar -xzvf $out/$pkgname"}
+    ${lib.optionalString makeZip "unzip $out/$pkgname"}
 
-        ''
-        + lib.optionalString isWindows ''
-          # setup wine
-          export WINEPREFIX=$TMP
-          export HOME=$TMP
-          export WINEDLLOVERRIDES="winemac.drv=d"
-          export WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag
+  ''
+  + lib.optionalString isWindows ''
+    # setup wine
+    export WINEPREFIX=$TMP
+    export HOME=$TMP
+    export WINEDLLOVERRIDES="winemac.drv=d"
+    export WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag
 
-        ''
-        + ''
-          export PATH=`pwd`/$name:$PATH
+  ''
+  + ''
+    export PATH=`pwd`/$name:$PATH
 
-          echo " - running checks"
-          ruby ${../scripts/check-bundle.rb} $exeName $exeRunner
-        '';
-    }
-    // lib.optionalAttrs (pkgs.stdenv.buildPlatform.libc == "glibc") {
-      LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
-      LANG = "en_US.UTF-8";
-      LC_ALL = "en_US.UTF-8";
-    }
+    echo " - running checks"
+    ruby ${../scripts/check-bundle.rb} $exeName $exeRunner
+  '';
+}
+// lib.optionalAttrs (pkgs.stdenv.buildPlatform.libc == "glibc") {
+  LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
+  LANG = "en_US.UTF-8";
+  LC_ALL = "en_US.UTF-8";
+}

--- a/nix/rewrite-libs/flake.nix
+++ b/nix/rewrite-libs/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
-    haskellNix = {url = "github:input-output-hk/haskell.nix";};
+    haskellNix = {
+      url = "github:input-output-hk/haskell.nix";
+    };
     nixpkgs = {
       url = "github:NixOS/nixpkgs";
       follows = "haskellNix/nixpkgs-unstable";
@@ -9,13 +11,21 @@
       url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     };
   };
-  outputs = inputs @ {flake-utils, ...}: let
-    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
-    perSystem = system:
-      import ./rewrite-libs.nix {
-        inherit system;
-        inherit (inputs) nixpkgs haskellNix flake-utils;
-      };
-  in
+  outputs =
+    inputs@{ flake-utils, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        system:
+        import ./rewrite-libs.nix {
+          inherit system;
+          inherit (inputs) nixpkgs haskellNix flake-utils;
+        };
+    in
     flake-utils.lib.eachSystem supportedSystems perSystem;
 }

--- a/nix/rewrite-libs/nix/project.nix
+++ b/nix/rewrite-libs/nix/project.nix
@@ -3,44 +3,58 @@
   src,
   haskell-nix,
   ...
-}: let
-  shell = {pkgs, ...}: {
-    tools = {
-      cabal = {index-state = indexState;};
-      cabal-fmt = {index-state = indexState;};
-      haskell-language-server = {index-state = indexState;};
-      hoogle = {index-state = indexState;};
+}:
+let
+  shell =
+    { pkgs, ... }:
+    {
+      tools = {
+        cabal = {
+          index-state = indexState;
+        };
+        cabal-fmt = {
+          index-state = indexState;
+        };
+        haskell-language-server = {
+          index-state = indexState;
+        };
+        hoogle = {
+          index-state = indexState;
+        };
+      };
+      withHoogle = true;
+      buildInputs = [
+        pkgs.just
+        pkgs.gitAndTools.git
+        pkgs.haskellPackages.fourmolu
+        pkgs.haskellPackages.ghcid
+        pkgs.haskellPackages.hlint
+      ];
+      shellHook = ''
+        echo "Entering shell for rewrite-libs development"
+      '';
     };
-    withHoogle = true;
-    buildInputs = [
-      pkgs.just
-      pkgs.gitAndTools.git
-      pkgs.haskellPackages.fourmolu
-      pkgs.haskellPackages.ghcid
-      pkgs.haskellPackages.hlint
-    ];
-    shellHook = ''
-      echo "Entering shell for rewrite-libs development"
-    '';
-  };
 
-  mkProject = ctx @ {
-    lib,
-    pkgs,
-    ...
-  }: {
-    name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9123";
-    inherit src;
-    shell = shell {inherit pkgs;};
-    modules = [];
-  };
+  mkProject =
+    ctx@{
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      name = "cardano-deposit-wallet";
+      compiler-nix-name = "ghc9123";
+      inherit src;
+      shell = shell { inherit pkgs; };
+      modules = [ ];
+    };
   project = haskell-nix.cabalProject' mkProject;
   packages = {
     inherit project;
     default = packages.project.hsPkgs.rewrite-libs.components.exes.rewrite-libs;
   };
-in {
+in
+{
   inherit packages;
   devShell = project.shell;
 }

--- a/nix/rewrite-libs/rewrite-libs.nix
+++ b/nix/rewrite-libs/rewrite-libs.nix
@@ -4,18 +4,19 @@
   haskellNix,
   flake-utils,
   ...
-}: let
+}:
+let
   src = ./.;
   indexState = "2024-08-20T21:35:22Z";
   pkgs = import nixpkgs {
-    overlays = [haskellNix.overlay];
+    overlays = [ haskellNix.overlay ];
     inherit system;
   };
 in
-  import ./nix/project.nix {
-    inherit system;
-    inherit indexState;
-    inherit src;
-    inherit (pkgs) haskell-nix;
-    inherit pkgs;
-  }
+import ./nix/project.nix {
+  inherit system;
+  inherit indexState;
+  inherit src;
+  inherit (pkgs) haskell-nix;
+  inherit pkgs;
+}

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -12,36 +12,42 @@
   project,
   customConfigs,
 }:
-with project.pkgs; let
-  mkScript = envConfig: let
-    service = evalService {
-      inherit pkgs customConfigs;
-      serviceName = "cardano-wallet";
-      modules = [
-        ./nixos/cardano-wallet-service.nix
-        ({config, ...}: {
-          services.cardano-wallet = let
-            cfg = config.services.cardano-wallet;
-          in {
-            package = lib.mkDefault project.hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
-            walletMode = lib.mkDefault ({mainnet = "mainnet";}.${envConfig.name} or "testnet");
-            genesisFile =
-              lib.mkIf (cfg.walletMode != "mainnet")
-              (lib.mkDefault envConfig.nodeConfig.ByronGenesisFile);
-            database = lib.mkDefault null;
-            nodeSocket = lib.mkDefault "";
-            poolMetadataFetching = lib.mkDefault {
-              enable = lib.mkDefault true;
-              smashUrl =
-                lib.mkIf (envConfig ? smashUrl)
-                (lib.mkDefault envConfig.smashUrl);
-            };
-            tokenMetadataServer = lib.mkIf (envConfig ? metadataUrl) (lib.mkDefault envConfig.metadataUrl);
-          };
-        })
-      ];
-    };
-  in
+with project.pkgs;
+let
+  mkScript =
+    envConfig:
+    let
+      service = evalService {
+        inherit pkgs customConfigs;
+        serviceName = "cardano-wallet";
+        modules = [
+          ./nixos/cardano-wallet-service.nix
+          (
+            { config, ... }:
+            {
+              services.cardano-wallet =
+                let
+                  cfg = config.services.cardano-wallet;
+                in
+                {
+                  package = lib.mkDefault project.hsPkgs.cardano-wallet-application.components.exes.cardano-wallet;
+                  walletMode = lib.mkDefault ({ mainnet = "mainnet"; }.${envConfig.name} or "testnet");
+                  genesisFile = lib.mkIf (cfg.walletMode != "mainnet") (
+                    lib.mkDefault envConfig.nodeConfig.ByronGenesisFile
+                  );
+                  database = lib.mkDefault null;
+                  nodeSocket = lib.mkDefault "";
+                  poolMetadataFetching = lib.mkDefault {
+                    enable = lib.mkDefault true;
+                    smashUrl = lib.mkIf (envConfig ? smashUrl) (lib.mkDefault envConfig.smashUrl);
+                  };
+                  tokenMetadataServer = lib.mkIf (envConfig ? metadataUrl) (lib.mkDefault envConfig.metadataUrl);
+                };
+            }
+          )
+        ];
+      };
+    in
     writeScriptBin "cardano-wallet-${envConfig.name}" ''
       #!${pkgs.runtimeShell}
       set -euo pipefail
@@ -71,18 +77,20 @@ with project.pkgs; let
     tree
   ];
 in
-  cardanoLib.forEnvironments (environment:
-    lib.recurseIntoAttrs (
-      let
-        wallet = mkScript environment;
-      in
-        {
-          inherit wallet;
-        }
-        // lib.optionalAttrs stdenv.buildPlatform.isLinux {
-          wallet-debug = pkgs.symlinkJoin {
-            inherit (wallet) name;
-            paths = [wallet] ++ debugDeps;
-          };
-        }
-    ))
+cardanoLib.forEnvironments (
+  environment:
+  lib.recurseIntoAttrs (
+    let
+      wallet = mkScript environment;
+    in
+    {
+      inherit wallet;
+    }
+    // lib.optionalAttrs stdenv.buildPlatform.isLinux {
+      wallet-debug = pkgs.symlinkJoin {
+        inherit (wallet) name;
+        paths = [ wallet ] ++ debugDeps;
+      };
+    }
+  )
+)

--- a/nix/set-git-rev/flake.nix
+++ b/nix/set-git-rev/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
-    haskellNix = {url = "github:input-output-hk/haskell.nix";};
+    haskellNix = {
+      url = "github:input-output-hk/haskell.nix";
+    };
     nixpkgs = {
       url = "github:NixOS/nixpkgs";
       follows = "haskellNix/nixpkgs-unstable";
@@ -9,13 +11,21 @@
       url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     };
   };
-  outputs = inputs @ {flake-utils, ...}: let
-    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
-    perSystem = system:
-      import ./set-git-rev.nix {
-        inherit system;
-        inherit (inputs) nixpkgs haskellNix flake-utils;
-      };
-  in
+  outputs =
+    inputs@{ flake-utils, ... }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        system:
+        import ./set-git-rev.nix {
+          inherit system;
+          inherit (inputs) nixpkgs haskellNix flake-utils;
+        };
+    in
     flake-utils.lib.eachSystem supportedSystems perSystem;
 }

--- a/nix/set-git-rev/nix/project.nix
+++ b/nix/set-git-rev/nix/project.nix
@@ -3,44 +3,58 @@
   src,
   haskell-nix,
   ...
-}: let
-  shell = {pkgs, ...}: {
-    tools = {
-      cabal = {index-state = indexState;};
-      cabal-fmt = {index-state = indexState;};
-      haskell-language-server = {index-state = indexState;};
-      hoogle = {index-state = indexState;};
+}:
+let
+  shell =
+    { pkgs, ... }:
+    {
+      tools = {
+        cabal = {
+          index-state = indexState;
+        };
+        cabal-fmt = {
+          index-state = indexState;
+        };
+        haskell-language-server = {
+          index-state = indexState;
+        };
+        hoogle = {
+          index-state = indexState;
+        };
+      };
+      withHoogle = true;
+      buildInputs = [
+        pkgs.just
+        pkgs.gitAndTools.git
+        pkgs.haskellPackages.fourmolu
+        pkgs.haskellPackages.ghcid
+        pkgs.haskellPackages.hlint
+      ];
+      shellHook = ''
+        echo "Entering shell for set-git-rev development"
+      '';
     };
-    withHoogle = true;
-    buildInputs = [
-      pkgs.just
-      pkgs.gitAndTools.git
-      pkgs.haskellPackages.fourmolu
-      pkgs.haskellPackages.ghcid
-      pkgs.haskellPackages.hlint
-    ];
-    shellHook = ''
-      echo "Entering shell for set-git-rev development"
-    '';
-  };
 
-  mkProject = ctx @ {
-    lib,
-    pkgs,
-    ...
-  }: {
-    name = "cardano-deposit-wallet";
-    compiler-nix-name = "ghc9123";
-    inherit src;
-    shell = shell {inherit pkgs;};
-    modules = [];
-  };
+  mkProject =
+    ctx@{
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      name = "cardano-deposit-wallet";
+      compiler-nix-name = "ghc9123";
+      inherit src;
+      shell = shell { inherit pkgs; };
+      modules = [ ];
+    };
   project = haskell-nix.cabalProject' mkProject;
   packages = {
     inherit project;
     default = packages.project.hsPkgs.set-git-rev.components.exes.set-git-rev;
   };
-in {
+in
+{
   inherit packages;
   devShell = project.shell;
 }

--- a/nix/set-git-rev/set-git-rev.nix
+++ b/nix/set-git-rev/set-git-rev.nix
@@ -4,18 +4,19 @@
   haskellNix,
   flake-utils,
   ...
-}: let
+}:
+let
   src = ./.;
   indexState = "2024-08-20T21:35:22Z";
   pkgs = import nixpkgs {
-    overlays = [haskellNix.overlay];
+    overlays = [ haskellNix.overlay ];
     inherit system;
   };
 in
-  import ./nix/project.nix {
-    inherit system;
-    inherit indexState;
-    inherit src;
-    inherit (pkgs) haskell-nix;
-    inherit pkgs;
-  }
+import ./nix/project.nix {
+  inherit system;
+  inherit indexState;
+  inherit src;
+  inherit (pkgs) haskell-nix;
+  inherit pkgs;
+}

--- a/nix/windows-migration-tests-bundle.nix
+++ b/nix/windows-migration-tests-bundle.nix
@@ -14,16 +14,26 @@
 {
   system ? builtins.currentSystem,
   crossSystem ? null,
-  config ? {},
-  project ? import ../default.nix {inherit system crossSystem config;},
+  config ? { },
+  project ? import ../default.nix { inherit system crossSystem config; },
   pkgs ? project.pkgs,
-}: let
+}:
+let
   name = "cardano-wallet-${project.version}-migration-tests-win64";
-  migration-tests = import ./migration-tests.nix {inherit system crossSystem config pkgs;};
+  migration-tests = import ./migration-tests.nix {
+    inherit
+      system
+      crossSystem
+      config
+      pkgs
+      ;
+  };
 in
-  pkgs.buildPackages.runCommand name {
-    nativeBuildInputs = [pkgs.buildPackages.zip];
-  } ''
+pkgs.buildPackages.runCommand name
+  {
+    nativeBuildInputs = [ pkgs.buildPackages.zip ];
+  }
+  ''
     mkdir -p $out/nix-support
     cd ${migration-tests}
     zip -r $out/${name}.zip .

--- a/nix/windows-test-exe.nix
+++ b/nix/windows-test-exe.nix
@@ -9,10 +9,10 @@
   pkgs,
   test,
   name,
-  extraPkgs ? [],
-  testDataDirs ? [],
+  extraPkgs ? [ ],
+  testDataDirs ? [ ],
 }:
-pkgs.runCommand "win-test-${name}" {} ''
+pkgs.runCommand "win-test-${name}" { } ''
   mkdir -p $out
   cp -RL ${test}/bin/* $out/
   ${pkgs.lib.concatMapStringsSep "\n" (pkg: ''

--- a/scripts/ci/check-code-format.sh
+++ b/scripts/ci/check-code-format.sh
@@ -14,4 +14,9 @@ echo "+++ Check code format: cabal-fmt"
 
 find lib -name '*.cabal' -exec cabal-fmt -i {} \;
 
+echo "+++ Check code format: nixfmt"
+
+# shellcheck disable=SC2046
+nixfmt $(git ls-files -- '*.nix')
+
 git diff --exit-code

--- a/scripts/ci/flake.nix
+++ b/scripts/ci/flake.nix
@@ -11,21 +11,25 @@
     attic.url = "github:zhaofengli/attic";
   };
 
-  outputs = inputs: let
-    supportedSystems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-  in
+  outputs =
+    inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
     inputs.flake-utils.lib.eachSystem supportedSystems (
-      system: let
+      system:
+      let
         # Imports
         pkgs = inputs.nixpkgs.legacyPackages.${system};
         attic = inputs.attic.packages.${system}.default;
-      in {
-        packages = {};
+      in
+      {
+        packages = { };
 
         devShells.default = pkgs.mkShell {
           buildInputs = [

--- a/scripts/release/flake.nix
+++ b/scripts/release/flake.nix
@@ -9,20 +9,24 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs: let
-    supportedSystems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-  in
+  outputs =
+    inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
     inputs.flake-utils.lib.eachSystem supportedSystems (
-      system: let
+      system:
+      let
         # Imports
         pkgs = inputs.nixpkgs.legacyPackages.${system};
-      in {
-        packages = {};
+      in
+      {
+        packages = { };
 
         devShells.default = pkgs.mkShell {
           buildInputs = [


### PR DESCRIPTION
## Summary

- Pin `nixfmt-rfc-style` and `cabal-fmt` in the dev shell so every contributor and every CI job use the same version of every formatter.
- Add `just fmt` (runs `fourmolu` + `cabal-fmt` + `nixfmt`) and `just check-fmt` (runs the CI script locally).
- Extend `scripts/ci/check-code-format.sh` so CI actually enforces `nixfmt` on every tracked `*.nix` file.
- One-time sweep: normalise all `*.nix` with `nixfmt 1.1.0` so the tree matches what CI now enforces. No semantic changes.
- Document the rule in `CONTRIBUTING.md` and `docs/.../coding-standards.md`: **no drive-by reformatting.** A style change and a semantic change must not share a commit, and formatter switches are out of scope for feature/fix PRs.

## Why

PR #5258 re-formatted `flake.nix` unilaterally with `alejandra`, tucking the formatter swap inside a 7-line feature. That pattern — mixing style and semantics, plus changing formatter with no repo-wide decision — makes diffs unreviewable and `git blame` useless. This PR closes the loophole: one canonical formatter per language, pinned, CI-enforced, documented.

## Commits

1. `style: normalise all *.nix files with nixfmt 1.1.0` — the one-time sweep (1198/954 lines, formatter-only).
2. `chore(nix): pin formatters in dev shell, add just fmt, enforce nixfmt in CI`.
3. `docs(contributing): pin formatters, ban drive-by reformatting`.

## Test plan

- [x] `just check-fmt` passes on a clean tree.
- [x] `just fmt` is a no-op on a clean tree.
- [x] Each commit individually evaluates the flake (`nix eval .#cardano-wallet.name`).
- [x] CI green on PR.