### PR TITLE
fix(release): smoke-test built artifacts before upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,18 +57,28 @@ jobs:
             runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
             output: ci.artifacts.linux64.release
             artifact-name: linux-release
+            extract: tar xzf
+            binary: cardano-wallet
           - name: Windows
             runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
             output: ci.artifacts.win64.release
             artifact-name: windows-release
+            extract: unzip -o
+            binary: cardano-wallet.exe
           - name: macOS Silicon
             runner: '["self-hosted", "macOS", "ARM64", "cardano-wallet"]'
             output: packages.aarch64-darwin.ci.artifacts.macos-silicon.release
             artifact-name: macos-silicon-release
+            extract: tar xzf
+            binary: cardano-wallet
           - name: Docker Image
             runner: '["self-hosted", "linux", "x86_64", "cardano-wallet"]'
             output: ci.artifacts.dockerImage
             artifact-name: docker-image
+            # Docker images are smoke-tested separately; skip the
+            # archive-based checks below by leaving `binary` empty.
+            extract: ''
+            binary: ''
     steps:
       - name: Checkout release candidate
         uses: actions/checkout@v6
@@ -76,8 +86,64 @@ jobs:
           ref: ${{ needs.prepare.outputs.release-candidate-branch }}
           fetch-depth: 0
 
+      - name: Sanity-check checkout
+        env:
+          EXPECTED_COMMIT: ${{ needs.prepare.outputs.release-candidate-commit }}
+          EXPECTED_CABAL_VERSION: ${{ needs.prepare.outputs.release-cabal-version }}
+        run: |
+          actual_commit=$(git rev-parse HEAD)
+          if [ "$actual_commit" != "$EXPECTED_COMMIT" ]; then
+            echo "ERROR: working tree HEAD ($actual_commit) does not match release-candidate-commit ($EXPECTED_COMMIT)"
+            exit 1
+          fi
+          actual_cabal_version=$(grep -m1 '^version' lib/wallet/cardano-wallet.cabal | awk '{print $2}')
+          if [ "$actual_cabal_version" != "$EXPECTED_CABAL_VERSION" ]; then
+            echo "ERROR: cabal version ($actual_cabal_version) does not match release-cabal-version ($EXPECTED_CABAL_VERSION)"
+            exit 1
+          fi
+          echo "Checkout OK: $actual_commit @ $actual_cabal_version"
+
       - name: Build
         run: nix build --quiet -o result .#${{ matrix.output }}
+
+      - name: Smoke test built artifact
+        if: matrix.binary != ''
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
+        run: |
+          archive=$(find result/ -maxdepth 2 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | head -1)
+          if [ -z "$archive" ]; then
+            echo "ERROR: no archive found in result/"
+            ls -laR result/
+            exit 1
+          fi
+          archive_basename=$(basename "$archive")
+          if ! echo "$archive_basename" | grep -q "$EXPECTED_VERSION"; then
+            echo "ERROR: archive name '$archive_basename' does not contain expected version $EXPECTED_VERSION"
+            exit 1
+          fi
+          # The Windows binary cannot be executed on the linux build runner
+          # without wine; the verify-artifacts job covers it with wine.
+          if [ "${{ matrix.name }}" = "Windows" ]; then
+            echo "Archive name OK; skipping in-process version check on Windows."
+            exit 0
+          fi
+          tmp=$(mktemp -d)
+          archive_abs=$(readlink -f "$archive")
+          ( cd "$tmp" && ${{ matrix.extract }} "$archive_abs" )
+          binary=$(find "$tmp" -name "${{ matrix.binary }}" -type f | head -1)
+          if [ -z "$binary" ]; then
+            echo "ERROR: binary ${{ matrix.binary }} not found in extracted archive"
+            find "$tmp" -type f
+            exit 1
+          fi
+          version_output=$("$binary" version 2>&1)
+          echo "Version output: $version_output"
+          echo "Expected: $EXPECTED_VERSION"
+          if ! echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
+            echo "ERROR: binary embeds wrong version (expected $EXPECTED_VERSION)"
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
         if: matrix.binary != ''
         env:
           EXPECTED_VERSION: ${{ needs.prepare.outputs.release-version }}
+          EXPECTED_COMMIT: ${{ needs.prepare.outputs.release-candidate-commit }}
         run: |
           archive=$(find result/ -maxdepth 2 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | head -1)
           if [ -z "$archive" ]; then
@@ -140,9 +141,14 @@ jobs:
           fi
           version_output=$("$binary" version 2>&1)
           echo "Version output: $version_output"
-          echo "Expected: $EXPECTED_VERSION"
+          echo "Expected version: $EXPECTED_VERSION"
+          echo "Expected commit:  $EXPECTED_COMMIT"
           if ! echo "$version_output" | grep -q "$EXPECTED_VERSION"; then
             echo "ERROR: binary embeds wrong version (expected $EXPECTED_VERSION)"
+            exit 1
+          fi
+          if ! echo "$version_output" | grep -q "$EXPECTED_COMMIT"; then
+            echo "ERROR: binary embeds wrong commit (expected $EXPECTED_COMMIT)"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,8 @@ jobs:
             echo "ERROR: working tree HEAD ($actual_commit) does not match release-candidate-commit ($EXPECTED_COMMIT)"
             exit 1
           fi
-          actual_cabal_version=$(grep -m1 '^version' lib/wallet/cardano-wallet.cabal | awk '{print $2}')
+          # release-cabal-version strips the leading "0." (see scripts/release/release-candidate.sh:42).
+          actual_cabal_version=$(grep -m1 '^version' lib/wallet/cardano-wallet.cabal | awk '{print $2}' | sed 's/^0\.//')
           if [ "$actual_cabal_version" != "$EXPECTED_CABAL_VERSION" ]; then
             echo "ERROR: cabal version ($actual_cabal_version) does not match release-cabal-version ($EXPECTED_CABAL_VERSION)"
             exit 1


### PR DESCRIPTION
Closes #5273.

## Why

Last night's nightly Release [run #25536061161](https://github.com/cardano-foundation/cardano-wallet/actions/runs/25536061161) shipped a Linux artifact built from the previous RC: tarball named `cardano-wallet-v2026-05-05-linux64.tar.gz`, embedded `git revision: 1129e3a6…` (HEAD of `release-candidate/v2026-05-05`), even though the runner had checked out `release-candidate/v2026-05-08` at `f4bdf3b54f…`. macOS and Windows builds packaged the right revision; only the Linux build went stale.

`Verify Linux` caught the discrepancy in the smoke test, but only *after* the broken artifact had already been uploaded.

The root cause is not yet fully identified (issue #5273 has the analysis). This PR doesn't try to fix the root cause — it makes the failure mode more diagnosable and stops the broken artifact at the build job rather than the verify job.

## What

Two new steps in the `build-artifacts` job in `.github/workflows/release.yml`.

### 1. `Sanity-check checkout` — runs after `actions/checkout`

Asserts that:
- `git rev-parse HEAD` matches `needs.prepare.outputs.release-candidate-commit`
- `lib/wallet/cardano-wallet.cabal`'s `version:` field (with the leading `0.` stripped, matching `scripts/release/release-candidate.sh:42`) matches `needs.prepare.outputs.release-cabal-version`

If either differs, the job fails before invoking `nix build`.

### 2. `Smoke test built artifact` — runs after `nix build`, before `Upload artifact`

For Linux and macOS:
- Locate the archive in `result/`
- Assert its filename contains the expected git tag (e.g. `v2026-05-08`)
- Extract and run `cardano-wallet version`; assert the output contains the expected git tag

For Windows: only the filename check runs (no wine on the build host; `verify-artifacts` still does the wine-based version check).

For the Docker Image entry: matrix fields `extract: ''` and `binary: ''` are empty, so the smoke-test step's `if: matrix.binary != ''` skip kicks in.

## What I deliberately did *not* change

I considered but rejected three other proposals (full reasoning in #5273):

- **Folding `gitrev` into the release-build derivation hash** — already done. `gitrev` is interpolated into the `installPhase` string in `nix/release-build.nix`.
- **Adding a `version` env attr in `nix/release-package.nix`** — already done. The cabal version is embedded in the derivation `name` via `walletLib.gitTagFromCabalVersion exe.meta.name`.
- **Hardening the `self.rev or "0000…"` fallback in `flake.nix`** — last night's failure had a real-but-stale gitrev (`1129e3a6…`), not the all-zeros fallback.

## Test evidence

Self-tested before requesting review.

**Negative control** ([run #25552326078](https://github.com/cardano-foundation/cardano-wallet/actions/runs/25552326078)): a throwaway branch deliberately patched `scripts/release/release-candidate.sh` to skip the cabal-version sed, so the resulting test-rc branch had the stale `0.2026.4.17` version while prepare reported `release-cabal-version=2026.5.8`. The new `Sanity-check checkout` step caught it on every platform with the expected error:

```
ERROR: cabal version (0.2026.4.17) does not match release-cabal-version (2026.5.8)
```

**Positive control** ([run #25552442853](https://github.com/cardano-foundation/cardano-wallet/actions/runs/25552442853)): clean `workflow_dispatch` on this PR's branch (`release_type: nightly`) — should reach `Verify *` end-to-end without tripping the new steps. The first attempt ([#25552279258](https://github.com/cardano-foundation/cardano-wallet/actions/runs/25552279258)) tripped the cabal check on a leading-`0.` formatting issue in the comparison itself; that's the second commit on this branch.

## Test plan for reviewer

- [ ] CI on this PR is green
- [ ] Linked positive-control run reaches `Verify *` end-to-end
- [ ] Linked negative-control run fails at `Sanity-check checkout` with the cabal-version error above