### PR TITLE
chore: bump cardano-node-runtime to 11.0.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,16 +86,16 @@
     "blst_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1749204514,
-        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.15",
+        "ref": "v0.3.14",
         "repo": "blst",
         "type": "github"
       }
@@ -458,11 +458,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1778244515,
-        "narHash": "sha256-+d8z1O81ILxT6zx8bJvaZbAXtW+JJJtTt0sM+JZ1U8w=",
+        "lastModified": 1775058616,
+        "narHash": "sha256-G9mCZaFhxBJ4CCSW+YSHUy5myBLpr3CSgRe+oADrs1M=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "04b4be26b8d6e3666d0cc4dd18c7e86614951d8e",
+        "rev": "4b790b1ce019e32680d584f7cf30d88889bc954b",
         "type": "github"
       },
       "original": {
@@ -491,11 +491,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1778201302,
-        "narHash": "sha256-o7/IIVuyb7wcdr2r6MiUbItp8b0Vno5snTA5FEQaQH8=",
+        "lastModified": 1775004062,
+        "narHash": "sha256-VSxoJD5zb3BlDpvQieWBB44AKM8FSr7MT0GCzOlzhXE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7439176528877c25032f5af55ce6ca5e3dd04d92",
+        "rev": "5da730e51c6b8130320d83da0740e66e4bdfd7ea",
         "type": "github"
       },
       "original": {
@@ -669,11 +669,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1778202991,
-        "narHash": "sha256-u7o9nsiggfU601lRY/rtTrzWyROlai/xXSHJ0RdTwd4=",
+        "lastModified": 1775005722,
+        "narHash": "sha256-2ucRXQobMiOfA22I8R0b36Zfmd7OkWXCvKLxwMwioo4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "405e72bb0b436b3a1728713f4b8b81ee79b88e02",
+        "rev": "9373f20d7b8c6edd73000854401912e0a91f82b9",
         "type": "github"
       },
       "original": {
@@ -1223,11 +1223,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1777941182,
-        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
@@ -1471,11 +1471,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1775749320,
-        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
         "type": "github"
       },
       "original": {
@@ -1518,11 +1518,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -1690,11 +1690,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1778113854,
-        "narHash": "sha256-DwLWzpWyPwubVRZCZLhsc2R4aUeNEGng1vL08kZZunk=",
+        "lastModified": 1775003016,
+        "narHash": "sha256-s9+yhzF1MoX0+BsJFykizAXoSmQwotwKxbFWvD1P9X8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "166b880930f411975aec6c0238d95e498e0bc45e",
+        "rev": "551d2e4a33de0c7fd938e78f24a68014dac5aec2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1776203472,
-        "narHash": "sha256-husRfOULFemi5q+JpO7deykZxTKSIz0E4fCR387aO3Y=",
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3831817e4131b3ef5fe262e3f853b87bec8a24a0",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       },
       "original": {
@@ -69,16 +69,16 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1739372843,
-        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -86,16 +86,16 @@
     "blst_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1739372843,
-        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "lastModified": 1749204514,
+        "narHash": "sha256-Q9/zGN93TnJt2c8YvSaURstoxT02ts3nVkO5V08m4TI=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -231,16 +231,16 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1776219966,
-        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
+        "lastModified": 1777953209,
+        "narHash": "sha256-+dod+EL73MICgbgflyJnwDlxbCeaBbBLrr2tLX59hAA=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
+        "rev": "97036a66bcf8c89f687ae57a048eecc0389977ef",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.1",
+        "ref": "11.0.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -458,11 +458,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1775058616,
-        "narHash": "sha256-G9mCZaFhxBJ4CCSW+YSHUy5myBLpr3CSgRe+oADrs1M=",
+        "lastModified": 1778244515,
+        "narHash": "sha256-+d8z1O81ILxT6zx8bJvaZbAXtW+JJJtTt0sM+JZ1U8w=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4b790b1ce019e32680d584f7cf30d88889bc954b",
+        "rev": "04b4be26b8d6e3666d0cc4dd18c7e86614951d8e",
         "type": "github"
       },
       "original": {
@@ -491,11 +491,11 @@
     "hackage-for-stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1775004062,
-        "narHash": "sha256-VSxoJD5zb3BlDpvQieWBB44AKM8FSr7MT0GCzOlzhXE=",
+        "lastModified": 1778201302,
+        "narHash": "sha256-o7/IIVuyb7wcdr2r6MiUbItp8b0Vno5snTA5FEQaQH8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5da730e51c6b8130320d83da0740e66e4bdfd7ea",
+        "rev": "7439176528877c25032f5af55ce6ca5e3dd04d92",
         "type": "github"
       },
       "original": {
@@ -669,11 +669,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1775005722,
-        "narHash": "sha256-2ucRXQobMiOfA22I8R0b36Zfmd7OkWXCvKLxwMwioo4=",
+        "lastModified": 1778202991,
+        "narHash": "sha256-u7o9nsiggfU601lRY/rtTrzWyROlai/xXSHJ0RdTwd4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "9373f20d7b8c6edd73000854401912e0a91f82b9",
+        "rev": "405e72bb0b436b3a1728713f4b8b81ee79b88e02",
         "type": "github"
       },
       "original": {
@@ -1200,11 +1200,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1777941182,
+        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
         "type": "github"
       },
       "original": {
@@ -1223,11 +1223,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1777941182,
+        "narHash": "sha256-FX3+8GIrB2z4akmcYTStELDKVJWgqy9yFt0mxwpU3Qc=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "9de00113c11ba8cac908a63acf34b193cda7475b",
         "type": "github"
       },
       "original": {
@@ -1471,11 +1471,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -1518,11 +1518,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -1690,11 +1690,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1775003016,
-        "narHash": "sha256-s9+yhzF1MoX0+BsJFykizAXoSmQwotwKxbFWvD1P9X8=",
+        "lastModified": 1778113854,
+        "narHash": "sha256-DwLWzpWyPwubVRZCZLhsc2R4aUeNEGng1vL08kZZunk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "551d2e4a33de0c7fd938e78f24a68014dac5aec2",
+        "rev": "166b880930f411975aec6c0238d95e498e0bc45e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.7.1";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=11.0.1";
     mithril = {
       url = "github:input-output-hk/mithril?ref=2603.1";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
@@ -403,7 +403,7 @@ preparePoolRetirement nodeSegment certs = do
           , "--tx-in"
           , untag faucetInput
           , "--ttl"
-          , "400"
+          , "6000000"
           , "--fee"
           , show faucetAmt
           , "--out-file"

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/KeyRegistration.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/KeyRegistration.hs
@@ -91,7 +91,7 @@ prepareStakeKeyRegistration = do
         , "--tx-out"
         , sink <> "+" <> "1000000"
         , "--ttl"
-        , "400"
+        , "6000000"
         , "--fee"
         , show (faucetAmt - depositAmt - 1_000_000)
         , "--certificate-file"

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenesisFiles.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenesisFiles.hs
@@ -271,7 +271,7 @@ generateGenesis initialFunds genesisMods = do
                     -- based on the protocol version rather than just the era,
                     -- so we need to set it to a realisitic value.
                     & ppProtocolVersionL
-                        .~ Ledger.ProtVer (natVersion @10) 0
+                        .~ Ledger.ProtVer (natVersion @12) 0
                     -- Sensible pool & reward parameters:
                     & ppNOptL
                         .~ 3


### PR DESCRIPTION
Closes #5276.

## Summary

- `flake.nix`: `cardano-node-runtime` ref `10.7.1` -> [`11.0.1`](https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1)
- `flake.lock`: updates the `cardano-node-runtime` input to node commit `97036a66bcf8c89f687ae57a048eecc0389977ef`, plus the nested runtime inputs required by that flake (`CHaP`, `iohk-nix`, `blst`). The wallet's own root `haskell.nix`, `hackage.nix`, and `iohk-nix` inputs stay unchanged from `master`.
- `lib/local-cluster/.../GenesisFiles.hs`: shelley genesis `ProtVer (natVersion @10) 0` -> `(natVersion @12) 0`. Required because node 11.0 with `setExperimental True` forges at `ProtVer 12.0` (was `11.0` in 10.7.x); see [`48a71bb0e`](https://github.com/IntersectMBO/cardano-node/commit/48a71bb0e). Same surgery as #5249 was for the 10.7 line.
- `lib/local-cluster/.../{ConfiguredPool,KeyRegistration}.hs`: extends early local-cluster bootstrap transaction TTLs so setup certificates survive node 11 startup/tx-submission timing and are forged before the integration tests inspect stake-pool retirement state.

This is the runtime-only bump: only the bundled cardano-node binary changes. Haskell-side dependency bumps (`cardano-api 10 -> 11`, `cardano-ledger-conway 1.22.0 -> 1.22.1`, CHaP index-state) are tracked in #5275.

## Test plan

- [x] `nix build .#cardano-node .#cardano-cli` -> `cardano-node 11.0.1`, `cardano-cli 11.0.0.0` from the new input
- [x] `nix build` (default outputs build gate) green
- [x] `just test-local-cluster` -- 39 examples, 0 failures (real cluster boot scenarios under node 11.0.1)
- [x] `just conway-integration-tests-match 4 ""` -- 1037 examples, 0 failures, 39 pending (~23 min)
- [x] `nix develop --quiet .#docs --command mdbook build -d ../../_build-test docs/site` -- local docs build green after keeping root docs/toolchain inputs unchanged
- [x] Focused local repro after TTL fix: `integration-exe --match '/API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_LIST_01 - List stake pools/pools have the correct retirement information/' --seed 161854318` -- 1 example, 0 failures
- [x] Focused local repro after TTL fix: `integration-exe --match '/API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_GARBAGE_COLLECTION_01 - retired pools are garbage collected on schedule and not before/' --seed 161854318` -- 1 example, 0 failures
