### PR TITLE
feat: decommission SealedTx cardano-api surface (follow-up to #5236)

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -632,11 +632,13 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
     , TxChange (..)
     , UnsignedTx (..)
-    , getSealedTxWitnesses
     , serialisedTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txMintBurnMaxTokenQuantity
+    )
+import Cardano.Wallet.Primitive.Types.Tx.SealedTx
+    ( sealedTxWitnessCount
     )
 import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo
@@ -4052,7 +4054,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
                 $ L.nubBy samePaymentKey
                 $ filter isInpOurs
                 $ (apiDecoded ^. #inputs) ++ (apiDecoded ^. #collateral)
-    let totalNumberOfWits = length $ getSealedTxWitnesses sealedTx
+    let totalNumberOfWits = sealedTxWitnessCount sealedTx
 
     when (countJoinsQuits (apiDecoded ^. #certificates) > 1)
         $ liftHandler
@@ -4218,7 +4220,7 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                     $ L.nubBy samePaymentKey
                     $ filter isInpOurs
                     $ (apiDecoded ^. #inputs) ++ (apiDecoded ^. #collateral)
-        let totalNumberOfWits = length $ getSealedTxWitnesses sealedTx
+        let totalNumberOfWits = sealedTxWitnessCount sealedTx
         let paymentWitsRequired =
                 fromIntegral pWitsPerInput * witsRequiredForInputs
         let allWitsRequired =

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -173,7 +173,8 @@ import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
     )
 import Cardano.Ledger.Binary
-    ( serialize'
+    ( DecoderError
+    , serialize'
     , shelleyProtVer
     )
 import Cardano.Mnemonic
@@ -181,6 +182,9 @@ import Cardano.Mnemonic
     )
 import Cardano.Pool.Types
     ( PoolId
+    )
+import Cardano.Read.Ledger.Tx.CBOR
+    ( deserializeTx
     )
 import Cardano.Wallet
     ( BuiltTx (..)
@@ -628,8 +632,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
     , TxChange (..)
     , UnsignedTx (..)
-    , cardanoTxInExactEra
     , getSealedTxWitnesses
+    , serialisedTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txMintBurnMaxTokenQuantity
@@ -867,7 +871,7 @@ import qualified Cardano.Balance.Tx.Balance as Write
     )
 import qualified Cardano.Balance.Tx.Eras as Write
     ( IsRecentEra (recentEra)
-    , RecentEra
+    , RecentEra (..)
     )
 import qualified Cardano.Balance.Tx.Sign as Write
     ( TimelockKeyWitnessCounts (..)
@@ -920,6 +924,7 @@ import qualified Cardano.Wallet.Registry as Registry
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -3793,23 +3798,29 @@ balanceTransaction ctx (ApiT wid) body = do
                     $ map fromExternalInput
                     $ body ^. #inputs
 
-        tx <-
-            maybe
-                ( liftHandler
+        let sealedTx = getApiT $ body ^. #transaction
+            bytes = BL.fromStrict (serialisedTx sealedTx)
+            readErr :: forall a. Handler a
+            readErr =
+                liftHandler
                     . throwE
                     . W.ErrPartialTxNotInNodeEra
                     $ AnyRecentEra era
-                )
-                pure
-                . cardanoTxInExactEra (cardanoEraFromRecentEra era)
-                . getApiT
-                $ body ^. #transaction
+        ledgerTx <- case era of
+            Write.RecentEraConway ->
+                case deserializeTx bytes :: Either DecoderError (Read.Tx Read.Conway) of
+                    Right (Read.Tx t) -> pure t
+                    Left _ -> readErr
+            Write.RecentEraDijkstra ->
+                case deserializeTx bytes :: Either DecoderError (Read.Tx Read.Dijkstra) of
+                    Right (Read.Tx t) -> pure t
+                    Left _ -> readErr
 
         case mExternalUTxO of
             Right externalUTxO ->
                 pure
                     $ Write.PartialTx
-                        (fromCardanoApiTx tx)
+                        ledgerTx
                         externalUTxO
                         (fromApiRedeemer <$> body ^. #redeemers)
                         (Write.StakeKeyDepositMap mempty)

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -141,6 +141,7 @@ library scenarios
     , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-core
+    , cardano-ledger-read
     , cardano-protocol-tpraos
     , cardano-wallet
     , cardano-wallet-api

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -193,7 +193,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMetadata (..)
     , TxMetadataValue (..)
     , TxScriptValidity (..)
-    , cardanoTxIdeallyNoLaterThan
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)
@@ -372,19 +371,22 @@ import Prelude
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Read.Ledger.Tx.Metadata as Meta
+    ( getEraMetadata
+    )
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
-import qualified Cardano.Wallet.Api.Types.Era as ApiEra
-    ( toAnyCardanoEra
-    )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Metadata as Meta
+    ( getMetadata
+    )
 import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxMetadata as W
-    ( fromShelleyMetadata
-    , metadataValueToJsonNoSchema
+    ( metadataValueToJsonNoSchema
     )
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BL
@@ -480,10 +482,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let ApiSerialisedTransaction apiTx _ = getFromResponse #transaction rTx
         signedTx <- signTx ctx wa apiTx [expectResponseCode HTTP.status202]
 
-        let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
-        let tx =
-                cardanoTxIdeallyNoLaterThan era
-                    $ getApiT (signedTx ^. #serialisedTxSealed)
+        let tx = getApiT (signedTx ^. #serialisedTxSealed)
         case getMetadataFromTx tx of
             Nothing -> error "Tx doesn't include metadata"
             Just m -> case Map.lookup 1 m of
@@ -554,10 +553,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             let ApiSerialisedTransaction apiTx _ = getFromResponse #transaction rTx
             signedTx <- signTx ctx wa apiTx [expectResponseCode HTTP.status202]
 
-            let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
-            let tx =
-                    cardanoTxIdeallyNoLaterThan era
-                        $ getApiT (signedTx ^. #serialisedTxSealed)
+            let tx = getApiT (signedTx ^. #serialisedTxSealed)
             case getMetadataFromTx tx of
                 Nothing -> error "Tx doesn't include metadata"
                 Just m -> case Map.lookup 1 m of
@@ -713,10 +709,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 ]
             let ApiSerialisedTransaction apiTx _ = getFromResponse #transaction rTx
             signedTx <- signTx ctx wa apiTx [expectResponseCode HTTP.status202]
-            let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
-            let tx =
-                    cardanoTxIdeallyNoLaterThan era
-                        $ getApiT (signedTx ^. #serialisedTxSealed)
+            let tx = getApiT (signedTx ^. #serialisedTxSealed)
 
             let extractTxt (TxMetaText txt) = txt
                 extractTxt _ =
@@ -6728,18 +6721,14 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     toBase64 = T.decodeUtf8 . convertToBase Base64
 
-    -- Check for the presence of metadata on signed transaction
+    -- Check for the presence of metadata on signed transaction.
+    -- Ledger-native: does not round-trip through cardano-api.
     getMetadataFromTx
-        :: InAnyCardanoEra Cardano.Tx
+        :: SealedTx
         -> Maybe (Map.Map Word64 TxMetadataValue)
-    getMetadataFromTx (InAnyCardanoEra _ tx) =
-        Cardano.getTxBody tx
-            & \body ->
-                Cardano.txMetadata (Cardano.getTxBodyContent body) & \case
-                    Cardano.TxMetadataNone ->
-                        Nothing
-                    Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
-                        Just (W.fromShelleyMetadata (Cardano.toShelleyMetadata m))
+    getMetadataFromTx sealed = case unsafeReadTx sealed of
+        Read.EraValue (readTx :: Read.Tx era) ->
+            unTxMetadata <$> Meta.getMetadata (Meta.getEraMetadata readTx)
 
     -- Construct a JSON payment request for the given quantity of lovelace.
     mkTxPayload
@@ -7379,10 +7368,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
         let ApiSerialisedTransaction apiTx _ = getFromResponse #transaction rTx
         signedTx <- signTx ctx wa apiTx [expectResponseCode HTTP.status202]
-        let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
-        let tx =
-                cardanoTxIdeallyNoLaterThan era
-                    $ getApiT (signedTx ^. #serialisedTxSealed)
+        let tx = getApiT (signedTx ^. #serialisedTxSealed)
 
         let extractTxt (TxMetaText txt) = txt
             extractTxt _ =

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -385,7 +385,6 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Read as Read
 import qualified Codec.CBOR.Term as CBOR
-import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -638,8 +637,8 @@ withNodeNetworkLayerBase
 
         -- NOTE: only shelley-era transactions can be submitted: the stored
         -- 'EraValue Read.Tx' carries the era so no query is needed.
-        _postSealedTx txSubmissionQueue tx = do
-            liftIO $ traceWith tr $ MsgPostTx $ BS.fromStrict $ serialisedTx tx
+        -- Logging is handled by 'postTxToQueue'.
+        _postSealedTx txSubmissionQueue tx =
             case unsafeReadTx tx of
                 Read.EraValue readTx ->
                     postTxToQueue tr txSubmissionQueue readTx

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -38,7 +38,6 @@ import Cardano.Api
     , CardanoEra (..)
     , NodeToClientVersion (..)
     , SlotNo (..)
-    , toConsensusGenTx
     )
 import Cardano.BM.Data.Severity
     ( Severity (..)
@@ -113,10 +112,8 @@ import Cardano.Wallet.Primitive.Ledger.Read.Eras
     ( fromAnyCardanoEra
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( UnsealException (..)
-    , nodeToClientVersions
+    ( nodeToClientVersions
     , toCardanoEra
-    , unsealShelleyTx
     )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter
@@ -523,7 +520,7 @@ withNodeNetworkLayerBase
                     slottingParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
                 , postSealedTx =
-                    _postSealedTx txSubmissionQ readCurrentNodeEra
+                    _postSealedTx txSubmissionQ
                 , postTx =
                     postTxToQueue tr txSubmissionQ
                 , stakeDistribution =
@@ -639,27 +636,13 @@ withNodeNetworkLayerBase
                 cont $ atomically . putTMVar var
                 atomically $ readTMVar var
 
-        -- NOTE1: only shelley transactions can be submitted like this, because they
-        -- are deserialised as shelley transactions before submitting.
-        --
-        -- NOTE2: It is not ideal to query the current era again here because we
-        -- should in practice use the same era as the one used to construct the
-        -- transaction. However, when turning transactions to 'SealedTx', we loose
-        -- all form of type-level indicator about the era. The 'SealedTx' type
-        -- shouldn't be needed anymore since we've dropped jormungandr, so we could
-        -- instead carry a transaction from cardano-api types with proper typing.
-        _postSealedTx txSubmissionQueue readCurrentEra tx = do
+        -- NOTE: only shelley-era transactions can be submitted: the stored
+        -- 'EraValue Read.Tx' carries the era so no query is needed.
+        _postSealedTx txSubmissionQueue tx = do
             liftIO $ traceWith tr $ MsgPostTx $ BS.fromStrict $ serialisedTx tx
-            preferredEra <- liftIO readCurrentEra
-            case unsealShelleyTx preferredEra tx of
-                Left (UnsealedTxInUnsupportedEra era) ->
-                    throwE $ ErrPostTxEraUnsupported era
-                Right tx' -> do
-                    let cmd = CmdSubmitTx . toConsensusGenTx $ tx'
-                    liftIO (send txSubmissionQueue cmd) >>= \case
-                        SubmitSuccess -> pure ()
-                        SubmitFail e ->
-                            throwE $ ErrPostTxValidationError $ T.pack $ show e
+            case unsafeReadTx tx of
+                Read.EraValue readTx ->
+                    postTxToQueue tr txSubmissionQueue readTx
 
         _stakeDistribution queue coin = do
             liftIO $ traceWith tr $ MsgWillQueryRewardsForStake coin

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -41,7 +41,6 @@ module Cardano.Wallet.Primitive.Ledger.Shelley
 
       -- * Conversions
     , toCardanoHash
-    , unsealShelleyTx
     , toCardanoTxId
     , toCardanoTxIn
     , fromCardanoTxIn
@@ -94,9 +93,6 @@ module Cardano.Wallet.Primitive.Ledger.Shelley
     , interval0
     , interval1
     , numberOfTransactionsInBlock
-
-      -- * Errors
-    , UnsealException (..)
     ) where
 
 import Cardano.Address.KeyHash
@@ -116,7 +112,6 @@ import Cardano.Api
     , NetworkId
     , ShelleyBasedEra (..)
     , ShelleyGenesis (..)
-    , TxInMode (..)
     )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash)
@@ -304,7 +299,6 @@ import qualified Cardano.Ledger.State as Ledger
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
-import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.AssetId as W
@@ -329,10 +323,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
-    ( SealedTx
-    , cardanoTxIdeallyNoLaterThan
-    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
     ( Tx (..)
     )
@@ -1118,28 +1108,6 @@ rewardAccountFromAddress (W.Address bytes) = refToAccount . ref =<< parseAddr by
     refToAccount (SL.StakeRefBase cred) = Just $ fromStakeCredential cred
     refToAccount (SL.StakeRefPtr _) = Nothing
     refToAccount SL.StakeRefNull = Nothing
-
-newtype UnsealException
-    = UnsealedTxInUnsupportedEra (Read.EraValue Read.Era)
-
--- | Converts 'SealedTx' to something that can be submitted with the
--- 'Cardano.Api' local tx submission client.
-unsealShelleyTx
-    :: Read.EraValue Read.Era
-    -- ^ Preferred latest era (see 'ideallyNoLaterThan')
-    -> W.SealedTx
-    -> Either UnsealException TxInMode
-unsealShelleyTx era wtx =
-    case W.cardanoTxIdeallyNoLaterThan (Eras.toAnyCardanoEra era) wtx of
-        Cardano.InAnyCardanoEra BabbageEra tx ->
-            Right $ TxInMode ShelleyBasedEraBabbage tx
-        Cardano.InAnyCardanoEra ConwayEra tx ->
-            Right $ TxInMode ShelleyBasedEraConway tx
-        Cardano.InAnyCardanoEra unsupportedEra _ ->
-            Left
-                $ UnsealedTxInUnsupportedEra
-                $ Eras.fromAnyCardanoEra
-                $ AnyCardanoEra unsupportedEra
 
 instance
     (forall era. IsCardanoEra era => Show (thing era))

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -26,7 +26,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , ScriptWitnessIndex (..)
 
       -- * Serialisation
-    , SealedTx (serialisedTx)
+    , SealedTx (serialisedTx, unsafeReadTx)
     , cardanoTxIdeallyNoLaterThan
     , cardanoTxInExactEra
     , sealedTxFromBytes

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -28,7 +28,6 @@ module Cardano.Wallet.Primitive.Types.Tx
       -- * Serialisation
     , SealedTx (serialisedTx, unsafeReadTx)
     , cardanoTxIdeallyNoLaterThan
-    , cardanoTxInExactEra
     , sealedTxFromBytes
     , sealedTxFromBytes'
     , sealedTxFromCardano
@@ -84,7 +83,6 @@ import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( SealedTx (..)
     , SerialisedTx (..)
     , cardanoTxIdeallyNoLaterThan
-    , cardanoTxInExactEra
     , getSealedTxBody
     , getSealedTxWitnesses
     , mockSealedTx

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -29,6 +29,7 @@ module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     , SerialisedTx (..)
     , getSealedTxBody
     , getSealedTxWitnesses
+    , sealedTxWitnessCount
     , persistSealedTx
     , unPersistSealedTx
 
@@ -48,6 +49,11 @@ import Cardano.Api
 import Cardano.Api.Tx
     ( Tx (ShelleyTx)
     )
+import Cardano.Ledger.Api
+    ( addrTxWitsL
+    , bootAddrTxWitsL
+    , witsTxL
+    )
 import Cardano.Ledger.Binary
     ( DecoderError
     )
@@ -64,9 +70,11 @@ import Cardano.Wallet.Read.Eras
     , Babbage
     , Conway
     , Dijkstra
+    , Era (..)
     , IsEra
     , Mary
     , Shelley
+    , theEra
     )
 import Cardano.Wallet.Util
     ( HasCallStack
@@ -75,6 +83,9 @@ import Cardano.Wallet.Util
 import Control.DeepSeq
     ( NFData (..)
     , deepseq
+    )
+import Control.Lens
+    ( (^.)
     )
 import Data.Bifunctor
     ( first
@@ -110,6 +121,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Set as Set
 import qualified Data.Text as T
 
 -- | 'SealedTx' is a transaction for any hard fork era,
@@ -224,6 +236,30 @@ getSealedTxWitnesses stx =
                 $ "getSealedTxWitnesses: "
                 +|| e
                 ||+ ""
+
+-- | Total number of key witnesses (VKey + bootstrap) in
+-- a 'SealedTx'. Ledger-native: does not round-trip
+-- through cardano-api.
+--
+-- Equivalent of @length (getSealedTxWitnesses stx)@ for
+-- the wallet's fee / witness-count accounting. Byron txs
+-- are counted as 0 — the wallet does not construct Byron
+-- txs through 'SealedTx'.
+sealedTxWitnessCount :: SealedTx -> Int
+sealedTxWitnessCount stx = case unsafeReadTx stx of
+    EraValue (Read.Tx tx :: Read.Tx era) -> case theEra @era of
+        Byron -> 0
+        Shelley -> countLedgerTxWits tx
+        Allegra -> countLedgerTxWits tx
+        Mary -> countLedgerTxWits tx
+        Alonzo -> countLedgerTxWits tx
+        Babbage -> countLedgerTxWits tx
+        Conway -> countLedgerTxWits tx
+        Dijkstra -> countLedgerTxWits tx
+  where
+    countLedgerTxWits tx =
+        Set.size (tx ^. witsTxL . addrTxWitsL)
+            + Set.size (tx ^. witsTxL . bootAddrTxWitsL)
 
 -- | Convert a cardano-api 'Tx' to 'EraValue Read.Tx'.
 cardanoApiTxToReadTx

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -19,7 +19,6 @@ module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( -- * Types
       SealedTx (serialisedTx, unsafeReadTx)
     , cardanoTxIdeallyNoLaterThan
-    , cardanoTxInExactEra
     , sealedTxFromBytes
     , sealedTxFromBytes'
     , sealedTxFromCardano
@@ -84,9 +83,6 @@ import Data.ByteArray
     )
 import Data.ByteString
     ( ByteString
-    )
-import Data.Data
-    ( Proxy (..)
     )
 import Data.Either
     ( partitionEithers
@@ -191,25 +187,6 @@ cardanoTxIdeallyNoLaterThan maxEra stx =
                         $ "cardanoTxIdeallyNoLaterThan: "
                         +|| e
                         ||+ ""
-
--- | Re-deserialises the bytes of the 'SealedTx' as a
--- transaction in the provided era, and that era only.
-cardanoTxInExactEra
-    :: forall era
-     . Cardano.IsShelleyBasedEra era
-    => CardanoEra era
-    -> SealedTx
-    -> Maybe (Cardano.Tx era)
-cardanoTxInExactEra _ tx =
-    eitherToMaybe
-        $ deserialiseFromCBOR
-            ( Cardano.AsTx
-                (Cardano.proxyToAsType $ Proxy @era)
-            )
-        $ serialisedTx tx
-  where
-    eitherToMaybe :: Either a b -> Maybe b
-    eitherToMaybe = either (const Nothing) Just
 
 -- | Temporary: reconstructs cardano-api TxBody from
 -- bytes. Will be removed when callers migrate.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     , sealedTxFromCardano
     , sealedTxFromCardano'
     , sealedTxFromCardanoBody
+    , sealedTxFromLedgerTx
     , unsafeSealedTxFromBytes
     , SerialisedTx (..)
     , getSealedTxBody
@@ -52,6 +53,7 @@ import Cardano.Ledger.Binary
     )
 import Cardano.Read.Ledger.Tx.CBOR
     ( deserializeTx
+    , serializeTx
     )
 import Cardano.Wallet.Read
     ( EraValue (..)
@@ -410,6 +412,16 @@ withinEra = (>=) `on` numberEra
         BabbageEra -> 6
         ConwayEra -> 7
         _ -> 8
+
+-- | Construct a 'SealedTx' from a ledger-native
+-- 'Read.Tx'. Serialises to CBOR via ledger-read;
+-- bypasses cardano-api entirely.
+sealedTxFromLedgerTx
+    :: forall era
+     . Read.IsEra era
+    => Read.Tx era -> SealedTx
+sealedTxFromLedgerTx tx =
+    SealedTx True (EraValue tx) (BL.toStrict (serializeTx tx))
 
 -- | Deserialise a transaction to construct a
 -- 'SealedTx'.

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -1436,10 +1436,8 @@ encodingFromTheFuture tx current = shelleyEraNum tx > eraNum current
 compareOnCBOR
     :: Cardano.IsShelleyBasedEra era
     => Cardano.Tx era -> SealedTx -> Property
-compareOnCBOR b sealed = case cardanoTx sealed of
-    InAnyCardanoEra era a ->
-        unsafeWithShelleyBasedEra era
-            $ Cardano.serialiseToCBOR a ==== Cardano.serialiseToCBOR b
+compareOnCBOR b sealed =
+    serialisedTx sealed ==== Cardano.serialiseToCBOR b
 
 unsafeWithShelleyBasedEra
     :: Cardano.CardanoEra era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -58,10 +58,6 @@ import Cardano.Address.KeyHash
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Api.Extra
-    ( cardanoApiEraConstraints
-    , toCardanoApiTx
-    )
 import Cardano.Balance.Tx.Eras
     ( IsRecentEra
     , RecentEra (..)
@@ -145,10 +141,12 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx
-    , sealedTxFromCardano'
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxTokenQuantity
+    )
+import Cardano.Wallet.Primitive.Types.Tx.SealedTx
+    ( sealedTxFromLedgerTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( TxMetadata
@@ -583,14 +581,14 @@ mkRewardAccount network acct =
 -- restructured.
 sealWriteTx
     :: forall era
-     . IsRecentEra era
-    => RecentEra era
+     . RecentEra era
     -> Write.Tx era
     -> SealedTx
-sealWriteTx era tx =
-    cardanoApiEraConstraints era
-        $ sealedTxFromCardano'
-        $ toCardanoApiTx tx
+sealWriteTx era tx = case era of
+    RecentEraConway ->
+        sealedTxFromLedgerTx (Read.Tx tx :: Read.Tx Read.Conway)
+    RecentEraDijkstra ->
+        sealedTxFromLedgerTx (Read.Tx tx :: Read.Tx Read.Dijkstra)
 
 -- | Project a 'Cardano.NetworkId' onto the ledger's
 -- 'Network' (magic-free) for cert / withdrawal construction.

--- a/specs/002-decommission-sealedtx/plan.md
+++ b/specs/002-decommission-sealedtx/plan.md
@@ -1,0 +1,61 @@
+# Decommission `SealedTx.hs` cardano-api surface
+
+Follow-up to PR #5236. Removes the remaining three `Cardano.Api*`
+imports from `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs`
+by eliminating the bridge functions they support.
+
+## Current cardano-api surface in `SealedTx.hs`
+
+| Symbol | Uses cardano-api for | External callers |
+|---|---|---|
+| `cardanoTxIdeallyNoLaterThan`, `cardanoTxInExactEra` | `deserialiseFromCBOR` of `InAnyCardanoEra Cardano.Tx` | `Shelley/Transaction.hs`, `Ledger/Shelley.hs`, `Server.hs`, integration tests |
+| `sealedTxFromCardano`, `sealedTxFromCardano'` | accept `Cardano.Tx` / `InAnyCardanoEra Cardano.Tx` | `Wallet.hs`, `Transaction.Ledger.hs`, `Shelley.Transaction.hs`, API server, tests |
+| `sealedTxFromCardanoBody` | constructor from `Cardano.TxBody` | old tx path in `Shelley.Transaction.hs` |
+| `getSealedTxBody`, `getSealedTxWitnesses` | re-extract `Cardano.TxBody` / `Cardano.KeyWitness` | signing in `Shelley.Transaction.hs`, API redeemer accounting, tests |
+| `cardanoApiTxToReadTx` | `ShelleyTx`-dispatched projection to `EraValue Read.Tx` | only called from `sealedTxFromCardano` / `sealedTxFromCardano'` |
+
+## Plan
+
+Each step is a standalone bisect-safe commit.
+
+1. **Caller-side reader swap.** Replace `cardanoTxIdeallyNoLaterThan` and
+   `cardanoTxInExactEra` call sites with
+   `Cardano.Read.Ledger.Tx.CBOR.deserializeTx`. The helpers remain in
+   `SealedTx.hs` but lose external callers.
+
+2. **Delete `sealedTxFromCardano` / `sealedTxFromCardano'` /
+   `sealedTxFromCardanoBody`.** Every producer of a `Cardano.Tx` /
+   `Cardano.TxBody` today already has the CBOR bytes in hand. Replace
+   with `sealedTxFromBytes`. This also kills the only caller of
+   `cardanoApiTxToReadTx`.
+
+3. **Delete `getSealedTxBody` / `getSealedTxWitnesses`.** Gated on
+   deletion of the old `Shelley.Transaction.hs` signing path. API /
+   tests read the same information via `EraValue Read.Tx` accessors.
+
+4. **Delete `cardanoApiTxToReadTx` + `cardanoTxFromBytes` private
+   helpers.** They have no callers after steps 1–3.
+
+5. **Remove `Cardano.Api` + `Cardano.Api.Tx` imports from `SealedTx.hs`.**
+   The module's only remaining external types are `Cardano.Ledger.Binary`,
+   `Cardano.Read.Ledger.Tx.CBOR`, and `Cardano.Wallet.Read`. Note:
+   `cardano-api` stays in `lib/primitive/cardano-wallet-primitive.cabal`
+   until the other 7 primitive-layer files also shed their imports —
+   out of scope for this PR.
+
+## Not in this PR
+
+- Deleting `lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs` and
+  the other legacy modules (`Delegation.hs`, `Voting.hs`). That's the
+  parallel transaction-layer swap — tracked in #5243.
+- Removing `cardano-api` from the `cardano-wallet-primitive` cabal
+  dependency list. Blocked on steps above plus the other 7 primitive
+  modules.
+- Removing `lib/cardano-api-extra/`. Phase D of #5237.
+
+## Acceptance criteria
+
+- [ ] `grep -n "^import.*Cardano\.Api" lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs` returns 0 results.
+- [ ] Every commit builds `nix build .#cardano-wallet .#unit-cardano-wallet-unit`.
+- [ ] Every commit passes `fourmolu --mode check` and `hlint lib`.
+- [ ] Conway integration tests green on final tip.


### PR DESCRIPTION
## Summary

Progress toward removing `Cardano.Api*` from `Cardano.Wallet.Primitive.Types.Tx.SealedTx`. Moves the first set of production and test call sites off the deprecated surface. Follow-up #5272 now finishes the remaining SealedTx cleanup.

Base branch: `001-drop-cardano-api` (#5236).
Rebased after #5270 merged and #5236 was rebased onto `master`.

## What this PR does

Eight bisect-safe commits:

| # | SHA | Effect |
|---|---|---|
| 1 | `04d65b2` | `docs`: plan document for the decommission series |
| 2 | `b4b87af` | Test helper `compareOnCBOR` -> raw `serialisedTx` bytes, avoiding a cardano-api roundtrip |
| 3 | `282807d` | Submission path `_postSealedTx` -> `EraValue Read.Tx` + `consensusGenTxFromTxRecent`; deletes `unsealShelleyTx` / `UnsealException` |
| 4 | `a6d0c9d` | `parsePartialTx` -> `deserializeTx :: Either DecoderError (Read.Tx era)` per era |
| 5 | `f1ba908` | Delete `cardanoTxInExactEra` after the callers are gone |
| 6 | `55f2bd9` | Add `sealedTxFromLedgerTx :: Read.IsEra era => Read.Tx era -> SealedTx`; migrate `sealWriteTx` off `toCardanoApiTx`/`sealedTxFromCardano'` |
| 7 | `e6feabc` | Add `sealedTxWitnessCount :: SealedTx -> Int` via ledger witnesses; migrate Server.hs away from `getSealedTxWitnesses` |
| 8 | `c2ca434` | Integration test `getMetadataFromTx` -> `Meta.getMetadata . Meta.getEraMetadata` on `EraValue Read.Tx` |

New ledger-native surface added to `SealedTx`:

- `sealedTxFromLedgerTx :: Read.IsEra era => Read.Tx era -> SealedTx`
- `sealedTxWitnessCount :: SealedTx -> Int`

Deleted:

- `cardanoTxInExactEra`
- `Cardano.Wallet.Primitive.Ledger.Shelley.unsealShelleyTx` / `UnsealException`

## What this PR does not do

The deprecated SealedTx cardano-api exports are removed in #5272, not here.

Out of scope:

- Removing `cardano-api` from `cardano-wallet-primitive.cabal`.
- Removing `lib/cardano-api-extra/`.

## Test plan

- [x] Rebased cleanly onto updated #5236 after #5270 merged (2026-04-25).
- [ ] CI green on the rebased tip.
