### PR TITLE
feat: wallet-owned types + ledger-native builders (drop-cardano-api foundation)

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server.hs
@@ -208,8 +208,9 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
-    , NetworkId (..)
+    , NetworkId
     , fromSNetworkId
+    , networkIdToLedger
     )
 import Cardano.Wallet.Primitive.Types
     ( PoolMetadataSource (..)
@@ -266,6 +267,7 @@ import Prelude
 import qualified Cardano.Address.Derivation as CA
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Style.Shelley as CA
+import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Wallet.Address.Derivation.Shared as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Data.Text as T
@@ -798,9 +800,8 @@ postAnyAddress net addrData = do
   where
     fromXPub = fromJust . CA.xpubFromBytes
     fromPub = fromJust . CA.pubFromBytes
-    netTag = case net of
-        NMainnet -> 1
-        NTestnet _ -> 0
+    netTag =
+        toInteger $ Ledger.networkToWord8 $ networkIdToLedger net
     spendingFrom cred = case cred of
         CredentialPubKey bytes ->
             CA.PaymentFromKey $ CA.liftPub $ fromPub bytes

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server.hs
@@ -23,9 +23,6 @@ import Cardano.Address.Script
     ( prettyErrValidateScript
     , validateScript
     )
-import Cardano.Api
-    ( NetworkId
-    )
 import Cardano.Pool.Metadata
     ( HealthCheckSMASH (NoSmashConfigured)
     , defaultManagerSettings
@@ -211,7 +208,8 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
-    , networkIdVal
+    , NetworkId (..)
+    , fromSNetworkId
     )
 import Cardano.Wallet.Primitive.Types
     ( PoolMetadataSource (..)
@@ -268,7 +266,6 @@ import Prelude
 import qualified Cardano.Address.Derivation as CA
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Style.Shelley as CA
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Address.Derivation.Shared as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Data.Text as T
@@ -300,7 +297,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> byronCoinSelections
         :<|> byronTransactions
         :<|> byronMigrations
-        :<|> network' (networkIdVal (sNetworkId @n))
+        :<|> network' (fromSNetworkId (sNetworkId @n))
         :<|> proxy
         :<|> settingS
         :<|> smash
@@ -344,7 +341,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     addresses =
         listAddresses shelley (normalizeDelegationAddress @_ @ShelleyKey @n)
             :<|> (handler ApiAddressInspect . inspectAddress . unApiAddressInspectData)
-            :<|> (handler id . postAnyAddress (networkIdVal (sNetworkId @n)))
+            :<|> (handler id . postAnyAddress (fromSNetworkId (sNetworkId @n)))
       where
         toServerError :: TextDecodingError -> ServerError
         toServerError = apiError err400 BadRequest . T.pack . getTextDecodingError
@@ -802,8 +799,8 @@ postAnyAddress net addrData = do
     fromXPub = fromJust . CA.xpubFromBytes
     fromPub = fromJust . CA.pubFromBytes
     netTag = case net of
-        Cardano.Mainnet -> 1
-        _ -> 0
+        NMainnet -> 1
+        NTestnet _ -> 0
     spendingFrom cred = case cred of
         CredentialPubKey bytes ->
             CA.PaymentFromKey $ CA.liftPub $ fromPub bytes

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/NetworkInformation.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/NetworkInformation.hs
@@ -11,11 +11,6 @@ module Cardano.Wallet.Api.Http.Server.Handlers.NetworkInformation
     )
 where
 
-import Cardano.Api
-    ( NetworkId
-    , toNetworkMagic
-    , unNetworkMagic
-    )
 import Cardano.Wallet.Api.Types
     ( ApiBlockInfo (..)
     , ApiBlockReference (..)
@@ -31,6 +26,9 @@ import Cardano.Wallet.Network
     )
 import Cardano.Wallet.Pools
     ( EpochInfo (..)
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkId (..)
     )
 import Cardano.Wallet.Primitive.Slotting
     ( RelativeTime
@@ -48,6 +46,10 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , SlotId
     , SlotNo (..)
+    )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..)
+    , mainnetMagic
     )
 import Control.Monad.IO.Class
     ( liftIO
@@ -79,7 +81,6 @@ import Servant.Server
     )
 import Prelude
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Era as ApiEra
 import qualified Cardano.Wallet.Read as Read
@@ -121,10 +122,15 @@ getNetworkInformation
                 , Api.networkInfo =
                     Api.ApiNetworkInfo
                         ( case nid of
-                            Cardano.Mainnet -> "mainnet"
-                            Cardano.Testnet _ -> "testnet"
+                            NMainnet -> "mainnet"
+                            NTestnet _ -> "testnet"
                         )
-                        (fromIntegral $ unNetworkMagic $ toNetworkMagic nid)
+                        ( case nid of
+                            NMainnet ->
+                                fromIntegral
+                                    $ getProtocolMagic mainnetMagic
+                            NTestnet magic -> fromIntegral magic
+                        )
                 , Api.walletMode = mode
                 }
       where

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -40,7 +40,9 @@ library
   build-depends:
     , aeson
     , array
+    , attoparsec
     , base
+    , base16-bytestring
     , bech32
     , bech32-th
     , binary
@@ -204,6 +206,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxExtended
     Cardano.Wallet.Primitive.Types.Tx.TxIn
     Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    Cardano.Wallet.Primitive.Types.Tx.TxMetadata
     Cardano.Wallet.Primitive.Types.Tx.TxOut
     Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     Cardano.Wallet.Primitive.Types.TxParameters

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE Rank2Types #-}
-
 -- |
 -- Copyright: © 2020-2022 IOHK
 -- License: Apache-2.0
@@ -8,41 +5,16 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
     ( fromSealedTx
     ) where
 
-import Cardano.Api
-    ( InAnyCardanoEra (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.SealedTx
-    ( SealedTx (unsafeCardanoTx)
+    ( SealedTx (unsafeReadTx)
     )
 import Cardano.Wallet.Read
-    ( EraValue (..)
-    , Tx (..)
+    ( EraValue
+    , Tx
     )
-import Cardano.Wallet.Read.Eras
-    ( Allegra
-    , Alonzo
-    , Babbage
-    , Conway
-    , Mary
-    , Shelley
-    )
-import Prelude
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
 
+-- | Extract the 'EraValue Tx' from a 'SealedTx'.
 fromSealedTx :: W.SealedTx -> EraValue Tx
-fromSealedTx sealed =
-    case unsafeCardanoTx sealed of
-        InAnyCardanoEra _ce tx -> fromCardanoApiTx tx
-
-fromCardanoApiTx :: Cardano.Tx era -> EraValue Tx
-fromCardanoApiTx tx0 = case tx0 of
-    Cardano.ShelleyTx era tx -> case era of
-        Cardano.ShelleyBasedEraShelley -> EraValue (Tx tx :: Tx Shelley)
-        Cardano.ShelleyBasedEraAllegra -> EraValue (Tx tx :: Tx Allegra)
-        Cardano.ShelleyBasedEraMary -> EraValue (Tx tx :: Tx Mary)
-        Cardano.ShelleyBasedEraAlonzo -> EraValue (Tx tx :: Tx Alonzo)
-        Cardano.ShelleyBasedEraBabbage -> EraValue (Tx tx :: Tx Babbage)
-        Cardano.ShelleyBasedEraConway -> EraValue (Tx tx :: Tx Conway)
-        _ -> error "fromCardanoApiTx: era not yet supported"
+fromSealedTx = unsafeReadTx

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Primitive.NetworkId
     , withSNetworkId
     , networkIdVal
     , networkIdToLedger
+    , sNetworkIdToLedger
     )
 where
 
@@ -79,6 +80,10 @@ class NetworkDiscriminantCheck k where
     Value level network discrimination
 ------------------------------------------------------------------------------}
 
+-- | Value-level network identifier used where the wallet still needs the
+-- testnet magic. The ledger 'Ledger.Network' only distinguishes mainnet from
+-- testnet, so use 'networkIdToLedger' at ledger boundaries that do not need
+-- the magic.
 data NetworkId
     = NMainnet
     | NTestnet Natural
@@ -141,10 +146,14 @@ networkIdVal (STestnet snat) = Cardano.Testnet networkMagic
     networkMagic =
         Cardano.NetworkMagic . fromIntegral $ fromSNat snat
 
+-- | Project a wallet 'NetworkId' to the ledger's magic-free 'Ledger.Network'.
+networkIdToLedger :: NetworkId -> Ledger.Network
+networkIdToLedger NMainnet = Ledger.Mainnet
+networkIdToLedger (NTestnet _) = Ledger.Testnet
+
 -- | Convert a 'SNetworkId' to a ledger 'Network' value.
-networkIdToLedger :: SNetworkId n -> Ledger.Network
-networkIdToLedger SMainnet = Ledger.Mainnet
-networkIdToLedger (STestnet _) = Ledger.Testnet
+sNetworkIdToLedger :: SNetworkId n -> Ledger.Network
+sNetworkIdToLedger = networkIdToLedger . fromSNetworkId
 
 {-----------------------------------------------------------------------------
    conversions

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs
@@ -23,6 +23,7 @@ module Cardano.Wallet.Primitive.NetworkId
     , fromSNetworkId
     , withSNetworkId
     , networkIdVal
+    , networkIdToLedger
     )
 where
 
@@ -51,6 +52,7 @@ import GHC.TypeNats
 import Prelude
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Data.Text as T
 
 {-------------------------------------------------------------------------------
@@ -138,6 +140,11 @@ networkIdVal (STestnet snat) = Cardano.Testnet networkMagic
   where
     networkMagic =
         Cardano.NetworkMagic . fromIntegral $ fromSNat snat
+
+-- | Convert a 'SNetworkId' to a ledger 'Network' value.
+networkIdToLedger :: SNetworkId n -> Ledger.Network
+networkIdToLedger SMainnet = Ledger.Mainnet
+networkIdToLedger (STestnet _) = Ledger.Testnet
 
 {-----------------------------------------------------------------------------
    conversions

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -305,7 +305,7 @@ sealedTxFromCardanoBody =
     mk body = Cardano.Tx body []
 
 -- | Try to deserialize bytes into 'EraValue Read.Tx',
--- trying Conway first, then older eras.
+-- trying the newest ledger era first, then older eras.
 readTxFromBytes
     :: AnyCardanoEra
     -> ByteString
@@ -315,7 +315,9 @@ readTxFromBytes maxEra bs =
         $ map snd
         $ filter
             (withinEra maxEra . fst)
-            [ tryEra @Conway
+            [ tryEra @Dijkstra
+                (AnyCardanoEra DijkstraEra)
+            , tryEra @Conway
                 (AnyCardanoEra ConwayEra)
             , tryEra @Babbage
                 (AnyCardanoEra BabbageEra)
@@ -357,6 +359,10 @@ readTxFromBytes maxEra bs =
 --
 -- Temporary: kept for functions that still need
 -- cardano-api types. Will be removed.
+--
+-- Dijkstra is intentionally absent here because the wallet's
+-- temporary 'CardanoApiEra' bridge does not support it. The
+-- ledger-native 'readTxFromBytes' path above already tries Dijkstra.
 cardanoTxFromBytes
     :: AnyCardanoEra
     -> ByteString

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,7 +17,7 @@
 -- This module provides the `SealedTx` data type.
 module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( -- * Types
-      SealedTx (serialisedTx, unsafeCardanoTx)
+      SealedTx (serialisedTx, unsafeReadTx)
     , cardanoTxIdeallyNoLaterThan
     , cardanoTxInExactEra
     , sealedTxFromBytes
@@ -40,15 +42,30 @@ import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
     , InAnyCardanoEra (..)
-    , InAnyShelleyBasedEra (..)
     , anyCardanoEra
     , deserialiseFromCBOR
     )
 import Cardano.Api.Tx
     ( Tx (ShelleyTx)
     )
-import Cardano.Binary
+import Cardano.Ledger.Binary
     ( DecoderError
+    )
+import Cardano.Read.Ledger.Tx.CBOR
+    ( deserializeTx
+    )
+import Cardano.Wallet.Read
+    ( EraValue (..)
+    )
+import Cardano.Wallet.Read.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Conway
+    , Dijkstra
+    , IsEra
+    , Mary
+    , Shelley
     )
 import Cardano.Wallet.Util
     ( HasCallStack
@@ -74,22 +91,14 @@ import Data.Data
 import Data.Either
     ( partitionEithers
     )
-import Data.Either.Extra
-    ( eitherToMaybe
-    )
 import Data.Function
     ( on
     )
 import Data.Text
     ( Text
     )
-import Data.Type.Equality
-    ( testEquality
-    , (:~:) (..)
-    )
 import Fmt
     ( Buildable (..)
-    , Builder
     , hexF
     , (+||)
     , (||+)
@@ -97,119 +106,94 @@ import Fmt
 import GHC.Generics
     ( Generic
     )
-import Text.Pretty.Simple
-    ( pShowNoColor
-    )
 import Prelude
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
--- | 'SealedTx' is a transaction for any hard fork era, possibly incomplete,
--- possibly unsigned, with dual representations to make it convenient to use.
+-- | 'SealedTx' is a transaction for any hard fork era,
+-- possibly incomplete, possibly unsigned, with dual
+-- representations to make it convenient to use.
 --
--- Serialisation/deserialisation is usually done at the application boundaries
--- (e.g. in the API server), and then the wallet core can use it either as a
--- 'ByteString', or as a 'Cardano.Api.Tx'.
+-- Serialisation/deserialisation is usually done at the
+-- application boundaries (e.g. in the API server), and
+-- then the wallet core can use it either as a
+-- 'ByteString', or as a 'Read.Tx'.
 --
--- Construct it with either 'sealedTxFromCardano' or 'sealedTxFromBytes'.
+-- Construct it with either 'sealedTxFromCardano' or
+-- 'sealedTxFromBytes'.
 data SealedTx = SealedTx
     { valid :: Bool
-    -- ^ Internal flag - indicates that the 'serialisedTx' bytes encode a valid
-    -- Cardano transaction. If the "proper" constructors are used, this will
-    -- always be True, but it will be False if 'mockSealedTx' is used to
-    -- construct a 'SealedTx' for unit tests.
-    , unsafeCardanoTx :: InAnyCardanoEra Cardano.Tx
-    -- ^ Decoded transaction. Potentially in the wrong era.
+    -- ^ Internal flag - indicates that the
+    -- 'serialisedTx' bytes encode a valid Cardano
+    -- transaction. If the "proper" constructors are
+    -- used, this will always be True, but it will be
+    -- False if 'mockSealedTx' is used to construct a
+    -- 'SealedTx' for unit tests.
+    , unsafeReadTx :: EraValue Read.Tx
+    -- ^ Decoded transaction.
+    -- Potentially in the wrong era.
     , serialisedTx :: ByteString
     -- ^ CBOR-serialised bytes of the transaction.
     }
     deriving stock (Generic)
 
 instance Show SealedTx where
-    -- InAnyCardanoEra is missing a Show instance, so define one inline.
     showsPrec d (SealedTx v tx' bs) =
         showParen (d > 10)
             $ showString "SealedTx "
-                . (if v then showParen True (showsTx tx') else showString "undefined")
+                . ( if v
+                        then showsPrec 11 tx'
+                        else showString "undefined"
+                  )
                 . showChar ' '
                 . showsPrec 11 bs
                 . showChar ' '
                 . showsPrec 11 v
-      where
-        showsTx :: InAnyCardanoEra Cardano.Tx -> ShowS
-        showsTx (InAnyCardanoEra era tx) =
-            showString "InAnyCardanoEra"
-                . showChar ' '
-                . showsPrec 11 era
-                . showChar ' '
-                . showsPrec 11 tx
 
 instance Buildable SealedTx where
-    build (SealedTx v tx' bs) = if v then buildTx tx' else hexF bs
-      where
-        buildTx :: InAnyCardanoEra Cardano.Tx -> Builder
-        buildTx (InAnyCardanoEra _ tx) = build $ pShowNoColor tx
+    build (SealedTx v tx' bs)
+        | v = build (show tx')
+        | otherwise = hexF bs
 
 instance Eq SealedTx where
-    SealedTx v1 tx1 bs1 == SealedTx v2 tx2 bs2
-        | v1 && v2 = sameEra tx1 tx2 && bs1 == bs2
+    SealedTx v1 _ bs1 == SealedTx v2 _ bs2
         | v1 == v2 = bs1 == bs2
         | otherwise = False
 
-sameEra :: InAnyCardanoEra a -> InAnyCardanoEra a -> Bool
-sameEra (InAnyCardanoEra e1 _) (InAnyCardanoEra e2 _) =
-    case testEquality e1 e2 of
-        Just Refl -> True
-        Nothing -> False
-
 instance NFData SealedTx where
-    rnf (SealedTx v (InAnyCardanoEra _ tx) bs) = tx' `deepseq` bs `deepseq` ()
-      where
-        -- Showing the transaction should be enough to fully evaluate it.
-        tx' = if v then show tx else ""
+    rnf (SealedTx v _ bs) =
+        v `deepseq` bs `deepseq` ()
 
--- Helper function to constrain the era of a 'SealedTx' to at most the provided
--- era. If this is not possible, the original 'SealedTx' is returned.
---
--- In contrast to the "most recent era" argument of @sealedTxFromBytes'@, this
--- function allows constraining the era at a point after the tx has been
--- deserialised. For instance, in a server handler with known current era,
--- instead of in an @Aeson.FromJSON@ instance.
---
--- >>> ideallyNoLaterThan alonzoEra alonzoCompatibleBabbageTx
--- alonzoCompatibleBabbageTx
---
--- >>> ideallyNoLaterThan alonzoEra alonzoIncompatibleBabbageTx
--- babbageTx
---
--- == Is this what we want? (for the new tx-workflow..)
---
--- Probably not. This is a minimally invasive approach to ensure:
--- - tx workflow works in both Alonzo and Babbage
--- - tx workflow tries to create Alonzo txs in Alonzo and Babbage txs in Babbage
---
--- With the added behaviour:
--- - tx workflow may partially work for babbage-only txs when in alonzo
-ideallyNoLaterThan
-    :: AnyCardanoEra
-    -> SealedTx
-    -> SealedTx
-ideallyNoLaterThan maxEra sealedTx =
-    either
-        (const sealedTx)
-        (sealedTxFromCardano)
-        (cardanoTxFromBytes maxEra (serialisedTx sealedTx))
-
+-- | Temporary: reconstructs 'InAnyCardanoEra Cardano.Tx'
+-- from bytes on demand. Will be removed when callers
+-- migrate to 'Read.Tx'.
 cardanoTxIdeallyNoLaterThan
     :: AnyCardanoEra
     -> SealedTx
     -> InAnyCardanoEra Cardano.Tx
-cardanoTxIdeallyNoLaterThan era = unsafeCardanoTx . ideallyNoLaterThan era
+cardanoTxIdeallyNoLaterThan maxEra stx =
+    case cardanoTxFromBytes
+        maxEra
+        (serialisedTx stx) of
+        Right tx -> tx
+        Left _ ->
+            -- Fall back: try all eras
+            case cardanoTxFromBytes
+                maxBound
+                (serialisedTx stx) of
+                Right tx -> tx
+                Left e ->
+                    internalError
+                        $ "cardanoTxIdeallyNoLaterThan: "
+                        +|| e
+                        ||+ ""
 
--- | Re-deserialises the bytes of the 'SealedTx' as a transaction in the
--- provided era, and that era only.
+-- | Re-deserialises the bytes of the 'SealedTx' as a
+-- transaction in the provided era, and that era only.
 cardanoTxInExactEra
     :: forall era
      . Cardano.IsShelleyBasedEra era
@@ -219,66 +203,187 @@ cardanoTxInExactEra
 cardanoTxInExactEra _ tx =
     eitherToMaybe
         $ deserialiseFromCBOR
-            (Cardano.AsTx (Cardano.proxyToAsType $ Proxy @era))
+            ( Cardano.AsTx
+                (Cardano.proxyToAsType $ Proxy @era)
+            )
         $ serialisedTx tx
-
-getSealedTxBody :: SealedTx -> InAnyCardanoEra Cardano.TxBody
-getSealedTxBody (SealedTx _ (InAnyCardanoEra era tx) _) =
-    InAnyCardanoEra era (Cardano.getTxBody tx)
-
-getSealedTxWitnesses
-    :: SealedTx -> [InAnyCardanoEra Cardano.KeyWitness]
-getSealedTxWitnesses (SealedTx _ (InAnyCardanoEra era tx) _) =
-    [InAnyCardanoEra era w | w <- Cardano.getTxWitnesses tx]
-
--- Every 'Cardano.Tx' is now in a Shelley-based era,
--- as the 'ByronTx' constructor has been removed in cardano-api-8.36.0.0
-castInAnyCardanoEraTx
-    :: InAnyCardanoEra Cardano.Tx -> InAnyShelleyBasedEra Cardano.Tx
-castInAnyCardanoEraTx (InAnyCardanoEra _era tx@(ShelleyTx era' _)) =
-    InAnyShelleyBasedEra era' tx
-
--- | Construct a 'SealedTx' from a "Cardano.Api" transaction.
-sealedTxFromCardano :: InAnyCardanoEra Cardano.Tx -> SealedTx
-sealedTxFromCardano tx =
-    SealedTx True tx (cardanoTxToBytes $ castInAnyCardanoEraTx tx)
   where
-    cardanoTxToBytes :: InAnyShelleyBasedEra Cardano.Tx -> ByteString
-    cardanoTxToBytes (InAnyShelleyBasedEra era tx') =
-        Cardano.shelleyBasedEraConstraints era (Cardano.serialiseToCBOR tx')
+    eitherToMaybe :: Either a b -> Maybe b
+    eitherToMaybe = either (const Nothing) Just
 
--- | Construct a 'SealedTx' from a "Cardano.Api" transaction.
+-- | Temporary: reconstructs cardano-api TxBody from
+-- bytes. Will be removed when callers migrate.
+getSealedTxBody
+    :: SealedTx -> InAnyCardanoEra Cardano.TxBody
+getSealedTxBody stx =
+    case cardanoTxFromBytes
+        maxBound
+        (serialisedTx stx) of
+        Right (InAnyCardanoEra era tx) ->
+            InAnyCardanoEra era (Cardano.getTxBody tx)
+        Left e ->
+            internalError
+                $ "getSealedTxBody: "
+                +|| e
+                ||+ ""
+
+-- | Temporary: reconstructs cardano-api witnesses from
+-- bytes. Will be removed when callers migrate.
+getSealedTxWitnesses
+    :: SealedTx
+    -> [InAnyCardanoEra Cardano.KeyWitness]
+getSealedTxWitnesses stx =
+    case cardanoTxFromBytes
+        maxBound
+        (serialisedTx stx) of
+        Right (InAnyCardanoEra era tx) ->
+            [ InAnyCardanoEra era w
+            | w <- Cardano.getTxWitnesses tx
+            ]
+        Left e ->
+            internalError
+                $ "getSealedTxWitnesses: "
+                +|| e
+                ||+ ""
+
+-- | Convert a cardano-api 'Tx' to 'EraValue Read.Tx'.
+cardanoApiTxToReadTx
+    :: Cardano.Tx era -> EraValue Read.Tx
+cardanoApiTxToReadTx (ShelleyTx sbe ledgerTx) =
+    case sbe of
+        Cardano.ShelleyBasedEraShelley ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Shelley)
+        Cardano.ShelleyBasedEraAllegra ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Allegra)
+        Cardano.ShelleyBasedEraMary ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Mary)
+        Cardano.ShelleyBasedEraAlonzo ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Alonzo)
+        Cardano.ShelleyBasedEraBabbage ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Babbage)
+        Cardano.ShelleyBasedEraConway ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Conway)
+        Cardano.ShelleyBasedEraDijkstra ->
+            EraValue (Read.Tx ledgerTx :: Read.Tx Dijkstra)
+
+-- | Construct a 'SealedTx' from a "Cardano.Api"
+-- transaction.
+sealedTxFromCardano
+    :: InAnyCardanoEra Cardano.Tx -> SealedTx
+sealedTxFromCardano (InAnyCardanoEra _era tx) =
+    let readTx = cardanoApiTxToReadTx tx
+        bs = cardanoApiTxToBytes tx
+    in  SealedTx True readTx bs
+  where
+    cardanoApiTxToBytes
+        :: Cardano.Tx e -> ByteString
+    cardanoApiTxToBytes tx'@(ShelleyTx sbe _) =
+        Cardano.shelleyBasedEraConstraints
+            sbe
+            (Cardano.serialiseToCBOR tx')
+
+-- | Construct a 'SealedTx' from a "Cardano.Api"
+-- transaction.
 sealedTxFromCardano'
-    :: Cardano.IsCardanoEra era => Cardano.Tx era -> SealedTx
-sealedTxFromCardano' = sealedTxFromCardano . InAnyCardanoEra Cardano.cardanoEra
+    :: Cardano.IsCardanoEra era
+    => Cardano.Tx era
+    -> SealedTx
+sealedTxFromCardano' =
+    sealedTxFromCardano
+        . InAnyCardanoEra Cardano.cardanoEra
 
 -- | Construct a 'SealedTx' from a 'Cardano.Api.TxBody'.
 sealedTxFromCardanoBody
-    :: Cardano.IsCardanoEra era => Cardano.TxBody era -> SealedTx
-sealedTxFromCardanoBody = sealedTxFromCardano . InAnyCardanoEra Cardano.cardanoEra . mk
+    :: Cardano.IsCardanoEra era
+    => Cardano.TxBody era
+    -> SealedTx
+sealedTxFromCardanoBody =
+    sealedTxFromCardano
+        . InAnyCardanoEra Cardano.cardanoEra
+        . mk
   where
     mk body = Cardano.Tx body []
 
--- | Deserialise a Cardano transaction. The transaction can be in the format of
--- any era. This function will try the most recent era first, then
--- previous eras until 'ByronEra'.
+-- | Try to deserialize bytes into 'EraValue Read.Tx',
+-- trying Conway first, then older eras.
+readTxFromBytes
+    :: AnyCardanoEra
+    -> ByteString
+    -> Either DecoderError (EraValue Read.Tx)
+readTxFromBytes maxEra bs =
+    asum
+        $ map snd
+        $ filter
+            (withinEra maxEra . fst)
+            [ tryEra @Conway
+                (AnyCardanoEra ConwayEra)
+            , tryEra @Babbage
+                (AnyCardanoEra BabbageEra)
+            , tryEra @Alonzo
+                (AnyCardanoEra AlonzoEra)
+            , tryEra @Mary
+                (AnyCardanoEra MaryEra)
+            , tryEra @Allegra
+                (AnyCardanoEra AllegraEra)
+            , tryEra @Shelley
+                (AnyCardanoEra ShelleyEra)
+            ]
+  where
+    lbs = BL.fromStrict bs
+
+    tryEra
+        :: forall era
+         . IsEra era
+        => AnyCardanoEra
+        -> ( AnyCardanoEra
+           , Either DecoderError (EraValue Read.Tx)
+           )
+    tryEra eraTag =
+        ( eraTag
+        , EraValue
+            <$> (deserializeTx lbs :: Either DecoderError (Read.Tx era))
+        )
+
+    asum :: [Either e a] -> Either e a
+    asum xs = case partitionEithers xs of
+        (_, (a : _)) -> Right a
+        ((e : _), []) -> Left e
+        ([], []) ->
+            internalError "readTxFromBytes: impossible"
+
+-- | Deserialise a Cardano transaction. The transaction
+-- can be in the format of any era. This function will
+-- try the most recent era first, then previous eras.
+--
+-- Temporary: kept for functions that still need
+-- cardano-api types. Will be removed.
 cardanoTxFromBytes
     :: AnyCardanoEra
-    -- ^ Most recent era
     -> ByteString
-    -- ^ Serialised transaction
     -> Either DecoderError (InAnyCardanoEra Cardano.Tx)
 cardanoTxFromBytes maxEra bs =
     asum
         $ map snd
         $ filter
             (withinEra maxEra . fst)
-            [ deserialise ConwayEra Cardano.AsConwayEra
-            , deserialise BabbageEra Cardano.AsBabbageEra
-            , deserialise AlonzoEra Cardano.AsAlonzoEra
-            , deserialise MaryEra Cardano.AsMaryEra
-            , deserialise AllegraEra Cardano.AsAllegraEra
-            , deserialise ShelleyEra Cardano.AsShelleyEra
+            [ deserialise
+                ConwayEra
+                Cardano.AsConwayEra
+            , deserialise
+                BabbageEra
+                Cardano.AsBabbageEra
+            , deserialise
+                AlonzoEra
+                Cardano.AsAlonzoEra
+            , deserialise
+                MaryEra
+                Cardano.AsMaryEra
+            , deserialise
+                AllegraEra
+                Cardano.AsAllegraEra
+            , deserialise
+                ShelleyEra
+                Cardano.AsShelleyEra
             ]
   where
     deserialise
@@ -286,22 +391,29 @@ cardanoTxFromBytes maxEra bs =
          . Cardano.IsShelleyBasedEra era
         => CardanoEra era
         -> Cardano.AsType era
-        -> (AnyCardanoEra, Either DecoderError (InAnyCardanoEra Cardano.Tx))
-    deserialise era asEra =
-        ( anyCardanoEra era
-        , InAnyCardanoEra era <$> deserialiseFromCBOR (Cardano.AsTx asEra) bs
+        -> ( AnyCardanoEra
+           , Either
+                DecoderError
+                (InAnyCardanoEra Cardano.Tx)
+           )
+    deserialise cera asEra =
+        ( anyCardanoEra cera
+        , InAnyCardanoEra cera
+            <$> deserialiseFromCBOR
+                (Cardano.AsTx asEra)
+                bs
         )
 
-    -- \| Given a list of deserialise results that may fail, return the first
-    -- success. If there was no success, then return the first failure message.
     asum :: [Either e a] -> Either e a
     asum xs = case partitionEithers xs of
         (_, (a : _)) -> Right a
         ((e : _), []) -> Left e
-        ([], []) -> internalError "cardanoTxFromBytes: impossible"
+        ([], []) ->
+            internalError
+                "cardanoTxFromBytes: impossible"
 
--- | @a `withinEra` b@ is 'True' iff @b@ is the same era as @a@, or an earlier
--- one.
+-- | @a `withinEra` b@ is 'True' iff @b@ is the same
+-- era as @a@, or an earlier one.
 withinEra :: AnyCardanoEra -> AnyCardanoEra -> Bool
 withinEra = (>=) `on` numberEra
   where
@@ -316,39 +428,49 @@ withinEra = (>=) `on` numberEra
         ConwayEra -> 7
         _ -> 8
 
--- | Deserialise a transaction to construct a 'SealedTx'.
-sealedTxFromBytes :: ByteString -> Either DecoderError SealedTx
+-- | Deserialise a transaction to construct a
+-- 'SealedTx'.
+sealedTxFromBytes
+    :: ByteString -> Either DecoderError SealedTx
 sealedTxFromBytes = sealedTxFromBytes' maxBound
 
--- | Deserialise a transaction to construct a 'SealedTx'.
+-- | Deserialise a transaction to construct a
+-- 'SealedTx'.
 sealedTxFromBytes'
     :: AnyCardanoEra
     -- ^ Most recent era
     -> ByteString
     -- ^ Serialised transaction
     -> Either DecoderError SealedTx
-sealedTxFromBytes' era bs =
+sealedTxFromBytes' maxEra bs =
     SealedTx True
-        <$> cardanoTxFromBytes era bs
+        <$> readTxFromBytes maxEra bs
         <*> pure bs
 
--- | Serialise a 'SealedTx' for storage in a database field. The difference
--- between 'persistSealedTx' and 'serialisedTx' is that this function has a
--- special check for values created by 'mockSealedTx'.
+-- | Serialise a 'SealedTx' for storage in a database
+-- field. The difference between 'persistSealedTx' and
+-- 'serialisedTx' is that this function has a special
+-- check for values created by 'mockSealedTx'.
 persistSealedTx :: SealedTx -> ByteString
 persistSealedTx tx = header <> serialisedTx tx
   where
-    header = if valid tx then mempty else mockSealedTxMagic
+    header =
+        if valid tx then mempty else mockSealedTxMagic
 
--- | Deserialise a 'SealedTx' which has been stored in a database field. This
--- function includes a special check for 'mockSealedTx' values.
-unPersistSealedTx :: ByteString -> Either Text SealedTx
+-- | Deserialise a 'SealedTx' which has been stored in
+-- a database field. This function includes a special
+-- check for 'mockSealedTx' values.
+unPersistSealedTx
+    :: ByteString -> Either Text SealedTx
 unPersistSealedTx bs = case unPersistMock bs of
-    Nothing -> first (T.pack . show) $ sealedTxFromBytes bs
+    Nothing ->
+        first (T.pack . show)
+            $ sealedTxFromBytes bs
     Just bs' -> Right $ mockSealedTx bs'
 
--- | A header for use by 'persistSealedTx' and 'unPersistSealedTx'. A valid
--- serialised Cardano transaction could not have this header, because they
+-- | A header for use by 'persistSealedTx' and
+-- 'unPersistSealedTx'. A valid serialised Cardano
+-- transaction could not have this header, because they
 -- always start with a CBOR map.
 mockSealedTxMagic :: ByteString
 mockSealedTxMagic = "MOCK"
@@ -358,32 +480,49 @@ unPersistMock bs
     | header == mockSealedTxMagic = Just body
     | otherwise = Nothing
   where
-    (header, body) = B8.splitAt (B8.length mockSealedTxMagic) bs
+    (header, body) =
+        B8.splitAt (B8.length mockSealedTxMagic) bs
 
--- | A serialised transaction that may be only partially signed, or even
--- invalid.
-newtype SerialisedTx = SerialisedTx {payload :: ByteString}
+-- | A serialised transaction that may be only partially
+-- signed, or even invalid.
+newtype SerialisedTx = SerialisedTx
+    {payload :: ByteString}
     deriving stock (Show, Eq, Generic, Ord)
     deriving newtype
-        (Semigroup, Monoid, ByteArray, ByteArrayAccess, NFData)
+        ( Semigroup
+        , Monoid
+        , ByteArray
+        , ByteArrayAccess
+        , NFData
+        )
 
-{-------------------------------------------------------------------------------
-                      Internal functions for unit testing
--------------------------------------------------------------------------------}
+{----------------------------------------------------
+    Internal functions for unit testing
+----------------------------------------------------}
 
 -- | Only use this for tests.
-unsafeSealedTxFromBytes :: HasCallStack => ByteString -> SealedTx
-unsafeSealedTxFromBytes = either (internalError . errMsg) id . sealedTxFromBytes
+unsafeSealedTxFromBytes
+    :: HasCallStack => ByteString -> SealedTx
+unsafeSealedTxFromBytes =
+    either (internalError . errMsg) id
+        . sealedTxFromBytes
   where
-    errMsg reason = "unsafeSealedTxFromBytes: " +|| reason ||+ ""
+    errMsg reason =
+        "unsafeSealedTxFromBytes: "
+            +|| reason
+            ||+ ""
 
--- | Construct a 'SealedTx' from a string which need not be a well-formed
--- serialised Cardano transaction.
+-- | Construct a 'SealedTx' from a string which need
+-- not be a well-formed serialised Cardano transaction.
 --
--- Be careful using the 'SealedTx', because any attempt to evaluate its
--- 'cardanoTx' field will crash.
-mockSealedTx :: HasCallStack => ByteString -> SealedTx
+-- Be careful using the 'SealedTx', because any attempt
+-- to evaluate its 'unsafeReadTx' field will crash.
+mockSealedTx
+    :: HasCallStack => ByteString -> SealedTx
 mockSealedTx =
     SealedTx
         False
-        (internalError "mockSealedTx: attempted to decode gibberish")
+        ( internalError
+            "mockSealedTx: \
+            \attempted to decode gibberish"
+        )

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs
@@ -1,0 +1,688 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: 2018-2022 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Metadata embedded in transactions. Wallet-owned copy of types and
+-- JSON conversion originally from @cardano-api@.
+module Cardano.Wallet.Primitive.Types.Tx.TxMetadata
+    ( -- * Types
+      TxMetadata (..)
+    , TxMetadataValue (..)
+
+      -- * Constructing metadata
+    , makeTransactionMetadata
+    , metaTextChunks
+    , metaBytesChunks
+
+      -- * Validating metadata
+    , validateTxMetadata
+    , TxMetadataRangeError (..)
+
+      -- * Conversion to\/from JSON
+    , TxMetadataJsonSchema (..)
+    , metadataFromJson
+    , metadataToJson
+    , metadataValueFromJsonNoSchema
+    , metadataValueToJsonNoSchema
+    , TxMetadataJsonError (..)
+    , TxMetadataJsonSchemaError (..)
+
+      -- * Internal conversion functions
+    , toShelleyMetadata
+    , fromShelleyMetadata
+    , toShelleyMetadatum
+    , fromShelleyMetadatum
+
+      -- * Shared parsing utils
+    , parseAll
+    , pUnsigned
+    , pSigned
+    , pBytes
+    )
+where
+
+import Control.Applicative
+    ( Alternative (..)
+    )
+import Control.Monad
+    ( guard
+    , when
+    )
+import Data.Bifunctor
+    ( bimap
+    , first
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Map.Strict
+    ( Map
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Word
+    ( Word64
+    )
+import GHC.Exts
+    ( IsList (..)
+    )
+import Prelude
+
+import Cardano.Ledger.Binary qualified as CBOR
+import Cardano.Ledger.Shelley.TxAuxData qualified as Shelley
+import Codec.CBOR.Magic qualified as CBOR
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Text qualified as Aeson.Text
+import Data.Attoparsec.ByteString.Char8 qualified as Atto
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Char8 qualified as B8
+import Data.List qualified as L
+import Data.Map.Lazy qualified as Map.Lazy
+import Data.Map.Strict qualified as Map
+import Data.Scientific qualified as Scientific
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import Data.Text.Lazy qualified as T.Lazy
+import Data.Text.Lazy.Builder qualified as T.Builder
+
+-- ----------------------------------------------------------------------------
+-- TxMetadata types
+--
+
+newtype TxMetadata
+    = TxMetadata {unTxMetadata :: Map Word64 TxMetadataValue}
+    deriving (Eq, Show)
+
+data TxMetadataValue
+    = TxMetaMap [(TxMetadataValue, TxMetadataValue)]
+    | TxMetaList [TxMetadataValue]
+    | TxMetaNumber Integer
+    | TxMetaBytes ByteString
+    | TxMetaText Text
+    deriving (Eq, Ord, Show)
+
+-- Note the order of constructors is the same as the ledger definitions
+-- so that the Ord instance is consistent with the ledger one.
+-- This is checked by prop_ord_distributive_TxMetadata
+
+-- | Merge metadata maps. When there are clashing entries the left hand
+-- side takes precedence.
+instance Semigroup TxMetadata where
+    TxMetadata m1 <> TxMetadata m2 = TxMetadata (m1 <> m2)
+
+instance Monoid TxMetadata where
+    mempty = TxMetadata mempty
+
+makeTransactionMetadata :: Map Word64 TxMetadataValue -> TxMetadata
+makeTransactionMetadata = TxMetadata
+
+-- | Create a 'TxMetadataValue' from a 'Text' as a list of chunks of
+-- an acceptable size.
+metaTextChunks :: Text -> TxMetadataValue
+metaTextChunks =
+    TxMetaList
+        . chunks
+            txMetadataTextStringMaxByteLength
+            TxMetaText
+            (BS.length . T.encodeUtf8)
+            utf8SplitAt
+  where
+    fromBuilder = T.Lazy.toStrict . T.Builder.toLazyText
+
+    utf8SplitAt n =
+        bimap fromBuilder fromBuilder
+            . snd
+            . T.foldl
+                ( \(len, (left, right)) char ->
+                    let sz =
+                            BS.length
+                                ( T.encodeUtf8
+                                    (T.singleton char)
+                                )
+                    in  if len + sz > n
+                            then
+                                ( n + 1
+                                ,
+                                    ( left
+                                    , right
+                                        <> T.Builder.singleton
+                                            char
+                                    )
+                                )
+                            else
+                                ( len + sz
+                                ,
+                                    ( left
+                                        <> T.Builder.singleton
+                                            char
+                                    , right
+                                    )
+                                )
+                )
+                (0, (mempty, mempty))
+
+-- | Create a 'TxMetadataValue' from a 'ByteString' as a list of
+-- chunks of an acceptable size.
+metaBytesChunks :: ByteString -> TxMetadataValue
+metaBytesChunks =
+    TxMetaList
+        . chunks
+            txMetadataByteStringMaxLength
+            TxMetaBytes
+            BS.length
+            BS.splitAt
+
+-- ----------------------------------------------------------------------------
+-- Internal conversion functions
+--
+
+toShelleyMetadata
+    :: Map Word64 TxMetadataValue -> Map Word64 Shelley.Metadatum
+toShelleyMetadata = Map.map toShelleyMetadatum
+
+toShelleyMetadatum :: TxMetadataValue -> Shelley.Metadatum
+toShelleyMetadatum (TxMetaNumber x) = Shelley.I x
+toShelleyMetadatum (TxMetaBytes x) = Shelley.B x
+toShelleyMetadatum (TxMetaText x) = Shelley.S x
+toShelleyMetadatum (TxMetaList xs) =
+    Shelley.List
+        [toShelleyMetadatum x | x <- xs]
+toShelleyMetadatum (TxMetaMap xs) =
+    Shelley.Map
+        [ ( toShelleyMetadatum k
+          , toShelleyMetadatum v
+          )
+        | (k, v) <- xs
+        ]
+
+fromShelleyMetadata
+    :: Map Word64 Shelley.Metadatum -> Map Word64 TxMetadataValue
+fromShelleyMetadata = Map.Lazy.map fromShelleyMetadatum
+
+fromShelleyMetadatum :: Shelley.Metadatum -> TxMetadataValue
+fromShelleyMetadatum (Shelley.I x) = TxMetaNumber x
+fromShelleyMetadatum (Shelley.B x) = TxMetaBytes x
+fromShelleyMetadatum (Shelley.S x) = TxMetaText x
+fromShelleyMetadatum (Shelley.List xs) =
+    TxMetaList
+        [fromShelleyMetadatum x | x <- xs]
+fromShelleyMetadatum (Shelley.Map xs) =
+    TxMetaMap
+        [ ( fromShelleyMetadatum k
+          , fromShelleyMetadatum v
+          )
+        | (k, v) <- xs
+        ]
+
+-- | Transform a string-like structure into chunks with a maximum size;
+-- Chunks are filled from left to right.
+chunks
+    :: Int
+    -- ^ Chunk max size (inclusive)
+    -> (str -> chunk)
+    -- ^ Hoisting
+    -> (str -> Int)
+    -- ^ Measuring
+    -> (Int -> str -> (str, str))
+    -- ^ Splitting
+    -> str
+    -- ^ String
+    -> [chunk]
+chunks maxLength strHoist strLength strSplitAt str
+    | strLength str > maxLength =
+        let (h, t) = strSplitAt maxLength str
+        in  strHoist h
+                : chunks maxLength strHoist strLength strSplitAt t
+    | otherwise =
+        [strHoist str | strLength str > 0]
+
+-- ----------------------------------------------------------------------------
+-- Validate tx metadata
+--
+
+-- | Validate transaction metadata. This is for use with existing
+-- constructed metadata values, e.g. constructed manually or decoded
+-- from CBOR directly.
+validateTxMetadata
+    :: TxMetadata -> Either [(Word64, TxMetadataRangeError)] ()
+validateTxMetadata (TxMetadata m) =
+    case [ (k, err)
+         | (k, v) <- toList m
+         , err <- validateTxMetadataValue v
+         ] of
+        [] -> Right ()
+        errs -> Left errs
+
+validateTxMetadataValue :: TxMetadataValue -> [TxMetadataRangeError]
+validateTxMetadataValue (TxMetaNumber n) =
+    [ TxMetadataNumberOutOfRange n
+    | n > fromIntegral (maxBound :: Word64)
+        || n < negate (fromIntegral (maxBound :: Word64))
+    ]
+validateTxMetadataValue (TxMetaBytes bs) =
+    [ TxMetadataBytesTooLong len
+    | let len = BS.length bs
+    , len > txMetadataByteStringMaxLength
+    ]
+validateTxMetadataValue (TxMetaText txt) =
+    [ TxMetadataTextTooLong len
+    | let len = BS.length (T.encodeUtf8 txt)
+    , len > txMetadataTextStringMaxByteLength
+    ]
+validateTxMetadataValue (TxMetaList xs) =
+    foldMap validateTxMetadataValue xs
+validateTxMetadataValue (TxMetaMap kvs) =
+    foldMap
+        ( \(k, v) ->
+            validateTxMetadataValue k
+                <> validateTxMetadataValue v
+        )
+        kvs
+
+-- | The maximum byte length of a transaction metadata text string
+-- value.
+txMetadataTextStringMaxByteLength :: Int
+txMetadataTextStringMaxByteLength = 64
+
+-- | The maximum length of a transaction metadata byte string value.
+txMetadataByteStringMaxLength :: Int
+txMetadataByteStringMaxLength = 64
+
+-- | An error in transaction metadata due to an out-of-range value.
+data TxMetadataRangeError
+    = -- | The number is outside the maximum range of
+      -- @-2^64-1 .. 2^64-1@.
+      TxMetadataNumberOutOfRange !Integer
+    | -- | The length of a text string metadatum value exceeds the
+      -- maximum of 64 bytes as UTF8.
+      TxMetadataTextTooLong !Int
+    | -- | The length of a byte string metadatum value exceeds the
+      -- maximum of 64 bytes.
+      TxMetadataBytesTooLong !Int
+    deriving (Eq, Show)
+
+-- ----------------------------------------------------------------------------
+-- JSON conversion
+--
+
+-- | Schema for JSON / tx-metadata conversion.
+data TxMetadataJsonSchema
+    = -- | Use the \"no schema\" mapping between JSON and tx metadata.
+      TxMetadataJsonNoSchema
+    | -- | Use the \"detailed schema\" mapping between JSON and tx
+      -- metadata.
+      TxMetadataJsonDetailedSchema
+    deriving (Eq, Show)
+
+-- | Convert a value from JSON into tx metadata, using the given choice
+-- of mapping between JSON and tx metadata.
+metadataFromJson
+    :: TxMetadataJsonSchema
+    -> Aeson.Value
+    -> Either TxMetadataJsonError TxMetadata
+metadataFromJson schema =
+    \case
+        Aeson.Object m ->
+            fmap (TxMetadata . fromList)
+                . mapM (uncurry metadataKeyPairFromJson)
+                $ toList m
+        _ -> Left TxMetadataJsonToplevelNotMap
+  where
+    metadataKeyPairFromJson
+        :: Aeson.Key
+        -> Aeson.Value
+        -> Either
+            TxMetadataJsonError
+            (Word64, TxMetadataValue)
+    metadataKeyPairFromJson k v = do
+        k' <- convTopLevelKey k
+        v' <-
+            first
+                (TxMetadataJsonSchemaError k' v)
+                (metadataValueFromJson v)
+        first
+            (TxMetadataRangeError k' v)
+            (validateMetadataValue v')
+        return (k', v')
+
+    convTopLevelKey
+        :: Aeson.Key -> Either TxMetadataJsonError Word64
+    convTopLevelKey key =
+        case parseAll (pUnsigned <* Atto.endOfInput) k of
+            Just n
+                | n
+                    <= fromIntegral (maxBound :: Word64) ->
+                    Right (fromIntegral n)
+            _ -> Left (TxMetadataJsonToplevelBadKey k)
+      where
+        k = Aeson.toText key
+
+    validateMetadataValue
+        :: TxMetadataValue
+        -> Either TxMetadataRangeError ()
+    validateMetadataValue v =
+        case validateTxMetadataValue v of
+            [] -> Right ()
+            err : _ -> Left err
+
+    metadataValueFromJson
+        :: Aeson.Value
+        -> Either TxMetadataJsonSchemaError TxMetadataValue
+    metadataValueFromJson =
+        case schema of
+            TxMetadataJsonNoSchema ->
+                metadataValueFromJsonNoSchema
+            TxMetadataJsonDetailedSchema ->
+                metadataValueFromJsonDetailedSchema
+
+-- | Convert a tx metadata value into JSON, using the given choice of
+-- mapping between JSON and tx metadata.
+metadataToJson
+    :: TxMetadataJsonSchema
+    -> TxMetadata
+    -> Aeson.Value
+metadataToJson schema =
+    \(TxMetadata mdMap) ->
+        Aeson.object
+            [ (Aeson.fromString (show k), metadataValueToJson v)
+            | (k, v) <- toList mdMap
+            ]
+  where
+    metadataValueToJson :: TxMetadataValue -> Aeson.Value
+    metadataValueToJson =
+        case schema of
+            TxMetadataJsonNoSchema ->
+                metadataValueToJsonNoSchema
+            TxMetadataJsonDetailedSchema ->
+                metadataValueToJsonDetailedSchema
+
+-- ----------------------------------------------------------------------------
+-- JSON conversion using the "no schema" style
+--
+
+metadataValueToJsonNoSchema :: TxMetadataValue -> Aeson.Value
+metadataValueToJsonNoSchema = conv
+  where
+    conv :: TxMetadataValue -> Aeson.Value
+    conv (TxMetaNumber n) = Aeson.Number (fromInteger n)
+    conv (TxMetaBytes bs) =
+        Aeson.String
+            ( bytesPrefix
+                <> T.decodeLatin1 (B16.encode bs)
+            )
+    conv (TxMetaText txt) = Aeson.String txt
+    conv (TxMetaList vs) =
+        Aeson.Array (fromList (map conv vs))
+    conv (TxMetaMap kvs) =
+        Aeson.object
+            [ (convKey k, conv v)
+            | (k, v) <- kvs
+            ]
+
+    convKey :: TxMetadataValue -> Aeson.Key
+    convKey (TxMetaNumber n) = Aeson.fromString (show n)
+    convKey (TxMetaBytes bs) =
+        Aeson.fromText
+            $ bytesPrefix
+                <> T.decodeLatin1 (B16.encode bs)
+    convKey (TxMetaText txt) = Aeson.fromText txt
+    convKey v =
+        Aeson.fromText
+            . T.Lazy.toStrict
+            . Aeson.Text.encodeToLazyText
+            . conv
+            $ v
+
+metadataValueFromJsonNoSchema
+    :: Aeson.Value
+    -> Either
+        TxMetadataJsonSchemaError
+        TxMetadataValue
+metadataValueFromJsonNoSchema = conv
+  where
+    conv
+        :: Aeson.Value
+        -> Either TxMetadataJsonSchemaError TxMetadataValue
+    conv Aeson.Null = Left TxMetadataJsonNullNotAllowed
+    conv Aeson.Bool{} = Left TxMetadataJsonBoolNotAllowed
+    conv (Aeson.Number d) =
+        case Scientific.floatingOrInteger d
+                :: Either Double Integer of
+            Left n -> Left (TxMetadataJsonNumberNotInteger n)
+            Right n -> Right (TxMetaNumber n)
+    conv (Aeson.String s)
+        | Just s' <- T.stripPrefix bytesPrefix s
+        , let bs' = T.encodeUtf8 s'
+        , Right bs <- B16.decode bs'
+        , not (B8.any (\c -> c >= 'A' && c <= 'F') bs') =
+            Right (TxMetaBytes bs)
+    conv (Aeson.String s) = Right (TxMetaText s)
+    conv (Aeson.Array vs) =
+        fmap TxMetaList
+            . traverse conv
+            $ toList vs
+    conv (Aeson.Object kvs) =
+        fmap
+            ( TxMetaMap
+                . sortCanonicalForCbor
+            )
+            . traverse
+                ( (\(k, v) -> (,) (convKey k) <$> conv v)
+                    . first Aeson.toText
+                )
+            $ toList kvs
+
+    convKey :: Text -> TxMetadataValue
+    convKey s =
+        fromMaybe (TxMetaText s)
+            $ parseAll
+                ( (fmap TxMetaNumber pSigned <* Atto.endOfInput)
+                    <|> ( fmap TxMetaBytes pBytes
+                            <* Atto.endOfInput
+                        )
+                )
+                s
+
+-- | JSON strings that are base16 encoded and prefixed with
+-- 'bytesPrefix' will be encoded as CBOR bytestrings.
+bytesPrefix :: Text
+bytesPrefix = "0x"
+
+-- | Sorts the list by the first value in the tuple using the rules
+-- for canonical CBOR (RFC 7049 section 3.9).
+sortCanonicalForCbor
+    :: [(TxMetadataValue, TxMetadataValue)]
+    -> [(TxMetadataValue, TxMetadataValue)]
+sortCanonicalForCbor =
+    map snd
+        . L.sortOn fst
+        . map
+            ( \e@(k, _) ->
+                (CBOR.uintegerFromBytes $ serialiseKey k, e)
+            )
+  where
+    serialiseKey =
+        CBOR.serialize' CBOR.shelleyProtVer . toShelleyMetadatum
+
+-- ----------------------------------------------------------------------------
+-- JSON conversion using the "detailed schema" style
+--
+
+metadataValueToJsonDetailedSchema
+    :: TxMetadataValue -> Aeson.Value
+metadataValueToJsonDetailedSchema = conv
+  where
+    conv :: TxMetadataValue -> Aeson.Value
+    conv (TxMetaNumber n) =
+        singleFieldObject "int"
+            . Aeson.Number
+            $ fromInteger n
+    conv (TxMetaBytes bs) =
+        singleFieldObject "bytes"
+            . Aeson.String
+            $ T.decodeLatin1 (B16.encode bs)
+    conv (TxMetaText txt) =
+        singleFieldObject "string"
+            . Aeson.String
+            $ txt
+    conv (TxMetaList vs) =
+        singleFieldObject "list"
+            . Aeson.Array
+            $ fromList (map conv vs)
+    conv (TxMetaMap kvs) =
+        singleFieldObject "map"
+            . Aeson.Array
+            $ fromList
+                [ Aeson.object
+                    [("k", conv k), ("v", conv v)]
+                | (k, v) <- kvs
+                ]
+
+    singleFieldObject name v = Aeson.object [(name, v)]
+
+metadataValueFromJsonDetailedSchema
+    :: Aeson.Value
+    -> Either
+        TxMetadataJsonSchemaError
+        TxMetadataValue
+metadataValueFromJsonDetailedSchema = conv
+  where
+    conv
+        :: Aeson.Value
+        -> Either
+            TxMetadataJsonSchemaError
+            TxMetadataValue
+    conv (Aeson.Object m) =
+        case toList m of
+            [("int", Aeson.Number d)] ->
+                case Scientific.floatingOrInteger d
+                        :: Either Double Integer of
+                    Left n ->
+                        Left
+                            (TxMetadataJsonNumberNotInteger n)
+                    Right n -> Right (TxMetaNumber n)
+            [("bytes", Aeson.String s)]
+                | Right bs <-
+                    B16.decode (T.encodeUtf8 s) ->
+                    Right (TxMetaBytes bs)
+            [("string", Aeson.String s)] ->
+                Right (TxMetaText s)
+            [("list", Aeson.Array vs)] ->
+                fmap TxMetaList
+                    . traverse conv
+                    $ toList vs
+            [("map", Aeson.Array kvs)] ->
+                fmap TxMetaMap
+                    . traverse convKeyValuePair
+                    $ toList kvs
+            [(key, v)]
+                | key
+                    `elem` [ "int"
+                           , "bytes"
+                           , "string"
+                           , "list"
+                           , "map"
+                           ] ->
+                    Left
+                        ( TxMetadataJsonTypeMismatch
+                            (Aeson.toText key)
+                            v
+                        )
+            kvs ->
+                Left
+                    ( TxMetadataJsonBadObject
+                        (first Aeson.toText <$> kvs)
+                    )
+    conv v = Left (TxMetadataJsonNotObject v)
+
+    convKeyValuePair
+        :: Aeson.Value
+        -> Either
+            TxMetadataJsonSchemaError
+            (TxMetadataValue, TxMetadataValue)
+    convKeyValuePair (Aeson.Object m)
+        | KeyMap.size m == 2
+        , Just k <- KeyMap.lookup "k" m
+        , Just v <- KeyMap.lookup "v" m =
+            (,) <$> conv k <*> conv v
+    convKeyValuePair v = Left (TxMetadataJsonBadMapPair v)
+
+-- ----------------------------------------------------------------------------
+-- Shared JSON conversion error types
+--
+
+data TxMetadataJsonError
+    = TxMetadataJsonToplevelNotMap
+    | TxMetadataJsonToplevelBadKey !Text
+    | TxMetadataJsonSchemaError
+        !Word64
+        !Aeson.Value
+        !TxMetadataJsonSchemaError
+    | TxMetadataRangeError
+        !Word64
+        !Aeson.Value
+        !TxMetadataRangeError
+    deriving (Eq, Show)
+
+data TxMetadataJsonSchemaError
+    = -- Only used for 'TxMetadataJsonNoSchema'
+      TxMetadataJsonNullNotAllowed
+    | TxMetadataJsonBoolNotAllowed
+    | -- Used by both mappings
+      TxMetadataJsonNumberNotInteger !Double
+    | -- Only used for 'TxMetadataJsonDetailedSchema'
+      TxMetadataJsonNotObject !Aeson.Value
+    | TxMetadataJsonBadObject ![(Text, Aeson.Value)]
+    | TxMetadataJsonBadMapPair !Aeson.Value
+    | TxMetadataJsonTypeMismatch !Text !Aeson.Value
+    deriving (Eq, Show)
+
+-- ----------------------------------------------------------------------------
+-- Shared parsing utils
+--
+
+parseAll :: Atto.Parser a -> Text -> Maybe a
+parseAll p =
+    either (const Nothing) Just
+        . Atto.parseOnly p
+        . T.encodeUtf8
+
+pUnsigned :: Atto.Parser Integer
+pUnsigned = do
+    bs <- Atto.takeWhile1 Atto.isDigit
+    guard (not (BS.length bs > 1 && B8.head bs == '0'))
+    return $! BS.foldl' step 0 bs
+  where
+    step a w = a * 10 + fromIntegral (w - 48)
+
+pSigned :: Atto.Parser Integer
+pSigned = Atto.signed pUnsigned
+
+pBytes :: Atto.Parser ByteString
+pBytes = do
+    _ <- Atto.string "0x"
+    remaining <- Atto.takeByteString
+    when (B8.any hexUpper remaining)
+        $ fail
+            ( "Unexpected uppercase hex characters in "
+                <> show remaining
+            )
+    case B16.decode remaining of
+        Right bs -> return bs
+        _ ->
+            fail
+                ( "Expecting base16 encoded string, found: "
+                    <> show remaining
+                )
+  where
+    hexUpper c = c >= 'A' && c <= 'F'

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs
@@ -5,8 +5,13 @@
 -- Copyright: 2018-2022 IOHK, 2023 Cardano Foundation
 -- License: Apache-2.0
 --
--- Metadata embedded in transactions. Wallet-owned copy of types and
--- JSON conversion originally from @cardano-api@.
+-- Metadata embedded in transactions. Wallet-owned copy of the
+-- @cardano-api@ surface.
+--
+-- The ledger already provides 'Cardano.Ledger.Metadata.Metadatum';
+-- this module converts to and from it below. It keeps the wallet-facing
+-- constructors and JSON schema helpers while the API and tests still use
+-- the old @cardano-api@ metadata shape.
 module Cardano.Wallet.Primitive.Types.Tx.TxMetadata
     ( -- * Types
       TxMetadata (..)

--- a/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Server.hs
+++ b/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Server.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.Pools
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     , SNetworkId
-    , networkIdVal
+    , fromSNetworkId
     )
 import Cardano.Wallet.Primitive.Types
     ( WalletId
@@ -219,7 +219,7 @@ serveUI ul config _ alByron _alIcarus alShelley _alShared _spl _ntp bs =
     ok _ = renderHtml . rogerH @Text $ "ok"
     alert = renderHtml . alertH
     nl = netLayer alByron
-    nid = networkIdVal (sNetworkId @n)
+    nid = fromSNetworkId (sNetworkId @n)
     mode = case bs of
         NodeSource{} -> Node
     _ = networkInfoH

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -249,6 +249,7 @@ test-suite unit
     Cardano.Wallet.Shelley.CompatibilitySpec
     Cardano.Wallet.Shelley.LaunchSpec
     Cardano.Wallet.Shelley.NetworkSpec
+    Cardano.Wallet.Shelley.TransactionLedgerSpec
     Cardano.Wallet.Shelley.TransactionSpec
     Cardano.Wallet.Submissions.Gen
     Cardano.Wallet.Submissions.OperationsSpec

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -79,11 +79,15 @@ test-suite unit
     , cardano-crypto
     , cardano-crypto-class
     , cardano-diffusion:api
+    , cardano-ledger-allegra
     , cardano-ledger-alonzo
+    , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-binary
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application

--- a/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -11,8 +11,6 @@ module Cardano.Wallet.Api.ServerSpec (spec) where
 import Cardano.Api
     ( AnyCardanoEra (..)
     , CardanoEra (..)
-    , NetworkId (..)
-    , NetworkMagic (..)
     )
 import Cardano.BM.Trace
     ( nullTracer
@@ -46,6 +44,9 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     )
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkId (..)
     )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException
@@ -237,7 +238,7 @@ networkInfoSpec = describe "getNetworkInformation" $ do
                 Right info <-
                     run
                         $ runHandler
-                        $ getNetworkInformation (Testnet $ NetworkMagic 1) nl Node
+                        $ getNetworkInformation (NTestnet 1) nl Node
 
                 --  0              20
                 --  *               |        *

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -1,0 +1,1726 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{- HLINT ignore "Use null" -}
+{- HLINT ignore "Use camelCase" -}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+#if __GLASGOW_HASKELL__ >= 902
+{-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
+#endif
+
+module Cardano.Wallet.Shelley.TransactionLedgerSpec (spec) where
+
+import Cardano.Address.Derivation
+    ( XPrv
+    , XPub
+    , toXPub
+    , xprvFromBytes
+    , xprvToBytes
+    , xpubPublicKey
+    )
+import Cardano.Address.KeyHash
+    ( KeyHash (..)
+    , KeyRole (Delegation, Payment)
+    )
+import Cardano.Address.Script
+    ( Script (..)
+    )
+import Cardano.Api
+    ( AnyCardanoEra (..)
+    , CardanoEra (..)
+    , InAnyCardanoEra (..)
+    )
+import Cardano.Api.Extra
+    ( CardanoApiEra
+    , cardanoApiEraConstraints
+    , cardanoEraFromRecentEra
+    , shelleyBasedEraFromRecentEra
+    )
+import Cardano.Api.Gen
+    ( genTx
+    , genTxBodyContent
+    , genTxInEra
+    , genWitnesses
+    )
+import Cardano.Balance.Tx.Balance
+    ( ErrBalanceTx (..)
+    , ErrBalanceTxUnableToCreateChangeError (..)
+    )
+import Cardano.Balance.Tx.Eras
+    ( AnyRecentEra (..)
+    , RecentEra (..)
+    )
+import Cardano.Balance.Tx.Gen
+    ( mockPParams
+    )
+import Cardano.Balance.Tx.SizeEstimation
+    ( TxSkeleton (..)
+    , estimateTxSize
+    )
+import Cardano.Mnemonic
+    ( SomeMnemonic (SomeMnemonic)
+    )
+import Cardano.Wallet
+    ( Fee (..)
+    , Percentile (..)
+    , calculateFeePercentiles
+    , signTransaction
+    )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..)
+    , deriveRewardAccount
+    , hex
+    , paymentAddress
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( ShelleyKey
+    )
+import Cardano.Wallet.Address.Keys.WalletKey
+    ( getRawKey
+    , liftRawKey
+    , publicKey
+    )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (..)
+    )
+import Cardano.Wallet.Gen
+    ( genMnemonic
+    , genScript
+    )
+import Cardano.Wallet.Primitive.Ledger.Convert
+    ( toLedgerCoin
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
+    ( txIntegrity
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
+    ( fromSealedTx
+    )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( toCardanoTxIn
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( SNetworkId (..)
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , PassphraseScheme (..)
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..)
+    )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( AssetName (UnsafeAssetName)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( genCoinPositive
+    , shrinkCoinPositive
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( ClearCredentials
+    , RootCredentials (..)
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRange
+    , shrinkTokenBundleSmallRange
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId (UnsafeTokenPolicyId)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
+    ( genTokenPolicyId
+    , shrinkTokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx (..)
+    , TxMetadata (..)
+    , TxMetadataValue (..)
+    , cardanoTxIdeallyNoLaterThan
+    , getSealedTxWitnesses
+    , sealedTxFromBytes
+    , sealedTxFromBytes'
+    , sealedTxFromCardano
+    , sealedTxFromCardano'
+    , serialisedTx
+    )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxConstraints (..)
+    , TxSize (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutTokenBundle
+    )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO (..)
+    )
+import Cardano.Wallet.Shelley.Transaction
+    ( mkByronWitness
+    , mkShelleyWitness
+    , mkUnsignedTx
+    , newTransactionLayer
+    )
+import Cardano.Wallet.Shelley.Transaction.Ledger
+    ( TxWitnessTag (..)
+    , txConstraints
+    )
+import Cardano.Wallet.Transaction
+    ( SelectionOf (..)
+    , TransactionLayer (..)
+    , WitnessCountCtx (..)
+    , selectionDelta
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex
+    )
+import Control.Arrow
+    ( first
+    )
+import Control.Monad
+    ( replicateM
+    )
+import Control.Monad.Random
+    ( MonadRandom (..)
+    , Random (randomR, randomRs)
+    , random
+    , randoms
+    )
+import Control.Monad.Trans.Except
+    ( except
+    , runExceptT
+    )
+import Cryptography.Hash.Blake
+    ( blake2b224
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Either
+    ( isRight
+    )
+import Data.Function
+    ( on
+    , (&)
+    )
+import Data.IntCast
+    ( intCast
+    )
+import Data.List
+    ( nub
+    )
+import Data.List.NonEmpty
+    ( NonEmpty (..)
+    )
+import Data.Map.Strict
+    ( Map
+    )
+import Data.Maybe
+    ( fromJust
+    , isJust
+    )
+import Data.Ord
+    ( comparing
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Quantity
+    ( Quantity (..)
+    )
+import Data.Semigroup
+    ( mtimesDefault
+    )
+import Data.Type.Equality
+    ( testEquality
+    , (:~:) (..)
+    )
+import Data.Word
+    ( Word16
+    , Word64
+    , Word8
+    )
+import Fmt
+    ( Buildable (..)
+    , pretty
+    , (+||)
+    , (||+)
+    )
+import Numeric.Natural
+    ( Natural
+    )
+import Ouroboros.Network.Block
+    ( SlotNo (..)
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , pendingWith
+    , shouldBe
+    , shouldSatisfy
+    )
+import Test.Hspec.QuickCheck
+    ( prop
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , InfiniteList (..)
+    , Property
+    , Testable
+    , arbitraryPrintableChar
+    , checkCoverage
+    , choose
+    , conjoin
+    , counterexample
+    , cover
+    , forAll
+    , forAllShow
+    , frequency
+    , oneof
+    , property
+    , scale
+    , suchThat
+    , vector
+    , vectorOf
+    , withMaxSuccess
+    , (.||.)
+    , (===)
+    )
+import Test.QuickCheck.Extra
+    ( chooseNatural
+    )
+import Test.QuickCheck.Gen
+    ( Gen (..)
+    , listOf1
+    )
+import Test.QuickCheck.Random
+    ( QCGen
+    )
+import Test.Utils.Pretty
+    ( Pretty (..)
+    , (====)
+    )
+import Prelude
+
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Balance.Tx.Eras as Write
+    ( Conway
+    , IsRecentEra
+    , RecentEra (RecentEraConway, RecentEraDijkstra)
+    )
+import qualified Cardano.Balance.Tx.Primitive as BT
+import qualified Cardano.Crypto.Hash.Blake2b as Crypto
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+spec :: Spec
+spec = describe "TransactionSpec" $ do
+    decodeSealedTxSpec
+    forAllRecentEras feeEstimationRegressionSpec
+    forAllRecentEras binaryCalculationsSpec
+    transactionConstraintsSpec
+    describe "Sign transaction" $ do
+        -- TODO [ADP-2849] The implementation must be restricted to work only in
+        -- 'RecentEra's, not just the tests.
+        spec_forAllRecentErasPendingConway
+            "signTransaction adds reward account witness when necessary"
+            prop_signTransaction_addsRewardAccountKey
+        spec_forAllRecentErasPendingConway
+            "signTransaction adds extra key witnesses when necessary"
+            prop_signTransaction_addsExtraKeyWitnesses
+        spec_forAllRecentErasPendingConway
+            "signTransaction adds tx in witnesses when necessary"
+            prop_signTransaction_addsTxInWitnesses
+        spec_forAllRecentErasPendingConway
+            "signTransaction adds collateral witnesses when necessary"
+            prop_signTransaction_addsTxInCollateralWitnesses
+        spec_forAllRecentErasPendingConway
+            "signTransaction never removes witnesses"
+            prop_signTransaction_neverRemovesWitnesses
+        spec_forAllRecentErasPendingConway
+            "signTransaction never changes tx body"
+            prop_signTransaction_neverChangesTxBody
+        spec_forAllRecentErasPendingConway
+            "signTransaction preserves script integrity"
+            prop_signTransaction_preservesScriptIntegrity
+
+spec_forAllRecentErasPendingConway
+    :: Testable prop => String -> (AnyRecentEra -> prop) -> Spec
+spec_forAllRecentErasPendingConway description p =
+    describe description
+        $ forAllRecentEras
+        $ \(AnyRecentEra recentEra) ->
+            case recentEra of
+                Write.RecentEraConway ->
+                    it (show recentEra) $ property $ p (AnyRecentEra recentEra)
+                Write.RecentEraDijkstra ->
+                    it (show recentEra) $ pendingWith "TODO: Dijkstra"
+
+instance Arbitrary SealedTx where
+    arbitrary = sealedTxFromCardano <$> genTx
+
+showTransactionBody
+    :: RecentEra era
+    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+    -> String
+showTransactionBody recentEra =
+    either show show
+        . Cardano.createTransactionBody
+            (shelleyBasedEraFromRecentEra recentEra)
+
+unsafeMakeTransactionBody
+    :: RecentEra era
+    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+    -> Cardano.TxBody (CardanoApiEra era)
+unsafeMakeTransactionBody recentEra =
+    either (error . show) id
+        . Cardano.createTransactionBody
+            (shelleyBasedEraFromRecentEra recentEra)
+
+stakeAddressForKey
+    :: SL.Network
+    -> XPub
+    -> Cardano.StakeAddress
+stakeAddressForKey net pubkey =
+    Cardano.StakeAddress
+        net
+        (SL.KeyHashObj (SL.KeyHash $ hash pubkey))
+  where
+    hash :: XPub -> Crypto.Hash Crypto.Blake2b_224 a
+    hash = fromJust . Crypto.hashFromBytes . blake2b224 . xpubPublicKey
+
+withdrawalForKey
+    :: SL.Network
+    -> XPub
+    -> L.Coin
+    -> ( Cardano.StakeAddress
+       , L.Coin
+       , Cardano.BuildTxWith
+            Cardano.BuildTx
+            (Cardano.Witness Cardano.WitCtxStake era)
+       )
+withdrawalForKey net pubkey wdrlAmt =
+    ( stakeAddressForKey net pubkey
+    , wdrlAmt
+    , Cardano.BuildTxWith
+        $ Cardano.KeyWitness Cardano.KeyWitnessForStakeAddr
+    )
+
+mkCredentials
+    :: (XPrv, Passphrase "encryption")
+    -> ClearCredentials ShelleyKey
+mkCredentials (pk, hpwd) = RootCredentials (liftRawKey ShelleyKeyS pk) hpwd
+
+prop_signTransaction_addsRewardAccountKey
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> UTxO
+    -- ^ UTxO of wallet
+    -> Coin
+    -- ^ Amount to withdraw
+    -> Property
+prop_signTransaction_addsRewardAccountKey
+    (AnyRecentEra (recentEra :: RecentEra era))
+    rootXPrv
+    utxo
+    wdrlAmt =
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
+            let
+                shelleyEra :: Cardano.ShelleyBasedEra (CardanoApiEra era)
+                shelleyEra = shelleyBasedEraFromRecentEra recentEra
+
+                era = cardanoEraFromRecentEra recentEra
+
+                creds@(RootCredentials pk hpwd) = mkCredentials rootXPrv
+
+                rawRewardK :: (XPrv, Passphrase "encryption")
+                rawRewardK =
+                    ( getRawKey ShelleyKeyS
+                        $ deriveRewardAccount hpwd pk minBound
+                    , hpwd
+                    )
+
+                rewardAcctPubKey :: XPub
+                rewardAcctPubKey = toXPub $ fst rawRewardK
+
+                extraWdrls =
+                    [ withdrawalForKey
+                        SL.Mainnet
+                        rewardAcctPubKey
+                        (toLedgerCoin wdrlAmt)
+                    ]
+
+                addWithdrawals
+                    :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                addWithdrawals txBodyContent =
+                    txBodyContent
+                        { Cardano.txWithdrawals =
+                            case Cardano.txWithdrawals txBodyContent of
+                                Cardano.TxWithdrawalsNone ->
+                                    Cardano.TxWithdrawals shelleyEra extraWdrls
+                                Cardano.TxWithdrawals _ wdrls ->
+                                    Cardano.TxWithdrawals shelleyEra
+                                        $ wdrls <> extraWdrls
+                        }
+
+            withBodyContent recentEra addWithdrawals $ \(txBody, wits) -> do
+                let
+                    tl = testTxLayer
+
+                    sealedTx = sealedTxFromCardano' $ Cardano.Tx txBody wits
+                    sealedTx' =
+                        signTransaction
+                            ShelleyKeyS
+                            tl
+                            (AnyCardanoEra era)
+                            AnyWitnessCountCtx
+                            (const Nothing)
+                            Nothing
+                            creds
+                            utxo
+                            Nothing
+                            sealedTx
+
+                    expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
+                    expectedWits =
+                        InAnyCardanoEra era
+                            <$> [ mkShelleyWitness txBody rawRewardK
+                                ]
+
+                expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+
+instance Arbitrary (ShelleyKey 'RootK XPrv) where
+    shrink _ = []
+    arbitrary = genRootKeysSeqWithPass =<< genPassphrase (0, 16)
+
+genRootKeysSeqWithPass
+    :: Passphrase "encryption"
+    -> Gen (ShelleyKey depth XPrv)
+genRootKeysSeqWithPass encryptionPass = do
+    s <- SomeMnemonic <$> genMnemonic @15
+    g <- Just . SomeMnemonic <$> genMnemonic @12
+    return $ Shelley.unsafeGenerateKeyFromSeed (s, g) encryptionPass
+
+genPassphrase :: (Int, Int) -> Gen (Passphrase purpose)
+genPassphrase range = do
+    n <- choose range
+    InfiniteList bytes _ <- arbitrary
+    return $ Passphrase $ BA.convert $ BS.pack $ take n bytes
+
+prop_signTransaction_addsExtraKeyWitnesses
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> UTxO
+    -- ^ UTxO of wallet
+    -> [(XPrv, Passphrase "encryption")]
+    -- ^ Keys
+    -> Property
+prop_signTransaction_addsExtraKeyWitnesses
+    (AnyRecentEra (recentEra :: RecentEra era))
+    rootK
+    utxo
+    extraKeys =
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
+            let
+                alonzoOnwards :: Cardano.AlonzoEraOnwards (CardanoApiEra era)
+                alonzoOnwards = case recentEra of
+                    Write.RecentEraConway -> Cardano.AlonzoEraOnwardsConway
+                    Write.RecentEraDijkstra ->
+                        error "alonzoOnwards: Dijkstra not yet supported"
+
+                era = cardanoEraFromRecentEra recentEra
+
+                keys
+                    :: (XPrv, Passphrase "encryption")
+                    -> Cardano.SigningKey Cardano.PaymentExtendedKey
+                keys = Cardano.PaymentExtendedSigningKey . fst
+
+                hashes :: [Cardano.Hash Cardano.PaymentKey]
+                hashes =
+                    ( Cardano.verificationKeyHash
+                        . Cardano.castVerificationKey
+                        . Cardano.getVerificationKey
+                        . keys
+                    )
+                        <$> extraKeys
+
+                addExtraWits
+                    :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                    -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                addExtraWits txBodyContent =
+                    txBodyContent
+                        { Cardano.txExtraKeyWits =
+                            Cardano.TxExtraKeyWitnesses alonzoOnwards hashes
+                        }
+
+            withBodyContent recentEra addExtraWits $ \(txBody, wits) -> do
+                let
+                    tl = testTxLayer
+
+                    sealedTx = sealedTxFromCardano' $ Cardano.Tx txBody wits
+                    sealedTx' =
+                        signTransaction
+                            ShelleyKeyS
+                            tl
+                            (AnyCardanoEra era)
+                            AnyWitnessCountCtx
+                            (lookupFnFromKeys extraKeys)
+                            Nothing
+                            (mkCredentials rootK)
+                            utxo
+                            Nothing
+                            sealedTx
+
+                    expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
+                    expectedWits =
+                        InAnyCardanoEra era
+                            . mkShelleyWitness txBody
+                            <$> extraKeys
+
+                expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+
+keyToAddress :: (XPrv, Passphrase "encryption") -> Address
+keyToAddress (xprv, _pwd) =
+    -- TODO, decrypt?
+    paymentAddress @ShelleyKey @'CredFromKeyK SMainnet
+        . publicKey ShelleyKeyS
+        . liftRawKey ShelleyKeyS
+        $ xprv
+
+utxoFromKeys
+    :: [(XPrv, Passphrase "encryption")]
+    -> (UTxO -> Property)
+    -> Property
+utxoFromKeys keys utxoProp =
+    let
+        addresses :: [Address]
+        addresses = keyToAddress <$> keys
+
+        txOuts :: [TxOut]
+        txOuts = (flip foldMap) addresses $ \addr ->
+            [TxOut addr mempty]
+
+        isUnique :: [TxIn] -> Bool
+        isUnique txIns = nub txIns == txIns
+    in
+        forAll (vectorOf (length txOuts) genTxIn `suchThat` isUnique)
+            $ \txIns -> do
+                let utxo = UTxO $ Map.fromList $ zip txIns txOuts
+                utxoProp utxo
+
+lookupFnFromKeys
+    :: [(XPrv, Passphrase "encryption")]
+    -> ( Address
+         -> Maybe (ShelleyKey 'CredFromKeyK XPrv, Passphrase "encryption")
+       )
+lookupFnFromKeys keys addr =
+    let
+        addrMap
+            :: Map
+                Address
+                (ShelleyKey 'CredFromKeyK XPrv, Passphrase "encryption")
+        addrMap =
+            Map.fromList
+                $ zip
+                    (keyToAddress <$> keys)
+                    (first (liftRawKey ShelleyKeyS) <$> keys)
+    in
+        Map.lookup addr addrMap
+
+withBodyContent
+    :: era ~ CardanoApiEra era'
+    => RecentEra era'
+    -> ( Cardano.TxBodyContent Cardano.BuildTx era
+         -> Cardano.TxBodyContent Cardano.BuildTx era
+       )
+    -> ((Cardano.TxBody era, [Cardano.KeyWitness era]) -> Property)
+    -> Property
+withBodyContent recentEra modTxBody cont =
+    forAllShow (genTxBodyContent era) (showTransactionBody recentEra)
+        $ \txBodyContent -> do
+            let
+                txBodyContent' = modTxBody txBodyContent
+                txBody = unsafeMakeTransactionBody recentEra txBodyContent'
+
+            forAll (genWitnesses era txBody) $ \wits -> cont (txBody, wits)
+  where
+    era = cardanoEraFromRecentEra recentEra
+
+checkSubsetOf :: (Eq a, Show a) => [a] -> [a] -> Property
+checkSubsetOf as bs =
+    property
+        $ counterexample counterexampleText
+        $ all ((`Set.member` ys) . ShowOrd) as
+  where
+    xs = Set.fromList (ShowOrd <$> as)
+    ys = Set.fromList (ShowOrd <$> bs)
+
+    counterexampleText =
+        unlines
+            [ "the following set:"
+            , showSet xs
+            , "is not a subset of:"
+            , showSet ys
+            , "rogue elements:"
+            , showSet (xs `Set.difference` ys)
+            ]
+      where
+        showSet = pretty . fmap (show . unShowOrd) . F.toList
+
+prop_signTransaction_addsTxInWitnesses
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> NonEmpty (XPrv, Passphrase "encryption")
+    -- ^ Keys
+    -> Property
+prop_signTransaction_addsTxInWitnesses
+    (AnyRecentEra recentEra)
+    rootK
+    extraKeysNE =
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
+            let extraKeys = NE.toList extraKeysNE
+
+            utxoFromKeys extraKeys $ \utxo -> do
+                let
+                    era = cardanoEraFromRecentEra recentEra
+
+                    txIns :: [TxIn]
+                    txIns = Map.keys $ unUTxO utxo
+
+                    addTxIns
+                        :: Cardano.TxBodyContent Cardano.BuildTx era
+                        -> Cardano.TxBodyContent Cardano.BuildTx era
+                    addTxIns txBodyContent =
+                        txBodyContent
+                            { Cardano.txIns =
+                                (,Cardano.BuildTxWith
+                                    (Cardano.KeyWitness Cardano.KeyWitnessForSpending))
+                                    . toCardanoTxIn
+                                    <$> txIns
+                            }
+
+                withBodyContent recentEra addTxIns $ \(txBody, wits) -> do
+                    let
+                        tl = testTxLayer
+
+                        sealedTx = sealedTxFromCardano' $ Cardano.Tx txBody wits
+                        sealedTx' =
+                            signTransaction
+                                ShelleyKeyS
+                                tl
+                                (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                                AnyWitnessCountCtx
+                                (lookupFnFromKeys extraKeys)
+                                Nothing
+                                (mkCredentials rootK)
+                                utxo
+                                Nothing
+                                sealedTx
+
+                        expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
+                        expectedWits =
+                            InAnyCardanoEra era
+                                . mkShelleyWitness txBody
+                                <$> extraKeys
+
+                    expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+
+prop_signTransaction_addsTxInCollateralWitnesses
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> NonEmpty (XPrv, Passphrase "encryption")
+    -- ^ Keys
+    -> Property
+prop_signTransaction_addsTxInCollateralWitnesses
+    (AnyRecentEra (recentEra :: RecentEra era))
+    rootK
+    extraKeysNE =
+        cardanoApiEraConstraints recentEra $ withMaxSuccess 10 $ do
+            let
+                alonzoOnwards :: Cardano.AlonzoEraOnwards (CardanoApiEra era)
+                alonzoOnwards = case recentEra of
+                    Write.RecentEraConway -> Cardano.AlonzoEraOnwardsConway
+                    Write.RecentEraDijkstra ->
+                        error "alonzoOnwards: Dijkstra not yet supported"
+
+                era = cardanoEraFromRecentEra recentEra
+
+                extraKeys = NE.toList extraKeysNE
+
+            utxoFromKeys extraKeys $ \utxo -> do
+                let
+                    txIns :: [TxIn]
+                    txIns = Map.keys $ unUTxO utxo
+
+                    addTxCollateralIns
+                        :: Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                        -> Cardano.TxBodyContent Cardano.BuildTx (CardanoApiEra era)
+                    addTxCollateralIns txBodyContent =
+                        txBodyContent
+                            { Cardano.txInsCollateral =
+                                Cardano.TxInsCollateral
+                                    alonzoOnwards
+                                    (toCardanoTxIn <$> txIns)
+                            }
+
+                withBodyContent recentEra addTxCollateralIns $ \(txBody, wits) -> do
+                    let
+                        tl = testTxLayer
+
+                        sealedTx = sealedTxFromCardano' $ Cardano.Tx txBody wits
+                        sealedTx' =
+                            signTransaction
+                                ShelleyKeyS
+                                tl
+                                (AnyCardanoEra era)
+                                AnyWitnessCountCtx
+                                (lookupFnFromKeys extraKeys)
+                                Nothing
+                                (mkCredentials rootK)
+                                utxo
+                                Nothing
+                                sealedTx
+
+                        expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
+                        expectedWits =
+                            InAnyCardanoEra era
+                                . mkShelleyWitness txBody
+                                <$> extraKeys
+
+                    expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+
+prop_signTransaction_neverRemovesWitnesses
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> UTxO
+    -- ^ UTxO of wallet
+    -> [(XPrv, Passphrase "encryption")]
+    -- ^ Extra keys to form basis of address -> key lookup function
+    -> Property
+prop_signTransaction_neverRemovesWitnesses
+    (AnyRecentEra recentEra)
+    rootK
+    utxo
+    extraKeys =
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
+            $ \tx -> do
+                let
+                    tl = testTxLayer
+
+                    sealedTx = sealedTxFromCardano' tx
+                    sealedTx' =
+                        signTransaction
+                            ShelleyKeyS
+                            tl
+                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            AnyWitnessCountCtx
+                            (lookupFnFromKeys extraKeys)
+                            Nothing
+                            (mkCredentials rootK)
+                            utxo
+                            Nothing
+                            sealedTx
+
+                    witnessesBefore = getSealedTxWitnesses sealedTx
+                    witnessesAfter = getSealedTxWitnesses sealedTx'
+
+                checkCoverage
+                    $ cover 10 (not $ null witnessesBefore) "witnesses non-empty before"
+                    $ witnessesBefore `checkSubsetOf` witnessesAfter
+
+prop_signTransaction_neverChangesTxBody
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> UTxO
+    -- ^ UTxO of wallet
+    -> [(XPrv, Passphrase "encryption")]
+    -- ^ Extra keys to form basis of address -> key lookup function
+    -> Property
+prop_signTransaction_neverChangesTxBody
+    (AnyRecentEra recentEra)
+    rootK
+    utxo
+    extraKeys =
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
+            $ \tx -> do
+                let
+                    era = cardanoEraFromRecentEra recentEra
+                    tl = testTxLayer
+
+                    sealedTx = sealedTxFromCardano' tx
+                    sealedTx' =
+                        signTransaction
+                            ShelleyKeyS
+                            tl
+                            (AnyCardanoEra era)
+                            AnyWitnessCountCtx
+                            (lookupFnFromKeys extraKeys)
+                            Nothing
+                            (mkCredentials rootK)
+                            utxo
+                            Nothing
+                            sealedTx
+
+                    txBodyContent
+                        :: InAnyCardanoEra Cardano.Tx
+                        -> InAnyCardanoEra (Cardano.TxBodyContent Cardano.ViewTx)
+                    txBodyContent
+                        (InAnyCardanoEra e (Cardano.Tx body _wits)) =
+                            InAnyCardanoEra e $ Cardano.getTxBodyContent body
+
+                    bodyContentBefore = txBodyContent $ cardanoTx sealedTx
+                    bodyContentAfter = txBodyContent $ cardanoTx sealedTx'
+
+                    equal
+                        :: InAnyCardanoEra (Cardano.TxBodyContent Cardano.ViewTx)
+                        -> InAnyCardanoEra (Cardano.TxBodyContent Cardano.ViewTx)
+                        -> Bool
+                    equal (InAnyCardanoEra era1 x1) (InAnyCardanoEra era2 x2) =
+                        case era1 `testEquality` era2 of
+                            Nothing -> False
+                            Just Refl ->
+                                unsafeWithShelleyBasedEra era1
+                                    $ x1 == x2
+
+                bodyContentBefore `equal` bodyContentAfter
+
+prop_signTransaction_preservesScriptIntegrity
+    :: AnyRecentEra
+    -- ^ Era
+    -> (XPrv, Passphrase "encryption")
+    -- ^ Root key of wallet
+    -> UTxO
+    -- ^ UTxO of wallet
+    -> Property
+prop_signTransaction_preservesScriptIntegrity
+    (AnyRecentEra recentEra)
+    rootK
+    utxo =
+        cardanoApiEraConstraints recentEra
+            $ withMaxSuccess 10
+            $ forAll (genTxInEra $ cardanoEraFromRecentEra recentEra)
+            $ \tx -> do
+                let
+                    tl = testTxLayer
+
+                    sealedTx = sealedTxFromCardano' tx
+                    sealedTx' =
+                        signTransaction
+                            ShelleyKeyS
+                            tl
+                            (AnyCardanoEra $ cardanoEraFromRecentEra recentEra)
+                            AnyWitnessCountCtx
+                            (const Nothing)
+                            Nothing
+                            (mkCredentials rootK)
+                            utxo
+                            Nothing
+                            sealedTx
+
+                    getScriptIntegrityHash :: SealedTx -> Maybe ByteString
+                    getScriptIntegrityHash =
+                        fmap getHash . txIntegrity . fromSealedTx
+
+                    scriptIntegrityHashBefore =
+                        getScriptIntegrityHash sealedTx
+                    scriptIntegrityHashAfter =
+                        getScriptIntegrityHash sealedTx'
+
+                checkCoverage
+                    $ cover
+                        30
+                        (isJust scriptIntegrityHashBefore)
+                        "script integrity hash exists"
+                    $ conjoin
+                        [ scriptIntegrityHashBefore == scriptIntegrityHashAfter
+                            & counterexample
+                                ( "script integrity hash before: "
+                                    <> show scriptIntegrityHashBefore
+                                )
+                            & counterexample
+                                ( "script integrity hash after: "
+                                    <> show scriptIntegrityHashAfter
+                                )
+                        ]
+
+forAllRecentEras :: (AnyRecentEra -> Spec) -> Spec
+forAllRecentEras eraSpec = do
+    eraSpec (AnyRecentEra RecentEraConway)
+
+allEras :: [(Int, AnyCardanoEra)]
+allEras =
+    [ (1, AnyCardanoEra ByronEra)
+    , (2, AnyCardanoEra ShelleyEra)
+    , (3, AnyCardanoEra AllegraEra)
+    , (4, AnyCardanoEra MaryEra)
+    , (5, AnyCardanoEra AlonzoEra)
+    , (6, AnyCardanoEra BabbageEra)
+    , (7, AnyCardanoEra ConwayEra)
+    ]
+
+eraNum :: AnyCardanoEra -> Int
+eraNum e = case filter ((== e) . snd) allEras of
+    ((n, _) : _) -> n
+    [] -> error "era not found"
+
+shelleyEraNum :: AnyRecentEra -> Int
+shelleyEraNum (AnyRecentEra era) =
+    cardanoApiEraConstraints era
+        $ eraNum . AnyCardanoEra
+        $ cardanoEraFromRecentEra era
+
+instance Arbitrary AnyCardanoEra where
+    arbitrary = frequency $ zip [1 ..] $ map (pure . snd) allEras
+
+    -- Shrink by choosing a *later* era
+    shrink e = map snd $ filter ((> eraNum e) . fst) allEras
+
+decodeSealedTxSpec :: Spec
+decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
+    it "tx with withdrawal" $ do
+        let bytes = unsafeFromHex byteString
+        let sealedTx = sealedTxFromBytes bytes
+        sealedTx `shouldSatisfy` isRight
+
+    prop "roundtrip for Shelley witnesses" prop_sealedTxRecentEraRoundtrip
+  where
+    byteString =
+        mconcat
+            [ "84a70081825820410a9cd4af08b3abe25c2d3b87af4c23d0bb2fb7577b639d5cfbdf"
+            , "e13a4a696c0c0d80018182583901059f0c7b9899793d2c9afaeff4fd09bedd9df3b8"
+            , "cb1b9c301ab8e0f7fb3c13a29d3798f1b77b47f2ddb31c19326b87ed6f71fb9a2713"
+            , "3ad51b000001001d19d714021a000220ec03198d0f05a1581de1fb3c13a29d3798f1"
+            , "b77b47f2ddb31c19326b87ed6f71fb9a27133ad51b000000e8d4a510000e80a0f5f6"
+            ]
+
+feeEstimationRegressionSpec :: AnyRecentEra -> Spec
+feeEstimationRegressionSpec (AnyRecentEra (_era :: RecentEra era)) =
+    describe "Regression tests" $ do
+        it "#1740 Fee estimation at the boundaries" $ do
+            let requiredCostLovelace :: Natural
+                requiredCostLovelace = 166_029
+            let estimateFee =
+                    except
+                        $ Left
+                        $ ErrBalanceTxUnableToCreateChange
+                        $ ErrBalanceTxUnableToCreateChangeError
+                            { requiredCost =
+                                Ledger.Coin $ intCast requiredCostLovelace
+                            , shortfall =
+                                Ledger.Coin 100_000
+                            }
+            result <- runExceptT (calculateFeePercentiles @_ @era estimateFee)
+            result
+                `shouldBe` Right
+                    ( Percentile $ Fee $ Coin requiredCostLovelace
+                    , Percentile $ Fee $ Coin requiredCostLovelace
+                    )
+
+binaryCalculationsSpec :: AnyRecentEra -> Spec
+binaryCalculationsSpec (AnyRecentEra era) =
+    case era of
+        RecentEraConway -> binaryCalculationsSpec' era
+        RecentEraDijkstra ->
+            describe "binaryCalculationsSpec"
+                $ it "Dijkstra"
+                $ pendingWith "TODO: Dijkstra"
+
+-- Up till Mary era we have the following structure of transaction
+--   transaction =
+-- [ transaction_body
+-- , transaction_witness_set
+-- , auxiliary_data / null
+-- ]
+-- So we begin with 3-element array binary prefix, that is encoded as '83'
+-- From Alonzo on tx was enriched for isValid field making it
+-- 4-element array that is encoded as '84'.
+--   transaction =
+-- [ transaction_body
+-- , transaction_witness_set
+-- , bool
+-- , auxiliary_data / null
+-- ]
+-- Alonzo transaction stil has the same binary representation (array)
+-- for transaction outputs like in the previous eras.
+-- Babbage era changes this representation, and introduces map binary
+-- representation for transaction outputs as the concept of them is
+-- extended in this era.
+binaryCalculationsSpec'
+    :: forall era
+     . Write.IsRecentEra era
+    => RecentEra era -> Spec
+binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ do
+    describe "Byron witnesses - mainnet" $ do
+        let net = Cardano.Mainnet
+        it "1 input, 2 outputs" $ do
+            let pairs = [dummyWit 0]
+            let amtInp = 10_000_000
+            let amtFee = 129_700
+            let amtOut = 2_000_000
+            let amtChange = amtInp - amtOut - amtFee
+            let utxo =
+                    UTxO
+                        $ Map.fromList
+                            [
+                                ( TxIn dummyTxId 0
+                                , TxOut (dummyAddress 0) (coinToBundle amtInp)
+                                )
+                            ]
+            let outs =
+                    [ TxOut (dummyAddress 1) (coinToBundle amtOut)
+                    ]
+            let chgs =
+                    [ TxOut (dummyAddress 2) (coinToBundle amtChange)
+                    ]
+            let binary = case era of
+                    RecentEraConway ->
+                        "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
+            calculateBinary net utxo outs chgs pairs `shouldBe` binary
+
+        it "2 inputs, 3 outputs" $ do
+            let pairs = [dummyWit 0, dummyWit 1]
+            let amtInp = 10_000_000
+            let amtFee = 135_200
+            let amtOut = 6_000_000
+            let amtChange = 2 * amtInp - 2 * amtOut - amtFee
+            let utxo =
+                    UTxO
+                        $ Map.fromList
+                            [
+                                ( TxIn dummyTxId 0
+                                , TxOut (dummyAddress 0) (coinToBundle amtInp)
+                                )
+                            ,
+                                ( TxIn dummyTxId 1
+                                , TxOut (dummyAddress 1) (coinToBundle amtInp)
+                                )
+                            ]
+            let outs =
+                    [ TxOut (dummyAddress 2) (coinToBundle amtOut)
+                    , TxOut (dummyAddress 3) (coinToBundle amtOut)
+                    ]
+            let chgs =
+                    [ TxOut (dummyAddress 4) (coinToBundle amtChange)
+                    ]
+            let binary = case era of
+                    RecentEraConway ->
+                        "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000041a0845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010141a0f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
+            calculateBinary net utxo outs chgs pairs `shouldBe` binary
+
+    describe "Byron witnesses - testnet" $ do
+        let net = Cardano.Testnet (Cardano.NetworkMagic 0)
+        it "1 input, 2 outputs" $ do
+            let pairs = [dummyWit 0]
+            let amtInp = 10_000_000
+            let amtFee = 129_700
+            let amtOut = 2_000_000
+            let amtChange = amtInp - amtOut - amtFee
+            let utxo =
+                    UTxO
+                        $ Map.fromList
+                            [
+                                ( TxIn dummyTxId 0
+                                , TxOut (dummyAddress 0) (coinToBundle amtInp)
+                                )
+                            ]
+            let outs =
+                    [ TxOut (dummyAddress 1) (coinToBundle amtOut)
+                    ]
+            let chgs =
+                    [ TxOut (dummyAddress 2) (coinToBundle amtChange)
+                    ]
+            let binary = case era of
+                    RecentEraConway ->
+                        "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
+            calculateBinary net utxo outs chgs pairs `shouldBe` binary
+
+        it "2 inputs, 3 outputs" $ do
+            let pairs = [dummyWit 0, dummyWit 1]
+            let amtInp = 10_000_000
+            let amtFee = 135_200
+            let amtOut = 6_000_000
+            let amtChange = 2 * amtInp - 2 * amtOut - amtFee
+            let utxo =
+                    UTxO
+                        $ Map.fromList
+                            [
+                                ( TxIn dummyTxId 0
+                                , TxOut (dummyAddress 0) (coinToBundle amtInp)
+                                )
+                            ,
+                                ( TxIn dummyTxId 1
+                                , TxOut (dummyAddress 1) (coinToBundle amtInp)
+                                )
+                            ]
+            let outs =
+                    [ TxOut (dummyAddress 2) (coinToBundle amtOut)
+                    , TxOut (dummyAddress 3) (coinToBundle amtOut)
+                    ]
+            let chgs =
+                    [ TxOut (dummyAddress 4) (coinToBundle amtChange)
+                    ]
+            let binary = case era of
+                    RecentEraConway ->
+                        "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010144a1024100845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
+                    RecentEraDijkstra ->
+                        error "unreachable: Dijkstra"
+            calculateBinary net utxo outs chgs pairs `shouldBe` binary
+  where
+    slotNo = SlotNo 7_750
+    md = Nothing
+    calculateBinary net utxo outs chgs pairs =
+        cardanoApiEraConstraints era $ hex (Cardano.serialiseToCBOR ledgerTx)
+      where
+        ledgerTx :: Cardano.Tx (CardanoApiEra era)
+        ledgerTx = Cardano.makeSignedTransaction addrWits unsigned
+        mkByronWitness' unsignedTx (_, (TxOut addr _)) =
+            mkByronWitness unsignedTx net addr
+        addrWits = zipWith (mkByronWitness' unsigned) inps pairs
+        fee = toLedgerCoin $ selectionDelta cs
+        unsigned =
+            either (error . show) id
+                $ mkUnsignedTx
+                    (Nothing, slotNo)
+                    (Right cs)
+                    md
+                    mempty
+                    []
+                    fee
+                    TokenMap.empty
+                    TokenMap.empty
+                    Map.empty
+                    Map.empty
+                    Nothing
+                    Nothing
+        cs =
+            Selection
+                { inputs = NE.fromList inps
+                , collateral = []
+                , extraCoinSource = Coin 0
+                , extraCoinSink = Coin 0
+                , outputs = outs
+                , change = chgs
+                , assetsToMint = mempty
+                , assetsToBurn = mempty
+                }
+        inps = Map.toList $ unUTxO utxo
+
+transactionConstraintsSpec :: Spec
+transactionConstraintsSpec = describe "Transaction constraints" $ do
+    it "size of empty transaction" prop_txConstraints_txBaseSize
+    it "size of non-empty transaction"
+        $ property prop_txConstraints_txSize
+
+--------------------------------------------------------------------------------
+-- Roundtrip tests for SealedTx
+
+prop_sealedTxRecentEraRoundtrip
+    :: AnyRecentEra
+    -> AnyCardanoEra
+    -> Pretty DecodeSetup
+    -> Property
+prop_sealedTxRecentEraRoundtrip
+    txEra@(AnyRecentEra era)
+    currentEra
+    (Pretty tc) =
+        cardanoApiEraConstraints era
+            $ let tx = makeShelleyTx era tc
+                  txBytes = Cardano.serialiseToCBOR tx
+                  sealedTxC = sealedTxFromCardano' tx
+                  sealedTxB = sealedTxFromBytes' currentEra txBytes
+              in  conjoin
+                    [ txBytes ==== serialisedTx sealedTxC
+                    , either
+                        (\e -> counterexample (show e) False)
+                        (compareOnCBOR tx)
+                        sealedTxB
+                    ]
+                    .||. encodingFromTheFuture (txEra) currentEra
+
+makeShelleyTx
+    :: Write.IsRecentEra era
+    => RecentEra era
+    -> DecodeSetup
+    -> Cardano.Tx (CardanoApiEra era)
+makeShelleyTx era' testCase =
+    cardanoApiEraConstraints era'
+        $ let DecodeSetup utxo outs md slotNo pairs _netwk = testCase
+              inps = Map.toList $ unUTxO utxo
+              fee = toLedgerCoin $ selectionDelta cs
+              unsigned =
+                either (error . show) id
+                    $ mkUnsignedTx
+                        (Nothing, slotNo)
+                        (Right cs)
+                        md
+                        mempty
+                        []
+                        fee
+                        TokenMap.empty
+                        TokenMap.empty
+                        Map.empty
+                        Map.empty
+                        Nothing
+                        Nothing
+              addrWits =
+                map (mkShelleyWitness unsigned) pairs
+              cs =
+                Selection
+                    { inputs = NE.fromList inps
+                    , collateral = []
+                    , extraCoinSource = Coin 0
+                    , extraCoinSink = Coin 0
+                    , outputs = []
+                    , change = outs
+                    , -- TODO: [ADP-346]
+                      assetsToMint = TokenMap.empty
+                    , assetsToBurn = TokenMap.empty
+                    }
+          in  Cardano.makeSignedTransaction addrWits unsigned
+
+encodingFromTheFuture :: AnyRecentEra -> AnyCardanoEra -> Bool
+encodingFromTheFuture tx current = shelleyEraNum tx > eraNum current
+
+compareOnCBOR
+    :: Cardano.IsShelleyBasedEra era
+    => Cardano.Tx era -> SealedTx -> Property
+compareOnCBOR b sealed = case cardanoTx sealed of
+    InAnyCardanoEra era a ->
+        unsafeWithShelleyBasedEra era
+            $ Cardano.serialiseToCBOR a ==== Cardano.serialiseToCBOR b
+
+unsafeWithShelleyBasedEra
+    :: Cardano.CardanoEra era
+    -> (Cardano.IsShelleyBasedEra era => a)
+    -> a
+unsafeWithShelleyBasedEra era a = case era of
+    ByronEra ->
+        error "TestSpec: Byron not supported anymore"
+    ShelleyEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraShelley a
+    AllegraEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraAllegra a
+    MaryEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraMary a
+    AlonzoEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraAlonzo a
+    BabbageEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraBabbage a
+    ConwayEra ->
+        Cardano.shelleyBasedEraConstraints Cardano.ShelleyBasedEraConway a
+    DijkstraEra ->
+        error "unsafeWithShelleyBasedEra: DijkstraEra not yet supported"
+
+--------------------------------------------------------------------------------
+
+newtype ForByron a = ForByron {getForByron :: a} deriving (Show, Eq)
+
+data DecodeSetup = DecodeSetup
+    { inputs :: UTxO
+    , outputs :: [TxOut] -- TODO: add datums
+    , metadata :: Maybe TxMetadata
+    , ttl :: SlotNo
+    , keyPasswd :: [(XPrv, Passphrase "encryption")]
+    , network :: Cardano.NetworkId
+    }
+    deriving (Show)
+
+instance Arbitrary DecodeSetup where
+    arbitrary = do
+        utxo <- arbitrary
+        DecodeSetup utxo
+            <$> listOf1 arbitrary
+            <*> arbitrary
+            <*> arbitrary
+            <*> vectorOf (Map.size $ unUTxO utxo) arbitrary
+            <*> arbitrary
+
+    shrink (DecodeSetup i o m t k n) =
+        [ DecodeSetup i' o' m' t' k' n'
+        | (i', o', m', t', k', n') <- shrink (i, o, m, t, k, n)
+        ]
+
+instance Arbitrary (ForByron DecodeSetup) where
+    arbitrary = do
+        test <- arbitrary
+        pure $ ForByron (test{metadata = Nothing})
+
+instance Arbitrary TxMetadata where
+    arbitrary = TxMetadata <$> arbitrary
+    shrink (TxMetadata md) = TxMetadata <$> shrink md
+
+instance Arbitrary TxMetadataValue where
+    -- Note: test generation at the integration level is very simple. More
+    -- detailed metadata tests are done at unit level.
+    arbitrary = TxMetaNumber <$> arbitrary
+
+instance Arbitrary UTxO where
+    arbitrary = do
+        n <- choose (1, 10)
+        inps <- vectorOf n arbitrary
+        let addr = Address $ BS.pack (1 : replicate 56 0)
+        coins <- vectorOf n arbitrary
+        let outs = map (TxOut addr) coins
+        pure $ UTxO $ Map.fromList $ zip inps outs
+
+instance Arbitrary XPrv where
+    arbitrary = fromJust . xprvFromBytes . BS.pack <$> vectorOf 96 arbitrary
+
+-- Necessary unsound Show instance for QuickCheck failure reporting
+instance Show XPrv where
+    show = show . xprvToBytes
+
+-- Necessary unsound Eq instance for QuickCheck properties
+instance Eq XPrv where
+    (==) = (==) `on` xprvToBytes
+
+instance Arbitrary (Passphrase "user") where
+    arbitrary = do
+        n <- choose (passphraseMinLength p, passphraseMaxLength p)
+        bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
+        return $ Passphrase $ BA.convert bytes
+      where
+        p = Proxy :: Proxy "user"
+
+    shrink (Passphrase bytes)
+        | BA.length bytes <= passphraseMinLength p = []
+        | otherwise =
+            [ Passphrase
+                $ BA.convert
+                $ B8.take (passphraseMinLength p)
+                $ BA.convert bytes
+            ]
+      where
+        p = Proxy :: Proxy "user"
+
+instance Arbitrary (Passphrase "encryption") where
+    arbitrary =
+        preparePassphrase EncryptWithPBKDF2
+            <$> arbitrary @(Passphrase "user")
+
+instance Arbitrary (Quantity "byte" Word16) where
+    arbitrary = Quantity <$> choose (128, 2_048)
+    shrink (Quantity size)
+        | size <= 1 = []
+        | otherwise = Quantity <$> shrink size
+
+dummyAddress :: Word8 -> Address
+dummyAddress b =
+    Address $ BS.pack $ 1 : replicate 56 b
+
+coinToBundle :: Word64 -> TokenBundle
+coinToBundle = TokenBundle.fromCoin . Coin.fromWord64
+
+dummyWit :: Word8 -> (XPrv, Passphrase "encryption")
+dummyWit b =
+    (fromJust $ xprvFromBytes $ BS.pack $ replicate 96 b, mempty)
+
+dummyTxId :: Hash "Tx"
+dummyTxId = Hash $ BS.pack $ replicate 32 0
+
+cardanoTx :: SealedTx -> InAnyCardanoEra Cardano.Tx
+cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
+
+testTxLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
+testTxLayer = newTransactionLayer ShelleyKeyS Cardano.Mainnet
+
+--------------------------------------------------------------------------------
+-- Transaction constraints
+--------------------------------------------------------------------------------
+
+emptyTxSkeleton :: TxSkeleton
+emptyTxSkeleton =
+    TxSkeleton TxWitnessShelleyUTxO 0 [] [] Nothing
+
+mockTxConstraints :: TxConstraints
+mockTxConstraints =
+    txConstraints
+        (mockPParams @Write.Conway)
+        TxWitnessShelleyUTxO
+data MockSelection = MockSelection
+    { txInputCount :: Int
+    , txOutputs :: [TxOut]
+    , txRewardWithdrawal :: Coin
+    }
+    deriving (Eq, Show)
+
+genMockSelection :: Gen MockSelection
+genMockSelection = do
+    txInputCount <-
+        oneof [pure 0, choose (1, 1_000)]
+    txOutputCount <-
+        oneof [pure 0, choose (1, 1_000)]
+    txOutputs <- replicateM txOutputCount genOut
+    txRewardWithdrawal <-
+        Coin <$> oneof [pure 0, chooseNatural (1, 1_000_000)]
+    pure
+        MockSelection
+            { txInputCount
+            , txOutputs
+            , txRewardWithdrawal
+            }
+  where
+    genOut = TxOut (dummyAddress dummyByte) <$> genTokenBundleSmallRange
+      where
+        dummyByte :: Word8
+        dummyByte = fromIntegral $ fromEnum 'A'
+
+shrinkMockSelection :: MockSelection -> [MockSelection]
+shrinkMockSelection mock =
+    [ MockSelection i o r
+    | (i, o, r) <- shrink (txInputCount, txOutputs, txRewardWithdrawal)
+    ]
+  where
+    MockSelection
+        { txInputCount
+        , txOutputs
+        , txRewardWithdrawal
+        } = mock
+
+instance Arbitrary MockSelection where
+    arbitrary = genMockSelection
+    shrink = shrinkMockSelection
+
+-- Tests that using 'txBaseSize' to estimate the size of an empty selection
+-- produces a result that is consistent with the result of using
+-- 'estimateTxSize'.
+--
+prop_txConstraints_txBaseSize :: Property
+prop_txConstraints_txBaseSize =
+    txBaseSize mockTxConstraints
+        === fromBTTxSize (estimateTxSize emptyTxSkeleton)
+  where
+    fromBTTxSize (BT.TxSize n) = TxSize n
+
+-- Tests that using 'txConstraints' to estimate the size of a non-empty
+-- selection produces a result that is consistent with the result of using
+-- 'estimateTxSize'.
+--
+prop_txConstraints_txSize :: MockSelection -> Property
+prop_txConstraints_txSize mock =
+    counterexample ("result: " <> show result)
+        $ counterexample ("lower bound: " <> show lowerBound)
+        $ counterexample ("upper bound: " <> show upperBound)
+        $ conjoin
+            [ result >= lowerBound
+            , result <= upperBound
+            ]
+  where
+    MockSelection{txInputCount, txOutputs} = mock
+    result :: TxSize
+    result =
+        mconcat
+            [ txBaseSize mockTxConstraints
+            , txInputCount `mtimesDefault` txInputSize mockTxConstraints
+            , F.foldMap (txOutputSize mockTxConstraints . tokens) txOutputs
+            ]
+    fromBTTxSize (BT.TxSize n) = TxSize n
+    toBTTxOut (TxOut (Address a) b) =
+        BT.TxOut (BT.Address a) (toBTTokenBundle b)
+    toBTTokenBundle (TokenBundle.TokenBundle c tm) =
+        BT.TokenBundle (toBTCoin c) (toBTTokenMap tm)
+    toBTCoin (Coin n) = BT.Coin n
+    toBTTokenMap =
+        BT.fromFlatList
+            . fmap toBTEntry
+            . TokenMap.toFlatList
+    toBTEntry (AssetId (UnsafeTokenPolicyId (Hash pid)) (UnsafeAssetName an), q) =
+        ( BT.AssetId
+            (BT.UnsafeTokenPolicyId (BT.Hash pid))
+            (BT.UnsafeAssetName an)
+        , toBTTokenQuantity q
+        )
+    toBTTokenQuantity (TokenQuantity n) = BT.TokenQuantity n
+    lowerBound =
+        fromBTTxSize
+            $ estimateTxSize
+                emptyTxSkeleton
+                    { txInputCount
+                    , txOutputs = fmap toBTTxOut txOutputs
+                    }
+    -- We allow a small amount of overestimation due to the slight variation in
+    -- the marginal size of an input:
+    upperBound = lowerBound <> txInputCount `mtimesDefault` TxSize 4
+
+newtype Large a = Large {unLarge :: a}
+    deriving (Eq, Show)
+
+instance Arbitrary (Large TokenBundle) where
+    arbitrary = fmap Large . genTxOutTokenBundle =<< choose (1, 128)
+
+instance Arbitrary AnyRecentEra where
+    arbitrary = return (AnyRecentEra RecentEraConway)
+
+instance Arbitrary AssetId where
+    arbitrary =
+        AssetId
+            <$> arbitrary
+            -- In the calculation of the size of the Tx, the minting of assets
+            -- increases the size of the Tx by both a constant factor per asset
+            -- plus a variable factor (the size of the asset name). In a typical
+            -- setting, the constant factor dominantes (it's about 40 bytes per
+            -- asset, whereas the size of an asset name has a maximum of 32 bytes).
+            -- So we create a generator here that forces the variable factor to
+            -- dominate so we can test the sanity of the estimation algorithm.
+            <*> (UnsafeAssetName . BS.pack <$> vector 128)
+
+instance Arbitrary Coin where
+    arbitrary = genCoinPositive
+    shrink = shrinkCoinPositive
+
+instance Arbitrary (Hash "Tx") where
+    arbitrary = do
+        bs <- vectorOf 32 arbitrary
+        pure $ Hash $ BS.pack bs
+
+instance Arbitrary Cardano.NetworkId where
+    arbitrary =
+        oneof
+            [ pure Cardano.Mainnet
+            , Cardano.Testnet . Cardano.NetworkMagic <$> arbitrary
+            ]
+
+instance Arbitrary TokenBundle where
+    arbitrary = genTokenBundleSmallRange
+    shrink = shrinkTokenBundleSmallRange
+
+instance Arbitrary TokenPolicyId where
+    arbitrary = genTokenPolicyId
+    shrink = shrinkTokenPolicyId
+
+instance Arbitrary (Script KeyHash) where
+    arbitrary = do
+        keyHashes <- vectorOf 10 arbitrary
+        genScript keyHashes
+
+instance Arbitrary TxIn where
+    arbitrary = do
+        ix <- scale (`mod` 3) arbitrary
+        txId <- arbitrary
+        pure $ TxIn txId ix
+
+instance Arbitrary TxOut where
+    arbitrary =
+        TxOut addr <$> scale (`mod` 4) genTokenBundleSmallRange
+      where
+        addr = Address $ BS.pack (1 : replicate 56 0)
+    shrink (TxOut addr bundle) =
+        [ TxOut addr bundle'
+        | bundle' <- shrinkTokenBundleSmallRange bundle
+        ]
+
+instance Arbitrary KeyHash where
+    arbitrary = do
+        cred <- oneof [pure Payment, pure Delegation]
+        KeyHash cred . BS.pack <$> vectorOf 28 arbitrary
+
+-- https://mail.haskell.org/pipermail/haskell-cafe/2016-August/124742.html
+mkGen :: (QCGen -> a) -> Gen a
+mkGen f = MkGen $ \g _ -> f g
+
+instance MonadRandom Gen where
+    getRandom = mkGen (fst . random)
+    getRandoms = mkGen randoms
+    getRandomR range = mkGen (fst . randomR range)
+    getRandomRs range = mkGen (randomRs range)
+
+newtype ShowBuildable a = ShowBuildable a
+    deriving newtype (Arbitrary)
+
+instance Buildable a => Show (ShowBuildable a) where
+    show (ShowBuildable x) = pretty x
+
+instance Arbitrary (Hash "Datum") where
+    arbitrary = pure $ Hash $ BS.pack $ replicate 28 0
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- | A convenient wrapper type that allows values of any type with a 'Show'
+--   instance to be ordered.
+newtype ShowOrd a = ShowOrd {unShowOrd :: a}
+    deriving (Eq, Show)
+
+instance (Eq a, Show a) => Ord (ShowOrd a) where
+    compare = comparing show

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -51,6 +51,7 @@ import Cardano.Api.Extra
     , cardanoApiEraConstraints
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
+    , toCardanoApiTx
     )
 import Cardano.Api.Gen
     ( genTx
@@ -72,6 +73,25 @@ import Cardano.Balance.Tx.Gen
 import Cardano.Balance.Tx.SizeEstimation
     ( TxSkeleton (..)
     , estimateTxSize
+    )
+import Cardano.Ledger.Address
+    ( Withdrawals (..)
+    )
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Api
+    ( addrTxWitsL
+    , bodyTxL
+    , bootAddrTxWitsL
+    , eraProtVerLow
+    , witsTxL
+    )
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (..)
+    )
+import Cardano.Ledger.Binary
+    ( serialize
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic)
@@ -104,7 +124,9 @@ import Cardano.Wallet.Gen
     , genScript
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
-    ( toLedgerCoin
+    ( Convert (..)
+    , toConwayTxOut
+    , toLedgerCoin
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
     ( txIntegrity
@@ -197,13 +219,16 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     )
 import Cardano.Wallet.Shelley.Transaction
-    ( mkByronWitness
-    , mkShelleyWitness
-    , mkUnsignedTx
+    ( mkShelleyWitness
     , newTransactionLayer
+    )
+import Cardano.Wallet.Shelley.Transaction.Build
+    ( mkLedgerTx
     )
 import Cardano.Wallet.Shelley.Transaction.Ledger
     ( TxWitnessTag (..)
+    , mkByronWitnessLedger
+    , mkShelleyWitnessLedger
     , txConstraints
     )
 import Cardano.Wallet.Transaction
@@ -217,6 +242,10 @@ import Cardano.Wallet.Unsafe
     )
 import Control.Arrow
     ( first
+    )
+import Control.Lens
+    ( (.~)
+    , (^.)
     )
 import Control.Monad
     ( replicateM
@@ -271,6 +300,9 @@ import Data.Quantity
     )
 import Data.Semigroup
     ( mtimesDefault
+    )
+import Data.Sequence.Strict
+    ( fromList
     )
 import Data.Type.Equality
     ( testEquality
@@ -363,6 +395,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -1121,7 +1154,7 @@ binaryCalculationsSpec (AnyRecentEra era) =
 -- extended in this era.
 binaryCalculationsSpec'
     :: forall era
-     . Write.IsRecentEra era
+     . (Write.IsRecentEra era, era ~ Write.Conway)
     => RecentEra era -> Spec
 binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ do
     describe "Byron witnesses - mainnet" $ do
@@ -1149,8 +1182,6 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
-                    RecentEraDijkstra ->
-                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
         it "2 inputs, 3 outputs" $ do
@@ -1181,8 +1212,6 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000041a0845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010141a0f5f6"
-                    RecentEraDijkstra ->
-                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
     describe "Byron witnesses - testnet" $ do
@@ -1210,8 +1239,6 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a102d90102818458200100000000000000000000000000000000000000000000000000000000000000584005dacf0a9cbb4b5429ca2a31187c71d07c51b1151042076c536308c105069be7d099ed1e0b4be87303c03e8ae02586fb568ad8556cb108c00b8e63bc2adbc6065820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
-                    RecentEraDijkstra ->
-                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
 
         it "2 inputs, 3 outputs" $ do
@@ -1242,36 +1269,47 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             let binary = case era of
                     RecentEraConway ->
                         "84a400d901028282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000101838258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a005b8d808258390103030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031a005b8d808258390104040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404041a007801e0021a0002102003191e46a102d9010282845820130ae82201d7072e6fbfc0a1884fb54636554d14945b799125cf7ce38d477f515840b5b781d37d9a31dcbb000d92a461c3bc260e069c24d26d3996c6cadb03ae3ab518e8c7c19bd119fdcf112d4be101d20c7524065722ee0a25d97f31374fe9ef055820010101010101010101010101010101010101010101010101010101010101010144a1024100845820010000000000000000000000000000000000000000000000000000000000000058405257f6056570317ebd7a878f032932bdf7a0e9e43f27296a12e22dd5c92f1f08b27c95b182c68ce3b1ed6942f2a4cc63aac7a89530c6086aaa3913685f75060f5820000000000000000000000000000000000000000000000000000000000000000044a1024100f5f6"
-                    RecentEraDijkstra ->
-                        error "unreachable: Dijkstra"
             calculateBinary net utxo outs chgs pairs `shouldBe` binary
   where
     slotNo = SlotNo 7_750
-    md = Nothing
     calculateBinary net utxo outs chgs pairs =
-        cardanoApiEraConstraints era $ hex (Cardano.serialiseToCBOR ledgerTx)
+        hex
+            $ BL.toStrict
+            $ serialize (eraProtVerLow @era) ledgerTx
       where
-        ledgerTx :: Cardano.Tx (CardanoApiEra era)
-        ledgerTx = Cardano.makeSignedTransaction addrWits unsigned
-        mkByronWitness' unsignedTx (_, (TxOut addr _)) =
-            mkByronWitness unsignedTx net addr
-        addrWits = zipWith (mkByronWitness' unsigned) inps pairs
+        ledgerTx =
+            baseTx
+                & witsTxL . bootAddrTxWitsL .~ Set.fromList byronWits
+        body = baseTx ^. bodyTxL
+        byronWits =
+            zipWith
+                ( \(_, TxOut addr _) xprv ->
+                    mkByronWitnessLedger
+                        era
+                        body
+                        net
+                        addr
+                        xprv
+                )
+                inps
+                pairs
         fee = toLedgerCoin $ selectionDelta cs
-        unsigned =
-            either (error . show) id
-                $ mkUnsignedTx
-                    (Nothing, slotNo)
-                    (Right cs)
-                    md
-                    mempty
-                    []
-                    fee
-                    TokenMap.empty
-                    TokenMap.empty
-                    Map.empty
-                    Map.empty
-                    Nothing
-                    Nothing
+        baseTx =
+            mkLedgerTx
+                era
+                (Set.fromList $ map (toLedger . fst) inps)
+                ( fromList
+                    $ map toConwayTxOut (outs <> chgs)
+                )
+                fee
+                ( ValidityInterval
+                    SNothing
+                    (SJust slotNo)
+                )
+                (Withdrawals Map.empty)
+                mempty
+                mempty
+                Map.empty
         cs =
             Selection
                 { inputs = NE.fromList inps
@@ -1318,45 +1356,69 @@ prop_sealedTxRecentEraRoundtrip
                     .||. encodingFromTheFuture (txEra) currentEra
 
 makeShelleyTx
-    :: Write.IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> DecodeSetup
     -> Cardano.Tx (CardanoApiEra era)
-makeShelleyTx era' testCase =
-    cardanoApiEraConstraints era'
-        $ let DecodeSetup utxo outs md slotNo pairs _netwk = testCase
-              inps = Map.toList $ unUTxO utxo
-              fee = toLedgerCoin $ selectionDelta cs
-              unsigned =
-                either (error . show) id
-                    $ mkUnsignedTx
-                        (Nothing, slotNo)
-                        (Right cs)
-                        md
-                        mempty
-                        []
+makeShelleyTx era' testCase = case era' of
+    Write.RecentEraConway -> go era'
+    Write.RecentEraDijkstra ->
+        error "makeShelleyTx: Dijkstra not yet supported"
+  where
+    go
+        :: forall e
+         . (Write.IsRecentEra e, e ~ Write.Conway)
+        => RecentEra e
+        -> Cardano.Tx (CardanoApiEra e)
+    go era'' =
+        cardanoApiEraConstraints era''
+            $ let DecodeSetup utxo outs md slotNo pairs _netwk =
+                    testCase
+                  inps = Map.toList $ unUTxO utxo
+                  fee = toLedgerCoin $ selectionDelta cs
+                  metadata = case md of
+                    Nothing -> Map.empty
+                    Just (TxMetadata m) ->
+                        Cardano.toShelleyMetadata m
+                  baseTx =
+                    mkLedgerTx
+                        era''
+                        ( Set.fromList
+                            $ map (toLedger . fst) inps
+                        )
+                        ( fromList
+                            $ map toConwayTxOut outs
+                        )
                         fee
-                        TokenMap.empty
-                        TokenMap.empty
-                        Map.empty
-                        Map.empty
-                        Nothing
-                        Nothing
-              addrWits =
-                map (mkShelleyWitness unsigned) pairs
-              cs =
-                Selection
-                    { inputs = NE.fromList inps
-                    , collateral = []
-                    , extraCoinSource = Coin 0
-                    , extraCoinSink = Coin 0
-                    , outputs = []
-                    , change = outs
-                    , -- TODO: [ADP-346]
-                      assetsToMint = TokenMap.empty
-                    , assetsToBurn = TokenMap.empty
-                    }
-          in  Cardano.makeSignedTransaction addrWits unsigned
+                        ( ValidityInterval
+                            SNothing
+                            (SJust slotNo)
+                        )
+                        (Withdrawals Map.empty)
+                        mempty
+                        mempty
+                        metadata
+                  body = baseTx ^. bodyTxL
+                  shelleyWits =
+                    map
+                        (mkShelleyWitnessLedger era'' body)
+                        pairs
+                  ledgerTx =
+                    baseTx
+                        & witsTxL . addrTxWitsL
+                            .~ Set.fromList shelleyWits
+                  cs =
+                    Selection
+                        { inputs = NE.fromList inps
+                        , collateral = []
+                        , extraCoinSource = Coin 0
+                        , extraCoinSink = Coin 0
+                        , outputs = []
+                        , change = outs
+                        , -- TODO: [ADP-346]
+                          assetsToMint = TokenMap.empty
+                        , assetsToBurn = TokenMap.empty
+                        }
+              in  toCardanoApiTx ledgerTx
 
 encodingFromTheFuture :: AnyRecentEra -> AnyCardanoEra -> Bool
 encodingFromTheFuture tx current = shelleyEraNum tx > eraNum current

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -239,6 +239,7 @@ library
     Cardano.Wallet.Shelley.Network
     Cardano.Wallet.Shelley.Transaction
     Cardano.Wallet.Shelley.Transaction.Build
+    Cardano.Wallet.Shelley.Transaction.Ledger
     Cardano.Wallet.Submissions.Operations
     Cardano.Wallet.Submissions.Primitives
     Cardano.Wallet.Submissions.Properties.Common

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -59,6 +59,7 @@ library
     , cardano-ledger-api
     , cardano-ledger-byron
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-ledger-read
     , cardano-slotting
     , cardano-strict-containers
@@ -237,6 +238,7 @@ library
     Cardano.Wallet.Shelley.BlockchainSource
     Cardano.Wallet.Shelley.Network
     Cardano.Wallet.Shelley.Transaction
+    Cardano.Wallet.Shelley.Transaction.Build
     Cardano.Wallet.Submissions.Operations
     Cardano.Wallet.Submissions.Primitives
     Cardano.Wallet.Submissions.Properties.Common

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -56,8 +56,10 @@ library
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-allegra
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-byron
+    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-read

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -48,6 +48,7 @@ module Cardano.Wallet.Shelley.Transaction
     , mkByronWitness
     , mkShelleyWitness
     , mkUnsignedTx
+    , signTransaction
     , _txRewardWithdrawalCost
     , _txRewardWithdrawalSize
     , txWitnessTagForKey

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Build ledger transactions directly using @mkBasicTxBody@ and lenses,
+-- bypassing @Cardano.Api.TxBodyContent@.
+module Cardano.Wallet.Shelley.Transaction.Build
+    ( mkLedgerTx
+    ) where
+
+import Cardano.Balance.Tx.Eras
+    ( IsRecentEra
+    , RecentEra (..)
+    )
+import Cardano.Balance.Tx.Tx
+    ( Tx
+    )
+import Cardano.Ledger.Address
+    ( Withdrawals
+    )
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Api.Tx
+    ( auxDataTxL
+    , mkBasicTx
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( feeTxBodyL
+    , inputsTxBodyL
+    , mintTxBodyL
+    , mkBasicTxBody
+    , outputsTxBodyL
+    , vldtTxBodyL
+    , withdrawalsTxBodyL
+    )
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (SJust, SNothing)
+    )
+import Cardano.Ledger.Coin
+    ( Coin
+    )
+import Cardano.Ledger.Core
+    ( TxCert
+    , TxOut
+    , auxDataHashTxBodyL
+    , certsTxBodyL
+    , hashTxAuxData
+    , metadataTxAuxDataL
+    , mkBasicTxAuxData
+    )
+import Cardano.Ledger.Mary.Value
+    ( MultiAsset
+    )
+import Cardano.Ledger.Metadata
+    ( Metadatum
+    )
+import Cardano.Ledger.TxIn
+    ( TxIn
+    )
+import Control.Lens
+    ( (&)
+    , (.~)
+    )
+import Data.Map.Strict
+    ( Map
+    )
+import Data.Sequence.Strict
+    ( StrictSeq
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Word
+    ( Word64
+    )
+import Prelude
+
+import qualified Data.Map.Strict as Map
+
+-- | Build a ledger 'Tx' directly from its components, using
+-- @mkBasicTxBody@ and ledger lenses.
+mkLedgerTx
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> Set TxIn
+    -- ^ Inputs
+    -> StrictSeq (TxOut era)
+    -- ^ Outputs
+    -> Coin
+    -- ^ Fee
+    -> ValidityInterval
+    -- ^ Validity interval
+    -> Withdrawals
+    -- ^ Withdrawals
+    -> StrictSeq (TxCert era)
+    -- ^ Certificates
+    -> MultiAsset
+    -- ^ Minting
+    -> Map Word64 Metadatum
+    -- ^ Metadata
+    -> Tx era
+mkLedgerTx era ins outs fee validity wdrls certs mint metadata =
+    case era of
+        RecentEraConway -> go
+        RecentEraDijkstra ->
+            error "mkLedgerTx: Dijkstra era not yet supported"
+  where
+    go =
+        let
+            auxData
+                | Map.null metadata = SNothing
+                | otherwise =
+                    SJust
+                        $ mkBasicTxAuxData
+                        & metadataTxAuxDataL .~ metadata
+            body =
+                mkBasicTxBody
+                    & inputsTxBodyL .~ ins
+                    & outputsTxBodyL .~ outs
+                    & feeTxBodyL .~ fee
+                    & vldtTxBodyL .~ validity
+                    & withdrawalsTxBodyL .~ wdrls
+                    & certsTxBodyL .~ certs
+                    & mintTxBodyL .~ mint
+                    & auxDataHashTxBodyL
+                        .~ fmap hashTxAuxData auxData
+        in
+            mkBasicTx body
+                & auxDataTxL .~ auxData

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -21,9 +21,8 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
 
       -- * Signing
     , signTransaction
-    -- TODO: mkShelleyWitness and mkByronWitness take
-    -- Cardano.TxBody and cannot be used with ledger types
-    -- directly. Signing is handled through signTransaction.
+    , mkShelleyWitnessLedger
+    , mkByronWitnessLedger
 
       -- * Payload
     , TxPayload (..)
@@ -71,8 +70,14 @@ import Cardano.Balance.Tx.Eras
 import Cardano.Balance.Tx.SizeEstimation
     ( TxWitnessTag (..)
     )
+import Cardano.Crypto.DSIGN
+    ( SignedDSIGN (SignedDSIGN)
+    , rawDeserialiseSigDSIGN
+    , rawDeserialiseVerKeyDSIGN
+    )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash)
+    , hashToBytes
     )
 import Cardano.Ledger.Address
     ( Withdrawals (Withdrawals)
@@ -87,6 +92,21 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
     ( TxCert
     )
+import Cardano.Ledger.Hashes
+    ( EraIndependentTxBody
+    , HashAnnotated (hashAnnotated)
+    , extractHash
+    )
+import Cardano.Ledger.Keys
+    ( VKey (VKey)
+    )
+import Cardano.Ledger.Keys.Bootstrap
+    ( BootstrapWitness
+    , makeBootstrapWitness
+    )
+import Cardano.Ledger.Keys.WitVKey
+    ( WitVKey (WitVKey)
+    )
 import Cardano.Ledger.Metadata
     ( Metadatum
     )
@@ -96,6 +116,9 @@ import Cardano.Wallet.Address.Derivation
     )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( toRewardAccountRaw
+    )
+import Cardano.Wallet.Address.Encoding
+    ( toHDPayloadAddress
     )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS
@@ -193,10 +216,13 @@ import Ouroboros.Network.Block
 import Prelude
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Certificate as ApiCert
 import qualified Cardano.Api.Experimental.Certificate as ExpCert
 import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Tx as Write
+import qualified Cardano.Crypto as CC
+import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as LApi
@@ -211,6 +237,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
 import qualified Cardano.Wallet.Read as Read
+import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
@@ -776,3 +803,78 @@ toLedgerStakeCred = \case
 -- | Convert a wallet 'Coin' to a ledger 'Coin'.
 toLedgerCoin :: Coin -> Ledger.Coin
 toLedgerCoin = toCardanoLovelace
+
+-- | Construct a Shelley-era key witness directly from
+-- ledger types, bypassing cardano-api.
+--
+-- Signs the transaction body hash with the extended
+-- private key and constructs a 'WitVKey'.
+mkShelleyWitnessLedger
+    :: forall era
+     . Write.IsRecentEra era
+    => RecentEra era
+    -> Write.TxBody era
+    -> (XPrv, Passphrase "encryption")
+    -> Keys.WitVKey Keys.Witness
+mkShelleyWitnessLedger _era body (xprv, pwd) =
+    WitVKey vkey sig
+  where
+    xprv' =
+        Crypto.HD.xPrvChangePass pwd BS.empty xprv
+    bodyHash =
+        hashToBytes
+            $ extractHash
+            $ hashAnnotated @_ @EraIndependentTxBody body
+    xsig =
+        Crypto.HD.sign
+            (BS.empty :: BS.ByteString)
+            xprv'
+            bodyHash
+    vkey =
+        case rawDeserialiseVerKeyDSIGN
+            (Crypto.HD.xpubPublicKey $ toXPub xprv') of
+            Just vk -> VKey vk
+            Nothing ->
+                error
+                    "mkShelleyWitnessLedger: \
+                    \invalid public key"
+    sig =
+        case rawDeserialiseSigDSIGN
+            (Crypto.HD.unXSignature xsig) of
+            Just s -> SignedDSIGN s
+            Nothing ->
+                error
+                    "mkShelleyWitnessLedger: \
+                    \invalid signature"
+
+-- | Construct a Byron bootstrap witness directly from
+-- ledger types, bypassing cardano-api.
+--
+-- Hashes the transaction body and creates a bootstrap
+-- witness with Byron address attributes.
+mkByronWitnessLedger
+    :: forall era
+     . Write.IsRecentEra era
+    => RecentEra era
+    -> Write.TxBody era
+    -> Cardano.NetworkId
+    -> Address
+    -> (XPrv, Passphrase "encryption")
+    -> BootstrapWitness
+mkByronWitnessLedger _era body net addr (xprv, pwd) =
+    makeBootstrapWitness txHash signingKey addrAttr
+  where
+    txHash =
+        extractHash $ hashAnnotated @_ @EraIndependentTxBody body
+    signingKey =
+        CC.SigningKey
+            $ Crypto.HD.xPrvChangePass pwd BS.empty xprv
+    addrAttr =
+        Byron.mkAttributes
+            $ Byron.AddrAttributes
+                (toHDPayloadAddress addr)
+                networkMagic
+    networkMagic = case net of
+        Cardano.Mainnet -> Byron.NetworkMainOrStage
+        Cardano.Testnet (Cardano.NetworkMagic m) ->
+            Byron.NetworkTestnet m

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -38,6 +38,10 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
       -- * Reward withdrawal cost estimation
     , _txRewardWithdrawalCost
     , _txRewardWithdrawalSize
+
+      -- * Ledger-native certificates
+    , certificateFromDelegationActionLedger
+    , certificateFromVotingActionLedger
     -- TODO: mkUnsignedTransaction uses Cardano.NetworkId,
     -- Cardano.Certificate, and other cardano-api types
     -- pervasively. Needs a ledger-native rewrite.
@@ -45,7 +49,15 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
 
 import Cardano.Address.Derivation
     ( XPrv
+    , XPub
     , toXPub
+    , xpubPublicKey
+    )
+import Cardano.Address.KeyHash
+    ( KeyHash (..)
+    )
+import Cardano.Address.Script
+    ( Script (..)
     )
 import Cardano.Api.Extra
     ( CardanoApiEra
@@ -58,6 +70,9 @@ import Cardano.Balance.Tx.Eras
     )
 import Cardano.Balance.Tx.SizeEstimation
     ( TxWitnessTag (..)
+    )
+import Cardano.Crypto.Hash.Class
+    ( Hash (UnsafeHash)
     )
 import Cardano.Ledger.Address
     ( Withdrawals (Withdrawals)
@@ -87,6 +102,8 @@ import Cardano.Wallet.Flavor
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( Convert (toLedger)
+    , toLedgerDelegatee
+    , toLedgerTimelockScript
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
     ( getTxExtended
@@ -100,6 +117,9 @@ import Cardano.Wallet.Primitive.Passphrase
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx
@@ -131,21 +151,26 @@ import Cardano.Wallet.Shelley.Transaction.Build
     ( mkLedgerTx
     )
 import Cardano.Wallet.Transaction
-    ( ErrMkTransaction (..)
+    ( DelegationAction (..)
+    , ErrMkTransaction (..)
     , ErrMkTransactionOutputTokenQuantityExceedsLimitError (..)
     , PreSelection (..)
     , SelectionOf (..)
     , TransactionCtx (..)
+    , VotingAction (..)
     , Withdrawal (..)
     , WitnessCountCtx (..)
     , selectionDelta
     )
-import Cardano.Wallet.Transaction.Delegation
-    ( certificateFromDelegationAction
-    )
 import Control.Monad
     ( forM_
     , when
+    )
+import Cryptography.Hash.Blake
+    ( blake2b224
+    )
+import Data.ByteString.Short
+    ( toShort
     )
 import Data.Generics.Internal.VL.Lens
     ( view
@@ -173,7 +198,12 @@ import qualified Cardano.Api.Experimental.Certificate as ExpCert
 import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Tx as Write
 import qualified Cardano.Ledger.Address as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Api as LApi
 import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Conway.TxCert as Conway
+import qualified Cardano.Ledger.Credential as Cred
+import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
@@ -231,19 +261,18 @@ mkTransactionLedger
         let wdrl = view #txWithdrawal ctx
         let delta = selectionDelta cs
         let md = view #txMetadata ctx
-        let certs =
+        let ledgerCerts =
                 case view #txDelegationAction ctx of
                     Nothing -> []
                     Just action ->
                         let stakeXPub =
                                 toXPub $ fst stakeCreds
-                        in  certificateFromDelegationAction
+                        in  certificateFromDelegationActionLedger
                                 era
                                 (Left stakeXPub)
                                 (view #txDeposit ctx)
                                 action
         outs <- extractValidatedOutputs (Right cs)
-        let apiCerts = ledgerCertsFromApi era certs
         let ledgerTx =
                 buildLedgerTx
                     era
@@ -252,7 +281,7 @@ mkTransactionLedger
                     wdrl
                     delta
                     md
-                    apiCerts
+                    ledgerCerts
                     outs
                     cs
         let signed =
@@ -613,3 +642,137 @@ extractValidatedOutputs sel =
                                 , quantityMaxBound =
                                     txOutMaxTokenQuantity
                                 }
+
+{--------------------------------------------------------------
+    Ledger-native certificates
+--------------------------------------------------------------}
+
+-- | Build ledger delegation certificates directly,
+-- without going through cardano-api.
+certificateFromDelegationActionLedger
+    :: RecentEra era
+    -> Either XPub (Script KeyHash)
+    -> Maybe Coin
+    -> DelegationAction
+    -> [TxCert era]
+certificateFromDelegationActionLedger
+    RecentEraConway
+    cred
+    depositM
+    da =
+        case (da, depositM) of
+            (Join poolId, _) ->
+                [ Conway.mkDelegTxCert
+                    (toLedgerStakeCred cred)
+                    ( toLedgerDelegatee
+                        (Just poolId)
+                        Nothing
+                    )
+                ]
+            (JoinRegisteringKey poolId, Just deposit) ->
+                [ Conway.mkRegDepositTxCert
+                    (toLedgerStakeCred cred)
+                    (toLedgerCoin deposit)
+                , Conway.mkDelegTxCert
+                    (toLedgerStakeCred cred)
+                    ( toLedgerDelegatee
+                        (Just poolId)
+                        Nothing
+                    )
+                ]
+            (JoinRegisteringKey _, Nothing) ->
+                error
+                    "certificateFromDelegationAction\
+                    \Ledger: deposit required in \
+                    \Conway era for registration \
+                    \(joining)"
+            (Quit, Just deposit) ->
+                [ Conway.mkUnRegDepositTxCert
+                    (toLedgerStakeCred cred)
+                    (toLedgerCoin deposit)
+                ]
+            (Quit, Nothing) ->
+                error
+                    "certificateFromDelegationAction\
+                    \Ledger: deposit required in \
+                    \Conway era for registration \
+                    \(quitting)"
+certificateFromDelegationActionLedger
+    RecentEraDijkstra
+    _
+    _
+    _ =
+        error
+            "certificateFromDelegationAction\
+            \Ledger: Dijkstra not yet supported"
+
+-- | Build ledger voting certificates directly,
+-- without going through cardano-api.
+certificateFromVotingActionLedger
+    :: RecentEra era
+    -> Either XPub (Script KeyHash)
+    -> Maybe Coin
+    -> VotingAction
+    -> [TxCert era]
+certificateFromVotingActionLedger
+    RecentEraConway
+    cred
+    depositM
+    va =
+        case (va, depositM) of
+            (Vote action, _) ->
+                [ Conway.mkDelegTxCert
+                    (toLedgerStakeCred cred)
+                    ( toLedgerDelegatee
+                        Nothing
+                        (Just action)
+                    )
+                ]
+            (VoteRegisteringKey action, Just deposit) ->
+                [ Conway.mkRegDepositTxCert
+                    (toLedgerStakeCred cred)
+                    (toLedgerCoin deposit)
+                , Conway.mkDelegTxCert
+                    (toLedgerStakeCred cred)
+                    ( toLedgerDelegatee
+                        Nothing
+                        (Just action)
+                    )
+                ]
+            (VoteRegisteringKey _, Nothing) ->
+                error
+                    "certificateFromVotingAction\
+                    \Ledger: deposit required in \
+                    \Conway era for registration"
+certificateFromVotingActionLedger
+    RecentEraDijkstra
+    _
+    _
+    _ =
+        error
+            "certificateFromVotingAction\
+            \Ledger: Dijkstra not yet supported"
+
+-- | Build a ledger 'StakeCredential' from an XPub
+-- or script, without cardano-api.
+toLedgerStakeCred
+    :: Either XPub (Script KeyHash)
+    -> Cred.StakeCredential
+toLedgerStakeCred = \case
+    Left xpub ->
+        Cred.KeyHashObj
+            . Keys.KeyHash
+            . UnsafeHash
+            . toShort
+            . blake2b224
+            $ xpubPublicKey xpub
+    Right script ->
+        Cred.ScriptHashObj
+            $ LApi.hashScript
+                @LApi.ConwayEra
+            $ Alonzo.NativeScript
+            $ toLedgerTimelockScript script
+
+-- | Convert a wallet 'Coin' to a ledger 'Coin'.
+toLedgerCoin :: Coin -> Ledger.Coin
+toLedgerCoin = toCardanoLovelace

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -1,0 +1,572 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Transaction construction using ledger types directly,
+-- bypassing @Cardano.Api@.
+module Cardano.Wallet.Shelley.Transaction.Ledger
+    ( mkTransactionLedger
+    , constructUnsignedTxLedger
+    ) where
+
+import Cardano.Address.Derivation
+    ( XPrv
+    , toXPub
+    )
+import Cardano.Api.Extra
+    ( CardanoApiEra
+    , cardanoApiEraConstraints
+    , toCardanoApiTx
+    )
+import Cardano.Balance.Tx.Eras
+    ( IsRecentEra
+    , RecentEra (..)
+    )
+import Cardano.Ledger.Address
+    ( Withdrawals (Withdrawals)
+    )
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (Mainnet, Testnet)
+    , StrictMaybe (SJust, SNothing)
+    )
+import Cardano.Ledger.Core
+    ( TxCert
+    )
+import Cardano.Ledger.Metadata
+    ( Metadatum
+    )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..)
+    , RewardAccount
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( toRewardAccountRaw
+    )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS
+    )
+import Cardano.Wallet.Primitive.Ledger.Convert
+    ( Convert (toLedger)
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
+    ( getTxExtended
+    )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( toCardanoLovelace
+    , toLedgerStakeCredential
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..)
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx
+    , sealedTxFromCardano'
+    )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( txOutMaxTokenQuantity
+    )
+import Cardano.Wallet.Primitive.Types.Tx.Tx
+    ( TxMetadata
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxExtended
+    ( TxExtended (walletTx)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..)
+    )
+import Cardano.Wallet.Shelley.Transaction
+    ( signTransaction
+    )
+import Cardano.Wallet.Shelley.Transaction.Build
+    ( mkLedgerTx
+    )
+import Cardano.Wallet.Transaction
+    ( ErrMkTransaction (..)
+    , ErrMkTransactionOutputTokenQuantityExceedsLimitError (..)
+    , PreSelection (..)
+    , SelectionOf (..)
+    , TransactionCtx (..)
+    , Withdrawal (..)
+    , WitnessCountCtx (..)
+    , selectionDelta
+    )
+import Cardano.Wallet.Transaction.Delegation
+    ( certificateFromDelegationAction
+    )
+import Control.Monad
+    ( forM_
+    , when
+    )
+import Data.Generics.Internal.VL.Lens
+    ( view
+    )
+import Data.Map.Strict
+    ( Map
+    )
+import Data.Sequence.Strict
+    ( StrictSeq
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Word
+    ( Word64
+    )
+import Ouroboros.Network.Block
+    ( SlotNo
+    )
+import Prelude
+
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Certificate as ApiCert
+import qualified Cardano.Api.Experimental.Certificate as ExpCert
+import qualified Cardano.Balance.Tx.Eras as Write
+import qualified Cardano.Balance.Tx.Tx as Write
+import qualified Cardano.Ledger.Address as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.TxIn as Ledger
+import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+import qualified Cardano.Wallet.Read as Read
+import qualified Data.Foldable as F
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+
+-- | Build and sign a transaction using ledger types
+-- directly.
+--
+-- Replaces 'mkTransaction' by calling 'mkLedgerTx' instead
+-- of 'mkUnsignedTx', and converting wallet types to ledger
+-- types internally.
+mkTransactionLedger
+    :: forall era k
+     . IsRecentEra era
+    => RecentEra era
+    -> Cardano.NetworkId
+    -> KeyFlavorS k
+    -> (XPrv, Passphrase "encryption")
+    -> ( Address
+         -> Maybe
+                (k 'CredFromKeyK XPrv, Passphrase "encryption")
+       )
+    -> TransactionCtx
+    -> SelectionOf TxOut
+    -> Either ErrMkTransaction (W.Tx, SealedTx)
+mkTransactionLedger
+    era
+    net
+    keyF
+    stakeCreds
+    addrResolver
+    ctx
+    cs = do
+        let network = ledgerNetworkOf net
+        let ttl = txValidityInterval ctx
+        let wdrl = view #txWithdrawal ctx
+        let delta = selectionDelta cs
+        let md = view #txMetadata ctx
+        let certs =
+                case view #txDelegationAction ctx of
+                    Nothing -> []
+                    Just action ->
+                        let stakeXPub =
+                                toXPub $ fst stakeCreds
+                        in  certificateFromDelegationAction
+                                era
+                                (Left stakeXPub)
+                                (view #txDeposit ctx)
+                                action
+        outs <- extractValidatedOutputs (Right cs)
+        let apiCerts = ledgerCertsFromApi era certs
+        let ledgerTx =
+                buildLedgerTx
+                    era
+                    ttl
+                    network
+                    wdrl
+                    delta
+                    md
+                    apiCerts
+                    outs
+                    cs
+        let signed =
+                signTransaction
+                    keyF
+                    net
+                    AnyWitnessCountCtx
+                    acctResolver
+                    (const Nothing)
+                    Nothing
+                    (const Nothing)
+                    addrResolver
+                    inputResolver
+                    ledgerTx
+        let (txExt, sealed) = case era of
+                RecentEraConway ->
+                    let readTx =
+                            Read.Tx signed
+                                :: Read.Tx Read.Conway
+                    in  ( getTxExtended readTx
+                        , sealWriteTx era signed
+                        )
+                RecentEraDijkstra ->
+                    error
+                        "mkTransactionLedger: Dijkstra \
+                        \not yet supported"
+        let withResolvedInputs tx =
+                tx
+                    { W.resolvedInputs =
+                        fmap Just
+                            <$> F.toList (view #inputs cs)
+                    }
+        Right
+            ( withResolvedInputs (walletTx txExt)
+            , sealed
+            )
+      where
+        inputResolver :: TxIn -> Maybe Address
+        inputResolver i =
+            let index =
+                    Map.fromList
+                        (F.toList $ view #inputs cs)
+            in  do
+                    TxOut addr _ <- Map.lookup i index
+                    pure addr
+
+        acctResolver
+            :: RewardAccount
+            -> Maybe (XPrv, Passphrase "encryption")
+        acctResolver acct =
+            let (rewardAcnt, pwdAcnt) = stakeCreds
+                acct' =
+                    toRewardAccountRaw $ toXPub rewardAcnt
+            in  if acct == acct'
+                    then Just (rewardAcnt, pwdAcnt)
+                    else Nothing
+
+-- | Build an unsigned transaction using ledger types
+-- directly.
+--
+-- Replaces 'constructUnsignedTx' by calling 'mkLedgerTx'
+-- instead of 'mkUnsignedTx'.
+constructUnsignedTxLedger
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> Network
+    -> ( Maybe TxMetadata
+       , [Cardano.Certificate (CardanoApiEra era)]
+       )
+    -- TODO: replace Cardano.Certificate with ledger TxCert
+    -> (Maybe SlotNo, SlotNo)
+    -> Withdrawal
+    -> Either PreSelection (SelectionOf TxOut)
+    -> W.Coin
+    -> Either ErrMkTransaction (Write.Tx era)
+constructUnsignedTxLedger
+    era
+    network
+    (md, certs)
+    ttl
+    wdrl
+    cs
+    fee = do
+        outs <- extractValidatedOutputs cs
+        let lCerts = ledgerCertsFromApi era certs
+        Right
+            $ buildLedgerTxRaw
+                era
+                ttl
+                network
+                wdrl
+                fee
+                md
+                lCerts
+                outs
+                cs
+
+-- | Convert cardano-api certificates to ledger 'TxCert',
+-- pattern-matching on the era to prove the type equality
+-- @ShelleyLedgerEra (CardanoApiEra era) ~ era@.
+ledgerCertsFromApi
+    :: RecentEra era
+    -> [Cardano.Certificate (CardanoApiEra era)]
+    -> [TxCert era]
+ledgerCertsFromApi RecentEraConway certs =
+    map (unCert . certToLedger) certs
+ledgerCertsFromApi RecentEraDijkstra _ =
+    error
+        "ledgerCertsFromApi: Dijkstra not yet supported"
+
+-- | Convert wallet/context types and call 'mkLedgerTx'.
+buildLedgerTx
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> (Maybe SlotNo, SlotNo)
+    -> Network
+    -> Withdrawal
+    -> W.Coin
+    -> Maybe TxMetadata
+    -> [TxCert era]
+    -> [TxOut]
+    -> SelectionOf TxOut
+    -> Write.Tx era
+buildLedgerTx era ttl network wdrl fee md certs outs cs =
+    mkLedgerTx
+        era
+        ins
+        ledgerOuts
+        ledgerFee
+        validity
+        wdrls
+        ledgerCerts
+        mempty -- TODO: minting support
+        metadata
+  where
+    ins :: Set Ledger.TxIn
+    ins =
+        Set.fromList
+            $ map (toLedger . fst)
+            $ F.toList (view #inputs cs)
+
+    ledgerOuts :: StrictSeq (Write.TxOut era)
+    ledgerOuts =
+        StrictSeq.fromList $ map toLedgerTxOut outs
+
+    ledgerFee :: Ledger.Coin
+    ledgerFee = toCardanoLovelace fee
+
+    validity :: ValidityInterval
+    validity = mkValidityInterval ttl
+
+    wdrls :: Withdrawals
+    wdrls = mkWithdrawalsLedger network wdrl
+
+    ledgerCerts :: StrictSeq (TxCert era)
+    ledgerCerts = StrictSeq.fromList certs
+
+    metadata :: Map Word64 Metadatum
+    metadata = case md of
+        Nothing -> Map.empty
+        Just m -> Cardano.toShelleyMetadata (Cardano.unTxMetadata m)
+
+-- | Lower-level builder that takes already-converted
+-- types.
+buildLedgerTxRaw
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> (Maybe SlotNo, SlotNo)
+    -> Network
+    -> Withdrawal
+    -> W.Coin
+    -> Maybe TxMetadata
+    -> [TxCert era]
+    -> [TxOut]
+    -> Either PreSelection (SelectionOf TxOut)
+    -> Write.Tx era
+buildLedgerTxRaw
+    era
+    ttl
+    network
+    wdrl
+    fee
+    md
+    certs
+    outs
+    cs =
+        mkLedgerTx
+            era
+            ins
+            ledgerOuts
+            ledgerFee
+            validity
+            wdrls
+            ledgerCerts
+            mempty -- TODO: minting support
+            metadata
+      where
+        ins :: Set Ledger.TxIn
+        ins = case cs of
+            Right selOf ->
+                Set.fromList
+                    $ map (toLedger . fst)
+                    $ F.toList (view #inputs selOf)
+            Left _preSel ->
+                Set.empty
+
+        ledgerOuts :: StrictSeq (Write.TxOut era)
+        ledgerOuts =
+            StrictSeq.fromList $ map toLedgerTxOut outs
+
+        ledgerFee :: Ledger.Coin
+        ledgerFee = toCardanoLovelace fee
+
+        validity :: ValidityInterval
+        validity = mkValidityInterval ttl
+
+        wdrls :: Withdrawals
+        wdrls = mkWithdrawalsLedger network wdrl
+
+        ledgerCerts :: StrictSeq (TxCert era)
+        ledgerCerts = StrictSeq.fromList certs
+
+        metadata :: Map Word64 Metadatum
+        metadata = case md of
+            Nothing -> Map.empty
+            Just m -> Cardano.toShelleyMetadata (Cardano.unTxMetadata m)
+
+-- | Convert a wallet 'TxOut' to a ledger 'TxOut'.
+toLedgerTxOut
+    :: forall era
+     . IsRecentEra era
+    => TxOut
+    -> Write.TxOut era
+toLedgerTxOut =
+    case Write.recentEra @era :: Write.RecentEra era of
+        RecentEraConway -> Convert.toConwayTxOut
+        RecentEraDijkstra ->
+            error
+                "toLedgerTxOut: Dijkstra not yet supported"
+
+-- | Convert a @(Maybe SlotNo, SlotNo)@ validity interval
+-- pair to a ledger 'ValidityInterval'.
+mkValidityInterval
+    :: (Maybe SlotNo, SlotNo) -> ValidityInterval
+mkValidityInterval (mStart, end) =
+    ValidityInterval
+        { invalidBefore = maybe SNothing SJust mStart
+        , invalidHereafter = SJust end
+        }
+
+-- | Build ledger 'Withdrawals' directly from wallet types.
+mkWithdrawalsLedger
+    :: Network -> Withdrawal -> Withdrawals
+mkWithdrawalsLedger network = \case
+    NoWithdrawal -> Withdrawals Map.empty
+    WithdrawalExternal acc _ amt _ ->
+        Withdrawals
+            $ Map.singleton
+                (mkRewardAccount network acc)
+                (toCardanoLovelace amt)
+    WithdrawalSelf acc _ amt ->
+        Withdrawals
+            $ Map.singleton
+                (mkRewardAccount network acc)
+                (toCardanoLovelace amt)
+
+-- | Build a ledger 'RewardAccount' from a wallet
+-- 'RewardAccount' and a 'Network'.
+mkRewardAccount
+    :: Network
+    -> RewardAccount
+    -> Ledger.AccountAddress
+mkRewardAccount network acct =
+    Ledger.AccountAddress
+        network
+        (Ledger.AccountId (toLedgerStakeCredential acct))
+
+-- | Convert a cardano-api 'Certificate' to the underlying
+-- ledger certificate newtype.
+--
+-- Temporary bridge until certificate construction itself
+-- produces ledger certs directly.
+certToLedger
+    :: Cardano.Certificate era
+    -> ExpCert.Certificate (Cardano.ShelleyLedgerEra era)
+certToLedger (ApiCert.ShelleyRelatedCertificate w c) =
+    Cardano.shelleyToBabbageEraConstraints w
+        $ ExpCert.Certificate c
+certToLedger (ApiCert.ConwayCertificate w c) =
+    Cardano.conwayEraOnwardsConstraints w
+        $ ExpCert.Certificate c
+
+-- | Unwrap a 'Certificate' newtype to get the underlying
+-- 'TxCert'.
+unCert :: ExpCert.Certificate era -> TxCert era
+unCert (ExpCert.Certificate c) = c
+
+-- | Seal a ledger 'Tx' into a 'SealedTx' by going through
+-- cardano-api serialisation.
+--
+-- TODO: avoid cardano-api roundtrip when SealedTx is
+-- restructured.
+sealWriteTx
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> Write.Tx era
+    -> SealedTx
+sealWriteTx era tx =
+    cardanoApiEraConstraints era
+        $ sealedTxFromCardano'
+        $ toCardanoApiTx tx
+
+-- | Project a 'Cardano.NetworkId' onto the ledger's
+-- 'Network' (magic-free) for cert / withdrawal construction.
+ledgerNetworkOf :: Cardano.NetworkId -> Network
+ledgerNetworkOf Cardano.Mainnet = Mainnet
+ledgerNetworkOf (Cardano.Testnet _) = Testnet
+
+-- | Validate transaction outputs (token quantities).
+extractValidatedOutputs
+    :: Either PreSelection (SelectionOf TxOut)
+    -> Either ErrMkTransaction [TxOut]
+extractValidatedOutputs sel =
+    mapM validateOut $ case sel of
+        Right selOf ->
+            view #outputs selOf
+                ++ F.toList (view #change selOf)
+        Left preSel -> view #outputs preSel
+  where
+    validateOut
+        :: TxOut -> Either ErrMkTransaction TxOut
+    validateOut out = do
+        verifyOutputTokenQuantities out
+        return out
+      where
+        verifyOutputTokenQuantities
+            :: TxOut -> Either ErrMkTransaction ()
+        verifyOutputTokenQuantities
+            ( TxOut
+                    addr
+                    (TokenBundle.TokenBundle _ toks)
+                ) =
+                forM_
+                    (TokenMap.toFlatList toks)
+                    $ \(aid, qty) ->
+                        when
+                            (qty > txOutMaxTokenQuantity)
+                            $ Left
+                            $ ErrMkTransactionOutputTokenQuantityExceedsLimit
+                            $ ErrMkTransactionOutputTokenQuantityExceedsLimitError
+                                { address = addr
+                                , asset = aid
+                                , quantity = qty
+                                , quantityMaxBound =
+                                    txOutMaxTokenQuantity
+                                }

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -15,8 +15,32 @@
 -- Transaction construction using ledger types directly,
 -- bypassing @Cardano.Api@.
 module Cardano.Wallet.Shelley.Transaction.Ledger
-    ( mkTransactionLedger
+    ( -- * Transaction construction
+      mkTransactionLedger
     , constructUnsignedTxLedger
+
+      -- * Signing
+    , signTransaction
+    -- TODO: mkShelleyWitness and mkByronWitness take
+    -- Cardano.TxBody and cannot be used with ledger types
+    -- directly. Signing is handled through signTransaction.
+
+      -- * Payload
+    , TxPayload (..)
+
+      -- * Constraints
+    , txConstraints
+
+      -- * Witness tags
+    , TxWitnessTag (..)
+    , txWitnessTagForKey
+
+      -- * Reward withdrawal cost estimation
+    , _txRewardWithdrawalCost
+    , _txRewardWithdrawalSize
+    -- TODO: mkUnsignedTransaction uses Cardano.NetworkId,
+    -- Cardano.Certificate, and other cardano-api types
+    -- pervasively. Needs a ledger-native rewrite.
     ) where
 
 import Cardano.Address.Derivation
@@ -31,6 +55,9 @@ import Cardano.Api.Extra
 import Cardano.Balance.Tx.Eras
     ( IsRecentEra
     , RecentEra (..)
+    )
+import Cardano.Balance.Tx.SizeEstimation
+    ( TxWitnessTag (..)
     )
 import Cardano.Ledger.Address
     ( Withdrawals (Withdrawals)
@@ -95,6 +122,10 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     )
 import Cardano.Wallet.Shelley.Transaction
     ( signTransaction
+    , txConstraints
+    , txWitnessTagForKey
+    , _txRewardWithdrawalCost
+    , _txRewardWithdrawalSize
     )
 import Cardano.Wallet.Shelley.Transaction.Build
     ( mkLedgerTx
@@ -154,6 +185,18 @@ import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+
+-- | Transaction payload using ledger types directly.
+--
+-- Replaces the cardano-api 'Cardano.Wallet.Shelley.Transaction.TxPayload'
+-- which uses @Cardano.TxMetadata@ and @Cardano.Certificate@.
+data TxPayload era = TxPayload
+    { _metadata :: Maybe TxMetadata
+    -- ^ User or application-defined metadata to be
+    -- included in the transaction.
+    , _certificates :: StrictSeq (TxCert era)
+    -- ^ Certificates to be included in the transaction.
+    }
 
 -- | Build and sign a transaction using ledger types
 -- directly.

--- a/specs/001-drop-cardano-api/checklists/requirements.md
+++ b/specs/001-drop-cardano-api/checklists/requirements.md
@@ -31,7 +31,7 @@
 
 ## Notes
 
-- The spec references library names (cardano-api, cardano-ledger) because they are the domain entities being discussed, not implementation choices.
-- Context section documents the balance-tx and coin-selection extractions as completed prerequisites.
-- FR-001 through FR-013 cover all remaining usage areas: ledger re-exports, serialization, NetworkId, certificates, TxMetadata, SealedTx, toConsensusGenTx, TxBodyContent, cardano-api-extra, era GADTs, benchmarks, and Byron support.
-- Added User Story 5 (test generators) to cover the cardano-api-extra elimination path.
+- US1 (upstream pin) is the critical gate — identified by analyzing the transitive dependency through `cardano-balance-transaction`
+- The spec documents the specific breaking API changes from the upstream removal (CardanoApiEra, toCardanoApiTx, fromCardanoApiTx) to ensure the plan accounts for cascading changes
+- SC-001 explicitly requires checking the transitive closure, not just direct dependencies
+- Assumption about byte-identical CBOR is critical for database compatibility (US5) — must be validated during planning

--- a/specs/001-drop-cardano-api/checklists/requirements.md
+++ b/specs/001-drop-cardano-api/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Remove cardano-api Dependency
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec references library names (cardano-api, cardano-ledger) because they are the domain entities being discussed, not implementation choices. The spec is about *removing* a dependency, so naming it is inherent to the problem statement.
+- FR-001 through FR-012 map cleanly to the 6 phases identified in the existing feasibility analysis.
+- All success criteria are verifiable through existing test infrastructure.

--- a/specs/001-drop-cardano-api/checklists/requirements.md
+++ b/specs/001-drop-cardano-api/checklists/requirements.md
@@ -31,6 +31,7 @@
 
 ## Notes
 
-- The spec references library names (cardano-api, cardano-ledger) because they are the domain entities being discussed, not implementation choices. The spec is about *removing* a dependency, so naming it is inherent to the problem statement.
-- FR-001 through FR-012 map cleanly to the 6 phases identified in the existing feasibility analysis.
-- All success criteria are verifiable through existing test infrastructure.
+- The spec references library names (cardano-api, cardano-ledger) because they are the domain entities being discussed, not implementation choices.
+- Context section documents the balance-tx and coin-selection extractions as completed prerequisites.
+- FR-001 through FR-013 cover all remaining usage areas: ledger re-exports, serialization, NetworkId, certificates, TxMetadata, SealedTx, toConsensusGenTx, TxBodyContent, cardano-api-extra, era GADTs, benchmarks, and Byron support.
+- Added User Story 5 (test generators) to cover the cardano-api-extra elimination path.

--- a/specs/001-drop-cardano-api/data-model.md
+++ b/specs/001-drop-cardano-api/data-model.md
@@ -36,6 +36,10 @@ Where `LedgerTx era` wraps `Ledger.Tx (CardanoLedgerEra era)` using the wallet-r
 - `TxMetadata`: `Map Word64 TxMetadataValue`
 - `TxMetadataValue`: ADT with constructors `TxMetaMap`, `TxMetaList`, `TxMetaNumber`, `TxMetaBytes`, `TxMetaText`
 
+Ledger also provides `Cardano.Ledger.Metadata.Metadatum`. The wallet type
+keeps the existing constructor names and JSON schema helpers for REST API and
+database compatibility, with conversion functions to and from the ledger type.
+
 **Validation rules**:
 - Byte strings limited to 64 bytes per chunk
 - Text strings limited to 64 bytes UTF-8 encoded per chunk
@@ -47,7 +51,12 @@ Where `LedgerTx era` wraps `Ledger.Tx (CardanoLedgerEra era)` using the wallet-r
 
 **Location**: `lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs`
 
-**Change**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion. Add `networkIdToLedger :: SNetworkId n -> Ledger.Network` for the few places that need a ledger-level network value.
+**Change**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion once all remaining cardano-api consumers migrate. Add `networkIdToLedger :: NetworkId -> Ledger.Network` and `sNetworkIdToLedger :: SNetworkId n -> Ledger.Network` for the places that only need a ledger-level, magic-free network value.
+
+The wallet `NetworkId` remains the value-level type where testnet magic is
+needed. Ledger `Network` distinguishes mainnet from testnet, but does not carry
+the testnet magic required by network information, local cluster setup, and
+Byron witness construction.
 
 ### Era types (unchanged, bridge removed)
 

--- a/specs/001-drop-cardano-api/data-model.md
+++ b/specs/001-drop-cardano-api/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: Remove cardano-api Dependency
+
+**Feature Branch**: `001-drop-cardano-api`
+**Date**: 2026-04-09
+
+## Entities
+
+### SealedTx (modified)
+
+**Location**: `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs`
+
+**Current representation**:
+```
+SealedTx { valid :: Bool, unsafeCardanoTx :: InAnyCardanoEra Cardano.Tx, serialisedTx :: ByteString }
+```
+
+**Target representation**:
+```
+SealedTx { valid :: Bool, unsafeLedgerTx :: EraValue LedgerTx, serialisedTx :: ByteString }
+```
+
+Where `LedgerTx era` wraps `Ledger.Tx (CardanoLedgerEra era)` using the wallet-read era system.
+
+**Validation rules**: 
+- `serialisedTx` must round-trip through CBOR encode/decode
+- `valid` is True for all properly-constructed instances
+- Database-stored CBOR from previous versions must deserialize into the new representation
+
+**State transitions**: None — SealedTx is immutable once constructed.
+
+### TxMetadata (new wallet-owned type)
+
+**Location**: `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs` (new module)
+
+**Fields**:
+- `TxMetadata`: `Map Word64 TxMetadataValue`
+- `TxMetadataValue`: ADT with constructors `TxMetaMap`, `TxMetaList`, `TxMetaNumber`, `TxMetaBytes`, `TxMetaText`
+
+**Validation rules**:
+- Byte strings limited to 64 bytes per chunk
+- Text strings limited to 64 bytes UTF-8 encoded per chunk
+- JSON serialization must match `TxMetadataJsonDetailedSchema` format exactly
+
+**Relationships**: Used by SealedTx (embedded), REST API response types, SQLite storage layer.
+
+### NetworkId (simplified)
+
+**Location**: `lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs`
+
+**Change**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion. Add `networkIdToLedger :: SNetworkId n -> Ledger.Network` for the few places that need a ledger-level network value.
+
+### Era types (unchanged, bridge removed)
+
+**Location**: `lib/cardano-wallet-read/haskell/Cardano/Wallet/Read/Eras.hs`
+
+**Change**: No modification to the era GADT itself. The bridge module `Cardano.Wallet.Primitive.Ledger.Read.Eras` loses its `cardanoApiEraFromRead`/`readEraFromCardanoApi` functions.
+
+## Relationship Map
+
+```
+REST API ──uses──> TxMetadata (JSON serialization)
+REST API ──uses──> SealedTx (CBOR hex in responses)
+SealedTx ──contains──> EraValue LedgerTx (decoded)
+SealedTx ──contains──> ByteString (raw CBOR)
+SealedTx ──submits-via──> GenTx (ouroboros-consensus)
+Wallet DB ──stores──> SealedTx.serialisedTx (CBOR blob)
+Wallet DB ──stores──> TxMetadata (JSON text)
+NetworkId ──converts-to──> Ledger.Network (for ouroboros)
+Era GADT ──indexes──> LedgerTx, certificates, all era-dependent types
+```
+
+## Migration Impact
+
+No database schema changes. Stored CBOR and JSON remain wire-compatible. The representation changes are internal to the Haskell types — serialization format is preserved exactly.

--- a/specs/001-drop-cardano-api/plan.md
+++ b/specs/001-drop-cardano-api/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Remove cardano-api Dependency
+
+**Branch**: `001-drop-cardano-api` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-drop-cardano-api/spec.md`
+**Issue**: #5237
+
+## Summary
+
+Remove all direct and transitive dependencies on `cardano-api` from `cardano-wallet`. Single PR, bisect-safe commit sequence using the additive-then-remove pattern: add new ledger-native paths alongside old cardano-api paths, migrate consumers one at a time, then atomically remove all cardano-api remnants.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.6.x via Nix flake)
+**Primary Dependencies**: cardano-ledger-*, ouroboros-consensus-cardano, cardano-wallet-read, bech32, cardano-ledger-binary
+**Storage**: SQLite via persistent (CBOR blobs + JSON text for metadata)
+**Testing**: HUnit + QuickCheck + tasty; integration tests against local cardano-node cluster
+**Target Platform**: Linux (musl static), macOS (x86_64 + arm64), Windows (cross-compiled)
+**Project Type**: Haskell monorepo (32 cabal packages in `lib/`)
+**Constraints**: Wire-compatible serialization (CBOR, JSON) — no database migration. Every commit must compile and pass tests.
+**Scale/Scope**: 44 files across 9 packages importing Cardano.Api modules
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Maintenance-First Stability | PASS | Fewer dependencies, incremental commits, each green |
+| II. Era-Aware Design | PASS | cardano-wallet-read era GADTs already cover Byron–Dijkstra |
+| III. Type Safety as Security | PASS | Direct ledger types are more precise than wrappers |
+| IV. Formal Specification | PASS | OpenAPI spec unchanged |
+| V. Reproducible Builds | PASS | Standard Nix/cabal.project workflow |
+| VI. Comprehensive Testing | PASS | Each commit passes full test suite |
+| VII. Code Quality Gates | PASS | Each commit passes CI |
+
+## Commit Strategy
+
+**Principle**: Every commit compiles and passes tests. No broken intermediate states.
+
+**Pattern**: Additive-then-remove.
+
+### Phase A: Pin bump
+
+Update `cardano-balance-transaction` pin to `964e8a2`. Fix compilation against the new API. Both old and new cardano-api paths coexist — the wallet still depends on cardano-api directly, but `cardano-balance-transaction` no longer does.
+
+Each fix is a separate commit. Verify CBOR output is byte-identical.
+
+### Phase B: Add new paths alongside old
+
+Additive-only commits. Nothing is removed. The codebase temporarily has dual paths.
+
+- Wallet-owned `TxMetadata`/`TxMetadataValue` module (new file, not imported yet)
+- Ledger-native `SealedTx` constructor (new constructor alongside old one)
+- `networkIdToLedger` function (alongside existing `networkIdVal`)
+- Direct `cardano-ledger-api` certificate constructors (new helper functions)
+- `mkShelleyTx` + `HardForkGenTx` submission helpers (alongside `toConsensusGenTx`)
+- Ledger-native tx body construction helpers (alongside `TxBodyContent`)
+- Ledger testlib generators (alongside `cardano-api-extra` generators)
+
+Each addition is one or more commits. All compile because nothing depends on the new paths yet.
+
+### Phase C: Migrate consumers
+
+Switch call sites from old cardano-api paths to new ledger-native paths, one module at a time. Each commit:
+- Touches one module (or a small group of tightly-coupled modules)
+- Replaces cardano-api imports with new paths
+- Compiles and passes tests
+
+Order: start from leaf modules, work toward core. Suggested grouping:
+1. Re-export swaps (SlotNo, EpochNo, etc.) — mechanical, per-package
+2. Era type swaps (AnyCardanoEra → EraValue) — per-module
+3. Core type swaps (SealedTx, TxMetadata, NetworkId) — per-consumer
+4. Certificate and tx construction swaps — per-module
+5. Submission path swap
+6. Test generator swaps
+
+At the end of Phase C, no code uses cardano-api, but it's still in `build-depends`.
+
+### Phase D: Remove old paths (atomic)
+
+Single commit:
+- Delete bridge functions, old constructors, compatibility shims
+- Remove `cardano-api` from all `.cabal` `build-depends`
+- Remove `cardano-api` constraints from `cabal.project`
+- Delete `lib/cardano-api-extra/`
+
+This is the only commit that actually removes cardano-api. It compiles because Phase C already migrated all consumers.
+
+### Verification
+
+Run after Phase D:
+- `cardano-api` absent from `cabal build all --dry-run`
+- Zero `Cardano.Api` imports
+- Unit + integration tests green across Babbage, Conway, Dijkstra
+- API golden tests pass
+- Database snapshot from pre-removal loads without errors
+- Benchmarks show no regression
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/001-drop-cardano-api/
+├── plan.md              # This file
+├── research.md          # Design decisions
+├── data-model.md        # Entity changes
+├── quickstart.md        # Dev environment
+├── checklists/
+│   └── requirements.md
+├── spec.md              # Feature specification
+└── tasks.md             # Task checklist
+```
+
+### Affected source code
+
+```text
+lib/
+├── primitive/           # SealedTx, TxMetadata, NetworkId (13 files)
+├── api/                 # REST handlers, metadata schema (8 files)
+├── wallet/              # Transaction construction, certificates (7 files)
+├── network-layer/       # Node submission, consensus bridge (3 files)
+├── cardano-wallet-read/ # Era GADTs (bridge removal only)
+├── unit/                # Unit tests (4 files)
+├── integration/         # Integration tests (2 files)
+├── cardano-api-extra/   # DELETED in Phase D
+├── local-cluster/       # Test cluster setup (1 file)
+└── benchmarks/          # Benchmark harness (1 file)
+```

--- a/specs/001-drop-cardano-api/plan.md
+++ b/specs/001-drop-cardano-api/plan.md
@@ -49,7 +49,7 @@ Additive-only commits. Nothing is removed. The codebase temporarily has dual pat
 
 - Wallet-owned `TxMetadata`/`TxMetadataValue` module (new file, not imported yet)
 - Ledger-native `SealedTx` constructor (new constructor alongside old one)
-- `networkIdToLedger` function (alongside existing `networkIdVal`)
+- `networkIdToLedger` / `sNetworkIdToLedger` functions (alongside existing `networkIdVal`)
 - Direct `cardano-ledger-api` certificate constructors (new helper functions)
 - `mkShelleyTx` + `HardForkGenTx` submission helpers (alongside `toConsensusGenTx`)
 - Ledger-native tx body construction helpers (alongside `TxBodyContent`)

--- a/specs/001-drop-cardano-api/quickstart.md
+++ b/specs/001-drop-cardano-api/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Remove cardano-api Dependency
+
+## Prerequisites
+
+- Nix with flakes enabled
+- Access to `cardano-foundation/cardano-balance-transaction` (public repo)
+- Local clone of `cardano-wallet` on branch `001-drop-cardano-api`
+
+## Development Environment
+
+```bash
+cd /path/to/cardano-wallet
+nix develop
+```
+
+## Build & Test
+
+```bash
+# Build all packages
+just build
+
+# Run unit tests
+just test
+
+# Run integration tests (requires local cluster)
+just integration
+
+# Check for cardano-api in build plan
+cabal build all --dry-run 2>&1 | grep cardano-api
+
+# Verify no Cardano.Api imports remain
+grep -r "import.*Cardano\.Api" lib/ --include="*.hs" -l
+```
+
+## Key Files to Understand
+
+| File | Role |
+|------|------|
+| `cabal.project` (line 141) | `cardano-balance-transaction` pin |
+| `lib/primitive/lib/.../SealedTx.hs` | Core transaction type (rewrite target) |
+| `lib/primitive/lib/.../Tx/Tx.hs` | TxMetadata re-export (replace with owned type) |
+| `lib/primitive/lib/.../NetworkId.hs` | NetworkId with cardano-api bridge |
+| `lib/cardano-wallet-read/.../Eras.hs` | Era GADT system (keep, remove bridge) |
+| `lib/wallet/src/.../Transaction.hs` | Transaction construction (heaviest cardano-api usage) |
+| `lib/api/src/.../SchemaMetadata.hs` | REST API metadata serialization |
+| `lib/cardano-api-extra/` | Test generators (delete at end) |
+
+## Phase Verification
+
+After each phase, verify:
+1. `just ci` passes (lint + build + test)
+2. No new `Cardano.Api` imports introduced
+3. Integration tests pass on local cluster

--- a/specs/001-drop-cardano-api/research.md
+++ b/specs/001-drop-cardano-api/research.md
@@ -25,7 +25,7 @@
 
 **Decision**: Inline `TxMetadata` and `TxMetadataValue` as wallet-owned types in `Cardano.Wallet.Primitive.Types.Tx.TxMetadata`. Port the JSON schema conversion functions (`metadataFromJson`, `metadataToJson`, `TxMetadataJsonSchema`) from cardano-api source.
 
-**Rationale**: The types are simple ADTs (map of Word64 to values). The JSON conversion is ~200 lines of pure Haskell. The ledger has `Metadata` but with different JSON serialization. Inlining preserves wire compatibility exactly.
+**Rationale**: The types are simple ADTs (map of Word64 to values). The JSON conversion is ~200 lines of pure Haskell. The ledger has `Cardano.Ledger.Metadata.Metadatum`, but with different JSON serialization and constructor names. Inlining preserves wire compatibility exactly while conversion functions bridge to ledger metadata at transaction construction and decoding boundaries.
 
 **Alternatives considered**:
 - Using ledger `Metadata` directly — rejected, different JSON format would break REST API contract.
@@ -65,9 +65,9 @@
 
 ## Decision: NetworkId unification
 
-**Decision**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion. All call sites switch to `Cardano.Wallet.Primitive.NetworkId.SNetworkId` or the value-level `NetworkId` directly. Where ouroboros/ledger need a `Network` value, convert via `Ledger.Mainnet`/`Ledger.Testnet`.
+**Decision**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion once all remaining cardano-api consumers migrate. All call sites switch to `Cardano.Wallet.Primitive.NetworkId.SNetworkId` or the value-level `NetworkId` directly. Where ouroboros/ledger need a magic-free `Network` value, convert via `networkIdToLedger` / `sNetworkIdToLedger`.
 
-**Rationale**: The wallet's `NetworkId` already carries all needed information. The conversion to `Cardano.Api.NetworkId` was only needed because other cardano-api functions required it. Once those functions are replaced, the conversion is dead code.
+**Rationale**: The wallet's `NetworkId` still carries testnet magic, which `Ledger.Network` intentionally does not. `Ledger.Network` is the right type for ledger-facing code paths that only need the mainnet/testnet bit; wallet configuration, network information, and Byron witness construction still need the magic-bearing wallet type. The conversion to `Cardano.Api.NetworkId` was only needed because other cardano-api functions required it. Once those functions are replaced, the conversion is dead code.
 
 **Alternatives considered**: None.
 

--- a/specs/001-drop-cardano-api/research.md
+++ b/specs/001-drop-cardano-api/research.md
@@ -1,0 +1,95 @@
+# Research: Remove cardano-api Dependency
+
+**Feature Branch**: `001-drop-cardano-api`
+**Date**: 2026-04-09
+
+## Decision: Upstream pin strategy
+
+**Decision**: Pin `cardano-balance-transaction` main at `964e8a2` (current HEAD, post-merge of #32 and #33).
+
+**Rationale**: Both PRs (#32 — library/test removal, #33 — generator cleanup) merged to main. The branch `002-remove-cardano-api` is stale; main is ahead. Pins must target main commits per project policy.
+
+**Alternatives considered**: Pinning the branch tip (`dd21596`) — rejected because branch is behind main and project policy requires main-only pins.
+
+## Decision: SealedTx replacement representation
+
+**Decision**: Replace `InAnyCardanoEra Cardano.Api.Tx` with `EraValue (Tx era)` using `cardano-wallet-read`'s existing era GADT system, plus raw CBOR `ByteString`.
+
+**Rationale**: The wallet already has `EraValue` as an era-existential wrapper in `cardano-wallet-read`. Ledger `Tx` types are era-indexed. This is a natural fit — no new abstractions needed. The raw CBOR bytes remain the serialization format for database and submission.
+
+**Alternatives considered**: 
+- Wrapping `InAnyShelleyBasedEra` from ouroboros-consensus — rejected, still pulls in cardano-api types.
+- Storing only raw CBOR without decoded tx — rejected, too many call sites need decoded access.
+
+## Decision: TxMetadata type ownership
+
+**Decision**: Inline `TxMetadata` and `TxMetadataValue` as wallet-owned types in `Cardano.Wallet.Primitive.Types.Tx.TxMetadata`. Port the JSON schema conversion functions (`metadataFromJson`, `metadataToJson`, `TxMetadataJsonSchema`) from cardano-api source.
+
+**Rationale**: The types are simple ADTs (map of Word64 to values). The JSON conversion is ~200 lines of pure Haskell. The ledger has `Metadata` but with different JSON serialization. Inlining preserves wire compatibility exactly.
+
+**Alternatives considered**:
+- Using ledger `Metadata` directly — rejected, different JSON format would break REST API contract.
+- Depending on a cardano-api sub-library — rejected, defeats the purpose.
+
+## Decision: Era GADT unification
+
+**Decision**: Replace all `Cardano.Api.CardanoEra`, `AnyCardanoEra`, `InAnyCardanoEra`, `ShelleyBasedEra` usage with `cardano-wallet-read`'s `Era`, `EraValue`, `IsEra`.
+
+**Rationale**: `cardano-wallet-read` already provides a complete era system covering Byron through Dijkstra. The bridge module `Cardano.Wallet.Primitive.Ledger.Read.Eras` currently converts between the two — this bridge becomes unnecessary.
+
+**Alternatives considered**: None serious — the wallet's own era system was designed for this purpose.
+
+## Decision: Transaction submission path
+
+**Decision**: Replace `toConsensusGenTx` (cardano-api) with direct `mkShelleyTx` + hard fork combinator injection using ouroboros-consensus APIs.
+
+**Rationale**: `toConsensusGenTx` is a thin wrapper over `mkShelleyTx` from `ouroboros-consensus-cardano`. The wallet already depends on ouroboros-consensus. The multi-era dispatch via `HardForkGenTx` is available directly.
+
+**Alternatives considered**: Vendoring `toConsensusGenTx` — rejected, unnecessary indirection.
+
+## Decision: Certificate construction
+
+**Decision**: Use `cardano-ledger-api` certificate constructors directly. Handle Conway vs pre-Conway split using the wallet's existing era-indexed pattern.
+
+**Rationale**: `cardano-ledger-api` exposes `mkRegTxCert`, `mkDelegTxCert`, `mkRegDRepTxCert` etc. The Conway era split (new cert types vs legacy) is already handled by the ledger's era-indexed types. `cardano-api`'s `Certificate` type was just a wrapper.
+
+**Alternatives considered**: None — direct ledger usage is the obvious path.
+
+## Decision: Serialization functions
+
+**Decision**: Replace `serialiseToCBOR`/`deserialiseFromCBOR` with direct `serialize`/`decodeFull` from `cardano-ledger-binary`. Replace bech32 functions with `bech32`/`bech32-th` library directly.
+
+**Rationale**: cardano-api's serialization functions are thin wrappers over `cardano-ledger-binary` (for CBOR) and the `bech32` package (for bech32). The wallet already transitively depends on both.
+
+**Alternatives considered**: None — these are direct replacements with no semantic difference.
+
+## Decision: NetworkId unification
+
+**Decision**: Remove `networkIdVal :: SNetworkId n -> Cardano.NetworkId` conversion. All call sites switch to `Cardano.Wallet.Primitive.NetworkId.SNetworkId` or the value-level `NetworkId` directly. Where ouroboros/ledger need a `Network` value, convert via `Ledger.Mainnet`/`Ledger.Testnet`.
+
+**Rationale**: The wallet's `NetworkId` already carries all needed information. The conversion to `Cardano.Api.NetworkId` was only needed because other cardano-api functions required it. Once those functions are replaced, the conversion is dead code.
+
+**Alternatives considered**: None.
+
+## Decision: Test generator migration
+
+**Decision**: Replace `Cardano.Api.Gen` generators with `Arbitrary` instances from `cardano-ledger-conway:testlib` and wallet-native generators. Delete `lib/cardano-api-extra`.
+
+**Rationale**: The ledger testlib provides comprehensive `Arbitrary` instances for all ledger types. The `cardano-api-extra` package was a shim to get generators for cardano-api wrapper types — once the wrapper types are gone, the generators follow.
+
+**Alternatives considered**: Keeping generators as wallet-internal utilities — partially adopted, some wallet-specific generators (e.g., for SealedTx) will remain but produce ledger-native types.
+
+## Decision: Migration ordering
+
+**Decision**: Six phases, each independently mergeable:
+
+1. **Pin bump** — Update `cardano-balance-transaction` pin, fix compilation against new API
+2. **Ledger re-exports** — Replace `Cardano.Api` re-exports (SlotNo, EpochNo, etc.) with direct ledger imports
+3. **Era GADTs** — Remove cardano-api era types, unify on cardano-wallet-read
+4. **Core types** — SealedTx, TxMetadata, NetworkId, certificates
+5. **Transaction construction** — Replace TxBodyContent/createTransactionBody, submission path
+6. **Cleanup** — Remove cardano-api-extra, delete bridge modules, verify SC-001 through SC-007
+
+**Rationale**: Each phase targets a distinct layer of the dependency. Earlier phases unlock later ones. The ordering minimizes merge conflicts between phases.
+
+**Alternatives considered**: Single atomic removal — rejected, too risky for a production wallet. Would be a 5000+ line change impossible to review.

--- a/specs/001-drop-cardano-api/spec.md
+++ b/specs/001-drop-cardano-api/spec.md
@@ -7,17 +7,39 @@
 
 ## Context
 
-The `cardano-balance-transaction` and `cardano-coin-selection` libraries have already been extracted as standalone packages, removing two major consumers of cardano-api from the wallet's internal code. The remaining cardano-api usage spans 9 packages (71 imports across 45 files), concentrated in transaction construction, certificate handling, metadata types, and era GADTs.
+The `cardano-balance-transaction` and `cardano-coin-selection` libraries have been extracted as standalone packages. However, the version of `cardano-balance-transaction` currently pinned in `cabal.project` (commit `98e7f41`) still depends on `cardano-api`. An active branch (`002-remove-cardano-api`) in `cardano-foundation/cardano-balance-transaction` removes that dependency with breaking API changes:
 
-This spec covers the removal of all remaining cardano-api usage.
+- **Removed**: `CardanoApiEra` type family, `cardanoEraFromRecentEra`, `shelleyBasedEraFromRecentEra`, `toCardanoApiTx`, `fromCardanoApiTx`
+- **Changed**: transaction types are now ledger-native — no conversion layer needed
+- **Added**: `TimeTranslation`, `TxWithUTxO`, `UTxOAssumptions` modules; Dijkstra era support
+
+This means the wallet's cardano-api removal has a hard prerequisite: pin a version of `cardano-balance-transaction` that no longer depends on `cardano-api`. Without this, `cardano-api` remains in the transitive closure regardless of what the wallet does directly.
+
+After pinning the updated `cardano-balance-transaction`, the remaining direct cardano-api usage in the wallet spans 9 packages (71 imports across 45 files), concentrated in transaction construction, certificate handling, metadata types, and era GADTs.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Wallet builds without cardano-api (Priority: P1)
+### User Story 1 - Upstream dependency is cardano-api-free (Priority: P1)
+
+The wallet pins a version of `cardano-balance-transaction` that does not depend on `cardano-api`. The wallet code adapts to the breaking API changes this introduces: replacing `CardanoApiEra` type family usage with direct ledger era types, removing `toCardanoApiTx`/`fromCardanoApiTx` conversion calls, and updating era constraint handling.
+
+**Why this priority**: This is a gate. Until the transitive dependency through `cardano-balance-transaction` is cut, no amount of direct removal achieves the goal. The API changes also cascade into the wallet's transaction construction, delegation, and voting code.
+
+**Independent Test**: Pin the new `cardano-balance-transaction` version, build the wallet, run unit and integration tests. Verify `cardano-api` no longer appears in the build plan via `cardano-balance-transaction`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the wallet with the updated `cardano-balance-transaction` pin, **When** the build plan is inspected, **Then** `cardano-balance-transaction` does not pull in `cardano-api`.
+2. **Given** the updated pin, **When** wallet code that used `CardanoApiEra`, `toCardanoApiTx`, or `fromCardanoApiTx` is compiled, **Then** it builds successfully using direct ledger types.
+3. **Given** a funded wallet, **When** a transaction is balanced, signed, and submitted, **Then** it succeeds identically to before the pin update.
+
+---
+
+### User Story 2 - Wallet builds without cardano-api (Priority: P1)
 
 A developer building cardano-wallet from source no longer needs to compile the cardano-api package. The build dependency graph is shorter, version constraint conflicts involving cardano-api are eliminated. The wallet produces identical artifacts as before the removal.
 
-**Why this priority**: This is the core goal. Every other story depends on the wallet successfully building and passing all tests without cardano-api in its dependency closure.
+**Why this priority**: This is the end goal. Every other story supports getting here.
 
 **Independent Test**: Build the full project, run unit and integration tests. Verify `cardano-api` does not appear in the build plan output.
 
@@ -26,11 +48,11 @@ A developer building cardano-wallet from source no longer needs to compile the c
 1. **Given** the wallet codebase with cardano-api removed from all .cabal files, **When** a developer builds all packages, **Then** the build succeeds with no compilation errors.
 2. **Given** a successfully built wallet, **When** the full unit test suite runs, **Then** all tests pass with the same results as the pre-removal baseline.
 3. **Given** a successfully built wallet, **When** the integration test suite runs against a local cluster, **Then** all tests pass across all supported eras (Babbage, Conway, Dijkstra).
-4. **Given** the built project, **When** the build plan is inspected, **Then** `cardano-api` does not appear in the transitive dependency closure of any wallet package.
+4. **Given** the built project, **When** the build plan is inspected, **Then** `cardano-api` does not appear anywhere in the transitive dependency closure of any wallet package.
 
 ---
 
-### User Story 2 - Transaction lifecycle works identically (Priority: P1)
+### User Story 3 - Transaction lifecycle works identically (Priority: P1)
 
 A wallet user constructs, signs, and submits transactions through the REST API. The full transaction lifecycle — coin selection, balancing, signing, submission, confirmation — behaves identically. Transaction metadata, certificates (delegation, voting, registration), and multi-asset minting all work unchanged.
 
@@ -47,7 +69,7 @@ A wallet user constructs, signs, and submits transactions through the REST API. 
 
 ---
 
-### User Story 3 - REST API responses unchanged (Priority: P1)
+### User Story 4 - REST API responses unchanged (Priority: P1)
 
 External consumers of the wallet REST API (Daedalus, third-party integrations) receive identical JSON responses. No fields change names, types, or serialization formats. The OpenAPI specification remains unchanged.
 
@@ -62,7 +84,7 @@ External consumers of the wallet REST API (Daedalus, third-party integrations) r
 
 ---
 
-### User Story 4 - Serialization round-trips preserved (Priority: P2)
+### User Story 5 - Serialization round-trips preserved (Priority: P2)
 
 Existing wallet databases created by the current version can be read by the new version. Transaction CBOR stored in the database deserializes correctly. TxMetadata JSON stored in SQLite parses identically.
 
@@ -77,11 +99,11 @@ Existing wallet databases created by the current version can be read by the new 
 
 ---
 
-### User Story 5 - Test generators migrated (Priority: P2)
+### User Story 6 - Test generators migrated (Priority: P2)
 
 Property-based tests that currently use `Cardano.Api.Gen` (from `cardano-api-extra`) work with replacement generators that produce identical value distributions. Test coverage does not regress.
 
-**Why this priority**: The `cardano-api-extra` package exists solely to extend cardano-api with test generators. It cannot be eliminated until the generators are replaced.
+**Why this priority**: The `cardano-api-extra` package exists solely to extend cardano-api with test generators. It cannot be eliminated until the generators are replaced with ledger-native equivalents (using `Arbitrary` instances from `cardano-ledger-conway:testlib`).
 
 **Independent Test**: Run all property-based tests. Verify they pass with the same confidence level and cover the same value space.
 
@@ -92,7 +114,7 @@ Property-based tests that currently use `Cardano.Api.Gen` (from `cardano-api-ext
 
 ---
 
-### User Story 6 - Reduced build complexity (Priority: P3)
+### User Story 7 - Reduced build complexity (Priority: P3)
 
 The total number of transitive dependencies decreases. Build times improve because cardano-api (and its own transitive dependencies) no longer need compilation.
 
@@ -114,38 +136,42 @@ The total number of transitive dependencies decreases. Build times improve becau
 - What happens when a node returns era-specific error types during transaction submission?
 - How does cross-era transaction construction behave at era boundaries (a transaction constructed just before a hard fork)?
 - What happens if an upstream `cardano-ledger-*` package does not expose an equivalent for a function currently accessed via cardano-api?
+- Does the updated `cardano-balance-transaction` produce byte-identical CBOR for balanced transactions?
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The wallet MUST build and pass all tests without `cardano-api` in any package's build dependencies.
-- **FR-002**: The wallet MUST use `cardano-ledger-*` and `ouroboros-*` libraries directly for all types previously re-exported by cardano-api (SlotNo, ShelleyGenesis, NodeToClientVersion, era types).
-- **FR-003**: The wallet MUST provide its own CBOR serialization/deserialization replacing cardano-api's wrappers (serialiseToCBOR, deserialiseFromCBOR, serialiseToRawBytes, deserialiseFromRawBytes, serialiseToBech32, deserialiseFromBech32).
-- **FR-004**: The wallet MUST unify its internal NetworkId type (in `Cardano.Wallet.Primitive.NetworkId`) with the one previously imported from cardano-api, eliminating the dual-type bridge and conversion functions.
-- **FR-005**: The wallet MUST construct delegation, registration, and voting certificates directly via `cardano-ledger` APIs, handling pre-Conway vs Conway certificate format differences currently managed by `Cardano.Api.Certificate`.
-- **FR-006**: The wallet MUST define its own TxMetadata and TxMetadataValue types (or adopt ledger equivalents) that are wire-compatible with the current JSON serialization used in the REST API and database. The TxMetadataJsonSchema-based conversion (metadataFromJson, metadataToJson) must be preserved.
-- **FR-007**: The wallet MUST replace SealedTx's internal use of `InAnyCardanoEra Cardano.Api.Tx` with a ledger-native transaction representation, preserving all existing serialization and submission behavior.
-- **FR-008**: The wallet MUST replace `toConsensusGenTx` with a direct conversion from ledger Tx to Ouroboros GenTx for transaction submission, preserving the multi-era hard fork combinator dispatch.
-- **FR-009**: The wallet MUST replace `TxBodyContent` / `createTransactionBody` with direct ledger transaction body construction, covering all current fields: inputs, outputs, fees, withdrawals, certificates, metadata, minting, validity intervals, and voting procedures.
-- **FR-010**: The `cardano-api-extra` package MUST be removed from the repository after its generators are replaced with wallet-native equivalents.
-- **FR-011**: The wallet's era GADT system (`cardano-wallet-read`) MUST fully replace cardano-api's `AnyCardanoEra`, `CardanoEra`, `InAnyCardanoEra`, `InAnyShelleyBasedEra`, `IsCardanoEra`, and `ShelleyBasedEra` types across all 45 files currently importing them.
-- **FR-012**: All existing benchmarks MUST continue to produce comparable results (no performance regressions beyond measurement noise).
-- **FR-013**: Byron-era transaction support (currently via `Cardano.Api.Byron`) MUST be preserved using direct ledger types.
+- **FR-001**: The wallet MUST pin a version of `cardano-balance-transaction` that does not depend on `cardano-api`, and adapt to its breaking API changes (`CardanoApiEra` removal, direct ledger types, removed conversion functions).
+- **FR-002**: The wallet MUST build and pass all tests without `cardano-api` in any package's build dependencies or transitive closure.
+- **FR-003**: The wallet MUST use `cardano-ledger-*` and `ouroboros-*` libraries directly for all types previously re-exported by cardano-api (SlotNo, ShelleyGenesis, NodeToClientVersion, era types).
+- **FR-004**: The wallet MUST provide its own CBOR serialization/deserialization replacing cardano-api's wrappers (serialiseToCBOR, deserialiseFromCBOR, serialiseToRawBytes, deserialiseFromRawBytes, serialiseToBech32, deserialiseFromBech32).
+- **FR-005**: The wallet MUST unify its internal NetworkId type (in `Cardano.Wallet.Primitive.NetworkId`) with the one previously imported from cardano-api, eliminating the dual-type bridge and conversion functions.
+- **FR-006**: The wallet MUST construct delegation, registration, and voting certificates directly via `cardano-ledger` APIs, handling pre-Conway vs Conway certificate format differences currently managed by `Cardano.Api.Certificate`.
+- **FR-007**: The wallet MUST define its own TxMetadata and TxMetadataValue types (or adopt ledger equivalents) that are wire-compatible with the current JSON serialization used in the REST API and database. The TxMetadataJsonSchema-based conversion (metadataFromJson, metadataToJson) must be preserved.
+- **FR-008**: The wallet MUST replace SealedTx's internal use of `InAnyCardanoEra Cardano.Api.Tx` with a ledger-native transaction representation, preserving all existing serialization and submission behavior.
+- **FR-009**: The wallet MUST replace `toConsensusGenTx` with a direct conversion from ledger Tx to Ouroboros GenTx for transaction submission, preserving the multi-era hard fork combinator dispatch.
+- **FR-010**: The wallet MUST replace `TxBodyContent` / `createTransactionBody` with direct ledger transaction body construction, covering all current fields: inputs, outputs, fees, withdrawals, certificates, metadata, minting, validity intervals, and voting procedures.
+- **FR-011**: The `cardano-api-extra` package MUST be removed from the repository after its generators are replaced with wallet-native equivalents (using ledger testlib Arbitrary instances).
+- **FR-012**: The wallet's era GADT system (`cardano-wallet-read`) MUST fully replace cardano-api's `AnyCardanoEra`, `CardanoEra`, `InAnyCardanoEra`, `InAnyShelleyBasedEra`, `IsCardanoEra`, and `ShelleyBasedEra` types across all 45 files currently importing them.
+- **FR-013**: All existing benchmarks MUST continue to produce comparable results (no performance regressions beyond measurement noise).
+- **FR-014**: Byron-era transaction support (currently via `Cardano.Api.Byron`) MUST be preserved using direct ledger types.
 
 ### Key Entities
 
+- **cardano-balance-transaction pin**: The `source-repository-package` entry in `cabal.project`. Currently at commit `98e7f41` which depends on cardano-api. Must be bumped to a commit from the `002-remove-cardano-api` branch (or later) that removes this dependency.
 - **SealedTx**: The wallet's canonical serialized transaction type. Currently wraps `InAnyCardanoEra Cardano.Api.Tx`. Must be re-implemented around ledger-native Tx. Used in REST API, database, and submission layer.
 - **TxMetadata / TxMetadataValue**: Transaction metadata types exposed in the REST API and persisted in SQLite as JSON. Must be inlined or replaced with a compatible definition.
 - **NetworkId**: Network identifier. Two versions coexist (wallet's own in `Cardano.Wallet.Primitive.NetworkId` + cardano-api's). Must be unified to the wallet's own type.
 - **Era GADTs**: The type-level era representation. `cardano-wallet-read` has its own system; the bridge to cardano-api's era types must be removed.
-- **Cardano.Api.Gen generators**: QuickCheck generators for Cardano types used in property-based tests. Must be replaced with wallet-native generators.
+- **CardanoApiEra type family**: Currently used in wallet type signatures for certificates, key witnesses, and tx bodies. Will cease to exist after the `cardano-balance-transaction` bump — all these must switch to direct ledger era types.
+- **Cardano.Api.Gen generators**: QuickCheck generators for Cardano types used in property-based tests. Must be replaced with ledger testlib generators.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: `cardano-api` does not appear in the transitive dependency closure of any wallet package.
+- **SC-001**: `cardano-api` does not appear in the transitive dependency closure of any wallet package (including via `cardano-balance-transaction` and `cardano-coin-selection`).
 - **SC-002**: All existing unit tests pass without modification to test assertions (test infrastructure changes are acceptable).
 - **SC-003**: All existing integration tests pass across Babbage, Conway, and Dijkstra eras.
 - **SC-004**: REST API golden tests pass with no output differences.
@@ -155,9 +181,10 @@ The total number of transitive dependencies decreases. Build times improve becau
 
 ## Assumptions
 
+- The `cardano-balance-transaction` branch `002-remove-cardano-api` lands and is available to pin before or during this work. If it is delayed, phases that don't touch the balance-tx interface can still proceed, but SC-001 cannot be achieved.
 - The `cardano-ledger-*` and `ouroboros-*` packages expose sufficient public API surface to replace all functionality currently accessed through cardano-api. Where they don't, upstream contributions or local shims may be needed.
 - The `cardano-wallet-read` era system is mature enough to fully replace cardano-api's era GADTs without introducing new abstraction layers.
 - Database schema changes (if any) will use the existing persistent migration framework.
 - This removal can proceed incrementally — each phase independently mergeable — rather than requiring a single atomic change.
-- The standalone `cardano-balance-transaction` and `cardano-coin-selection` libraries (already extracted) do not re-introduce cardano-api into the wallet's transitive closure.
+- The `cardano-balance-transaction` removal produces byte-identical CBOR output, so no database migration is needed for stored transaction data.
 - Cross-platform compatibility (Linux, Windows, macOS) is preserved throughout the migration.

--- a/specs/001-drop-cardano-api/spec.md
+++ b/specs/001-drop-cardano-api/spec.md
@@ -5,30 +5,36 @@
 **Status**: Draft
 **Input**: User description: "Remove cardano-api dependency from cardano-wallet"
 
+## Context
+
+The `cardano-balance-transaction` and `cardano-coin-selection` libraries have already been extracted as standalone packages, removing two major consumers of cardano-api from the wallet's internal code. The remaining cardano-api usage spans 9 packages (71 imports across 45 files), concentrated in transaction construction, certificate handling, metadata types, and era GADTs.
+
+This spec covers the removal of all remaining cardano-api usage.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Wallet builds without cardano-api (Priority: P1)
 
-A developer building cardano-wallet from source no longer needs to compile the cardano-api package. The build dependency graph is shorter, compile times are reduced, and version constraint conflicts involving cardano-api are eliminated. The wallet produces identical artifacts (binaries, API responses, database state) as before the removal.
+A developer building cardano-wallet from source no longer needs to compile the cardano-api package. The build dependency graph is shorter, version constraint conflicts involving cardano-api are eliminated. The wallet produces identical artifacts as before the removal.
 
 **Why this priority**: This is the core goal. Every other story depends on the wallet successfully building and passing all tests without cardano-api in its dependency closure.
 
-**Independent Test**: Build the full project, run unit tests and integration tests. All existing tests pass with no behavioral changes. Verify `cardano-api` does not appear in the build plan output.
+**Independent Test**: Build the full project, run unit and integration tests. Verify `cardano-api` does not appear in the build plan output.
 
 **Acceptance Scenarios**:
 
 1. **Given** the wallet codebase with cardano-api removed from all .cabal files, **When** a developer builds all packages, **Then** the build succeeds with no compilation errors.
 2. **Given** a successfully built wallet, **When** the full unit test suite runs, **Then** all tests pass with the same results as the pre-removal baseline.
 3. **Given** a successfully built wallet, **When** the integration test suite runs against a local cluster, **Then** all tests pass across all supported eras (Babbage, Conway, Dijkstra).
-4. **Given** the built project, **When** the build plan is inspected, **Then** `cardano-api` does not appear anywhere in the transitive dependency closure of any wallet package.
+4. **Given** the built project, **When** the build plan is inspected, **Then** `cardano-api` does not appear in the transitive dependency closure of any wallet package.
 
 ---
 
 ### User Story 2 - Transaction lifecycle works identically (Priority: P1)
 
-A wallet user constructs, signs, and submits transactions through the REST API. The transaction lifecycle — from coin selection through to node submission and confirmation — behaves identically to the current implementation. Transaction metadata, certificates (delegation, voting, registration), and multi-asset minting all work unchanged.
+A wallet user constructs, signs, and submits transactions through the REST API. The full transaction lifecycle — coin selection, balancing, signing, submission, confirmation — behaves identically. Transaction metadata, certificates (delegation, voting, registration), and multi-asset minting all work unchanged.
 
-**Why this priority**: Transaction handling is the wallet's core function and the area most deeply entangled with cardano-api (SealedTx, TxBodyContent, toConsensusGenTx). Any regression here is a funds-at-risk issue.
+**Why this priority**: Transaction handling is the wallet's core function and the area most deeply entangled with cardano-api (SealedTx, TxBodyContent, toConsensusGenTx). Any regression is a funds-at-risk issue.
 
 **Independent Test**: Submit delegation, voting, and payment transactions with metadata on a local cluster. Verify transaction hashes, fees, and on-chain effects match expected values.
 
@@ -45,9 +51,9 @@ A wallet user constructs, signs, and submits transactions through the REST API. 
 
 External consumers of the wallet REST API (Daedalus, third-party integrations) receive identical JSON responses. No fields change names, types, or serialization formats. The OpenAPI specification remains unchanged.
 
-**Why this priority**: The REST API is the wallet's public contract. Any change to response formats would break downstream consumers.
+**Why this priority**: The REST API is the wallet's public contract. Any change to response formats breaks downstream consumers.
 
-**Independent Test**: Run the API golden tests. Compare API responses field-by-field against the pre-removal baseline for all transaction, address, and metadata endpoints.
+**Independent Test**: Run the API golden tests. Compare API responses against the pre-removal baseline for all transaction, address, and metadata endpoints.
 
 **Acceptance Scenarios**:
 
@@ -62,7 +68,7 @@ Existing wallet databases created by the current version can be read by the new 
 
 **Why this priority**: Users upgrading their wallet must not lose data or encounter corruption. Database compatibility is a hard constraint.
 
-**Independent Test**: Take a wallet database snapshot from the current version, start the new version against it, verify all data loads and displays correctly.
+**Independent Test**: Start the new version against a database snapshot from the current version, verify all data loads correctly.
 
 **Acceptance Scenarios**:
 
@@ -71,27 +77,43 @@ Existing wallet databases created by the current version can be read by the new 
 
 ---
 
-### User Story 5 - Reduced build complexity (Priority: P3)
+### User Story 5 - Test generators migrated (Priority: P2)
 
-The `cardano-api-extra` package is eliminated entirely. The total number of transitive dependencies decreases. Build times improve because cardano-api (and its own dependencies) no longer need compilation.
+Property-based tests that currently use `Cardano.Api.Gen` (from `cardano-api-extra`) work with replacement generators that produce identical value distributions. Test coverage does not regress.
 
-**Why this priority**: This is the motivating benefit of the removal — simpler builds, fewer version conflicts, faster CI.
+**Why this priority**: The `cardano-api-extra` package exists solely to extend cardano-api with test generators. It cannot be eliminated until the generators are replaced.
+
+**Independent Test**: Run all property-based tests. Verify they pass with the same confidence level and cover the same value space.
+
+**Acceptance Scenarios**:
+
+1. **Given** the wallet test suite, **When** property-based tests run with the replacement generators, **Then** all tests pass.
+2. **Given** the updated codebase, **When** the `cardano-api-extra` package directory is inspected, **Then** it no longer exists.
+
+---
+
+### User Story 6 - Reduced build complexity (Priority: P3)
+
+The total number of transitive dependencies decreases. Build times improve because cardano-api (and its own transitive dependencies) no longer need compilation.
+
+**Why this priority**: This is the motivating benefit — simpler builds, fewer version conflicts, faster CI.
 
 **Independent Test**: Compare dependency counts and CI build times before and after.
 
 **Acceptance Scenarios**:
 
-1. **Given** the updated codebase, **When** the cardano-api-extra package directory is inspected, **Then** it no longer exists.
-2. **Given** a clean build, **When** build time is measured, **Then** it is measurably shorter than the baseline.
+1. **Given** a clean build, **When** build time is measured, **Then** it is measurably shorter than the baseline.
+2. **Given** the build plan, **When** the transitive dependency count is measured, **Then** it is lower than the baseline.
 
 ---
 
 ### Edge Cases
 
 - What happens when deserializing a transaction from a pre-Shelley (Byron) era stored in the database?
-- How does the wallet handle a transaction CBOR blob that was serialized by the old cardano-api path — does the new deserialization path accept it?
+- How does the wallet handle a transaction CBOR blob serialized by the old cardano-api path — does the new deserialization path accept it?
 - What happens when a node returns era-specific error types during transaction submission?
-- How does cross-era transaction construction behave at era boundaries (e.g., a transaction constructed just before a hard fork)?
+- How does cross-era transaction construction behave at era boundaries (a transaction constructed just before a hard fork)?
+- What happens if an upstream `cardano-ledger-*` package does not expose an equivalent for a function currently accessed via cardano-api?
 
 ## Requirements *(mandatory)*
 
@@ -99,23 +121,25 @@ The `cardano-api-extra` package is eliminated entirely. The total number of tran
 
 - **FR-001**: The wallet MUST build and pass all tests without `cardano-api` in any package's build dependencies.
 - **FR-002**: The wallet MUST use `cardano-ledger-*` and `ouroboros-*` libraries directly for all types previously re-exported by cardano-api (SlotNo, ShelleyGenesis, NodeToClientVersion, era types).
-- **FR-003**: The wallet MUST provide its own CBOR serialization/deserialization replacing cardano-api's wrappers around ledger binary encoding.
-- **FR-004**: The wallet MUST unify its internal NetworkId type with the one previously imported from cardano-api, eliminating the dual-type bridge.
-- **FR-005**: The wallet MUST construct delegation, registration, and voting certificates directly via cardano-ledger, handling pre-Conway vs Conway format differences.
-- **FR-006**: The wallet MUST define its own TxMetadata type (or adopt a ledger equivalent) that is wire-compatible with the current JSON serialization used in the REST API and database.
-- **FR-007**: The wallet MUST replace SealedTx's internal use of cardano-api's era-indexed transaction type with a ledger-native transaction representation.
-- **FR-008**: The wallet MUST replace the cardano-api-based conversion to Ouroboros GenTx with a direct conversion from ledger Tx for transaction submission.
-- **FR-009**: The wallet MUST replace the TxBodyContent transaction builder with direct ledger transaction body construction.
-- **FR-010**: The `cardano-api-extra` package MUST be removed from the repository.
-- **FR-011**: The wallet's own era GADT system MUST fully replace cardano-api's AnyCardanoEra, CardanoEra, and InAnyCardanoEra types.
+- **FR-003**: The wallet MUST provide its own CBOR serialization/deserialization replacing cardano-api's wrappers (serialiseToCBOR, deserialiseFromCBOR, serialiseToRawBytes, deserialiseFromRawBytes, serialiseToBech32, deserialiseFromBech32).
+- **FR-004**: The wallet MUST unify its internal NetworkId type (in `Cardano.Wallet.Primitive.NetworkId`) with the one previously imported from cardano-api, eliminating the dual-type bridge and conversion functions.
+- **FR-005**: The wallet MUST construct delegation, registration, and voting certificates directly via `cardano-ledger` APIs, handling pre-Conway vs Conway certificate format differences currently managed by `Cardano.Api.Certificate`.
+- **FR-006**: The wallet MUST define its own TxMetadata and TxMetadataValue types (or adopt ledger equivalents) that are wire-compatible with the current JSON serialization used in the REST API and database. The TxMetadataJsonSchema-based conversion (metadataFromJson, metadataToJson) must be preserved.
+- **FR-007**: The wallet MUST replace SealedTx's internal use of `InAnyCardanoEra Cardano.Api.Tx` with a ledger-native transaction representation, preserving all existing serialization and submission behavior.
+- **FR-008**: The wallet MUST replace `toConsensusGenTx` with a direct conversion from ledger Tx to Ouroboros GenTx for transaction submission, preserving the multi-era hard fork combinator dispatch.
+- **FR-009**: The wallet MUST replace `TxBodyContent` / `createTransactionBody` with direct ledger transaction body construction, covering all current fields: inputs, outputs, fees, withdrawals, certificates, metadata, minting, validity intervals, and voting procedures.
+- **FR-010**: The `cardano-api-extra` package MUST be removed from the repository after its generators are replaced with wallet-native equivalents.
+- **FR-011**: The wallet's era GADT system (`cardano-wallet-read`) MUST fully replace cardano-api's `AnyCardanoEra`, `CardanoEra`, `InAnyCardanoEra`, `InAnyShelleyBasedEra`, `IsCardanoEra`, and `ShelleyBasedEra` types across all 45 files currently importing them.
 - **FR-012**: All existing benchmarks MUST continue to produce comparable results (no performance regressions beyond measurement noise).
+- **FR-013**: Byron-era transaction support (currently via `Cardano.Api.Byron`) MUST be preserved using direct ledger types.
 
 ### Key Entities
 
-- **SealedTx**: The wallet's canonical serialized transaction type. Currently wraps cardano-api's era-indexed Tx. Must be re-implemented around ledger-native Tx.
-- **TxMetadata / TxMetadataValue**: Transaction metadata types exposed in the REST API and persisted in SQLite. Must be inlined or replaced with a compatible definition.
-- **NetworkId**: Network identifier. Two versions currently coexist (wallet's own + cardano-api's). Must be unified.
-- **Era GADTs**: The type-level era representation system. cardano-wallet-read already has its own; the bridge to cardano-api's system must be removed.
+- **SealedTx**: The wallet's canonical serialized transaction type. Currently wraps `InAnyCardanoEra Cardano.Api.Tx`. Must be re-implemented around ledger-native Tx. Used in REST API, database, and submission layer.
+- **TxMetadata / TxMetadataValue**: Transaction metadata types exposed in the REST API and persisted in SQLite as JSON. Must be inlined or replaced with a compatible definition.
+- **NetworkId**: Network identifier. Two versions coexist (wallet's own in `Cardano.Wallet.Primitive.NetworkId` + cardano-api's). Must be unified to the wallet's own type.
+- **Era GADTs**: The type-level era representation. `cardano-wallet-read` has its own system; the bridge to cardano-api's era types must be removed.
+- **Cardano.Api.Gen generators**: QuickCheck generators for Cardano types used in property-based tests. Must be replaced with wallet-native generators.
 
 ## Success Criteria *(mandatory)*
 
@@ -125,15 +149,15 @@ The `cardano-api-extra` package is eliminated entirely. The total number of tran
 - **SC-002**: All existing unit tests pass without modification to test assertions (test infrastructure changes are acceptable).
 - **SC-003**: All existing integration tests pass across Babbage, Conway, and Dijkstra eras.
 - **SC-004**: REST API golden tests pass with no output differences.
-- **SC-005**: Database migration from a pre-removal wallet version completes without data loss.
-- **SC-006**: CI build time for a clean build decreases compared to the pre-removal baseline.
-- **SC-007**: The `cardano-api-extra` package directory no longer exists in the repository.
+- **SC-005**: A wallet database from the pre-removal version loads without errors or data loss.
+- **SC-006**: The `lib/cardano-api-extra` directory no longer exists in the repository.
+- **SC-007**: The total import count for `Cardano.Api` modules across the codebase is zero.
 
 ## Assumptions
 
 - The `cardano-ledger-*` and `ouroboros-*` packages expose sufficient public API surface to replace all functionality currently accessed through cardano-api. Where they don't, upstream contributions or local shims may be needed.
 - The `cardano-wallet-read` era system is mature enough to fully replace cardano-api's era GADTs without introducing new abstraction layers.
-- Database schema changes (if any) will use the existing persistent migration framework. No manual migration scripts are expected.
-- This removal can proceed incrementally (phase by phase) with each phase independently mergeable, rather than requiring a single atomic change.
-- The project remains in maintenance mode — this removal is a maintenance/infrastructure improvement, not a feature addition.
+- Database schema changes (if any) will use the existing persistent migration framework.
+- This removal can proceed incrementally — each phase independently mergeable — rather than requiring a single atomic change.
+- The standalone `cardano-balance-transaction` and `cardano-coin-selection` libraries (already extracted) do not re-introduce cardano-api into the wallet's transitive closure.
 - Cross-platform compatibility (Linux, Windows, macOS) is preserved throughout the migration.

--- a/specs/001-drop-cardano-api/spec.md
+++ b/specs/001-drop-cardano-api/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Remove cardano-api Dependency
+
+**Feature Branch**: `001-drop-cardano-api`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Remove cardano-api dependency from cardano-wallet"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Wallet builds without cardano-api (Priority: P1)
+
+A developer building cardano-wallet from source no longer needs to compile the cardano-api package. The build dependency graph is shorter, compile times are reduced, and version constraint conflicts involving cardano-api are eliminated. The wallet produces identical artifacts (binaries, API responses, database state) as before the removal.
+
+**Why this priority**: This is the core goal. Every other story depends on the wallet successfully building and passing all tests without cardano-api in its dependency closure.
+
+**Independent Test**: Build the full project, run unit tests and integration tests. All existing tests pass with no behavioral changes. Verify `cardano-api` does not appear in the build plan output.
+
+**Acceptance Scenarios**:
+
+1. **Given** the wallet codebase with cardano-api removed from all .cabal files, **When** a developer builds all packages, **Then** the build succeeds with no compilation errors.
+2. **Given** a successfully built wallet, **When** the full unit test suite runs, **Then** all tests pass with the same results as the pre-removal baseline.
+3. **Given** a successfully built wallet, **When** the integration test suite runs against a local cluster, **Then** all tests pass across all supported eras (Babbage, Conway, Dijkstra).
+4. **Given** the built project, **When** the build plan is inspected, **Then** `cardano-api` does not appear anywhere in the transitive dependency closure of any wallet package.
+
+---
+
+### User Story 2 - Transaction lifecycle works identically (Priority: P1)
+
+A wallet user constructs, signs, and submits transactions through the REST API. The transaction lifecycle — from coin selection through to node submission and confirmation — behaves identically to the current implementation. Transaction metadata, certificates (delegation, voting, registration), and multi-asset minting all work unchanged.
+
+**Why this priority**: Transaction handling is the wallet's core function and the area most deeply entangled with cardano-api (SealedTx, TxBodyContent, toConsensusGenTx). Any regression here is a funds-at-risk issue.
+
+**Independent Test**: Submit delegation, voting, and payment transactions with metadata on a local cluster. Verify transaction hashes, fees, and on-chain effects match expected values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a funded wallet, **When** a user submits a payment transaction with metadata via the REST API, **Then** the transaction is accepted by the node and the metadata is visible on-chain.
+2. **Given** a funded wallet, **When** a user delegates to a stake pool, **Then** the delegation certificate is correctly formed for the current era and the delegation takes effect.
+3. **Given** a funded wallet, **When** a user submits a transaction with multi-asset minting, **Then** the minted assets appear in the wallet balance.
+4. **Given** a funded wallet, **When** a user submits a governance vote (Conway era), **Then** the vote certificate is correctly formed and submitted.
+
+---
+
+### User Story 3 - REST API responses unchanged (Priority: P1)
+
+External consumers of the wallet REST API (Daedalus, third-party integrations) receive identical JSON responses. No fields change names, types, or serialization formats. The OpenAPI specification remains unchanged.
+
+**Why this priority**: The REST API is the wallet's public contract. Any change to response formats would break downstream consumers.
+
+**Independent Test**: Run the API golden tests. Compare API responses field-by-field against the pre-removal baseline for all transaction, address, and metadata endpoints.
+
+**Acceptance Scenarios**:
+
+1. **Given** a wallet with transaction history, **When** the transaction list endpoint is queried, **Then** the JSON response (including metadata serialization) is byte-identical to the pre-removal format.
+2. **Given** the wallet server, **When** the OpenAPI spec is regenerated, **Then** it matches the existing specification with no differences.
+
+---
+
+### User Story 4 - Serialization round-trips preserved (Priority: P2)
+
+Existing wallet databases created by the current version can be read by the new version. Transaction CBOR stored in the database deserializes correctly. TxMetadata JSON stored in SQLite parses identically.
+
+**Why this priority**: Users upgrading their wallet must not lose data or encounter corruption. Database compatibility is a hard constraint.
+
+**Independent Test**: Take a wallet database snapshot from the current version, start the new version against it, verify all data loads and displays correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a wallet database containing transactions from multiple eras, **When** the wallet starts with the new code, **Then** all historical transactions deserialize and display correctly.
+2. **Given** stored TxMetadata JSON in the database, **When** the new code reads it, **Then** the metadata round-trips identically through the new serialization path.
+
+---
+
+### User Story 5 - Reduced build complexity (Priority: P3)
+
+The `cardano-api-extra` package is eliminated entirely. The total number of transitive dependencies decreases. Build times improve because cardano-api (and its own dependencies) no longer need compilation.
+
+**Why this priority**: This is the motivating benefit of the removal — simpler builds, fewer version conflicts, faster CI.
+
+**Independent Test**: Compare dependency counts and CI build times before and after.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated codebase, **When** the cardano-api-extra package directory is inspected, **Then** it no longer exists.
+2. **Given** a clean build, **When** build time is measured, **Then** it is measurably shorter than the baseline.
+
+---
+
+### Edge Cases
+
+- What happens when deserializing a transaction from a pre-Shelley (Byron) era stored in the database?
+- How does the wallet handle a transaction CBOR blob that was serialized by the old cardano-api path — does the new deserialization path accept it?
+- What happens when a node returns era-specific error types during transaction submission?
+- How does cross-era transaction construction behave at era boundaries (e.g., a transaction constructed just before a hard fork)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The wallet MUST build and pass all tests without `cardano-api` in any package's build dependencies.
+- **FR-002**: The wallet MUST use `cardano-ledger-*` and `ouroboros-*` libraries directly for all types previously re-exported by cardano-api (SlotNo, ShelleyGenesis, NodeToClientVersion, era types).
+- **FR-003**: The wallet MUST provide its own CBOR serialization/deserialization replacing cardano-api's wrappers around ledger binary encoding.
+- **FR-004**: The wallet MUST unify its internal NetworkId type with the one previously imported from cardano-api, eliminating the dual-type bridge.
+- **FR-005**: The wallet MUST construct delegation, registration, and voting certificates directly via cardano-ledger, handling pre-Conway vs Conway format differences.
+- **FR-006**: The wallet MUST define its own TxMetadata type (or adopt a ledger equivalent) that is wire-compatible with the current JSON serialization used in the REST API and database.
+- **FR-007**: The wallet MUST replace SealedTx's internal use of cardano-api's era-indexed transaction type with a ledger-native transaction representation.
+- **FR-008**: The wallet MUST replace the cardano-api-based conversion to Ouroboros GenTx with a direct conversion from ledger Tx for transaction submission.
+- **FR-009**: The wallet MUST replace the TxBodyContent transaction builder with direct ledger transaction body construction.
+- **FR-010**: The `cardano-api-extra` package MUST be removed from the repository.
+- **FR-011**: The wallet's own era GADT system MUST fully replace cardano-api's AnyCardanoEra, CardanoEra, and InAnyCardanoEra types.
+- **FR-012**: All existing benchmarks MUST continue to produce comparable results (no performance regressions beyond measurement noise).
+
+### Key Entities
+
+- **SealedTx**: The wallet's canonical serialized transaction type. Currently wraps cardano-api's era-indexed Tx. Must be re-implemented around ledger-native Tx.
+- **TxMetadata / TxMetadataValue**: Transaction metadata types exposed in the REST API and persisted in SQLite. Must be inlined or replaced with a compatible definition.
+- **NetworkId**: Network identifier. Two versions currently coexist (wallet's own + cardano-api's). Must be unified.
+- **Era GADTs**: The type-level era representation system. cardano-wallet-read already has its own; the bridge to cardano-api's system must be removed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `cardano-api` does not appear in the transitive dependency closure of any wallet package.
+- **SC-002**: All existing unit tests pass without modification to test assertions (test infrastructure changes are acceptable).
+- **SC-003**: All existing integration tests pass across Babbage, Conway, and Dijkstra eras.
+- **SC-004**: REST API golden tests pass with no output differences.
+- **SC-005**: Database migration from a pre-removal wallet version completes without data loss.
+- **SC-006**: CI build time for a clean build decreases compared to the pre-removal baseline.
+- **SC-007**: The `cardano-api-extra` package directory no longer exists in the repository.
+
+## Assumptions
+
+- The `cardano-ledger-*` and `ouroboros-*` packages expose sufficient public API surface to replace all functionality currently accessed through cardano-api. Where they don't, upstream contributions or local shims may be needed.
+- The `cardano-wallet-read` era system is mature enough to fully replace cardano-api's era GADTs without introducing new abstraction layers.
+- Database schema changes (if any) will use the existing persistent migration framework. No manual migration scripts are expected.
+- This removal can proceed incrementally (phase by phase) with each phase independently mergeable, rather than requiring a single atomic change.
+- The project remains in maintenance mode — this removal is a maintenance/infrastructure improvement, not a feature addition.
+- Cross-platform compatibility (Linux, Windows, macOS) is preserved throughout the migration.

--- a/specs/001-drop-cardano-api/tasks.md
+++ b/specs/001-drop-cardano-api/tasks.md
@@ -28,7 +28,7 @@ Each task adds new code. Nothing is removed or changed. Dual paths coexist.
 
 - [ ] T007 [P] Create wallet-owned `TxMetadata`/`TxMetadataValue` in new module `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs` with JSON schema conversion ported from cardano-api (FR-007)
 - [ ] T008 [P] Add ledger-native constructor path to `SealedTx` (`EraValue LedgerTx` + CBOR) alongside existing `InAnyCardanoEra Cardano.Api.Tx` in `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs` (FR-008)
-- [ ] T009 [P] Add `networkIdToLedger :: SNetworkId n -> Ledger.Network` in `lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs` alongside existing `networkIdVal` (FR-005)
+- [ ] T009 [P] Add `networkIdToLedger :: NetworkId -> Ledger.Network` and `sNetworkIdToLedger :: SNetworkId n -> Ledger.Network` in `lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs` alongside existing `networkIdVal` (FR-005)
 - [ ] T010 [P] Add direct `cardano-ledger-api` certificate helper functions alongside `Cardano.Api.Certificate` usage in `lib/wallet/` and `lib/api/` (FR-006)
 - [ ] T011 [P] Add `mkShelleyTx` + `HardForkGenTx` submission helpers alongside `toConsensusGenTx` in `lib/network-layer/` (FR-009)
 - [ ] T012 [P] Add ledger-native tx body construction helpers alongside `TxBodyContent`/`createTransactionBody` in `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs` (FR-010)
@@ -69,7 +69,7 @@ Replace `AnyCardanoEra`, `CardanoEra`, `InAnyCardanoEra`, `ShelleyBasedEra`, `Is
 - [ ] T026 Switch `SealedTx` consumers in `lib/wallet/` (FR-008)
 - [ ] T027 Switch `SealedTx` consumers in `lib/api/` and `lib/network-layer/` (FR-008)
 - [ ] T028 Switch `TxMetadata` consumers from `Cardano.Api.TxMetadata` to wallet-owned type — `lib/primitive/`, `lib/api/` (FR-007)
-- [ ] T029 Switch `NetworkId` consumers from `networkIdVal` to `networkIdToLedger` (FR-005)
+- [ ] T029 Switch `NetworkId` consumers that do not need testnet magic from `networkIdVal` to `networkIdToLedger` (FR-005)
 - [ ] T030 Switch CBOR serialization from `serialiseToCBOR`/`deserialiseFromCBOR` to `cardano-ledger-binary` across all call sites (FR-004)
 - [ ] T031 Switch bech32 serialization to direct `bech32` library (FR-004)
 

--- a/specs/001-drop-cardano-api/tasks.md
+++ b/specs/001-drop-cardano-api/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Remove cardano-api Dependency
+
+**Input**: Design documents from `/specs/001-drop-cardano-api/`
+**Issue**: #5237
+
+## Commit discipline
+
+Every task produces one or more commits. Every commit compiles and passes tests. The additive-then-remove pattern ensures no broken intermediate states.
+
+---
+
+## Phase A: Pin Bump
+
+- [ ] T001 Update `cardano-balance-transaction` pin in `cabal.project` from `98e7f41` to `964e8a2`, update sha256, fix compilation
+- [ ] T002 Fix `CardanoApiEra` type family removal — replace with direct ledger era types in `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs`
+- [ ] T003 Remove `toCardanoApiTx`/`fromCardanoApiTx` calls in `lib/primitive/` and `lib/wallet/`
+- [ ] T004 Update era constraint signatures in `lib/api/src/Cardano/Wallet/Api/Http/Server.hs` and related handlers
+- [ ] T005 Run unit + integration tests, fix any remaining failures from API changes
+- [ ] T006 Compare CBOR output of balanced transactions before and after pin bump — verify byte-identical
+
+**Checkpoint**: `cardano-balance-transaction` no longer pulls in `cardano-api`. Wallet compiles, all tests pass.
+
+---
+
+## Phase B: Add New Paths Alongside Old (additive only)
+
+Each task adds new code. Nothing is removed or changed. Dual paths coexist.
+
+- [ ] T007 [P] Create wallet-owned `TxMetadata`/`TxMetadataValue` in new module `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxMetadata.hs` with JSON schema conversion ported from cardano-api (FR-007)
+- [ ] T008 [P] Add ledger-native constructor path to `SealedTx` (`EraValue LedgerTx` + CBOR) alongside existing `InAnyCardanoEra Cardano.Api.Tx` in `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs` (FR-008)
+- [ ] T009 [P] Add `networkIdToLedger :: SNetworkId n -> Ledger.Network` in `lib/primitive/lib/Cardano/Wallet/Primitive/NetworkId.hs` alongside existing `networkIdVal` (FR-005)
+- [ ] T010 [P] Add direct `cardano-ledger-api` certificate helper functions alongside `Cardano.Api.Certificate` usage in `lib/wallet/` and `lib/api/` (FR-006)
+- [ ] T011 [P] Add `mkShelleyTx` + `HardForkGenTx` submission helpers alongside `toConsensusGenTx` in `lib/network-layer/` (FR-009)
+- [ ] T012 [P] Add ledger-native tx body construction helpers alongside `TxBodyContent`/`createTransactionBody` in `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs` (FR-010)
+- [ ] T013 [P] Add ledger testlib `Arbitrary` instances and wallet-native generators for `SealedTx`/`TxMetadata` alongside `cardano-api-extra` generators (FR-011)
+- [ ] T014 [P] Add Byron-era ledger-native tx helpers alongside `Cardano.Api.Byron` usage (FR-014)
+
+**Checkpoint**: All new paths exist and compile. Old paths still used by consumers. No behavior change.
+
+---
+
+## Phase C: Migrate Consumers (one module at a time)
+
+Each task switches imports in one module or small group from cardano-api to the new paths. Each commit compiles and passes tests.
+
+### C1: Re-export swaps (mechanical — FR-003)
+
+Replace `Cardano.Api` imports of re-exported ledger types (SlotNo, EpochNo, Lovelace, Hash, TxId, etc.) with direct `cardano-ledger-*` / `ouroboros-*` imports.
+
+- [ ] T015 [P] Swap re-exports in `lib/primitive/` (13 files)
+- [ ] T016 [P] Swap re-exports in `lib/api/` (8 files)
+- [ ] T017 [P] Swap re-exports in `lib/wallet/` (7 files)
+- [ ] T018 [P] Swap re-exports in `lib/network-layer/` (3 files)
+- [ ] T019 [P] Swap re-exports in `lib/unit/`, `lib/integration/`, `lib/local-cluster/`, `lib/benchmarks/` (8 files)
+
+### C2: Era type swaps (FR-012)
+
+Replace `AnyCardanoEra`, `CardanoEra`, `InAnyCardanoEra`, `ShelleyBasedEra`, `IsCardanoEra` with `cardano-wallet-read` `Era`, `EraValue`, `IsEra`.
+
+- [ ] T020 Migrate era types in `lib/primitive/` modules
+- [ ] T021 Migrate era types in `lib/wallet/` modules
+- [ ] T022 Migrate era types in `lib/api/` modules
+- [ ] T023 Migrate era types in `lib/network-layer/` modules
+- [ ] T024 Migrate era types in test/benchmark packages
+
+### C3: Core type swaps
+
+- [ ] T025 Switch `SealedTx` consumers to ledger-native constructor — `lib/primitive/` internal modules (FR-008)
+- [ ] T026 Switch `SealedTx` consumers in `lib/wallet/` (FR-008)
+- [ ] T027 Switch `SealedTx` consumers in `lib/api/` and `lib/network-layer/` (FR-008)
+- [ ] T028 Switch `TxMetadata` consumers from `Cardano.Api.TxMetadata` to wallet-owned type — `lib/primitive/`, `lib/api/` (FR-007)
+- [ ] T029 Switch `NetworkId` consumers from `networkIdVal` to `networkIdToLedger` (FR-005)
+- [ ] T030 Switch CBOR serialization from `serialiseToCBOR`/`deserialiseFromCBOR` to `cardano-ledger-binary` across all call sites (FR-004)
+- [ ] T031 Switch bech32 serialization to direct `bech32` library (FR-004)
+
+### C4: Certificate + tx construction + submission swaps
+
+- [ ] T032 Switch certificate construction to `cardano-ledger-api` in `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs` (FR-006)
+- [ ] T033 Switch certificate construction in API-layer delegation/voting handlers in `lib/api/` (FR-006)
+- [ ] T034 Switch tx body construction from `TxBodyContent`/`createTransactionBody` to ledger-native in `lib/wallet/` (FR-010)
+- [ ] T035 Switch submission from `toConsensusGenTx` to `mkShelleyTx` + `HardForkGenTx` in `lib/network-layer/` (FR-009)
+- [ ] T036 Switch Byron-era tx handling from `Cardano.Api.Byron` to ledger-native in all packages (FR-014)
+
+### C5: Test generator swaps
+
+- [ ] T037 Switch generators in `lib/unit/` from `Cardano.Api.Gen` to ledger testlib / wallet-native (FR-011)
+- [ ] T038 Switch generators in `lib/integration/` (FR-011)
+
+**Checkpoint**: No code uses cardano-api. `cardano-api` still in `build-depends` but all imports gone.
+
+---
+
+## Phase D: Remove Old Paths (atomic commit)
+
+Single commit. Everything removed at once.
+
+- [ ] T039 Delete old `SealedTx` constructor (`InAnyCardanoEra` path), `networkIdVal` bridge, era bridge functions, `toConsensusGenTx` wrapper, old tx body construction, old certificate helpers
+- [ ] T040 Remove all remaining `Cardano.Api` imports (should be zero, but verify)
+- [ ] T041 Remove `cardano-api` from `build-depends` in all `.cabal` files
+- [ ] T042 Remove `cardano-api` constraints from `cabal.project`
+- [ ] T043 Delete `lib/cardano-api-extra/` directory
+
+**Checkpoint**: `cardano-api` gone from the build. Project compiles. All tests pass.
+
+---
+
+## Phase E: Verification
+
+- [ ] T044 Verify `cardano-api` absent from `cabal build all --dry-run` transitive closure (SC-001)
+- [ ] T045 Verify zero `Cardano.Api` imports across codebase (SC-007)
+- [ ] T046 Run API golden tests — no response format changes (SC-004)
+- [ ] T047 Load database snapshot from pre-removal version, verify all data loads (SC-005)
+- [ ] T048 Verify Byron-era transactions in database deserialize correctly
+- [ ] T049 Verify TxMetadata JSON round-trips identically through new path
+- [ ] T050 Run benchmarks, compare with pre-removal baseline (FR-013)
+- [ ] T051 Run `just ci` — full lint + build + test pass
+
+---
+
+## Dependencies
+
+```
+Phase A (pin bump)
+  ↓
+Phase B (add new paths) — all tasks parallel
+  ↓
+Phase C (migrate consumers) — C1 parallel per-package, then C2→C3→C4→C5 sequential
+  ↓
+Phase D (atomic removal) — single commit
+  ↓
+Phase E (verification) — all tasks parallel
+```
+
+Within Phase C, the ordering matters:
+- C1 (re-exports) before C2 (era types) — fewer import conflicts
+- C2 (era types) before C3 (core types) — SealedTx rewrite needs new era types
+- C3 (core types) before C4 (tx construction) — tx building uses SealedTx and TxMetadata
+- C4 before C5 (generators) — generators produce the new types


### PR DESCRIPTION
## Summary

**Foundation layer** of the cardano-api removal (phase A of the split of #5236). Adds wallet-owned types and ledger-native builders **without switching any existing call site** — the new code paths exist alongside the cardano-api paths and are only exercised by the new test duplicate. Low risk, reviewable in one sitting.

Companion PR (call-site migration) will be opened against this branch once merged. The review-response commit also tightens one existing address-network-tag helper to delegate the mainnet/testnet bit to ledger, with unchanged semantics.

## What lands here (15 commits, all bisect-safe)

| # | SHA | Purpose |
|---|---|---|
| 1–4 | docs | spec / plan / tasks artifacts (speckit) under `specs/001-drop-cardano-api/` |
| 5 | `7307a0fe` | Add the initial `SNetworkId n -> Ledger.Network` conversion, now exposed as `sNetworkIdToLedger` after review feedback |
| 6 | `e1a1acaf` | Rewrite `SealedTx` internals to `EraValue Read.Tx` (previous cardano-api reconstruction helpers retained as temporary bridges) |
| 7 | `fd5fe22f` | Replace `Cardano.Api.NetworkId` with wallet-owned `NetworkId` in 4 files |
| 8 | `393eaa28` | Add wallet-owned `TxMetadata` module (`lib/primitive/.../Types/Tx/TxMetadata.hs`) with JSON schema conversion ported from cardano-api |
| 9 | `92a7699d` | Add `Transaction.Build.mkLedgerTx` — builds a ledger `Tx era` from its components using `mkBasicTxBody` + lenses |
| 10 | `726656ab` | Add `Transaction.Ledger` — ledger-native tx construction (`mkTransactionLedger`, `constructUnsignedTxLedger`, `buildLedgerTx`, `TxPayload`, `mkRewardAccount`) |
| 11 | `68e441c5` | Complete `Transaction.Ledger` exports |
| 12 | `13e76caa` | Duplicate `TransactionSpec.hs` → `TransactionLedgerSpec.hs` as baseline for exercising the new builder in tests |
| 13 | `984e8177` | Add ledger-native cert helpers: `certificateFromDelegationActionLedger`, `certificateFromVotingActionLedger`, `toLedgerStakeCred`, `toLedgerCoin` |
| 14 | `d8e74e41` | Wire ledger-native witness construction (`mkShelleyWitnessLedger`, `mkByronWitnessLedger`) into `TransactionLedgerSpec` |
| 15 | `2e210821` | Address reviewer feedback: use `Ledger.networkToWord8` for address network tags; document wallet `NetworkId` vs ledger `Network`; try Dijkstra in ledger-native `SealedTx` decode; document why `TxMetadata` keeps the wallet/cardano-api-compatible surface while converting to ledger metadata internally |

## Ledger 1.19/1.20 adaptations applied

- `Ledger.Tx era` → `Write.Tx era` (balance-tx's `type Tx era = Core.Tx Core.TopTx era` alias for the 1.19 `TxLevel` kind lift)
- `Ledger.TxBody era` → `Write.TxBody era`
- `Ledger.RewardAccount` pattern synonym → `Ledger.AccountAddress (Ledger.AccountId …)` (1.20 rename)
- `KeyRole (Witness)` import → `Keys.Witness` qualified (1.20 reorg — `Witness` is a standalone type, not a `KeyRole` data constructor)
- `hashAnnotated body` → `hashAnnotated @_ @EraIndependentTxBody body` (1.20 `HashAnnotated x i | x -> i` functional dep can't resolve through `Write.TxBody era` type synonym)

## What is NOT in this PR

- No transaction construction, `balanceTx`, signing, cert construction, or `TxMetadata` consumer migration lands here. Those paths still go through cardano-api; the new ledger-native paths sit alongside for now. The only existing-path tweak is the equivalent `postAnyAddress` network tag helper change from manual 1/0 matching to `Ledger.networkToWord8`.
- No bridges are added or removed: `Cardano.Api.Extra` shim, `sealWriteTx`, and `certToLedger`/`unCert` helpers are untouched.
- No cabal changes to drop `cardano-api` (the dependency is still pulled in by the unchanged call sites).

## Per-commit CI gate

The original 14 commits were gated through `fourmolu --mode check` + `hlint lib` + `nix build .#cardano-wallet` and PASS individually.

The review-response commit `2e210821` was checked with direct Fourmolu on the touched Haskell files and a library-only Cabal build of `cardano-wallet-primitive`, `cardano-wallet-api`, and `cardano-wallet` inside `nix develop`. The stricter `just build` path currently stops in pre-existing `cardano-wallet-read` warnings promoted to errors before reaching the changed modules.

## Test plan

Review response:
- [x] `nix develop --command fourmolu --mode check` on touched Haskell files
- [x] `nix develop --command cabal build lib:cardano-wallet-primitive lib:cardano-wallet-api lib:cardano-wallet -O0 -v0`
- [ ] `nix develop --command just build 'cardano-wallet-primitive cardano-wallet-api cardano-wallet'` with `-Werror` is blocked by pre-existing `cardano-wallet-read` warnings

Original branch:

- [x] `nix build .#cardano-wallet` succeeds at every commit (bisect-safe)
- [x] `fourmolu --mode check` clean
- [x] `hlint lib` no hints
- [x] Full `build-gate (Linux)` CI on the previous tip before review-response commit
- [ ] Full CI on the new review-response tip
- [x] `unit-cardano-wallet-unit` test suite (deferred to CI)


