### PR TITLE
feat: finish SealedTx cardano-api decommission (follow-up to #5271)

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -161,9 +161,7 @@ import Cardano.Address.Script
 
 import Cardano.Api.Extra
     ( cardanoApiEraConstraints
-    , cardanoEraFromRecentEra
     , fromCardanoApiTx
-    , toCardanoApiTx
     )
 import Cardano.BM.Tracing
     ( HasPrivacyAnnotation (..)
@@ -672,6 +670,9 @@ import Cardano.Wallet.Registry
 import Cardano.Wallet.Shelley.Transaction
     ( TxWitnessTag
     )
+import Cardano.Wallet.Shelley.Transaction.Ledger
+    ( sealWriteTx
+    )
 import Cardano.Wallet.TokenMetadata
     ( TokenMetadataClient
     , fillMetadata
@@ -908,7 +909,6 @@ import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
     ( SealedTx
-    , sealedTxFromCardano
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
     ( TxMetadata
@@ -3585,7 +3585,8 @@ constructSharedTransaction
                     apiDecoded <-
                         decodeSharedTransaction api (ApiT wid)
                             $ ApiDecodeTransactionPostData
-                                { transaction = ApiT (sealWriteTx balancedTx)
+                                { transaction =
+                                    ApiT (sealWriteTx Write.recentEra balancedTx)
                                 , decrypt_metadata = Nothing
                                 }
                     let deposits = case optionalDelegationAction of
@@ -5522,17 +5523,6 @@ fromApiRedeemer = \case
                 (sNetworkIdToLedger (sNetworkId @n))
                 (Ledger.AccountId (toLedgerStakeCredential acct))
 
-sealWriteTx
-    :: forall era. Write.IsRecentEra era => Write.Tx era -> W.SealedTx
-sealWriteTx =
-    cardanoApiEraConstraints era'
-        $ W.sealedTxFromCardano
-            . Cardano.InAnyCardanoEra cardanoEra
-            . toCardanoApiTx
-  where
-    era' = Write.recentEra :: Write.RecentEra era
-    cardanoEra = cardanoEraFromRecentEra era'
-
 toApiSerialisedTransaction
     :: Write.IsRecentEra era
     => Maybe ApiSealedTxEncoding
@@ -5542,7 +5532,9 @@ toApiSerialisedTransaction maybeEncoding tx =
     let
         encoding = fromMaybe Base64Encoded maybeEncoding
     in
-        ApiSerialisedTransaction (ApiT $ sealWriteTx tx) encoding
+        ApiSerialisedTransaction
+            (ApiT $ sealWriteTx Write.recentEra tx)
+            encoding
 
 {-------------------------------------------------------------------------------
                                 Api Layer

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -86,10 +86,11 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxMetadata (..)
+    ( SealedTx
+    , TxMetadata (..)
     , TxMetadataValue (..)
     , TxScriptValidity (..)
-    , cardanoTxIdeallyNoLaterThan
+    , unsafeReadTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..)
@@ -117,9 +118,6 @@ import Data.Aeson
 import Data.Either.Combinators
     ( swapEither
     )
-import Data.Function
-    ( (&)
-    )
 import Data.Generics.Internal.VL.Lens
     ( view
     , (^.)
@@ -141,6 +139,9 @@ import Data.Time.Clock
 import Data.Time.Utils
     ( utcTimePred
     , utcTimeSucc
+    )
+import Data.Word
+    ( Word64
     )
 import Numeric.Natural
     ( Natural
@@ -215,12 +216,15 @@ import Prelude
 
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Style.Shelley as CA
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Faucet.Mnemonics as Mnemonics
-import qualified Cardano.Wallet.Api.Link as Link
-import qualified Cardano.Wallet.Api.Types.Era as ApiEra
-    ( toAnyCardanoEra
+import qualified Cardano.Read.Ledger.Tx.Metadata as Meta
+    ( getEraMetadata
     )
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Metadata as Meta
+    ( getMetadata
+    )
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE
@@ -234,6 +238,15 @@ data TestCase a = TestCase
     { query :: T.Text
     , assertions :: [(HTTP.Status, Either RequestException a) -> IO ()]
     }
+
+-- Check for the presence of metadata on a serialized transaction.
+-- Ledger-native: does not round-trip through cardano-api.
+getMetadataFromTx
+    :: SealedTx
+    -> Maybe (Map.Map Word64 TxMetadataValue)
+getMetadataFromTx sealed = case unsafeReadTx sealed of
+    Read.EraValue (readTx :: Read.Tx era) ->
+        unTxMetadata <$> Meta.getMetadata (Meta.getEraMetadata readTx)
 
 spec
     :: forall n
@@ -519,24 +532,12 @@ spec = describe "SHARED_TRANSACTIONS" $ do
 
             -- checking metadata before signing via directly inspecting serialized
             -- tx
-            let getMetadata (Cardano.InAnyCardanoEra _ tx) =
-                    Cardano.getTxBody tx
-                        & \body ->
-                            Cardano.txMetadata (Cardano.getTxBodyContent body) & \case
-                                Cardano.TxMetadataNone ->
-                                    Nothing
-                                Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
-                                    Just m
-
-            let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
-            let txbinary1 =
-                    cardanoTxIdeallyNoLaterThan era
-                        $ getApiT (txCbor1 ^. #serialisedTxSealed)
-            case getMetadata txbinary1 of
+            let txbinary1 = getApiT (txCbor1 ^. #serialisedTxSealed)
+            case getMetadataFromTx txbinary1 of
                 Nothing -> error "Tx doesn't include metadata"
                 Just m -> case Map.lookup 1 m of
                     Nothing -> error "Tx doesn't include metadata"
-                    Just (Cardano.TxMetaText "hello") -> pure ()
+                    Just (TxMetaText "hello") -> pure ()
                     Just _ -> error "Tx metadata incorrect"
 
             let (ApiSerialisedTransaction apiTx _) =
@@ -555,14 +556,12 @@ spec = describe "SHARED_TRANSACTIONS" $ do
             verify rDecodedTx2 decodedExpectations
 
             -- checking metadata after signing via directly inspecting serialized tx
-            let txbinary2 =
-                    cardanoTxIdeallyNoLaterThan era
-                        $ getApiT (signedTx ^. #serialisedTxSealed)
-            case getMetadata txbinary2 of
+            let txbinary2 = getApiT (signedTx ^. #serialisedTxSealed)
+            case getMetadataFromTx txbinary2 of
                 Nothing -> error "Tx doesn't include metadata"
                 Just m -> case Map.lookup 1 m of
                     Nothing -> error "Tx doesn't include metadata"
-                    Just (Cardano.TxMetaText "hello") -> pure ()
+                    Just (TxMetaText "hello") -> pure ()
                     Just _ -> error "Tx metadata incorrect"
 
             -- Submit tx

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -7125,30 +7125,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         \f2d40e61a300010481d879800581840000d8798082191a221a019d6038\
         \f5f6"
 
-    -- TODO: This function should really not exist, but instead, it should be
-    -- possible to construct a transaction from the API with additional required
-    -- signers!
-    -- TODO: remove no-unused-imports pragma once this function is fixed.
+    -- TODO ADP-3077: this should not exist — the API should be able to
+    -- construct a transaction with additional required signers directly.
+    -- When this is implemented, do it ledger-native on 'Read.Tx era' via
+    -- 'reqSignerHashesTxBodyL', restricted to Alonzo-and-later eras.
     addRequiredSigners :: SealedTx -> [XPub] -> SealedTx
     addRequiredSigners _tx _vks = error "TODO: ADP-3077 fix addRequiredSigners"
-
-    {-
-        case getSealedTxBody tx of
-            InAnyCardanoEra AlonzoEra (Cardano.ShelleyTxBody a body b c d e) ->
-                let body' = body
-                        { Alonzo.reqSignerHashes = Set.fromList $ hashKey <$> vks
-                        }
-                 in sealedTxFromCardanoBody (Cardano.ShelleyTxBody a body' b c d e
-            _ -> tx
-      where
-        hashKey :: forall kd. XPub -> Ledger.KeyHash kd StandardCrypto
-        hashKey =
-            Ledger.hashKey
-            . Ledger.VKey
-            . fromJust
-            . rawDeserialiseVerKeyDSIGN
-            . xpubPublicKey
-    -}
 
     fromTextEnvelope cborHex =
         let textEnvelope =

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -27,16 +27,12 @@ module Cardano.Wallet.Primitive.Types.Tx
 
       -- * Serialisation
     , SealedTx (serialisedTx, unsafeReadTx)
-    , cardanoTxIdeallyNoLaterThan
     , sealedTxFromBytes
     , sealedTxFromBytes'
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
-    , sealedTxFromCardanoBody
+    , sealedTxFromLedgerTx
     , unsafeSealedTxFromBytes
     , SerialisedTx (..)
-    , getSealedTxBody
-    , getSealedTxWitnesses
+    , sealedTxWitnessCount
     , persistSealedTx
     , unPersistSealedTx
 
@@ -82,16 +78,12 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( SealedTx (..)
     , SerialisedTx (..)
-    , cardanoTxIdeallyNoLaterThan
-    , getSealedTxBody
-    , getSealedTxWitnesses
     , mockSealedTx
     , persistSealedTx
     , sealedTxFromBytes
     , sealedTxFromBytes'
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
-    , sealedTxFromCardanoBody
+    , sealedTxFromLedgerTx
+    , sealedTxWitnessCount
     , unPersistSealedTx
     , unsafeSealedTxFromBytes
     , withinEra

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -18,17 +18,11 @@
 module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( -- * Types
       SealedTx (serialisedTx, unsafeReadTx)
-    , cardanoTxIdeallyNoLaterThan
     , sealedTxFromBytes
     , sealedTxFromBytes'
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
-    , sealedTxFromCardanoBody
     , sealedTxFromLedgerTx
     , unsafeSealedTxFromBytes
     , SerialisedTx (..)
-    , getSealedTxBody
-    , getSealedTxWitnesses
     , sealedTxWitnessCount
     , persistSealedTx
     , unPersistSealedTx
@@ -39,16 +33,6 @@ module Cardano.Wallet.Primitive.Types.Tx.SealedTx
     )
 where
 
-import Cardano.Api
-    ( AnyCardanoEra (..)
-    , CardanoEra (..)
-    , InAnyCardanoEra (..)
-    , anyCardanoEra
-    , deserialiseFromCBOR
-    )
-import Cardano.Api.Tx
-    ( Tx (ShelleyTx)
-    )
 import Cardano.Ledger.Api
     ( addrTxWitsL
     , bootAddrTxWitsL
@@ -117,7 +101,6 @@ import GHC.Generics
     )
 import Prelude
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
@@ -133,8 +116,7 @@ import qualified Data.Text as T
 -- then the wallet core can use it either as a
 -- 'ByteString', or as a 'Read.Tx'.
 --
--- Construct it with either 'sealedTxFromCardano' or
--- 'sealedTxFromBytes'.
+-- Construct it with either 'sealedTxFromLedgerTx' or 'sealedTxFromBytes'.
 data SealedTx = SealedTx
     { valid :: Bool
     -- ^ Internal flag - indicates that the
@@ -178,73 +160,12 @@ instance NFData SealedTx where
     rnf (SealedTx v _ bs) =
         v `deepseq` bs `deepseq` ()
 
--- | Temporary: reconstructs 'InAnyCardanoEra Cardano.Tx'
--- from bytes on demand. Will be removed when callers
--- migrate to 'Read.Tx'.
-cardanoTxIdeallyNoLaterThan
-    :: AnyCardanoEra
-    -> SealedTx
-    -> InAnyCardanoEra Cardano.Tx
-cardanoTxIdeallyNoLaterThan maxEra stx =
-    case cardanoTxFromBytes
-        maxEra
-        (serialisedTx stx) of
-        Right tx -> tx
-        Left _ ->
-            -- Fall back: try all eras
-            case cardanoTxFromBytes
-                maxBound
-                (serialisedTx stx) of
-                Right tx -> tx
-                Left e ->
-                    internalError
-                        $ "cardanoTxIdeallyNoLaterThan: "
-                        +|| e
-                        ||+ ""
-
--- | Temporary: reconstructs cardano-api TxBody from
--- bytes. Will be removed when callers migrate.
-getSealedTxBody
-    :: SealedTx -> InAnyCardanoEra Cardano.TxBody
-getSealedTxBody stx =
-    case cardanoTxFromBytes
-        maxBound
-        (serialisedTx stx) of
-        Right (InAnyCardanoEra era tx) ->
-            InAnyCardanoEra era (Cardano.getTxBody tx)
-        Left e ->
-            internalError
-                $ "getSealedTxBody: "
-                +|| e
-                ||+ ""
-
--- | Temporary: reconstructs cardano-api witnesses from
--- bytes. Will be removed when callers migrate.
-getSealedTxWitnesses
-    :: SealedTx
-    -> [InAnyCardanoEra Cardano.KeyWitness]
-getSealedTxWitnesses stx =
-    case cardanoTxFromBytes
-        maxBound
-        (serialisedTx stx) of
-        Right (InAnyCardanoEra era tx) ->
-            [ InAnyCardanoEra era w
-            | w <- Cardano.getTxWitnesses tx
-            ]
-        Left e ->
-            internalError
-                $ "getSealedTxWitnesses: "
-                +|| e
-                ||+ ""
-
 -- | Total number of key witnesses (VKey + bootstrap) in
 -- a 'SealedTx'. Ledger-native: does not round-trip
 -- through cardano-api.
 --
--- Equivalent of @length (getSealedTxWitnesses stx)@ for
--- the wallet's fee / witness-count accounting. Byron txs
--- are counted as 0 — the wallet does not construct Byron
--- txs through 'SealedTx'.
+-- Byron txs are counted as 0 — the wallet does not construct
+-- Byron txs through 'SealedTx'.
 sealedTxWitnessCount :: SealedTx -> Int
 sealedTxWitnessCount stx = case unsafeReadTx stx of
     EraValue (Read.Tx tx :: Read.Tx era) -> case theEra @era of
@@ -261,68 +182,10 @@ sealedTxWitnessCount stx = case unsafeReadTx stx of
         Set.size (tx ^. witsTxL . addrTxWitsL)
             + Set.size (tx ^. witsTxL . bootAddrTxWitsL)
 
--- | Convert a cardano-api 'Tx' to 'EraValue Read.Tx'.
-cardanoApiTxToReadTx
-    :: Cardano.Tx era -> EraValue Read.Tx
-cardanoApiTxToReadTx (ShelleyTx sbe ledgerTx) =
-    case sbe of
-        Cardano.ShelleyBasedEraShelley ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Shelley)
-        Cardano.ShelleyBasedEraAllegra ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Allegra)
-        Cardano.ShelleyBasedEraMary ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Mary)
-        Cardano.ShelleyBasedEraAlonzo ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Alonzo)
-        Cardano.ShelleyBasedEraBabbage ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Babbage)
-        Cardano.ShelleyBasedEraConway ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Conway)
-        Cardano.ShelleyBasedEraDijkstra ->
-            EraValue (Read.Tx ledgerTx :: Read.Tx Dijkstra)
-
--- | Construct a 'SealedTx' from a "Cardano.Api"
--- transaction.
-sealedTxFromCardano
-    :: InAnyCardanoEra Cardano.Tx -> SealedTx
-sealedTxFromCardano (InAnyCardanoEra _era tx) =
-    let readTx = cardanoApiTxToReadTx tx
-        bs = cardanoApiTxToBytes tx
-    in  SealedTx True readTx bs
-  where
-    cardanoApiTxToBytes
-        :: Cardano.Tx e -> ByteString
-    cardanoApiTxToBytes tx'@(ShelleyTx sbe _) =
-        Cardano.shelleyBasedEraConstraints
-            sbe
-            (Cardano.serialiseToCBOR tx')
-
--- | Construct a 'SealedTx' from a "Cardano.Api"
--- transaction.
-sealedTxFromCardano'
-    :: Cardano.IsCardanoEra era
-    => Cardano.Tx era
-    -> SealedTx
-sealedTxFromCardano' =
-    sealedTxFromCardano
-        . InAnyCardanoEra Cardano.cardanoEra
-
--- | Construct a 'SealedTx' from a 'Cardano.Api.TxBody'.
-sealedTxFromCardanoBody
-    :: Cardano.IsCardanoEra era
-    => Cardano.TxBody era
-    -> SealedTx
-sealedTxFromCardanoBody =
-    sealedTxFromCardano
-        . InAnyCardanoEra Cardano.cardanoEra
-        . mk
-  where
-    mk body = Cardano.Tx body []
-
 -- | Try to deserialize bytes into 'EraValue Read.Tx',
 -- trying the newest ledger era first, then older eras.
 readTxFromBytes
-    :: AnyCardanoEra
+    :: EraValue Read.Era
     -> ByteString
     -> Either DecoderError (EraValue Read.Tx)
 readTxFromBytes maxEra bs =
@@ -331,19 +194,19 @@ readTxFromBytes maxEra bs =
         $ filter
             (withinEra maxEra . fst)
             [ tryEra @Dijkstra
-                (AnyCardanoEra DijkstraEra)
+                (EraValue Dijkstra)
             , tryEra @Conway
-                (AnyCardanoEra ConwayEra)
+                (EraValue Conway)
             , tryEra @Babbage
-                (AnyCardanoEra BabbageEra)
+                (EraValue Babbage)
             , tryEra @Alonzo
-                (AnyCardanoEra AlonzoEra)
+                (EraValue Alonzo)
             , tryEra @Mary
-                (AnyCardanoEra MaryEra)
+                (EraValue Mary)
             , tryEra @Allegra
-                (AnyCardanoEra AllegraEra)
+                (EraValue Allegra)
             , tryEra @Shelley
-                (AnyCardanoEra ShelleyEra)
+                (EraValue Shelley)
             ]
   where
     lbs = BL.fromStrict bs
@@ -351,8 +214,8 @@ readTxFromBytes maxEra bs =
     tryEra
         :: forall era
          . IsEra era
-        => AnyCardanoEra
-        -> ( AnyCardanoEra
+        => EraValue Read.Era
+        -> ( EraValue Read.Era
            , Either DecoderError (EraValue Read.Tx)
            )
     tryEra eraTag =
@@ -368,86 +231,21 @@ readTxFromBytes maxEra bs =
         ([], []) ->
             internalError "readTxFromBytes: impossible"
 
--- | Deserialise a Cardano transaction. The transaction
--- can be in the format of any era. This function will
--- try the most recent era first, then previous eras.
---
--- Temporary: kept for functions that still need
--- cardano-api types. Will be removed.
---
--- Dijkstra is intentionally absent here because the wallet's
--- temporary 'CardanoApiEra' bridge does not support it. The
--- ledger-native 'readTxFromBytes' path above already tries Dijkstra.
-cardanoTxFromBytes
-    :: AnyCardanoEra
-    -> ByteString
-    -> Either DecoderError (InAnyCardanoEra Cardano.Tx)
-cardanoTxFromBytes maxEra bs =
-    asum
-        $ map snd
-        $ filter
-            (withinEra maxEra . fst)
-            [ deserialise
-                ConwayEra
-                Cardano.AsConwayEra
-            , deserialise
-                BabbageEra
-                Cardano.AsBabbageEra
-            , deserialise
-                AlonzoEra
-                Cardano.AsAlonzoEra
-            , deserialise
-                MaryEra
-                Cardano.AsMaryEra
-            , deserialise
-                AllegraEra
-                Cardano.AsAllegraEra
-            , deserialise
-                ShelleyEra
-                Cardano.AsShelleyEra
-            ]
-  where
-    deserialise
-        :: forall era
-         . Cardano.IsShelleyBasedEra era
-        => CardanoEra era
-        -> Cardano.AsType era
-        -> ( AnyCardanoEra
-           , Either
-                DecoderError
-                (InAnyCardanoEra Cardano.Tx)
-           )
-    deserialise cera asEra =
-        ( anyCardanoEra cera
-        , InAnyCardanoEra cera
-            <$> deserialiseFromCBOR
-                (Cardano.AsTx asEra)
-                bs
-        )
-
-    asum :: [Either e a] -> Either e a
-    asum xs = case partitionEithers xs of
-        (_, (a : _)) -> Right a
-        ((e : _), []) -> Left e
-        ([], []) ->
-            internalError
-                "cardanoTxFromBytes: impossible"
-
 -- | @a `withinEra` b@ is 'True' iff @b@ is the same
 -- era as @a@, or an earlier one.
-withinEra :: AnyCardanoEra -> AnyCardanoEra -> Bool
+withinEra :: EraValue Read.Era -> EraValue Read.Era -> Bool
 withinEra = (>=) `on` numberEra
   where
-    numberEra :: AnyCardanoEra -> Int
-    numberEra (AnyCardanoEra e) = case e of
-        ByronEra -> 1
-        ShelleyEra -> 2
-        AllegraEra -> 3
-        MaryEra -> 4
-        AlonzoEra -> 5
-        BabbageEra -> 6
-        ConwayEra -> 7
-        _ -> 8
+    numberEra :: EraValue Read.Era -> Int
+    numberEra (EraValue e) = case e of
+        Byron -> 1
+        Shelley -> 2
+        Allegra -> 3
+        Mary -> 4
+        Alonzo -> 5
+        Babbage -> 6
+        Conway -> 7
+        Dijkstra -> 8
 
 -- | Construct a 'SealedTx' from a ledger-native
 -- 'Read.Tx'. Serialises to CBOR via ledger-read;
@@ -463,12 +261,12 @@ sealedTxFromLedgerTx tx =
 -- 'SealedTx'.
 sealedTxFromBytes
     :: ByteString -> Either DecoderError SealedTx
-sealedTxFromBytes = sealedTxFromBytes' maxBound
+sealedTxFromBytes = sealedTxFromBytes' (EraValue Dijkstra)
 
 -- | Deserialise a transaction to construct a
 -- 'SealedTx'.
 sealedTxFromBytes'
-    :: AnyCardanoEra
+    :: EraValue Read.Era
     -- ^ Most recent era
     -> ByteString
     -- ^ Serialised transaction

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -261,7 +261,7 @@ sealedTxFromLedgerTx tx =
 -- 'SealedTx'.
 sealedTxFromBytes
     :: ByteString -> Either DecoderError SealedTx
-sealedTxFromBytes = sealedTxFromBytes' (EraValue Dijkstra)
+sealedTxFromBytes = sealedTxFromBytes' (EraValue Conway)
 
 -- | Deserialise a transaction to construct a
 -- 'SealedTx'.

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -1098,6 +1098,9 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
         sealedTx `shouldSatisfy` isRight
 
     prop "roundtrip for Shelley witnesses" prop_sealedTxRecentEraRoundtrip
+    prop
+        "default decoder roundtrips recent era transactions"
+        prop_sealedTxDefaultRecentEraRoundtrip
   where
     byteString =
         mconcat
@@ -1365,6 +1368,18 @@ prop_sealedTxRecentEraRoundtrip
                         sealedTxB
                     ]
                     .||. encodingFromTheFuture (txEra) currentEra
+
+prop_sealedTxDefaultRecentEraRoundtrip
+    :: Pretty DecodeSetup
+    -> Property
+prop_sealedTxDefaultRecentEraRoundtrip (Pretty tc) =
+    cardanoApiEraConstraints RecentEraConway
+        $ let tx = makeShelleyTx RecentEraConway tc
+              txBytes = Cardano.serialiseToCBOR tx
+          in  either
+                (\e -> counterexample (show e) False)
+                (compareOnCBOR tx)
+                (sealedTxFromBytes txBytes)
 
 makeShelleyTx
     :: RecentEra era

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -191,12 +191,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
-    , cardanoTxIdeallyNoLaterThan
-    , getSealedTxWitnesses
     , sealedTxFromBytes
     , sealedTxFromBytes'
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
+    , sealedTxFromLedgerTx
     , serialisedTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -396,6 +393,7 @@ import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -1355,7 +1353,10 @@ prop_sealedTxRecentEraRoundtrip
             $ let tx = makeShelleyTx era tc
                   txBytes = Cardano.serialiseToCBOR tx
                   sealedTxC = sealedTxFromCardano' tx
-                  sealedTxB = sealedTxFromBytes' currentEra txBytes
+                  sealedTxB =
+                    sealedTxFromBytes'
+                        (Eras.fromAnyCardanoEra currentEra)
+                        txBytes
               in  conjoin
                     [ txBytes ==== serialisedTx sealedTxC
                     , either
@@ -1568,8 +1569,43 @@ dummyWit b =
 dummyTxId :: Hash "Tx"
 dummyTxId = Hash $ BS.pack $ replicate 32 0
 
+sealedTxFromCardano :: InAnyCardanoEra Cardano.Tx -> SealedTx
+sealedTxFromCardano (InAnyCardanoEra _ tx) = sealedTxFromCardano' tx
+
+sealedTxFromCardano' :: Cardano.Tx era -> SealedTx
+sealedTxFromCardano' (Cardano.ShelleyTx sbe ledgerTx) = case sbe of
+    Cardano.ShelleyBasedEraShelley ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Shelley)
+    Cardano.ShelleyBasedEraAllegra ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Allegra)
+    Cardano.ShelleyBasedEraMary ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Mary)
+    Cardano.ShelleyBasedEraAlonzo ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Alonzo)
+    Cardano.ShelleyBasedEraBabbage ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Babbage)
+    Cardano.ShelleyBasedEraConway ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Conway)
+    Cardano.ShelleyBasedEraDijkstra ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Dijkstra)
+
+getSealedTxWitnesses
+    :: SealedTx
+    -> [InAnyCardanoEra Cardano.KeyWitness]
+getSealedTxWitnesses sealedTx =
+    case cardanoTx sealedTx of
+        InAnyCardanoEra era tx ->
+            InAnyCardanoEra era <$> Cardano.getTxWitnesses tx
+
 cardanoTx :: SealedTx -> InAnyCardanoEra Cardano.Tx
-cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
+cardanoTx sealedTx = case unsafeReadTx sealedTx of
+    Read.EraValue (Read.Tx tx :: Read.Tx era) -> case Read.theEra @era of
+        Read.Conway ->
+            InAnyCardanoEra Cardano.ConwayEra $ toCardanoApiTx tx
+        Read.Dijkstra ->
+            error "cardanoTx: Dijkstra not yet supported"
+        _ ->
+            error "cardanoTx: only recent eras are supported"
 
 testTxLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 testTxLayer = newTransactionLayer ShelleyKeyS Cardano.Mainnet

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -51,6 +51,7 @@ import Cardano.Api.Extra
     , cardanoApiEraConstraints
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
+    , toCardanoApiTx
     )
 import Cardano.Api.Gen
     ( genTx
@@ -169,12 +170,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
-    , cardanoTxIdeallyNoLaterThan
-    , getSealedTxWitnesses
     , sealedTxFromBytes
     , sealedTxFromBytes'
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
+    , sealedTxFromLedgerTx
     , serialisedTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -359,6 +357,7 @@ import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -1312,7 +1311,10 @@ prop_sealedTxRecentEraRoundtrip
             $ let tx = makeShelleyTx era tc
                   txBytes = Cardano.serialiseToCBOR tx
                   sealedTxC = sealedTxFromCardano' tx
-                  sealedTxB = sealedTxFromBytes' currentEra txBytes
+                  sealedTxB =
+                    sealedTxFromBytes'
+                        (Eras.fromAnyCardanoEra currentEra)
+                        txBytes
               in  conjoin
                     [ txBytes ==== serialisedTx sealedTxC
                     , either
@@ -1503,8 +1505,43 @@ dummyWit b =
 dummyTxId :: Hash "Tx"
 dummyTxId = Hash $ BS.pack $ replicate 32 0
 
+sealedTxFromCardano :: InAnyCardanoEra Cardano.Tx -> SealedTx
+sealedTxFromCardano (InAnyCardanoEra _ tx) = sealedTxFromCardano' tx
+
+sealedTxFromCardano' :: Cardano.Tx era -> SealedTx
+sealedTxFromCardano' (Cardano.ShelleyTx sbe ledgerTx) = case sbe of
+    Cardano.ShelleyBasedEraShelley ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Shelley)
+    Cardano.ShelleyBasedEraAllegra ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Allegra)
+    Cardano.ShelleyBasedEraMary ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Mary)
+    Cardano.ShelleyBasedEraAlonzo ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Alonzo)
+    Cardano.ShelleyBasedEraBabbage ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Babbage)
+    Cardano.ShelleyBasedEraConway ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Conway)
+    Cardano.ShelleyBasedEraDijkstra ->
+        sealedTxFromLedgerTx (Read.Tx ledgerTx :: Read.Tx Read.Dijkstra)
+
+getSealedTxWitnesses
+    :: SealedTx
+    -> [InAnyCardanoEra Cardano.KeyWitness]
+getSealedTxWitnesses sealedTx =
+    case cardanoTx sealedTx of
+        InAnyCardanoEra era tx ->
+            InAnyCardanoEra era <$> Cardano.getTxWitnesses tx
+
 cardanoTx :: SealedTx -> InAnyCardanoEra Cardano.Tx
-cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
+cardanoTx sealedTx = case unsafeReadTx sealedTx of
+    Read.EraValue (Read.Tx tx :: Read.Tx era) -> case Read.theEra @era of
+        Read.Conway ->
+            InAnyCardanoEra Cardano.ConwayEra $ toCardanoApiTx tx
+        Read.Dijkstra ->
+            error "cardanoTx: Dijkstra not yet supported"
+        _ ->
+            error "cardanoTx: only recent eras are supported"
 
 testTxLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 testTxLayer = newTransactionLayer ShelleyKeyS Cardano.Mainnet

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1061,6 +1061,9 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
         sealedTx `shouldSatisfy` isRight
 
     prop "roundtrip for Shelley witnesses" prop_sealedTxRecentEraRoundtrip
+    prop
+        "default decoder roundtrips recent era transactions"
+        prop_sealedTxDefaultRecentEraRoundtrip
   where
     byteString =
         mconcat
@@ -1323,6 +1326,18 @@ prop_sealedTxRecentEraRoundtrip
                         sealedTxB
                     ]
                     .||. encodingFromTheFuture (txEra) currentEra
+
+prop_sealedTxDefaultRecentEraRoundtrip
+    :: Pretty DecodeSetup
+    -> Property
+prop_sealedTxDefaultRecentEraRoundtrip (Pretty tc) =
+    cardanoApiEraConstraints RecentEraConway
+        $ let tx = makeShelleyTx RecentEraConway tc
+              txBytes = Cardano.serialiseToCBOR tx
+          in  either
+                (\e -> counterexample (show e) False)
+                (compareOnCBOR tx)
+                (sealedTxFromBytes txBytes)
 
 makeShelleyTx
     :: Write.IsRecentEra era

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -254,7 +254,6 @@ import Cardano.Address.Script
 import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
-    , inAnyCardanoEra
     , toCardanoApiTx
     )
 import Cardano.BM.Data.Severity
@@ -596,7 +595,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxId
     , TxMetadata (..)
     , UnsignedTx (..)
-    , sealedTxFromCardano
     )
 import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo (..)
@@ -640,6 +638,7 @@ import Cardano.Wallet.Shelley.Transaction.Ledger
     ( certificateFromDelegationActionLedger
     , certificateFromVotingActionLedger
     , constructUnsignedTxLedger
+    , sealWriteTx
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -2544,15 +2543,14 @@ buildAndSignTransactionPure
         wallet <- get
         (unsignedBalancedTx, updatedWalletState) <-
             lift
-                $ first toCardanoApiTx
-                    <$> buildTransactionPure @s
-                        wallet
-                        timeTranslation
-                        utxoIndex
-                        changeAddrGen
-                        pp
-                        preSelection
-                        txCtx
+                $ buildTransactionPure @s
+                    wallet
+                    timeTranslation
+                    utxoIndex
+                    changeAddrGen
+                    pp
+                    preSelection
+                    txCtx
         put wallet{getState = updatedWalletState}
 
         let mExternalRewardAccount = case view #txWithdrawal txCtx of
@@ -2573,7 +2571,7 @@ buildAndSignTransactionPure
                     (RootCredentials rootKey passphrase)
                     (wallet ^. #utxo)
                     Nothing
-                    (sealedTxFromCardano $ inAnyCardanoEra unsignedBalancedTx)
+                    (sealWriteTx (Write.recentEra @era) unsignedBalancedTx)
 
             tx = walletTx $ decodeTx txLayer anyCardanoEra signedTx
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -69,14 +69,12 @@ import Cardano.Address.Script
     , toScriptHash
     )
 import Cardano.Api
-    ( InAnyCardanoEra (..)
-    , NetworkId
+    ( NetworkId
     )
 -- Removed: Cardano.Api.Error no longer exists, using show instead
 
 import Cardano.Api.Extra
     ( CardanoApiEra
-    , cardanoApiEraConstraints
     , fromCardanoApiTx
     , shelleyBasedEraFromRecentEra
     , toCardanoApiTx
@@ -121,6 +119,7 @@ import Cardano.Wallet.Primitive.Ledger.Convert
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
     ( fromCardanoTx
+    , getTxExtended
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( cardanoCertKeysForWitnesses
@@ -167,9 +166,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
-    , cardanoTxIdeallyNoLaterThan
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
+    , sealedTxFromLedgerTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..)
@@ -295,7 +292,6 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
-import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
 import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
 import qualified Cardano.Wallet.Primitive.Types.AssetId as AssetId
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -420,27 +416,24 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
             Map.empty
             Nothing
             Nothing
-    let signed :: Cardano.Tx (CardanoApiEra era)
-        signed =
-            toCardanoApiTx
-                $ signTransaction
-                    keyF
-                    networkId
-                    AnyWitnessCountCtx
-                    acctResolver
-                    (const Nothing)
-                    Nothing
-                    (const Nothing)
-                    addrResolver
-                    inputResolver
-                    (fromCardanoApiTx $ Cardano.Tx unsigned [])
+    let signed =
+            signTransaction
+                keyF
+                networkId
+                AnyWitnessCountCtx
+                acctResolver
+                (const Nothing)
+                Nothing
+                (const Nothing)
+                addrResolver
+                inputResolver
+                (fromCardanoApiTx $ Cardano.Tx unsigned [])
     let withResolvedInputs tx =
             tx{resolvedInputs = second Just <$> F.toList (view #inputs cs)}
-    cardanoApiEraConstraints era
-        $ Right
-            ( withResolvedInputs $ walletTx $ fromCardanoTx signed
-            , sealedTxFromCardano' signed
-            )
+    Right
+        ( withResolvedInputs $ walletTx $ txExtendedFromRecentTx era signed
+        , sealRecentTx era signed
+        )
   where
     inputResolver :: TxIn -> Maybe Address
     inputResolver i =
@@ -629,7 +622,7 @@ newTransactionLayer
 newTransactionLayer keyF networkId =
     TransactionLayer
         { addVkWitnesses =
-            \era
+            \_era
              witCountCtx
              stakeCreds
              policyCreds
@@ -674,52 +667,59 @@ newTransactionLayer keyF networkId =
                                     , "transaction from a non-recent era."
                                     ]
 
-                    sealedTxFromCardano
-                        $ fromMaybe errNonRecentEra
-                        $ withRecentEraLedgerTx
-                            (cardanoTxIdeallyNoLaterThan (Eras.toAnyCardanoEra era) sealedTx)
-                        $ \ledgerTx ->
-                            signTransaction
-                                keyF
-                                networkId
-                                witCountCtx
-                                acctResolver
-                                policyResolver
-                                policyKeyM
-                                stakingScriptResolver
-                                addressResolver
-                                inputResolver
-                                ledgerTx
+                    fromMaybe errNonRecentEra
+                        $ withSealedTxRecentEra sealedTx
+                        $ \era' ledgerTx ->
+                            sealRecentTx era'
+                                $ signTransaction
+                                    keyF
+                                    networkId
+                                    witCountCtx
+                                    acctResolver
+                                    policyResolver
+                                    policyKeyM
+                                    stakingScriptResolver
+                                    addressResolver
+                                    inputResolver
+                                    ledgerTx
         , decodeTx = _decodeSealedTx
         , transactionWitnessTag = txWitnessTagForKey keyF
         }
 
-withRecentEraLedgerTx
-    :: InAnyCardanoEra Cardano.Tx
-    -> (forall era. Write.IsRecentEra era => Write.Tx era -> Write.Tx era)
-    -> Maybe (InAnyCardanoEra Cardano.Tx)
-withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
-    Cardano.ConwayEra ->
-        Just
-            . InAnyCardanoEra era
-            . toCardanoApiTx
-            . f
-            . fromCardanoApiTx
-            $ tx
-    Cardano.BabbageEra ->
-        Nothing
-    Cardano.AlonzoEra ->
-        Nothing
-    Cardano.MaryEra ->
-        Nothing
-    Cardano.AllegraEra ->
-        Nothing
-    Cardano.ShelleyEra ->
-        Nothing
-    Cardano.ByronEra ->
-        Nothing
-    Cardano.DijkstraEra ->
-        error "withRecentEraLedgerTx: DijkstraEra not yet supported"
+withSealedTxRecentEra
+    :: SealedTx
+    -> ( forall era
+          . Write.IsRecentEra era => RecentEra era -> Write.Tx era -> a
+       )
+    -> Maybe a
+withSealedTxRecentEra sealedTx f = case unsafeReadTx sealedTx of
+    Read.EraValue (Read.Tx tx :: Read.Tx era) -> case Read.theEra @era of
+        Read.Conway ->
+            Just $ f RecentEraConway tx
+        Read.Dijkstra ->
+            Just $ f RecentEraDijkstra tx
+        _ ->
+            Nothing
+
+txExtendedFromRecentTx
+    :: RecentEra era
+    -> Write.Tx era
+    -> TxExtended
+txExtendedFromRecentTx era tx = case era of
+    RecentEraConway ->
+        getTxExtended (Read.Tx tx :: Read.Tx Read.Conway)
+    RecentEraDijkstra ->
+        getTxExtended (Read.Tx tx :: Read.Tx Read.Dijkstra)
+
+sealRecentTx
+    :: RecentEra era
+    -> Write.Tx era
+    -> SealedTx
+sealRecentTx era tx = case era of
+    RecentEraConway ->
+        sealedTxFromLedgerTx (Read.Tx tx :: Read.Tx Read.Conway)
+    RecentEraDijkstra ->
+        sealedTxFromLedgerTx (Read.Tx tx :: Read.Tx Read.Dijkstra)
 
 -- | Construct a standard unsigned transaction.
 --
@@ -868,12 +868,9 @@ _decodeSealedTx
     :: Read.EraValue Read.Era
     -> SealedTx
     -> TxExtended
-_decodeSealedTx preferredLatestEra sealedTx =
-    case cardanoTxIdeallyNoLaterThan
-        (Eras.toAnyCardanoEra preferredLatestEra)
-        sealedTx of
-        Cardano.InAnyCardanoEra _ tx ->
-            fromCardanoTx tx
+_decodeSealedTx _preferredLatestEra sealedTx =
+    case unsafeReadTx sealedTx of
+        Read.EraValue tx -> getTxExtended tx
 
 -- FIXME: Make this a Allegra or Shelley transaction depending on the era we're
 -- in. However, quoting Duncan:

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -166,6 +166,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
+    , sealedTxFromBytes'
     , sealedTxFromLedgerTx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -622,7 +623,7 @@ newTransactionLayer
 newTransactionLayer keyF networkId =
     TransactionLayer
         { addVkWitnesses =
-            \_era
+            \preferredLatestEra
              witCountCtx
              stakeCreds
              policyCreds
@@ -668,7 +669,7 @@ newTransactionLayer keyF networkId =
                                     ]
 
                     fromMaybe errNonRecentEra
-                        $ withSealedTxRecentEra sealedTx
+                        $ withSealedTxRecentEra preferredLatestEra sealedTx
                         $ \era' ledgerTx ->
                             sealRecentTx era'
                                 $ signTransaction
@@ -687,19 +688,33 @@ newTransactionLayer keyF networkId =
         }
 
 withSealedTxRecentEra
-    :: SealedTx
+    :: Read.EraValue Read.Era
+    -> SealedTx
     -> ( forall era
           . Write.IsRecentEra era => RecentEra era -> Write.Tx era -> a
        )
     -> Maybe a
-withSealedTxRecentEra sealedTx f = case unsafeReadTx sealedTx of
-    Read.EraValue (Read.Tx tx :: Read.Tx era) -> case Read.theEra @era of
-        Read.Conway ->
-            Just $ f RecentEraConway tx
-        Read.Dijkstra ->
-            Just $ f RecentEraDijkstra tx
-        _ ->
-            Nothing
+withSealedTxRecentEra preferredLatestEra sealedTx f =
+    case readSealedTxIdeallyNoLaterThan preferredLatestEra sealedTx of
+        Read.EraValue (Read.Tx tx :: Read.Tx era) -> case Read.theEra @era of
+            Read.Conway ->
+                Just $ f RecentEraConway tx
+            Read.Dijkstra ->
+                Just $ f RecentEraDijkstra tx
+            _ ->
+                Nothing
+
+readSealedTxIdeallyNoLaterThan
+    :: Read.EraValue Read.Era
+    -> SealedTx
+    -> Read.EraValue Read.Tx
+readSealedTxIdeallyNoLaterThan preferredLatestEra sealedTx =
+    unsafeReadTx
+        $ fromMaybe sealedTx
+        $ either (const Nothing) Just
+        $ sealedTxFromBytes'
+            preferredLatestEra
+            (serialisedTx sealedTx)
 
 txExtendedFromRecentTx
     :: RecentEra era
@@ -868,8 +883,8 @@ _decodeSealedTx
     :: Read.EraValue Read.Era
     -> SealedTx
     -> TxExtended
-_decodeSealedTx _preferredLatestEra sealedTx =
-    case unsafeReadTx sealedTx of
+_decodeSealedTx preferredLatestEra sealedTx =
+    case readSealedTxIdeallyNoLaterThan preferredLatestEra sealedTx of
         Read.EraValue tx -> getTxExtended tx
 
 -- FIXME: Make this a Allegra or Shelley transaction depending on the era we're

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -19,6 +19,9 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
       mkTransactionLedger
     , constructUnsignedTxLedger
 
+      -- * Sealing
+    , sealWriteTx
+
       -- * Signing
     , signTransaction
     , mkShelleyWitnessLedger
@@ -573,12 +576,8 @@ mkRewardAccount network acct =
         network
         (Ledger.AccountId (toLedgerStakeCredential acct))
 
--- | Convert a cardano-api 'Certificate' to the underlying
--- | Seal a ledger 'Tx' into a 'SealedTx' by going through
--- cardano-api serialisation.
---
--- TODO: avoid cardano-api roundtrip when SealedTx is
--- restructured.
+-- | Seal a ledger 'Write.Tx' into a 'SealedTx'. Ledger-native;
+-- does not round-trip through cardano-api.
 sealWriteTx
     :: forall era
      . RecentEra era

--- a/specs/003-decommission-sealedtx-remainder/plan.md
+++ b/specs/003-decommission-sealedtx-remainder/plan.md
@@ -1,0 +1,148 @@
+# Plan: finish decommissioning the SealedTx cardano-api surface
+
+Follow-up to #5271. That PR moved every call site it could reach
+without rewriting the old tx builder (#5243) or the unit-test
+fixtures built on top of it. This PR handles the remainder so that
+`lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs`
+can drop its three `Cardano.Api*` imports and the deprecated
+bridges can be deleted.
+
+## Remaining callers (exhaustive, pre-PR snapshot)
+
+### Production code
+
+`lib/wallet/src/Cardano/Wallet.hs`
+- line 599 — re-export `sealedTxFromCardano`
+- line 2576 — `sealedTxFromCardano $ inAnyCardanoEra unsignedBalancedTx`
+  in `balanceTransaction` result wrapping.
+
+`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`
+- line 911 — import `sealedTxFromCardano`
+- line 5529 — `W.sealedTxFromCardano` in the decode-sign path.
+
+### Old tx builder (partially overlaps with #5243)
+
+`lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs`
+- 170–172 — imports `cardanoTxIdeallyNoLaterThan`,
+  `sealedTxFromCardano`, `sealedTxFromCardano'`
+- 442 — `sealedTxFromCardano' signed`
+- 677–680 — `sealedTxFromCardano` / `cardanoTxIdeallyNoLaterThan`
+- 872 — `cardanoTxIdeallyNoLaterThan`
+
+If #5243 lands first this file disappears and those sites go with
+it. If #5243 lags, migrate the four sites in place.
+
+### Integration tests
+
+`lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs`
+- 92 — import `cardanoTxIdeallyNoLaterThan`
+- 533, 559 — two `cardanoTxIdeallyNoLaterThan` sites, mirror of the
+  metadata extraction already ported in `TransactionsNew.hs` in
+  #5271.
+
+`lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs`
+- 7133 — `case getSealedTxBody tx of`
+- 7141 — `sealedTxFromCardanoBody (Cardano.ShelleyTxBody …)`
+
+This is the `addRequiredSigners` helper: injects extra key-hash
+witnesses into an Alonzo tx body to test required-signer plumbing.
+Needs a ledger-native helper on `Read.Tx era` that operates on
+`reqSignerHashesTxBodyL` / equivalent; Byron and pre-Alonzo paths
+do not apply.
+
+### Unit tests
+
+`lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs`
+~10 sites across imports, arbitrary instance, witness-count
+assertions, tx-construction helpers:
+- 172, 173, 176, 177 — import `cardanoTxIdeallyNoLaterThan`,
+  `getSealedTxWitnesses`, `sealedTxFromCardano`,
+  `sealedTxFromCardano'`
+- 416 — `arbitrary = sealedTxFromCardano <$> genTx`
+- 529, 549, 621, 641, 769, 791, 837, 857 — per-test
+  `sealedTxFromCardano' $ Cardano.Tx …` + witness subset checks
+- 881, 897, 898 — before/after witness-count comparison for
+  `addRequiredSigners`
+- 927, 983, 1314, 1507 — remaining `sealedTxFromCardano'` /
+  `cardanoTxIdeallyNoLaterThan maxBound` sites
+
+`lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`
+~9 sites with the same shape as `TransactionSpec.hs`
+(it is the ledger-balancer variant of the same test file):
+- imports at 194, 195, 198, 199
+- arbitrary at 454
+- per-test sites at 567, 587, 659, 679, 807, 829, 875, 895, 919,
+  935, 936, 965, 1021, 1357, 1572
+
+## Step-by-step plan
+
+Each step is one bisect-safe commit. Gate per commit: fourmolu +
+hlint + `nix build .#cardano-wallet .#unit-cardano-wallet-unit`.
+
+### Phase A — reachable without #5243
+
+1. `Shared/Transactions.hs` metadata extraction → ledger-native
+   (mirror the `TransactionsNew.hs:getMetadataFromTx` port from
+   #5271). Two call sites + import cleanup.
+
+2. `addRequiredSigners` in `TransactionsNew.hs` → ledger-native.
+   Operate on `Read.Tx era`, restricted to the Alonzo-and-later
+   arms that the test actually uses; drop the
+   `getSealedTxBody` + `sealedTxFromCardanoBody` round-trip.
+
+3. `Cardano.Wallet.hs:2576` balance-result wrapping →
+   `sealedTxFromLedgerTx` (already exported by SealedTx).
+
+4. `Server.hs:5529` decode-sign path → either
+   `sealedTxFromLedgerTx` or `sealedTxFromBytes`, depending on
+   what the surrounding code already has in hand. Drop the import.
+
+### Phase B — unit-test migration
+
+5. `TransactionSpec.hs` — swap the arbitrary instance and all
+   per-test call sites to `sealedTxFromLedgerTx` / a ledger-native
+   witness accessor. `getSealedTxWitnesses` assertions move to the
+   `addrTxWitsL` set via `sealedTxWitnessCount` or a new
+   `sealedTxWitnesses` that returns the ledger witness set.
+
+6. `TransactionLedgerSpec.hs` — same migration as step 5 applied
+   to the ledger-balancer variant. Likely a straight diff from
+   step 5.
+
+### Phase C — surface removal
+
+7. Delete `sealedTxFromCardano`, `sealedTxFromCardano'`,
+   `sealedTxFromCardanoBody` from `SealedTx.hs` and its
+   `Cardano.Wallet.Primitive.Types.Tx` re-export.
+
+8. Delete `getSealedTxBody`, `getSealedTxWitnesses`,
+   `cardanoApiTxToReadTx`, `cardanoTxFromBytes`,
+   `cardanoTxIdeallyNoLaterThan` from `SealedTx.hs`.
+
+9. Drop the three `Cardano.Api*` imports from `SealedTx.hs`. Tip
+   compiles with zero `Cardano.Api` references in the file.
+
+## Dependencies and ordering
+
+- Phase A is independent of #5243.
+- Phase B assumes the old tx builder is still live — it tests
+  `mkTransaction` / `balanceTransaction` which live in
+  `Shelley/Transaction.hs`. If #5243 lands first, large parts of
+  Phase B get deleted rather than migrated, and this plan shrinks
+  accordingly.
+- Phase C requires A and B (or #5243) done.
+
+## Not in this PR
+
+- `cardano-api` in `cardano-wallet-primitive.cabal` (seven other
+  primitive files still import it; separate initiative).
+- `lib/cardano-api-extra/` removal (Phase D of #5237).
+- `Shelley/Transaction.hs` module deletion itself (#5243).
+
+## Test plan
+
+- [ ] Plan committed, bisect-safe (docs-only)
+- [ ] Each subsequent commit passes the per-commit gate
+- [ ] Final tip: zero `Cardano.Api*` imports in
+      `lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs`
+- [ ] Conway integration tests green


### PR DESCRIPTION
## Summary

Follow-up to #5271. This PR finishes the `Cardano.Wallet.Primitive.Types.Tx.SealedTx` cardano-api decommission: the primitive `SealedTx` module no longer imports `Cardano.Api`, and the deprecated cardano-api-facing SealedTx exports are removed.

Base branch: `feat/drop-cardano-api-sealedtx` (#5271).
Rebased after #5270 merged, #5236 was rebased onto `master`, and #5271 was rebased onto #5236.

## What changed

| # | SHA | Purpose |
|---|---|---|
| 1 | `734f624` | Plan for finishing the SealedTx cardano-api decommission |
| 2 | `80a3de4` | Port metadata extraction in `Shared/Transactions` to ledger-native |
| 3 | `8faf76e` | Drop the dead cardano-api body in `addRequiredSigners` |
| 4 | `a929e8e` | Migrate `buildAndSignTransactionPure` to ledger-native seal |
| 5 | `e2e72af` | Drop the local `sealWriteTx` cardano-api bridge in Server.hs |
| 6 | `0b619dd` | Remove the `SealedTx` cardano-api surface and move remaining unit-test adapters local to tests |
| 7 | `b4da418` | Keep default sealed transaction byte decoding capped at the supported Conway era, and make signing/decoding re-read sealed bytes with the caller's preferred latest era |

## SealedTx surface removed

Removed from `Cardano.Wallet.Primitive.Types.Tx.SealedTx` and the umbrella `Cardano.Wallet.Primitive.Types.Tx` export list:

- `cardanoTxIdeallyNoLaterThan`
- `sealedTxFromCardano`
- `sealedTxFromCardano'`
- `sealedTxFromCardanoBody`
- `getSealedTxBody`
- `getSealedTxWitnesses`
- internal `cardanoTxFromBytes`
- internal `cardanoApiTxToReadTx`

`sealedTxFromBytes'` now takes `Read.EraValue Read.Era` instead of `AnyCardanoEra`, which lets the primitive module avoid `Cardano.Api` entirely.

## CI fix after rerun

The first rerun of #5272 exposed a real Conway integration failure: sealed Conway transaction bytes could be decoded as Dijkstra by the new ledger-native default path, after which downstream code hit the still-incomplete Dijkstra transaction support.

This PR now keeps the public `sealedTxFromBytes` default capped at Conway, and the transaction layer re-decodes sealed bytes with the preferred latest era supplied by the caller before signing or decoding. That preserves the old "no later than current era" behavior without restoring the cardano-api bridge.

## Remaining out of scope

- Removing `cardano-api` from `cardano-wallet-primitive.cabal`; other primitive modules still import it.
- Removing `lib/cardano-api-extra/`.
- Full deletion of the old `Shelley/Transaction.hs` module.

## Test plan

- [x] `nix develop --command fourmolu --mode inplace ...` on touched Haskell files
- [x] `git diff --check`
- [x] `nix develop --command just build 'cardano-wallet-primitive cardano-wallet cardano-wallet-unit:unit'`
- [x] `nix develop --command cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="TransactionSpec"'`
- [x] `nix develop --command cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="SealedTx serialisation/deserialisation"'`
- [x] `nix develop --command cabal build cardano-wallet cardano-wallet-api cardano-wallet-unit:unit --enable-tests --enable-benchmarks --minimize-conflict-set -O0 -v0`
- [x] `rg 'Cardano\.Api|qualified Cardano.Api' lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs` returns no matches
- [x] CI green on the rebased tip

