### PR TITLE
fix: use lib.splitString not builtins.splitString

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -371,7 +371,7 @@
               # See scripts/release/release-candidate.sh `tag_cabal_ver` for the inverse.
               releaseTag =
                 let
-                  parts = builtins.splitString "." version;
+                  parts = lib.splitString "." version;
                   pad = s: if builtins.stringLength s < 2 then "0" + s else s;
                   year = builtins.elemAt parts 0;
                   month = pad (builtins.elemAt parts 1);


### PR DESCRIPTION
Hotfix for #5265 — `builtins.splitString` doesn't exist (it's in `lib`). Broke `Build Docker Image` on the nightly immediately after #5265 landed.

## Test plan
- [x] `nix eval` with `lib.splitString` returns `v2026-04-17` for cabal version `2026.4.17`
- [ ] Nightly `Build Docker Image` job passes