### PR TITLE
fix: run verify-assets, publish-release, push-docker on nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,10 @@ jobs:
   verify-assets:
     name: "Verify Published Assets"
     needs: [prepare, create-release]
+    # Explicit `if:` overrides the default `success()` filter, which
+    # would otherwise skip this job because e2e-linux/e2e-windows are
+    # skipped on nightly runs.
+    if: ${{ !cancelled() && needs.create-release.result == 'success' }}
     uses: ./.github/workflows/verify-release.yml
     with:
       tag: ${{ needs.create-release.outputs.tag }}
@@ -372,7 +376,7 @@ jobs:
   publish-release:
     name: "Publish Release"
     needs: [prepare, create-release, verify-assets]
-    if: ${{ needs.verify-assets.result == 'success' }}
+    if: ${{ !cancelled() && needs.verify-assets.result == 'success' }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -389,6 +393,7 @@ jobs:
   push-docker:
     name: "Push Docker Image"
     needs: [prepare, create-release, publish-release]
+    if: ${{ !cancelled() && needs.publish-release.result == 'success' }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
@@ -439,8 +444,8 @@ jobs:
 
   update-docs:
     name: "Update Documentation Links"
-    if: inputs.release_type == 'release'
     needs: [prepare, create-release, publish-release]
+    if: ${{ !cancelled() && inputs.release_type == 'release' && needs.publish-release.result == 'success' }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -45,11 +45,11 @@ jobs:
           echo "::group::Download linux asset"
           gh release download "$TAG" \
             --repo cardano-foundation/cardano-wallet \
-            --pattern "cardano-wallet-${TAG}-linux64.tar.gz"
+            --pattern "cardano-wallet-${EXPECTED}-linux64.tar.gz"
           echo "::endgroup::"
 
           echo "::group::Extract and verify"
-          tar xzf "cardano-wallet-${TAG}-linux64.tar.gz"
+          tar xzf "cardano-wallet-${EXPECTED}-linux64.tar.gz"
           WALLET=$(find . -name cardano-wallet -type f | head -1)
           chmod +x "$WALLET"
           echo "Binary: $WALLET"
@@ -86,11 +86,11 @@ jobs:
           echo "::group::Download macOS asset"
           gh release download "$TAG" \
             --repo cardano-foundation/cardano-wallet \
-            --pattern "cardano-wallet-${TAG}-macos-silicon.tar.gz"
+            --pattern "cardano-wallet-${EXPECTED}-macos-silicon.tar.gz"
           echo "::endgroup::"
 
           echo "::group::Extract and verify"
-          tar xzf "cardano-wallet-${TAG}-macos-silicon.tar.gz"
+          tar xzf "cardano-wallet-${EXPECTED}-macos-silicon.tar.gz"
           WALLET=$(find . -name cardano-wallet -type f | head -1)
           chmod +x "$WALLET"
           echo "Binary: $WALLET"
@@ -129,11 +129,11 @@ jobs:
             Write-Host "::group::Download Windows asset"
             gh release download $TAG `
               --repo cardano-foundation/cardano-wallet `
-              --pattern "cardano-wallet.exe-${TAG}-win64.zip"
+              --pattern "cardano-wallet.exe-${EXPECTED}-win64.zip"
             Write-Host "::endgroup::"
 
             Write-Host "::group::Extract and verify"
-            Expand-Archive "cardano-wallet.exe-${TAG}-win64.zip" -DestinationPath .
+            Expand-Archive "cardano-wallet.exe-${EXPECTED}-win64.zip" -DestinationPath .
             $WALLET = Get-ChildItem -Recurse -Filter "cardano-wallet.exe" |
               Select-Object -First 1 -ExpandProperty FullName
             Write-Host "Binary: $WALLET"


### PR DESCRIPTION
## Summary

Follow-up to #5261 / #5262 / #5263. The nightly run at https://github.com/cardano-foundation/cardano-wallet/actions/runs/24722289961 revealed two remaining issues:

1. **Default `success()` filter poisons the downstream chain.** When `e2e-linux` / `e2e-windows` are skipped on nightly, the default success() filter on jobs without an explicit `if:` treats the transitive skip as non-success and skips them too. `verify-assets`, `publish-release`, `push-docker` and `update-docs` were all skipped on the nightly run even though `create-release` succeeded. (`push-docker` has actually been skipped on every prior nightly for the same reason — pre-existing.)
2. **Nightly asset filenames embed the release-version (date), not the tag.** `gh release upload file#label` only sets the display label; the real asset name stays as the source filename. So on nightly, `cardano-wallet-v2026-04-21-linux64.tar.gz` is the real asset and `cardano-wallet-nightly-linux64.tar.gz` is only a label. The new `verify-release.yml` was downloading by `cardano-wallet-\${TAG}-linux64.tar.gz` which would not match for nightly.

## Changes

- `release.yml` — add `if: \${{ !cancelled() && needs.<upstream>.result == 'success' }}` to `verify-assets`, `publish-release`, `push-docker`, `update-docs`.
- `verify-release.yml` — linux/macos/windows download patterns use `\$EXPECTED` (release-version) instead of `\$TAG`. Docker stays on `\$TAG` since the docker asset is renamed by tag at upload time.

## Test plan

- [ ] Dispatch `release.yml` nightly against this branch
- [ ] Verify the four post-create-release jobs actually run
- [ ] Nightly release un-drafts after `publish-release`
- [ ] Docker image pushed to Docker Hub under `nightly` tag