### PR TITLE
fix: correct release asset naming, docker tag format, and add publish gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,11 +348,14 @@ jobs:
           upload windows-release        zip     "cardano-wallet.exe-$TAG-win64.zip"
           upload macos-silicon-release   tar.gz  "cardano-wallet-$TAG-macos-silicon.tar.gz"
 
-          # Docker image has no extension
+          # Docker image has no extension; rename before upload so the asset
+          # name (not just its display label) matches the expected pattern.
           docker_file=$(find docker-image -type f | head -1)
           if [ -n "$docker_file" ]; then
-            echo "Uploading $docker_file as cardano-wallet-$TAG-docker-image.tgz"
-            gh release upload "$TAG" "$docker_file#cardano-wallet-$TAG-docker-image.tgz"
+            target="cardano-wallet-$TAG-docker-image.tgz"
+            cp "$docker_file" "$target"
+            echo "Uploading $target"
+            gh release upload "$TAG" "$target"
           fi
 
   push-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,8 @@ jobs:
     if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.build-artifacts.result == 'success' && needs.verify-artifacts.result == 'success' && needs.changelog.result == 'success' && (needs.e2e-linux.result == 'success' || needs.e2e-linux.result == 'skipped') && (needs.e2e-windows.result == 'success' || needs.e2e-windows.result == 'skipped') }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     environment: ${{ (inputs.release_type == 'release' && github.ref == 'refs/heads/master') && 'release' || '' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     env:
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
       RELEASE_CANDIDATE_COMMIT: ${{ needs.prepare.outputs.release-candidate-commit }}
@@ -358,9 +360,35 @@ jobs:
             gh release upload "$TAG" "$target"
           fi
 
+  verify-assets:
+    name: "Verify Published Assets"
+    needs: [prepare, create-release]
+    uses: ./.github/workflows/verify-release.yml
+    with:
+      tag: ${{ needs.create-release.outputs.tag }}
+      expected-version: ${{ needs.prepare.outputs.release-version }}
+    secrets: inherit
+
+  publish-release:
+    name: "Publish Release"
+    needs: [prepare, create-release, verify-assets]
+    if: ${{ needs.verify-assets.result == 'success' }}
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Un-draft release
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          echo "Publishing release $TAG"
+          gh release edit "$TAG" \
+            --repo cardano-foundation/cardano-wallet \
+            --draft=false
+
   push-docker:
     name: "Push Docker Image"
-    needs: [prepare, create-release]
+    needs: [prepare, create-release, publish-release]
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
@@ -412,7 +440,7 @@ jobs:
   update-docs:
     name: "Update Documentation Links"
     if: inputs.release_type == 'release'
-    needs: [prepare, create-release]
+    needs: [prepare, create-release, publish-release]
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -4,9 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to verify (e.g. v2026-03-31)'
+        description: 'Release tag to verify (e.g. v2026-03-31, nightly, test)'
         required: true
         type: string
+      expected-version:
+        description: 'Version string expected in binary output (defaults to tag). Set this when tag is nightly/test.'
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to verify (e.g. v2026-03-31, nightly, test)'
+        required: true
+        type: string
+      expected-version:
+        description: 'Version string expected in binary output (defaults to tag). Set this when tag is nightly/test.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   verify-linux:
@@ -20,6 +36,8 @@ jobs:
         run: |
           set -uo pipefail
           TAG="${{ inputs.tag }}"
+          EXPECTED="${{ inputs.expected-version }}"
+          EXPECTED="${EXPECTED:-$TAG}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT
           cd "$WORKDIR"
@@ -40,10 +58,10 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Check version"
-          if echo "$VERSION" | grep -q "$TAG"; then
-            echo "Version check passed: contains $TAG"
+          if echo "$VERSION" | grep -q "$EXPECTED"; then
+            echo "Version check passed: contains $EXPECTED"
           else
-            echo "::error::Version output does not contain $TAG"
+            echo "::error::Version output does not contain $EXPECTED"
             exit 1
           fi
           echo "::endgroup::"
@@ -59,6 +77,8 @@ jobs:
         run: |
           set -uo pipefail
           TAG="${{ inputs.tag }}"
+          EXPECTED="${{ inputs.expected-version }}"
+          EXPECTED="${EXPECTED:-$TAG}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT
           cd "$WORKDIR"
@@ -79,10 +99,10 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Check version"
-          if echo "$VERSION" | grep -q "$TAG"; then
-            echo "Version check passed: contains $TAG"
+          if echo "$VERSION" | grep -q "$EXPECTED"; then
+            echo "Version check passed: contains $EXPECTED"
           else
-            echo "::error::Version output does not contain $TAG"
+            echo "::error::Version output does not contain $EXPECTED"
             exit 1
           fi
           echo "::endgroup::"
@@ -98,6 +118,8 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $TAG = "${{ inputs.tag }}"
+          $EXPECTED = "${{ inputs.expected-version }}"
+          if ([string]::IsNullOrEmpty($EXPECTED)) { $EXPECTED = $TAG }
           $WORKDIR = New-TemporaryFile | ForEach-Object {
             Remove-Item $_; New-Item -ItemType Directory -Path $_
           }
@@ -120,10 +142,10 @@ jobs:
             Write-Host "::endgroup::"
 
             Write-Host "::group::Check version"
-            if ($VERSION -match [regex]::Escape($TAG)) {
-              Write-Host "Version check passed: contains $TAG"
+            if ($VERSION -match [regex]::Escape($EXPECTED)) {
+              Write-Host "Version check passed: contains $EXPECTED"
             } else {
-              Write-Host "::error::Version output does not contain $TAG"
+              Write-Host "::error::Version output does not contain $EXPECTED"
               exit 1
             }
             Write-Host "::endgroup::"
@@ -143,6 +165,8 @@ jobs:
         run: |
           set -uo pipefail
           TAG="${{ inputs.tag }}"
+          EXPECTED="${{ inputs.expected-version }}"
+          EXPECTED="${EXPECTED:-$TAG}"
           WORKDIR=$(mktemp -d)
           trap "rm -rf $WORKDIR" EXIT
           cd "$WORKDIR"
@@ -162,10 +186,10 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Check version"
-          if echo "$VERSION" | grep -q "$TAG"; then
-            echo "Version check passed: contains $TAG"
+          if echo "$VERSION" | grep -q "$EXPECTED"; then
+            echo "Version check passed: contains $EXPECTED"
           else
-            echo "::error::Version output does not contain $TAG"
+            echo "::error::Version output does not contain $EXPECTED"
             exit 1
           fi
           echo "::endgroup::"

--- a/flake.nix
+++ b/flake.nix
@@ -367,6 +367,17 @@
                 cardano-wallet
                 local-cluster
               ];
+              # Convert cabal version "YYYY.M.D" back to release tag "vYYYY-MM-DD".
+              # See scripts/release/release-candidate.sh `tag_cabal_ver` for the inverse.
+              releaseTag =
+                let
+                  parts = builtins.splitString "." version;
+                  pad = s: if builtins.stringLength s < 2 then "0" + s else s;
+                  year = builtins.elemAt parts 0;
+                  month = pad (builtins.elemAt parts 1);
+                  day = pad (builtins.elemAt parts 2);
+                in
+                "v${year}-${month}-${day}";
             in
 
             pkgs.callPackage ./nix/docker.nix {
@@ -383,7 +394,7 @@
                   }
                 ])
               ];
-              tag = if isRelease then version else revision;
+              tag = if isRelease then releaseTag else revision;
             };
 
           mkDevShells = project: rec {


### PR DESCRIPTION
## Summary

Three release-workflow regressions observed after v2026-04-17, bundled per #5261, #5262, #5263.

- **Fixes #5263** — Docker image was internally tagged with the cabal-style version (`2026.4.17`) instead of the release tag (`v2026-04-17`). `flake.nix` now derives `vYYYY-MM-DD` from the cabal version before passing `tag` to `docker.nix`.
- **Fixes #5261** — Docker tarball was uploaded as `result` (the nix symlink name). `gh release upload file#label` only sets the display label, not the asset filename. `release.yml` now copies the file to the expected `cardano-wallet-$TAG-docker-image.tgz` name before upload.
- **Fixes #5262** — `verify-release.yml` (docker load + run, linux/macos/windows binary smoke tests) is now callable via `workflow_call`. `release.yml` invokes it after `create-release` as `verify-assets`, and a new `publish-release` job un-drafts the GitHub release only after verification succeeds. `push-docker` and `update-docs` are gated on `publish-release` so nothing publishes if smoke tests fail.

  Verify runs for all release types (nightly, test, release). A new `expected-version` input lets the caller assert the binary version independently of the release tag name — needed for nightly/test, where the tag is `nightly`/`test` but the binary still prints the date-based version.

## Test plan

- [ ] Dispatch a nightly run from `fix/release-workflow-issues`; confirm `verify-assets` runs, `publish-release` un-drafts the release, and assets are named correctly.
- [ ] Confirm docker tarball is named `cardano-wallet-<tag>-docker-image.tgz` and `docker load` yields an image tagged `<tag>`.

Closes #5261.
Closes #5262.
Closes #5263.