### PR TITLE
fix: use builtins.match for cabal version to git tag conversion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -367,17 +367,17 @@
                 cardano-wallet
                 local-cluster
               ];
-              # Convert cabal version "YYYY.M.D" back to release tag "vYYYY-MM-DD".
-              # See scripts/release/release-candidate.sh `tag_cabal_ver` for the inverse.
+              # Convert cabal version ("0.YYYY.M.D" or "YYYY.M.D") to release
+              # tag "vYYYY-MM-DD". See scripts/release/release-candidate.sh
+              # `tag_cabal_ver` for the inverse.
               releaseTag =
                 let
-                  parts = lib.splitString "." version;
+                  re = ".*([[:digit:]]{4})\\.([[:digit:]]{1,2})\\.([[:digit:]]{1,2}).*";
+                  match = builtins.match re version;
                   pad = s: if builtins.stringLength s < 2 then "0" + s else s;
-                  year = builtins.elemAt parts 0;
-                  month = pad (builtins.elemAt parts 1);
-                  day = pad (builtins.elemAt parts 2);
                 in
-                "v${year}-${month}-${day}";
+                assert match != null;
+                "v${builtins.elemAt match 0}-${pad (builtins.elemAt match 1)}-${pad (builtins.elemAt match 2)}";
             in
 
             pkgs.callPackage ./nix/docker.nix {


### PR DESCRIPTION
Second hotfix for #5265. `lib` in flake.nix is the custom `nix/lib.nix` which only re-exports a subset of `nixpkgs.lib` — `splitString` isn't among them, so my first hotfix #5267 (`builtins.splitString` → `lib.splitString`) was equally broken.

Switch to `builtins.match` with a regex so we don't depend on the host lib's re-exports. The regex also tolerates the `0.` prefix present in `(builtins.head exes).version` since the cabal file reads `version: 0.2026.4.17`.

## Test plan
- [x] `nix eval` returns `v2026-04-17` for both `0.2026.4.17` and `2026.4.17`
- [ ] Nightly `Build Docker Image` passes