### PR TITLE
Use Mithril snapshots for every restoration benchmark run

### DIFF
--- a/.github/workflows/restoration-benchmarks.yml
+++ b/.github/workflows/restoration-benchmarks.yml
@@ -4,16 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * 1" # every Monday at midnight UTC
   workflow_dispatch:
-    inputs:
-      to-tip-timeout:
-        description: "Node sync timeout in hours"
-        type: choice
-        default: "4"
-        options:
-          - "infinite"
-          - "1"
-          - "2"
-          - "4"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -35,7 +25,7 @@ jobs:
     name: "Restore ${{ matrix.bench }}"
     needs: build
     runs-on: [self-hosted, linux, x86_64, cardano-wallet-bench]
-    timeout-minutes: 1380
+    timeout-minutes: 870
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +40,10 @@ jobs:
             node-db: mainnet-4
     env:
       LC_ALL: C.UTF-8
-      TO_TIP_TIMEOUT: ${{ inputs.to-tip-timeout }}
+      SETUP_TIMEOUT_SECONDS: 7200
+      BENCHMARK_TIMEOUT_SECONDS: 43200
+      SYNC_POLL_INTERVAL_SECONDS: 15
+      SYNC_STALE_SECONDS: 1200
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -61,7 +54,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
-          nix shell --quiet 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
+          nix shell --quiet '.#cardano-node' '.#cardano-cli' 'nixpkgs#coreutils' 'nixpkgs#gnugrep' 'nixpkgs#gawk' 'nixpkgs#jq' 'nixpkgs#time' 'nixpkgs#haskellPackages.hp2pretty' -c \
             bash scripts/ci/bench-restore.sh \
               mainnet ${{ matrix.bench }} $HOME/databases/node/${{ matrix.node-db }}
 
@@ -75,4 +68,5 @@ jobs:
             *.log
             *.svg
             *.hp
+            *.json
           if-no-files-found: ignore

--- a/flake.lock
+++ b/flake.lock
@@ -279,11 +279,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1767744144,
-        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
+        "lastModified": 1776635034,
+        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
+        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -1277,19 +1277,20 @@
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
+        "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1769104967,
-        "narHash": "sha256-0amlnplGcwe8KkwdsTCVStfS88bv2+5cOyzVTaFfEhk=",
+        "lastModified": 1776926918,
+        "narHash": "sha256-muV2LpheC4OZsU1ipL9j6TmjGufMpGrXzvon+eWahgg=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "567a8e8e63a449c9da70c8c3ddb09f8fab174e18",
+        "rev": "2478748ea9771baed8181ef0938c78f79ed60760",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2603.1",
+        "ref": "2617.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -1487,11 +1488,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -1601,6 +1602,27 @@
           "nixpkgs-unstable"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable_3"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776654897,
+        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "25d75be8139815a53560745fa060909777495105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "secp256k1": {
@@ -1741,11 +1763,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768158989,
-        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
     customConfig.url = "github:input-output-hk/empty-flake";
     cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=11.0.1";
     mithril = {
-      url = "github:input-output-hk/mithril?ref=2603.1";
+      url = "github:input-output-hk/mithril?ref=2617.0";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
   };

--- a/llm/reviews/5279/gate.sh
+++ b/llm/reviews/5279/gate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+bash -n scripts/ci/bench-restore.sh
+bash -n run/common/nix/snapshot.sh
+./scripts/shellcheck.sh scripts/ci/bench-restore.sh run/common/nix/snapshot.sh
+nix build --quiet .#ci.benchmarks.restore

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -78,7 +78,7 @@ cleanup() {
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell --quiet "github:input-output-hk/mithril?ref=2543.1-hotfix" -c $*
+    nix shell --quiet "github:input-output-hk/mithril?ref=2617.0" -c $*
 }
 
 # Trap the cleanup function on exit

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -1,12 +1,14 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
+MITHRIL_CLIENT_SOURCE="github:input-output-hk/mithril?ref=2543.1-hotfix"
+
 function mithril() {
-    nix shell --quiet 'github:input-output-hk/mithril?ref=2543.1-hotfix' --command mithril-client $@
+    nix shell --quiet "$MITHRIL_CLIENT_SOURCE" --command mithril-client "$@"
 }
 
 function jq() {
-    nix shell --quiet 'nixpkgs#jq' --command jq $@
+    nix shell --quiet 'nixpkgs#jq' --command jq "$@"
 }
 
 set -euo pipefail
@@ -14,8 +16,26 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 # shellcheck disable=SC1091
-# shellcheck disable=SC2086
-source ${SCRIPT_DIR}/.env
+source "${SCRIPT_DIR}/.env"
+
+set_stage() {
+    if [[ -n "${MITHRIL_STAGE_FILE:-}" ]]; then
+        printf '%s\n' "$1" >"$MITHRIL_STAGE_FILE"
+    fi
+}
+
+wipe_directory_contents() {
+    local dir=$1
+    if [[ -z "$dir" || "$dir" == "/" ]]; then
+        echo "Refusing to wipe unsafe NODE_DB path: $dir" >&2
+        exit 1
+    fi
+    mkdir -p "$dir"
+    (
+        shopt -s dotglob nullglob
+        rm -rf -- "${dir:?}"/*
+    )
+}
 
 export AGGREGATOR_ENDPOINT
 export GENESIS_VERIFICATION_KEY
@@ -24,9 +44,41 @@ export ANCILLARY_VERIFICATION_KEY
 mkdir -p ./databases
 
 NODE_DB=${NODE_DB:=./databases/node-db}
-mkdir -p "$NODE_DB"
-rm -rf "${NODE_DB:?}"/*
+wipe_directory_contents "$NODE_DB"
 
-hash=$(mithril cdb snapshot list --json | jq -r .[0].hash)
+client_version=$(mithril --version 2>/dev/null || echo "unknown")
+
+echo "MITHRIL_CLIENT_SOURCE=$MITHRIL_CLIENT_SOURCE"
+echo "MITHRIL_CLIENT_VERSION=$client_version"
+
+set_stage "setup:mithril-list"
+snapshots=$(mithril cdb snapshot list --json)
+snapshot=$(printf '%s\n' "$snapshots" | jq -c '.[0] // empty')
+hash=$(printf '%s\n' "$snapshot" | jq -r '.hash // .digest // empty')
+tip=$(printf '%s\n' "$snapshot" | jq -c '.beacon // .tip // null')
+
+if [[ -z "$hash" ]]; then
+    echo "FAILED - No Mithril snapshot hash found" >&2
+    exit 1
+fi
+
+echo "MITHRIL_SNAPSHOT_HASH=$hash"
+echo "MITHRIL_SNAPSHOT_TIP=$tip"
+
+if [[ -n "${MITHRIL_SNAPSHOT_INFO_FILE:-}" ]]; then
+    jq -n \
+        --arg client_source "$MITHRIL_CLIENT_SOURCE" \
+        --arg client_version "$client_version" \
+        --arg snapshot_hash "$hash" \
+        --argjson snapshot_tip "$tip" \
+        '{client_source:$client_source, client_version:$client_version, snapshot_hash:$snapshot_hash, snapshot_tip:$snapshot_tip}' \
+        >"$MITHRIL_SNAPSHOT_INFO_FILE"
+fi
+
+set_stage "setup:mithril-download"
 (cd "${NODE_DB}" && mithril cdb download --include-ancillary "$hash")
+
+set_stage "setup:mithril-extract"
 (cd "${NODE_DB}" && mv db/* . && rm -rf db)
+
+set_stage "setup:mithril-complete"

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 
-MITHRIL_CLIENT_SOURCE="github:input-output-hk/mithril?ref=2543.1-hotfix"
+MITHRIL_CLIENT_SOURCE=${MITHRIL_CLIENT_SOURCE:-"github:input-output-hk/mithril?ref=2617.0"}
 
 function mithril() {
     nix shell --quiet "$MITHRIL_CLIENT_SOURCE" --command mithril-client "$@"
@@ -9,6 +9,24 @@ function mithril() {
 
 function jq() {
     nix shell --quiet 'nixpkgs#jq' --command jq "$@"
+}
+
+detect_cardano_node_version() {
+    if [[ -n "${MITHRIL_CARDANO_NODE_VERSION:-}" ]]; then
+        echo "$MITHRIL_CARDANO_NODE_VERSION"
+        return
+    fi
+
+    if command -v cardano-node >/dev/null 2>&1; then
+        local version
+        if version=$(cardano-node --version | awk 'NR == 1 { print $2 }') \
+            && [[ -n "$version" ]]; then
+            echo "$version"
+            return
+        fi
+    fi
+
+    echo "10.7.1"
 }
 
 set -euo pipefail
@@ -77,6 +95,30 @@ fi
 
 set_stage "setup:mithril-download"
 (cd "${NODE_DB}" && mithril cdb download --include-ancillary "$hash")
+
+if [[ -n "${MITHRIL_UTXO_HD_FLAVOR:-}" ]]; then
+    case "$MITHRIL_UTXO_HD_FLAVOR" in
+        LMDB|Legacy) ;;
+        *)
+            echo "Unsupported MITHRIL_UTXO_HD_FLAVOR: $MITHRIL_UTXO_HD_FLAVOR" >&2
+            exit 1
+            ;;
+    esac
+
+    cardano_node_version=$(detect_cardano_node_version)
+    echo "MITHRIL_UTXO_HD_FLAVOR=$MITHRIL_UTXO_HD_FLAVOR"
+    echo "MITHRIL_CARDANO_NODE_VERSION=$cardano_node_version"
+
+    set_stage "setup:mithril-convert"
+    (
+        cd "${NODE_DB}"
+        mithril tools utxo-hd snapshot-converter \
+            --db-directory db \
+            --cardano-node-version "$cardano_node_version" \
+            --utxo-hd-flavor "$MITHRIL_UTXO_HD_FLAVOR" \
+            --commit
+    )
+fi
 
 set_stage "setup:mithril-extract"
 (cd "${NODE_DB}" && mv db/* . && rm -rf db)

--- a/scripts/ci/bench-restore.sh
+++ b/scripts/ci/bench-restore.sh
@@ -52,8 +52,10 @@ node_sync_progress=""
 final_tip_json="null"
 mithril_snapshot_hash=""
 mithril_snapshot_tip="null"
-mithril_client_source="github:input-output-hk/mithril?ref=2543.1-hotfix"
+mithril_client_source=${MITHRIL_CLIENT_SOURCE:-"github:input-output-hk/mithril?ref=2617.0"}
 mithril_client_version=""
+mithril_utxo_hd_flavor=${MITHRIL_UTXO_HD_FLAVOR:-LMDB}
+mithril_cardano_node_version=""
 
 iso_now() {
     date -u +%Y-%m-%dT%H:%M:%SZ
@@ -61,6 +63,19 @@ iso_now() {
 
 epoch_now() {
     date +%s
+}
+
+detect_cardano_node_version() {
+    if command -v cardano-node >/dev/null 2>&1; then
+        local version
+        if version=$(cardano-node --version | awk 'NR == 1 { print $2 }') \
+            && [[ -n "$version" ]]; then
+            echo "$version"
+            return
+        fi
+    fi
+
+    echo "10.7.1"
 }
 
 wipe_directory_contents() {
@@ -91,6 +106,8 @@ write_provenance() {
         --arg mithril_snapshot_hash "$mithril_snapshot_hash" \
         --arg mithril_client_source "$mithril_client_source" \
         --arg mithril_client_version "$mithril_client_version" \
+        --arg mithril_utxo_hd_flavor "$mithril_utxo_hd_flavor" \
+        --arg mithril_cardano_node_version "$mithril_cardano_node_version" \
         --arg setup_started_at "$setup_started_at" \
         --arg setup_finished_at "$setup_finished_at" \
         --arg node_sync_completed_at "$node_sync_completed_at" \
@@ -110,6 +127,8 @@ write_provenance() {
           mithril_snapshot_tip: $mithril_snapshot_tip,
           mithril_client_source: $mithril_client_source,
           mithril_client_version: $mithril_client_version,
+          mithril_utxo_hd_flavor: $mithril_utxo_hd_flavor,
+          mithril_cardano_node_version: $mithril_cardano_node_version,
           setup_started_at: $setup_started_at,
           setup_finished_at: $setup_finished_at,
           node_sync_completed_at: $node_sync_completed_at,
@@ -181,6 +200,10 @@ echo "SETUP_STARTED_AT=$setup_started_at"
 echo "--- Provision Mithril snapshot"
 wipe_directory_contents "$node_db"
 
+mithril_cardano_node_version=$(detect_cardano_node_version)
+echo "MITHRIL_UTXO_HD_FLAVOR=$mithril_utxo_hd_flavor"
+echo "MITHRIL_CARDANO_NODE_VERSION=$mithril_cardano_node_version"
+
 mithril_remaining=$(require_setup_time "setup:mithril-list")
 set +e
 timeout --foreground --kill-after=60s "$mithril_remaining" \
@@ -188,6 +211,8 @@ timeout --foreground --kill-after=60s "$mithril_remaining" \
       NODE_DB="$node_db" \
       MITHRIL_SNAPSHOT_INFO_FILE="$mithril_info_file" \
       MITHRIL_STAGE_FILE="$mithril_stage_file" \
+      MITHRIL_UTXO_HD_FLAVOR="$mithril_utxo_hd_flavor" \
+      MITHRIL_CARDANO_NODE_VERSION="$mithril_cardano_node_version" \
       "$repo_root/run/mainnet/nix/snapshot.sh"
 mithril_status=$?
 set -e

--- a/scripts/ci/bench-restore.sh
+++ b/scripts/ci/bench-restore.sh
@@ -11,43 +11,308 @@ fi
 network=$1
 bench=$2
 node_db=$3
+
+if [ "$network" != "mainnet" ]; then
+  echo "FAILED - Mithril-provisioned restoration benchmarks require mainnet" >&2
+  exit 64
+fi
+
+repo_root=$(pwd)
 artifact_name=restore-$network
 log=restore.log
 results=restore-$network.txt
 total_time=restore-time.txt
+provenance_file=restore-provenance-"$bench".json
+node_log_artifact=node-"$bench".log
 
-export TMPDIR="$TMPDIR/bench/restore"
-mkdir -p "$TMPDIR"
+# Workflow-provided phase budgets. Defaults keep manual runs aligned with the
+# scheduled restoration benchmark workflow.
+setup_timeout_seconds=${SETUP_TIMEOUT_SECONDS:-7200}
+benchmark_timeout_seconds=${BENCHMARK_TIMEOUT_SECONDS:-43200}
+sync_poll_interval_seconds=${SYNC_POLL_INTERVAL_SECONDS:-15}
+sync_stale_seconds=${SYNC_STALE_SECONDS:-1200}
+
+tmp_base=${TMPDIR:-/tmp}
+work_dir="$tmp_base/bench/restore/$bench"
+node_socket="$work_dir/node.socket"
+node_log="$work_dir/node.log"
+tip_file="$work_dir/node-tip.json"
+tip_error_file="$work_dir/node-tip.err"
+mithril_info_file="$work_dir/mithril-snapshot.json"
+mithril_stage_file="$work_dir/mithril-stage"
+
+node_pid=""
+failure_stage=""
+setup_started_at=""
+setup_finished_at=""
+benchmark_started_at=""
+node_sync_completed_at=""
+node_sync_wait_seconds=""
+node_sync_progress=""
+final_tip_json="null"
+mithril_snapshot_hash=""
+mithril_snapshot_tip="null"
+mithril_client_source="github:input-output-hk/mithril?ref=2543.1-hotfix"
+mithril_client_version=""
+
+iso_now() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+epoch_now() {
+    date +%s
+}
+
+wipe_directory_contents() {
+    local dir=$1
+    if [[ -z "$dir" || "$dir" == "/" ]]; then
+        echo "Refusing to wipe unsafe node DB path: $dir" >&2
+        exit 1
+    fi
+    mkdir -p "$dir"
+    (
+        shopt -s dotglob nullglob
+        rm -rf -- "${dir:?}"/*
+    )
+}
+
+write_provenance() {
+    if ! command -v jq >/dev/null 2>&1; then
+        return 0
+    fi
+
+    jq -n \
+        --arg workflow_run_id "${GITHUB_RUN_ID:-}" \
+        --arg bench_name "$bench" \
+        --arg network "$network" \
+        --arg node_db_path "$node_db" \
+        --arg node_socket_path "$node_socket" \
+        --arg node_log_path "$node_log" \
+        --arg mithril_snapshot_hash "$mithril_snapshot_hash" \
+        --arg mithril_client_source "$mithril_client_source" \
+        --arg mithril_client_version "$mithril_client_version" \
+        --arg setup_started_at "$setup_started_at" \
+        --arg setup_finished_at "$setup_finished_at" \
+        --arg node_sync_completed_at "$node_sync_completed_at" \
+        --arg node_sync_wait_seconds "$node_sync_wait_seconds" \
+        --arg benchmark_started_at "$benchmark_started_at" \
+        --arg failure_stage "$failure_stage" \
+        --argjson final_tip "$final_tip_json" \
+        --argjson mithril_snapshot_tip "$mithril_snapshot_tip" \
+        '{
+          workflow_run_id: $workflow_run_id,
+          bench_name: $bench_name,
+          network: $network,
+          node_db_path: $node_db_path,
+          node_socket_path: $node_socket_path,
+          node_log_path: $node_log_path,
+          mithril_snapshot_hash: $mithril_snapshot_hash,
+          mithril_snapshot_tip: $mithril_snapshot_tip,
+          mithril_client_source: $mithril_client_source,
+          mithril_client_version: $mithril_client_version,
+          setup_started_at: $setup_started_at,
+          setup_finished_at: $setup_finished_at,
+          node_sync_completed_at: $node_sync_completed_at,
+          node_sync_wait_seconds: $node_sync_wait_seconds,
+          benchmark_started_at: $benchmark_started_at,
+          final_tip: $final_tip,
+          failure_stage: $failure_stage
+        }' >"$provenance_file" || true
+}
+
+cleanup() {
+    status=$?
+
+    if [[ -n "$node_pid" ]] && kill -0 "$node_pid" 2>/dev/null; then
+        kill "$node_pid" 2>/dev/null || true
+        wait "$node_pid" 2>/dev/null || true
+    fi
+
+    if [[ -f "$node_log" ]]; then
+        cp "$node_log" "$node_log_artifact" 2>/dev/null || true
+    fi
+
+    if [[ $status -ne 0 && -n "$failure_stage" ]]; then
+        echo "FAILURE_STAGE=$failure_stage"
+    fi
+
+    write_provenance
+}
+trap cleanup EXIT
+
+fail_stage() {
+    failure_stage=$1
+    exit 1
+}
+
+remaining_setup_seconds() {
+    local now
+    now=$(epoch_now)
+    echo $((setup_deadline - now))
+}
+
+require_setup_time() {
+    local remaining
+    remaining=$(remaining_setup_seconds)
+    if (( remaining <= 0 )); then
+        fail_stage "$1"
+    fi
+    echo "$remaining"
+}
 
 echo "--- Build"
 nix build --quiet .#ci.benchmarks.restore -o bench-restore
 
-echo "--- Run benchmarks - $network"
+mkdir -p "$work_dir"
+mkdir -p "$node_db"
 
-CARDANO_NODE_CONFIGS=$(pwd)/configs/cardano
+setup_started_at=$(iso_now)
+setup_start_epoch=$(epoch_now)
+setup_deadline=$((setup_start_epoch + setup_timeout_seconds))
 
-TO_TIP_TIMEOUT=4
+echo "--- Setup restore benchmark node - $network/$bench"
+echo "BENCH_NAME=$bench"
+echo "NETWORK=$network"
+echo "NODE_DB=$node_db"
+echo "NODE_SOCKET_PATH=$node_socket"
+echo "NODE_LOG_PATH=$node_log"
+echo "SETUP_STARTED_AT=$setup_started_at"
 
-BENCH_CMD="./bench-restore/bin/restore $network --node-db $node_db --bench-name $bench"
-BENCH_CMD+=" --cardano-node-configs $CARDANO_NODE_CONFIGS "
-BENCH_CMD+=" +RTS -N -qg -A1m -I0 -T -M16G -hT -RTS"
+echo "--- Provision Mithril snapshot"
+wipe_directory_contents "$node_db"
 
-if [ "$TO_TIP_TIMEOUT" != "infinite" ]; then
-    BENCH_CMD+=" --to-tip-timeout $TO_TIP_TIMEOUT"
+mithril_remaining=$(require_setup_time "setup:mithril-list")
+set +e
+timeout --foreground --kill-after=60s "$mithril_remaining" \
+    env \
+      NODE_DB="$node_db" \
+      MITHRIL_SNAPSHOT_INFO_FILE="$mithril_info_file" \
+      MITHRIL_STAGE_FILE="$mithril_stage_file" \
+      "$repo_root/run/mainnet/nix/snapshot.sh"
+mithril_status=$?
+set -e
+
+if (( mithril_status != 0 )); then
+    if [[ -s "$mithril_stage_file" ]]; then
+        failure_stage=$(<"$mithril_stage_file")
+    else
+        failure_stage="setup:mithril-list"
+    fi
+    fail_stage "$failure_stage"
 fi
 
-# When testing this script itself,
-# use the  timeout  command to cut short execution time
-# BENCH_CMD="timeout -s INT 6s "$BENCH_CMD""
-echo "$BENCH_CMD"
+if [[ -s "$mithril_info_file" ]]; then
+    mithril_snapshot_hash=$(jq -r '.snapshot_hash // empty' "$mithril_info_file")
+    mithril_snapshot_tip=$(jq -c '.snapshot_tip // null' "$mithril_info_file")
+    mithril_client_source=$(jq -r '.client_source // empty' "$mithril_info_file")
+    mithril_client_version=$(jq -r '.client_version // empty' "$mithril_info_file")
+fi
 
-# shellcheck disable=SC2086
-command time -o "$total_time" -v $BENCH_CMD 2>&1 | tee $log || true
+echo "MITHRIL_CLIENT_SOURCE=$mithril_client_source"
+echo "MITHRIL_CLIENT_VERSION=$mithril_client_version"
+echo "MITHRIL_SNAPSHOT_HASH=$mithril_snapshot_hash"
+echo "MITHRIL_SNAPSHOT_TIP=$mithril_snapshot_tip"
 
-grep -v INFO $log | awk '/All results/,EOF { print $0 }' >"$results"
+echo "--- Start cardano-node"
+CARDANO_NODE_CONFIGS="$repo_root/configs/cardano"
+node_config_dir="$CARDANO_NODE_CONFIGS/$network"
+
+cardano-node run \
+    --topology "$node_config_dir/topology.json" \
+    --database-path "$node_db" \
+    --socket-path "$node_socket" \
+    --config "$node_config_dir/config.json" \
+    +RTS -N -A16m -qg -qb -RTS >"$node_log" 2>&1 &
+node_pid=$!
+echo "NODE_PID=$node_pid"
+
+echo "--- Wait for node sync"
+last_progress=""
+last_slot=""
+last_change_epoch=0
+first_valid_tip=false
+
+while true; do
+    require_setup_time "setup:node-sync" >/dev/null
+
+    set +e
+    cardano-cli query tip --mainnet --socket-path "$node_socket" \
+        >"$tip_file" 2>"$tip_error_file"
+    query_status=$?
+    set -e
+
+    if (( query_status != 0 )); then
+        if ! kill -0 "$node_pid" 2>/dev/null; then
+            if [[ "$first_valid_tip" == true ]]; then
+                fail_stage "setup:node-sync"
+            else
+                fail_stage "setup:node-start"
+            fi
+        fi
+        sleep "$sync_poll_interval_seconds"
+        continue
+    fi
+
+    first_valid_tip=true
+    progress=$(jq -r '.syncProgress // empty' "$tip_file" | tr -d '%')
+    slot=$(jq -r '.slot // empty' "$tip_file")
+    final_tip_json=$(jq -c . "$tip_file")
+
+    if [[ -z "$progress" ]]; then
+        fail_stage "setup:node-sync"
+    fi
+
+    node_sync_progress=$progress
+    echo "NODE_SYNC_PROGRESS=$node_sync_progress"
+
+    if awk -v progress="$progress" 'BEGIN { exit !(progress + 0 >= 99.9) }'; then
+        node_sync_completed_at=$(iso_now)
+        node_sync_wait_seconds=$(( $(epoch_now) - setup_start_epoch ))
+        setup_finished_at=$node_sync_completed_at
+        echo "NODE_SYNC_COMPLETED_AT=$node_sync_completed_at"
+        echo "NODE_SYNC_WAIT_SECONDS=$node_sync_wait_seconds"
+        break
+    fi
+
+    now=$(epoch_now)
+    if [[ "$progress" != "$last_progress" || "$slot" != "$last_slot" ]]; then
+        last_progress=$progress
+        last_slot=$slot
+        last_change_epoch=$now
+    elif (( last_change_epoch > 0 && now - last_change_epoch >= sync_stale_seconds )); then
+        fail_stage "setup:node-sync"
+    fi
+
+    sleep "$sync_poll_interval_seconds"
+done
+
+echo "--- Run benchmarks - $network"
+benchmark_started_at=$(iso_now)
+echo "BENCHMARK_STARTED_AT=$benchmark_started_at"
+
+BENCH_CMD=(
+    ./bench-restore/bin/restore
+    "$network"
+    --running-node "$node_socket"
+    --bench-name "$bench"
+    --cardano-node-configs "$CARDANO_NODE_CONFIGS"
+    --to-tip-timeout 1
+    +RTS -N -qg -A1m -I0 -T -M16G -hT -RTS
+)
+
+printf '%q ' "${BENCH_CMD[@]}"
+printf '\n'
+
+set +e
+command time -o "$total_time" -v \
+    timeout --foreground --kill-after=60s "$benchmark_timeout_seconds" \
+    "${BENCH_CMD[@]}" 2>&1 | tee "$log"
+bench_status=${PIPESTATUS[0]}
+set -e
+
+grep -v INFO "$log" 2>/dev/null | awk '/All results/,EOF { print $0 }' >"$results" || true
 
 echo "+++ Results - $network"
-
 cat "$results"
 
 echo "+++ Memory Summary - $network"
@@ -73,11 +338,17 @@ if [ -n "$rts_section" ]; then
     echo "$rts_section"
 fi
 
-mv restore.hp "$artifact_name".hp
-hp2pretty "$artifact_name".hp
+if [[ -f restore.hp ]]; then
+    mv restore.hp "$artifact_name".hp
+    hp2pretty "$artifact_name".hp
+fi
+
+if (( bench_status != 0 )); then
+    fail_stage "benchmark:restore"
+fi
 
 if [ -z "$(cat "$results")" ]; then
   echo "+++ Bad news"
   echo "FAILED - Missing results" >/dev/stderr
-  exit 1
+  fail_stage "benchmark:restore"
 fi

--- a/specs/005-mithril-bench-snapshots/checklists/requirements.md
+++ b/specs/005-mithril-bench-snapshots/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Mithril-Provisioned Restoration Benchmark Runs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately names the workflow's matrix legs (`base`, `seq0`, `seq1`, `rnd5`) and the term "Mithril" because they are part of the feature's identity in the source issue, not implementation choices the spec is making. The choice of *how* to provision from Mithril (CLI flag, action, script) is intentionally left to planning.
+- Two areas to revisit in `speckit-clarify`:
+  - **What counts as "synced"?** The spec says "synced/ready tip" but does not define the operational signal (tip lag below threshold, JSON-RPC ready flag, etc.). Picking one significantly shapes implementation and may belong in the spec.
+  - **Timeout values.** The spec mandates *bounded* setup and benchmark timeouts but deliberately does not set numbers. The team may want to commit to ranges in the spec rather than defer to planning.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/005-mithril-bench-snapshots/checklists/requirements.md
+++ b/specs/005-mithril-bench-snapshots/checklists/requirements.md
@@ -32,7 +32,9 @@
 ## Notes
 
 - The spec deliberately names the workflow's matrix legs (`base`, `seq0`, `seq1`, `rnd5`) and the term "Mithril" because they are part of the feature's identity in the source issue, not implementation choices the spec is making. The choice of *how* to provision from Mithril (CLI flag, action, script) is intentionally left to planning.
-- Two areas to revisit in `speckit-clarify`:
-  - **What counts as "synced"?** The spec says "synced/ready tip" but does not define the operational signal (tip lag below threshold, JSON-RPC ready flag, etc.). Picking one significantly shapes implementation and may belong in the spec.
-  - **Timeout values.** The spec mandates *bounded* setup and benchmark timeouts but deliberately does not set numbers. The team may want to commit to ranges in the spec rather than defer to planning.
+- 2026-05-11 clarification session (see `spec.md ## Clarifications`) resolved the previously open areas:
+  - Operational signal for "synced/ready tip" → node-reported `syncProgress` ≥ 99.9%.
+  - Bounded setup timeout → 2 hours per matrix leg.
+  - Bounded benchmark timeout → 12 hours per matrix leg.
+  - Per-leg DB lifecycle → wipe at run start, retain between runs for triage.
 - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md
+++ b/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md
@@ -1,0 +1,163 @@
+# Contract: Restoration Benchmark Workflow
+
+**Feature Branch**: `005-mithril-bench-snapshots`
+**Date**: 2026-05-11
+
+## Workflow Interface
+
+**File**: `/code/cardano-wallet-issue-5278/.github/workflows/restoration-benchmarks.yml`
+
+The workflow remains available through:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+```
+
+The restore job matrix remains:
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    include:
+      - bench: base
+        node-db: mainnet-1
+      - bench: seq0
+        node-db: mainnet-2
+      - bench: seq1
+        node-db: mainnet-3
+      - bench: rnd5
+        node-db: mainnet-4
+```
+
+Each matrix leg must call:
+
+```bash
+bash scripts/ci/bench-restore.sh mainnet "$bench" "$HOME/databases/node/$node_db"
+```
+
+with these environment values available to the script:
+
+```text
+SETUP_TIMEOUT_SECONDS=7200
+BENCHMARK_TIMEOUT_SECONDS=43200
+SYNC_POLL_INTERVAL_SECONDS=15
+SYNC_STALE_SECONDS=1200
+TMPDIR=<runner temp directory>
+```
+
+## Script Interface
+
+**File**: `/code/cardano-wallet-issue-5278/scripts/ci/bench-restore.sh`
+
+### Arguments
+
+```text
+bench-restore.sh NETWORK BENCH NODE_DB
+```
+
+- `NETWORK`: must be `mainnet` for Mithril-provisioned restoration benchmarks.
+- `BENCH`: one of `base`, `seq0`, `seq1`, `rnd5`.
+- `NODE_DB`: absolute or runner-home-relative path dedicated to that matrix leg.
+
+### Exit Classes
+
+The script exits non-zero on failure and prints one of:
+
+```text
+FAILURE_STAGE=setup:mithril-list
+FAILURE_STAGE=setup:mithril-download
+FAILURE_STAGE=setup:mithril-extract
+FAILURE_STAGE=setup:node-start
+FAILURE_STAGE=setup:node-sync
+FAILURE_STAGE=benchmark:restore
+```
+
+The script exits zero only after:
+
+1. The node database has been wiped at setup start.
+2. A Mithril snapshot has been downloaded and extracted into that database.
+3. A per-leg node has reported `syncProgress >= 99.9` through
+   `cardano-cli query tip`.
+4. The restore benchmark has completed and produced the normal result artifact.
+
+## Required Workflow Log Fields
+
+Each run must print these fields before the benchmark starts:
+
+```text
+BENCH_NAME=<base|seq0|seq1|rnd5>
+NETWORK=mainnet
+NODE_DB=<path>
+MITHRIL_CLIENT_SOURCE=github:input-output-hk/mithril?ref=2543.1-hotfix
+MITHRIL_CLIENT_VERSION=<version>
+MITHRIL_SNAPSHOT_HASH=<hash>
+SETUP_STARTED_AT=<ISO-8601 timestamp>
+NODE_SYNC_PROGRESS=<numeric percentage>
+NODE_SYNC_COMPLETED_AT=<ISO-8601 timestamp>
+NODE_SYNC_WAIT_SECONDS=<integer seconds>
+BENCHMARK_STARTED_AT=<ISO-8601 timestamp>
+```
+
+On setup failure, the log must still include every field known at the time of
+failure plus `FAILURE_STAGE=setup:<stage>`.
+
+On benchmark failure, the log must include all setup fields plus
+`FAILURE_STAGE=benchmark:restore`.
+
+## Required Artifacts
+
+The workflow upload step must continue accepting the current benchmark artifacts:
+
+```text
+*.txt
+*.log
+*.svg
+*.hp
+```
+
+It must also accept:
+
+```text
+*.json
+```
+
+for the per-leg provenance record.
+
+## Readiness Poll Contract
+
+The setup phase polls:
+
+```bash
+cardano-cli query tip --mainnet --socket-path "$NODE_SOCKET_PATH"
+```
+
+The response is valid for readiness when:
+
+```text
+syncProgress_without_percent >= 99.9
+```
+
+Polling stops with setup failure when:
+
+- the setup timeout reaches 7200 seconds, or
+- valid tip JSON has been observed, readiness is not reached, and both slot and
+  sync progress remain unchanged for 1200 seconds.
+
+## Database Lifecycle Contract
+
+For each matrix leg:
+
+```text
+previous DB at NODE_DB
+  -> wiped at setup start
+  -> populated from Mithril
+  -> written only by this leg's cardano-node
+  -> preserved after success or failure
+  -> wiped by the next run for the same leg
+```
+
+No end-of-run cleanup may remove `NODE_DB`.

--- a/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md
+++ b/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md
@@ -70,6 +70,7 @@ The script exits non-zero on failure and prints one of:
 ```text
 FAILURE_STAGE=setup:mithril-list
 FAILURE_STAGE=setup:mithril-download
+FAILURE_STAGE=setup:mithril-convert
 FAILURE_STAGE=setup:mithril-extract
 FAILURE_STAGE=setup:node-start
 FAILURE_STAGE=setup:node-sync
@@ -92,9 +93,11 @@ Each run must print these fields before the benchmark starts:
 BENCH_NAME=<base|seq0|seq1|rnd5>
 NETWORK=mainnet
 NODE_DB=<path>
-MITHRIL_CLIENT_SOURCE=github:input-output-hk/mithril?ref=2543.1-hotfix
+MITHRIL_CLIENT_SOURCE=github:input-output-hk/mithril?ref=2617.0
 MITHRIL_CLIENT_VERSION=<version>
 MITHRIL_SNAPSHOT_HASH=<hash>
+MITHRIL_UTXO_HD_FLAVOR=LMDB
+MITHRIL_CARDANO_NODE_VERSION=<version>
 SETUP_STARTED_AT=<ISO-8601 timestamp>
 NODE_SYNC_PROGRESS=<numeric percentage>
 NODE_SYNC_COMPLETED_AT=<ISO-8601 timestamp>

--- a/specs/005-mithril-bench-snapshots/data-model.md
+++ b/specs/005-mithril-bench-snapshots/data-model.md
@@ -1,0 +1,155 @@
+# Data Model: Mithril-Provisioned Restoration Benchmark Runs
+
+**Feature Branch**: `005-mithril-bench-snapshots`
+**Date**: 2026-05-11
+
+## Entities
+
+### RestorationBenchmarkLeg
+
+**Location**: `/code/cardano-wallet-issue-5278/.github/workflows/restoration-benchmarks.yml`
+
+**Fields**:
+- `bench`: one of `base`, `seq0`, `seq1`, `rnd5`
+- `network`: `mainnet`
+- `node_db_name`: stable per-leg database suffix, currently `mainnet-1`
+  through `mainnet-4`
+- `node_db_path`: absolute runner path, currently
+  `$HOME/databases/node/<node_db_name>`
+
+**Validation rules**:
+- `bench` must match a benchmark name accepted by `restore --bench-name`.
+- `node_db_path` must be unique across all concurrently scheduled matrix legs.
+- The path is wiped only at setup start.
+
+**State transitions**:
+- `scheduled` -> `setup-running` -> `benchmark-running` -> `succeeded`
+- `scheduled` -> `setup-running` -> `setup-failed`
+- `scheduled` -> `setup-running` -> `benchmark-running` -> `benchmark-failed`
+
+### MithrilSnapshot
+
+**Location**: selected by `/code/cardano-wallet-issue-5278/run/mainnet/nix/snapshot.sh`
+
+**Fields**:
+- `network`: `mainnet`
+- `hash`: snapshot hash selected from `mithril-client cdb snapshot list --json`
+- `client_source`: pinned Nix source identifier,
+  `github:input-output-hk/mithril?ref=2543.1-hotfix`
+- `client_version`: `mithril-client --version`
+- `tip`: best-effort snapshot tip metadata if exposed by the client JSON
+
+**Validation rules**:
+- `hash` must be non-empty before download starts.
+- Snapshot download and extraction must complete inside the setup timeout.
+- Failure to list, download, or extract a snapshot is a setup failure.
+
+**Relationships**:
+- Populates exactly one `PerLegNodeDatabase` for a benchmark leg.
+- Appears in the leg's provenance record and workflow logs.
+
+### PerLegNodeDatabase
+
+**Location**: `$HOME/databases/node/<matrix-node-db>` on the self-hosted runner
+
+**Fields**:
+- `path`: absolute filesystem path
+- `owner_leg`: benchmark leg that may write this database
+- `snapshot_hash`: hash of the Mithril snapshot used to populate it
+- `created_at`: setup timestamp for the current run
+
+**Validation rules**:
+- Only the owning leg may run `cardano-node` against this path.
+- The path is removed and recreated before each Mithril provisioning attempt.
+- No end-of-run cleanup removes this path.
+
+**State transitions**:
+- `previous-run-db` -> `wiped-at-setup-start`
+- `wiped-at-setup-start` -> `mithril-populated`
+- `mithril-populated` -> `node-writing`
+- `node-writing` -> `preserved-for-triage`
+
+### SetupPhase
+
+**Location**: `/code/cardano-wallet-issue-5278/scripts/ci/bench-restore.sh`
+
+**Fields**:
+- `started_at`
+- `finished_at`
+- `timeout_seconds`: `7200`
+- `node_socket_path`
+- `node_log_path`
+- `sync_poll_interval_seconds`: `15`
+- `sync_stale_seconds`: `1200`
+- `final_sync_progress`
+- `final_tip`
+- `failure_stage`: one of `mithril-list`, `mithril-download`,
+  `mithril-extract`, `node-start`, `node-sync`
+
+**Validation rules**:
+- The benchmark phase may not start before `final_sync_progress >= 99.9`.
+- The phase must fail non-zero if the setup timeout or stale heuristic fires.
+- The phase must log elapsed sync wait duration on success and failure.
+
+### BenchmarkPhase
+
+**Location**: `/code/cardano-wallet-issue-5278/scripts/ci/bench-restore.sh` invoking the `restore` executable
+
+**Fields**:
+- `started_at`
+- `finished_at`
+- `timeout_seconds`: `43200`
+- `bench_name`
+- `running_node_socket`
+- `result_file`: `restore-mainnet.txt`
+- `time_file`: `restore-time.txt`
+- `heap_profile`: `restore-mainnet.hp`
+
+**Validation rules**:
+- Uses `--running-node` with the socket prepared by `SetupPhase`.
+- Does not perform Mithril download or node replay as part of the measured
+  restoration work.
+- Timeout is classified as `benchmark:restore`.
+
+### RunProvenanceRecord
+
+**Location**: workflow logs and a per-leg JSON artifact in the workflow working directory
+
+**Fields**:
+- `workflow_run_id`
+- `bench_name`
+- `network`
+- `node_db_path`
+- `mithril_snapshot_hash`
+- `mithril_client_source`
+- `mithril_client_version`
+- `setup_started_at`
+- `node_sync_completed_at`
+- `node_sync_wait_seconds`
+- `benchmark_started_at`
+- `final_tip`
+- `failure_stage`
+
+**Validation rules**:
+- Required fields are printed to the workflow log before the script exits.
+- JSON artifact is best effort on failure, but logs must remain sufficient.
+- `benchmark_started_at` is set only after node readiness succeeds.
+
+## Relationship Map
+
+```text
+RestorationBenchmarkLeg owns one PerLegNodeDatabase
+MithrilSnapshot populates one PerLegNodeDatabase per run
+SetupPhase selects MithrilSnapshot and starts cardano-node
+SetupPhase emits RunProvenanceRecord
+BenchmarkPhase consumes the SetupPhase node socket
+BenchmarkPhase appends benchmark result artifacts
+RunProvenanceRecord links setup timing to benchmark timing
+```
+
+## Migration Impact
+
+No persistent database schema changes. The only persistent runner state is the
+existing per-leg node database directory, whose lifecycle changes from
+"reuse if present" to "wipe at setup start, repopulate from Mithril, preserve
+until next setup start".

--- a/specs/005-mithril-bench-snapshots/data-model.md
+++ b/specs/005-mithril-bench-snapshots/data-model.md
@@ -35,7 +35,7 @@
 - `network`: `mainnet`
 - `hash`: snapshot hash selected from `mithril-client cdb snapshot list --json`
 - `client_source`: pinned Nix source identifier,
-  `github:input-output-hk/mithril?ref=2543.1-hotfix`
+  `github:input-output-hk/mithril?ref=2617.0`
 - `client_version`: `mithril-client --version`
 - `tip`: best-effort snapshot tip metadata if exposed by the client JSON
 
@@ -84,7 +84,7 @@
 - `final_sync_progress`
 - `final_tip`
 - `failure_stage`: one of `mithril-list`, `mithril-download`,
-  `mithril-extract`, `node-start`, `node-sync`
+  `mithril-convert`, `mithril-extract`, `node-start`, `node-sync`
 
 **Validation rules**:
 - The benchmark phase may not start before `final_sync_progress >= 99.9`.

--- a/specs/005-mithril-bench-snapshots/plan.md
+++ b/specs/005-mithril-bench-snapshots/plan.md
@@ -19,7 +19,7 @@ helper, starting a per-leg `cardano-node`, polling `cardano-cli query tip` until
 ## Technical Context
 
 **Language/Version**: Bash for CI orchestration; Haskell/GHC 9.6.x via the Nix flake for the existing benchmark executable
-**Primary Dependencies**: GitHub Actions, Nix flake packages, `cardano-node`, `cardano-cli`, `mithril-client` from `github:input-output-hk/mithril?ref=2543.1-hotfix`, `jq`, GNU `timeout`, existing `ci.benchmarks.restore` derivation
+**Primary Dependencies**: GitHub Actions, Nix flake packages, `cardano-node`, `cardano-cli`, `mithril-client` from `github:input-output-hk/mithril?ref=2617.0`, `jq`, GNU `timeout`, existing `ci.benchmarks.restore` derivation
 **Storage**: Per-leg filesystem ChainDB under `$HOME/databases/node/<matrix-node-db>` on self-hosted benchmark runners
 **Testing**: Shell syntax/lint checks, Nix build of `.#ci.benchmarks.restore`, targeted workflow dispatch, workflow-log inspection for provenance and timeout classification
 **Target Platform**: Linux x86_64 self-hosted GitHub Actions runners labelled `cardano-wallet-bench`

--- a/specs/005-mithril-bench-snapshots/plan.md
+++ b/specs/005-mithril-bench-snapshots/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Mithril-Provisioned Restoration Benchmark Runs
+
+**Branch**: `005-mithril-bench-snapshots` | **Date**: 2026-05-11 | **Spec**: [/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/spec.md](/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/spec.md)
+**Input**: Feature specification from `/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/spec.md`
+**Issue**: #5278
+
+## Summary
+
+Change the restoration benchmark workflow so every matrix leg starts from a
+fresh mainnet Mithril ChainDB snapshot instead of whatever node database happens
+to exist on the self-hosted runner. The implementation stays at the CI
+orchestration layer: `.github/workflows/restoration-benchmarks.yml` keeps the
+four benchmark variants, while `scripts/ci/bench-restore.sh` owns the setup
+phase by wiping the per-leg database, calling the existing Mithril snapshot
+helper, starting a per-leg `cardano-node`, polling `cardano-cli query tip` until
+`syncProgress >= 99.9`, and only then running the restore benchmark with
+`--running-node`.
+
+## Technical Context
+
+**Language/Version**: Bash for CI orchestration; Haskell/GHC 9.6.x via the Nix flake for the existing benchmark executable
+**Primary Dependencies**: GitHub Actions, Nix flake packages, `cardano-node`, `cardano-cli`, `mithril-client` from `github:input-output-hk/mithril?ref=2543.1-hotfix`, `jq`, GNU `timeout`, existing `ci.benchmarks.restore` derivation
+**Storage**: Per-leg filesystem ChainDB under `$HOME/databases/node/<matrix-node-db>` on self-hosted benchmark runners
+**Testing**: Shell syntax/lint checks, Nix build of `.#ci.benchmarks.restore`, targeted workflow dispatch, workflow-log inspection for provenance and timeout classification
+**Target Platform**: Linux x86_64 self-hosted GitHub Actions runners labelled `cardano-wallet-bench`
+**Project Type**: Haskell monorepo with CI workflow and shell-script integration changes
+**Performance Goals**: All four matrix legs reach benchmark start within the 2 hour setup budget and preserve the existing restoration benchmark artifacts
+**Constraints**: Do not include Mithril download, extraction, node startup, or node sync in the reported restoration benchmark metric; preserve the last per-leg database after a failed run until the next run starts; never share mutable ChainDB state between matrix legs
+**Scale/Scope**: One scheduled/manual workflow, four matrix legs (`base`, `seq0`, `seq1`, `rnd5`), one CI script, one existing shared Mithril snapshot helper
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Maintenance-First Stability | PASS | The change is confined to benchmark CI orchestration and reuses existing benchmark and Mithril tooling. |
+| II. Era-Aware Design | PASS | No protocol-era domain logic changes are planned. The node and benchmark continue to use existing mainnet configs. |
+| III. Type Safety as Security | PASS | No cryptographic key, transaction, or wallet type changes are planned. |
+| IV. Formal Specification | PASS | REST API and Lean specifications are unaffected. |
+| V. Reproducible Builds | PASS | All new runtime tools come from `nix shell --quiet`; the Mithril client source stays pinned to the existing repo-local helper pattern. |
+| VI. Comprehensive Testing | PASS | Verification includes shell checks, Nix benchmark build, and an end-to-end restoration benchmark workflow run. |
+| VII. Code Quality Gates | PASS | CI must be green before the draft PR is marked ready. |
+
+## Project Structure
+
+### Documentation
+
+```text
+/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- restoration-benchmarks.md
+|-- checklists/
+|   `-- requirements.md
+`-- spec.md
+```
+
+### Affected Source Code
+
+```text
+/code/cardano-wallet-issue-5278/
+|-- .github/workflows/
+|   |-- restoration-benchmarks.yml     # Fixed setup/benchmark budgets, per-leg setup call, artifact upload
+|   `-- linux-mithril-sync.yml         # Reference pattern only; no behavioral change expected
+|-- scripts/ci/
+|   `-- bench-restore.sh               # Mithril setup, node lifecycle, sync polling, benchmark timeout
+|-- run/common/nix/
+|   `-- snapshot.sh                    # Reused and possibly extended for provenance output
+|-- run/mainnet/nix/
+|   |-- .env                           # Mainnet Mithril aggregator and verification keys
+|   `-- snapshot.sh                    # Symlink entry point used by benchmark setup
+`-- lib/benchmarks/
+    |-- src/Cardano/Wallet/BenchShared.hs
+    `-- exe/restore-bench.hs           # Expected unchanged; touch only if `--running-node` cannot satisfy phase split
+```
+
+**Structure Decision**: Keep implementation in the existing CI surface. Avoid
+adding a second benchmark executable or a new package. Prefer a small shell
+helper/function inside `scripts/ci/bench-restore.sh`; extract a separate
+`scripts/ci/restore-mithril-node.sh` only if the script becomes hard to test.
+
+## Implementation Approach
+
+1. **Workflow contract update**
+   - Remove or stop using the operator-selected `to-tip-timeout` input.
+   - Set fixed budgets in the restore job: `SETUP_TIMEOUT_SECONDS=7200` and `BENCHMARK_TIMEOUT_SECONDS=43200`.
+   - Keep the four matrix entries and their existing unique node database names.
+   - Reduce the job timeout to the combined setup and benchmark budget plus CI overhead, for example 870 minutes.
+
+2. **Per-leg setup phase in `scripts/ci/bench-restore.sh`**
+   - Treat the third argument as the persistent per-leg database path.
+   - Emit setup provenance before destructive work: bench name, network, node DB path, runner temp path, and timestamps.
+   - Wipe `${node_db:?}` at the start of the setup phase only.
+   - Source `run/mainnet/nix/.env` through a path derived from the runtime repo root and call `run/mainnet/nix/snapshot.sh` with `NODE_DB=$node_db`.
+   - Log the Mithril client source identifier and `mithril-client --version` before snapshot listing/download.
+   - Capture the snapshot hash selected by the helper. If `snapshot.sh` is extended, make it print and optionally write this value without changing its current behavior for `linux-mithril-sync.yml`.
+
+3. **Node startup and readiness gate**
+   - Start one `cardano-node` per matrix leg using the existing mainnet config and the same isolated database path.
+   - Put the socket and node log under `$TMPDIR/bench/restore/<bench>/` so concurrent legs do not collide.
+   - Poll `cardano-cli query tip --mainnet --socket-path "$socket"` every 15 seconds.
+   - Parse `.syncProgress` as a percentage number after removing the trailing percent sign.
+   - Proceed only when `syncProgress >= 99.9`.
+   - Fail the setup phase if the 2 hour setup timeout expires or if the reported slot/progress stays unchanged for 20 minutes after the node first returns a valid JSON tip.
+
+4. **Benchmark phase**
+   - Run the existing `restore` executable with `--running-node "$socket"` so setup and node sync are complete before the measured wallet restoration work starts.
+   - Wrap the benchmark command in GNU `timeout --foreground --kill-after=60s "$BENCHMARK_TIMEOUT_SECONDS"`.
+   - Keep the existing result extraction, memory summary, heap profile conversion, and artifact names.
+   - Pass a very small `--to-tip-timeout` only as a defensive readiness check if the already-running node path still invokes `prepareNode`; it should not be the setup budget.
+
+5. **Failure classification**
+   - Emit `FAILURE_STAGE=setup:mithril-list`, `setup:mithril-download`, `setup:node-start`, `setup:node-sync`, or `benchmark:restore` before exiting non-zero.
+   - Preserve the per-leg database on all exits. The next run for the same leg will wipe it before provisioning.
+   - Kill the node process on script exit, but do not remove its database.
+
+6. **Observability**
+   - Emit line-oriented log fields and a small JSON provenance artifact containing snapshot hash, Mithril client source/version, node DB path, setup timings, final tip, and benchmark start time.
+   - Extend the workflow artifact upload pattern to include `*.json`.
+   - Record a successful end-to-end workflow URL in the PR before marking it ready.
+
+## Phase 0 Research Output
+
+Resolved in [/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/research.md](/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/research.md).
+
+## Phase 1 Design Output
+
+- Data model: [/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/data-model.md](/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/data-model.md)
+- Interface contract: [/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md](/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md)
+- Quickstart: [/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/quickstart.md](/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/quickstart.md)
+
+## Constitution Check After Design
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Maintenance-First Stability | PASS | Existing CI entry points are reused; no production wallet behavior changes. |
+| II. Era-Aware Design | PASS | No era-indexed code changes are required. |
+| III. Type Safety as Security | PASS | No type-safety regressions; shell changes only orchestrate benchmark infrastructure. |
+| IV. Formal Specification | PASS | No public API or formal spec change. |
+| V. Reproducible Builds | PASS | Runtime dependencies are supplied by `nix shell --quiet`; no unpinned external installer is introduced. |
+| VI. Comprehensive Testing | PASS | The required proof is a workflow run showing all four variants start after Mithril sync and produce artifacts. |
+| VII. Code Quality Gates | PASS | The PR remains draft until CI and the targeted benchmark workflow are green. |
+
+## Complexity Tracking
+
+No constitution violations. No additional complexity exception is requested.

--- a/specs/005-mithril-bench-snapshots/quickstart.md
+++ b/specs/005-mithril-bench-snapshots/quickstart.md
@@ -1,0 +1,132 @@
+# Quickstart: Mithril-Provisioned Restoration Benchmark Runs
+
+**Feature Branch**: `005-mithril-bench-snapshots`
+**Date**: 2026-05-11
+
+## Local Static Checks
+
+Run from `/code/cardano-wallet-issue-5278`:
+
+```bash
+bash -n scripts/ci/bench-restore.sh
+```
+
+```bash
+nix shell --quiet nixpkgs#shellcheck -c shellcheck scripts/ci/bench-restore.sh run/common/nix/snapshot.sh
+```
+
+```bash
+nix build --quiet .#ci.benchmarks.restore
+```
+
+## Local Dry Run
+
+Use this only to validate argument handling and early setup logging without a
+full mainnet run:
+
+```bash
+TMPDIR="${TMPDIR:-/tmp}" \
+SETUP_TIMEOUT_SECONDS=60 \
+BENCHMARK_TIMEOUT_SECONDS=60 \
+SYNC_STALE_SECONDS=30 \
+bash scripts/ci/bench-restore.sh mainnet base "$TMPDIR/cardano-wallet-restore-dry-run-node-db"
+```
+
+Expected dry-run outcome on a normal developer machine is a setup failure if
+network, disk, or runner resources are not available. The useful signal is that
+the log classifies the failure as `setup:<stage>` and preserves the node DB
+path rather than silently falling through to an existing database.
+
+## Failure-Stage Smokes
+
+The setup-timeout smoke can run on a normal developer machine. It proves that a
+stale per-leg node database is wiped before Mithril provisioning and that setup
+failure is classified:
+
+```bash
+dry_db=$(mktemp -d)
+dry_tmp=$(mktemp -d)
+touch "$dry_db/stale-marker"
+TMPDIR="$dry_tmp" \
+SETUP_TIMEOUT_SECONDS=1 \
+BENCHMARK_TIMEOUT_SECONDS=1 \
+SYNC_STALE_SECONDS=1 \
+bash scripts/ci/bench-restore.sh mainnet base "$dry_db"
+test ! -e "$dry_db/stale-marker"
+rm -rf "$dry_db" "$dry_tmp"
+```
+
+Expected log fields:
+
+```text
+BENCH_NAME=base
+NODE_DB=<temporary path>
+SETUP_STARTED_AT=<timestamp>
+FAILURE_STAGE=setup:mithril-list
+```
+
+The node-sync and benchmark-timeout smokes require a benchmark runner because
+they need a downloaded Mithril snapshot and a started mainnet node:
+
+```bash
+TMPDIR="${TMPDIR:-/tmp}" \
+SETUP_TIMEOUT_SECONDS=7200 \
+BENCHMARK_TIMEOUT_SECONDS=60 \
+SYNC_STALE_SECONDS=30 \
+bash scripts/ci/bench-restore.sh mainnet base "$HOME/databases/node/mainnet-smoke"
+```
+
+For node-sync validation, temporarily lower `SYNC_STALE_SECONDS` on the runner
+or interrupt node progress after startup; expected classification is
+`FAILURE_STAGE=setup:node-sync`. For benchmark-timeout validation, use a very
+small `BENCHMARK_TIMEOUT_SECONDS` after setup has completed; expected
+classification is `FAILURE_STAGE=benchmark:restore`.
+
+## End-to-End Workflow Check
+
+After implementation is pushed to the draft PR branch, trigger the workflow:
+
+```bash
+gh workflow run "Restoration Benchmarks" --ref 005-mithril-bench-snapshots
+```
+
+Watch the run:
+
+```bash
+gh run list --workflow "Restoration Benchmarks" --branch 005-mithril-bench-snapshots --limit 5
+```
+
+For the successful run, confirm each matrix leg log contains:
+
+```text
+MITHRIL_SNAPSHOT_HASH=
+MITHRIL_CLIENT_VERSION=
+NODE_DB=
+NODE_SYNC_COMPLETED_AT=
+NODE_SYNC_WAIT_SECONDS=
+BENCHMARK_STARTED_AT=
+```
+
+Confirm each matrix leg artifact contains the existing benchmark outputs:
+
+```text
+restore-mainnet.txt
+restore-time.txt
+restore-mainnet.hp
+restore-mainnet.svg
+```
+
+and the new provenance JSON artifact.
+
+## PR Evidence
+
+Before marking the PR ready for review, add a PR comment or description update
+with:
+
+```text
+Restoration Benchmarks workflow: <workflow-run-url>
+Evidence: all four variants started after Mithril-provisioned node sync and uploaded normal artifacts.
+```
+
+Also rerun any unrelated flaky CI job once the full workflow has finished, then
+wait for the PR checks to settle before requesting review.

--- a/specs/005-mithril-bench-snapshots/research.md
+++ b/specs/005-mithril-bench-snapshots/research.md
@@ -1,0 +1,142 @@
+# Research: Mithril-Provisioned Restoration Benchmark Runs
+
+**Feature Branch**: `005-mithril-bench-snapshots`
+**Date**: 2026-05-11
+
+## Decision: Reuse the existing Mithril snapshot helper
+
+**Decision**: Use `/code/cardano-wallet-issue-5278/run/mainnet/nix/snapshot.sh`
+as the benchmark setup entry point for downloading and extracting the latest
+mainnet Mithril snapshot. Extend `/code/cardano-wallet-issue-5278/run/common/nix/snapshot.sh`
+only as needed to emit snapshot provenance.
+
+**Rationale**: The repo already uses this helper in
+`/code/cardano-wallet-issue-5278/.github/workflows/linux-mithril-sync.yml`.
+It sources the mainnet Mithril aggregator and verification keys from
+`run/mainnet/nix/.env`, runs `mithril-client` through `nix shell --quiet`, wipes
+the target `NODE_DB`, downloads the selected snapshot, and moves the extracted
+`db/` contents into the node database path. Reusing it avoids a second Mithril
+client setup path.
+
+**Alternatives considered**:
+- Inline all Mithril commands in `restoration-benchmarks.yml`: rejected because
+  it duplicates a pattern already maintained in `run/common/nix/snapshot.sh`.
+- Use `run/mainnet/nix/run.sh` with `USE_MITHRIL`: rejected because it also owns
+  wallet/node service lifecycle and has cleanup behavior that does not match the
+  "preserve DB until next run starts" requirement.
+- Use `Cardano.Launcher.Mithril` from Haskell: rejected for this feature because
+  the benchmark workflow already has shell-level orchestration and the existing
+  CI helper is enough.
+
+## Decision: Own phase separation in `scripts/ci/bench-restore.sh`
+
+**Decision**: Move Mithril provisioning, node startup, node sync polling, and
+stage timing into `/code/cardano-wallet-issue-5278/scripts/ci/bench-restore.sh`.
+Then run the existing benchmark executable against an already-running node using
+`--running-node`.
+
+**Rationale**: The current benchmark executable can either start its own node or
+connect to an existing node. If the benchmark binary starts the node, the shell
+cannot enforce separate setup and benchmark timeouts. Preparing a synced node in
+the script lets the workflow keep setup failures distinct from benchmark
+failures while preserving the benchmark implementation and result format.
+
+**Alternatives considered**:
+- Keep letting `restore-bench` start the node: rejected because setup and
+  benchmark timeouts remain coupled at the process boundary.
+- Add a new benchmark executable mode: rejected unless implementation discovers
+  that the existing `--running-node` option is insufficient.
+
+## Decision: Wipe the per-leg database at setup start only
+
+**Decision**: For each matrix leg, remove the contents of the configured node
+database path immediately before Mithril provisioning. Do not remove the
+database on success or failure.
+
+**Rationale**: This satisfies the disk-footprint requirement and leaves the most
+recent failed run's database available for triage. The current workflow already
+assigns stable, unique database names: `mainnet-1`, `mainnet-2`, `mainnet-3`,
+and `mainnet-4`. Keeping those names maintains operator familiarity while
+preventing cross-leg state sharing.
+
+**Alternatives considered**:
+- Use a new timestamped database directory per run: rejected because it can
+  accumulate multiple full ChainDBs per leg.
+- Clean up at the end of each run: rejected because it removes failure evidence
+  that the spec requires preserving until the next run.
+
+## Decision: Poll `cardano-cli query tip` for readiness
+
+**Decision**: After node startup, poll:
+
+```bash
+cardano-cli query tip --mainnet --socket-path "$socket"
+```
+
+every 15 seconds. Parse the JSON `.syncProgress` field after removing `%`, and
+allow the benchmark phase to start only after the value is at least `99.9`.
+
+**Rationale**: The feature clarification names node-reported `syncProgress` from
+the canonical tip query as the readiness signal. Polling the node socket avoids
+guessing based on elapsed time or relying on wallet sync state.
+
+**Alternatives considered**:
+- Use the wallet `/v2/network/information` endpoint: rejected because this
+  benchmark does not need to start `cardano-wallet serve` and the clarified
+  signal is node-reported.
+- Use the benchmark executable's internal `Ready` wait as the only gate:
+  rejected because it hides setup timing and failure classification inside the
+  benchmark process.
+
+## Decision: Use a 15 second poll cadence and 20 minute stale heuristic
+
+**Decision**: Poll every 15 seconds. Once `cardano-cli query tip` returns valid
+JSON, track the last observed slot and sync progress. If neither value changes
+for 20 minutes before readiness is reached, classify the run as
+`setup:node-sync` failure and exit non-zero. The hard 2 hour setup timeout still
+applies around the entire setup phase.
+
+**Rationale**: A 15 second cadence keeps logs useful without flooding the GitHub
+Actions UI. A 20 minute no-progress window is long enough to avoid normal
+mainnet block cadence variance and short enough to surface a stuck node before
+the full setup budget is wasted.
+
+**Alternatives considered**:
+- Poll every second: rejected because it produces noisy logs and unnecessary
+  `cardano-cli` invocations.
+- Rely only on the 2 hour setup timeout: rejected because it delays diagnosis
+  when the node is clearly stalled.
+
+## Decision: Fixed setup and benchmark timeouts
+
+**Decision**: Use a fixed 2 hour setup timeout and a fixed 12 hour benchmark
+timeout per matrix leg. Implement both with GNU `timeout` from `nixpkgs#coreutils`.
+Keep the GitHub Actions job timeout slightly larger than the sum to allow
+checkout, artifact upload, and teardown.
+
+**Rationale**: The spec requires separate bounded budgets. Fixed budgets make
+scheduled benchmark results comparable and remove the current manual
+`to-tip-timeout` input as a source of run-to-run variation.
+
+**Alternatives considered**:
+- Keep the workflow dispatch `to-tip-timeout` choice: rejected because it lets
+  operators vary a required benchmark invariant.
+- Use only the job-level `timeout-minutes`: rejected because it cannot classify
+  whether setup or benchmark exceeded its budget.
+
+## Decision: Emit both logs and JSON provenance
+
+**Decision**: Print line-oriented provenance fields to the workflow log and
+write a JSON artifact for each matrix leg. Include Mithril snapshot hash,
+Mithril client source/version, node DB path, setup start/end, sync wait
+duration, final node tip, and benchmark start time.
+
+**Rationale**: The spec requires diagnosis from workflow logs alone. A JSON
+artifact gives reviewers and future scripts a stable format without replacing
+human-readable logs.
+
+**Alternatives considered**:
+- Artifact only: rejected because the requirement explicitly calls for workflow
+  logs to be sufficient.
+- Logs only: rejected because structured artifacts are cheap and make PR
+  evidence easier to inspect.

--- a/specs/005-mithril-bench-snapshots/spec.md
+++ b/specs/005-mithril-bench-snapshots/spec.md
@@ -5,6 +5,15 @@
 **Status**: Draft
 **Input**: GitHub issue cardano-foundation/cardano-wallet#5278 — "Use Mithril snapshots for every restoration benchmark run"
 
+## Clarifications
+
+### Session 2026-05-11
+
+- Q: What operational signal counts as "node synced/ready tip" before the wallet benchmark starts? → A: Node-reported sync progress reaches ≥ 99.9% (canonical `query tip` `syncProgress` field).
+- Q: What is the bounded setup timeout (Mithril download + extraction + node startup + node sync)? → A: 2 hours per matrix leg.
+- Q: What is the bounded benchmark timeout (wallet restoration phase alone, post-setup)? → A: 12 hours per matrix leg.
+- Q: What is the per-leg node DB lifecycle between runs? → A: Cleanup happens at the START of each run, not the end. The previous run's per-leg DB persists on disk until the next run for that leg begins, then is wiped before fresh Mithril provisioning. There is never more than one DB per leg at rest, and a failed run's DB stays available for triage until the next scheduled run.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 — Repeatable restoration benchmarks unaffected by stale runner state (Priority: P1)
@@ -69,17 +78,18 @@ The four restoration benchmark variants (`base`, `seq0`, `seq1`, `rnd5`) can run
 
 - **FR-001**: The restoration benchmark workflow MUST provision a node database from a Mithril snapshot at the start of every run, on every matrix leg, instead of relying on any pre-existing node database on the runner.
 - **FR-002**: Each matrix leg (`base`, `seq0`, `seq1`, `rnd5`) MUST operate on an isolated node database, such that two legs running concurrently cannot read or write the same database state.
-- **FR-003**: The workflow MUST start the wallet restoration benchmark measurement only after `cardano-node` has reached a synced/ready tip for that leg's database.
+- **FR-003**: The workflow MUST start the wallet restoration benchmark measurement only after `cardano-node` for that leg reports a sync progress value of at least 99.9% (as exposed by the node's canonical tip query). The signal MUST be polled, not assumed from elapsed time.
 - **FR-004**: The reported wallet restoration benchmark time MUST NOT include Mithril download, Mithril extraction, node startup, or node sync time. These setup phases MUST be timed and logged independently.
 - **FR-005**: For every run, the workflow logs MUST include, at minimum: (a) Mithril snapshot hash, (b) Mithril client source identifier and version, (c) the node database path used for that leg, (d) the elapsed node-sync wait duration, (e) the wall-clock time at which the wallet benchmark was started.
-- **FR-006**: The workflow MUST enforce a bounded timeout on the combined Mithril-provisioning-and-node-sync setup phase, and a separate bounded timeout on the wallet restoration benchmark phase. A timeout in one MUST NOT consume the budget of the other.
+- **FR-006**: The workflow MUST enforce a bounded timeout of 2 hours per matrix leg on the combined Mithril-provisioning-and-node-sync setup phase, and a separate bounded timeout of 12 hours per matrix leg on the wallet restoration benchmark phase. A timeout in one MUST NOT consume the budget of the other.
 - **FR-007**: When the setup phase fails or times out (Mithril download, extraction, node startup, or node sync), the workflow MUST classify the failure as a setup failure, distinct from a benchmark failure, in its logs and exit status.
 - **FR-008**: The change MUST be observable end-to-end by linking a successful workflow run in which all four restoration benchmark variants start after Mithril-provisioned node sync and produce the normal benchmark artifacts they produced before this change.
+- **FR-009**: Each matrix leg MUST wipe its per-leg node database path at the start of the run, immediately before Mithril provisioning. No end-of-run cleanup step is required; this guarantees at most one per-leg database is at rest between runs and preserves the most recent run's database for triage.
 
 ### Key Entities
 
 - **Mithril snapshot**: An immutable, hash-identified node database checkpoint published by the Mithril aggregator and consumed by a Mithril client. Has a snapshot hash, a network (mainnet), and an associated tip.
-- **Per-leg node database**: A filesystem location dedicated to one matrix leg's node instance, populated by extracting a Mithril snapshot, written to only by that leg's node process, and discarded (or treated as discardable) at run end.
+- **Per-leg node database**: A filesystem location dedicated to one matrix leg's node instance, populated by extracting a Mithril snapshot at the start of each run (after wiping any prior contents at the same path) and written to only by that leg's node process. Between runs, the previous run's database persists at this path (available for triage) until the next run for that leg wipes it.
 - **Setup phase**: The portion of a run that downloads the Mithril snapshot, extracts it, starts `cardano-node`, and waits for sync. Bounded by its own timeout. Time spent here is recorded but not attributed to the benchmark metric.
 - **Benchmark phase**: The portion of a run that executes the wallet restoration benchmark against an already-synced node. Bounded by its own timeout. Time spent here is the metric of interest.
 - **Run provenance record**: The set of log fields emitted on every run that lets a later reader identify the snapshot, client, database path, sync wait, and benchmark start time without re-running.

--- a/specs/005-mithril-bench-snapshots/spec.md
+++ b/specs/005-mithril-bench-snapshots/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Mithril-Provisioned Restoration Benchmark Runs
+
+**Feature Branch**: `005-mithril-bench-snapshots`
+**Created**: 2026-05-11
+**Status**: Draft
+**Input**: GitHub issue cardano-foundation/cardano-wallet#5278 — "Use Mithril snapshots for every restoration benchmark run"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Repeatable restoration benchmarks unaffected by stale runner state (Priority: P1)
+
+The benchmark operator triggers the restoration benchmark workflow and gets restoration timings that reflect wallet-restoration cost only, not the cost of replaying a stale ChainDB or recovering from a node-version mismatch. Each run starts from a known-good node database derived from a published Mithril snapshot, regardless of what the self-hosted runner had on disk previously.
+
+**Why this priority**: This is the core value of the change. Without it, results are unstable and runs frequently fail before the benchmark even begins, making the benchmark unusable as a regression signal.
+
+**Independent Test**: Trigger the restoration benchmark workflow on a runner whose persistent disk is empty, stale, or carries a database from an older node version. All four matrix variants (`base`, `seq0`, `seq1`, `rnd5`) must still complete and produce normal benchmark artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a benchmark runner with no usable persistent node database, **When** the restoration benchmark workflow runs, **Then** the workflow provisions a fresh node database from a Mithril snapshot and the benchmark completes without an unrelated replay/version failure.
+2. **Given** a benchmark runner whose persistent database was produced by an older node version, **When** the restoration benchmark workflow runs, **Then** the workflow ignores the existing on-disk database, provisions a fresh one from Mithril, and the benchmark completes.
+3. **Given** the workflow is invoked on a fresh schedule, **When** all four matrix legs run, **Then** each leg measures only wallet restoration time and not node bring-up time.
+
+---
+
+### User Story 2 — Failed runs are diagnosable from workflow logs alone (Priority: P2)
+
+When a restoration benchmark fails, the on-call engineer can determine from the workflow logs which Mithril snapshot was used, which Mithril client version produced it, where the node database lived on the runner, how long node sync took, and when the wallet benchmark actually started — without re-running anything or SSHing into the runner.
+
+**Why this priority**: Restoration benchmarks run on shared self-hosted runners and are infrequent. Investigating a failure days later, with no runner shell access, requires that provenance be captured at run time. Without this, an engineer cannot distinguish "Mithril upstream regressed" from "node failed to sync" from "wallet restoration regressed".
+
+**Independent Test**: Force a failure at each stage (Mithril download, extraction, node startup, node sync, benchmark) and confirm that the workflow log contains the provenance fields listed below at the point of failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow run that fails during Mithril download, **When** an engineer reads the logs, **Then** they see the requested snapshot hash and the Mithril client source/version.
+2. **Given** a workflow run that fails during node sync, **When** an engineer reads the logs, **Then** they see the node database path, the sync wait duration so far, and the last-known sync state.
+3. **Given** a workflow run that succeeds, **When** an engineer reads the logs, **Then** the recorded benchmark start time is clearly distinct from the node-sync completion time.
+
+---
+
+### User Story 3 — Matrix legs run in parallel without sharing mutable node state (Priority: P2)
+
+The four restoration benchmark variants (`base`, `seq0`, `seq1`, `rnd5`) can run simultaneously on the same runner (or across runners) without one leg's node corrupting another's database or one leg waiting on another's node startup.
+
+**Why this priority**: Parallel matrix execution is the whole reason restoration benchmarks complete in a workable wall-clock window. Sharing mutable node state across legs would either force serialization or produce cross-contaminated results.
+
+**Independent Test**: Trigger the workflow and observe that each matrix leg holds an isolated node database path; verify by inspecting log provenance that no two legs reference the same database path.
+
+**Acceptance Scenarios**:
+
+1. **Given** all four matrix legs are scheduled together, **When** they run in parallel, **Then** each leg's node database path is unique and not modified by any other leg.
+2. **Given** two legs run at the same time, **When** one leg's node is bringing up, **Then** the other leg's node startup is not blocked by it.
+
+---
+
+### Edge Cases
+
+- Mithril upstream returns no usable snapshot (network outage, signed-certificate gap, empty aggregator). The workflow must fail fast within the setup timeout and produce diagnosable logs rather than silently fall back to a stale on-disk database.
+- Mithril download succeeds but extraction fails (corrupt archive, disk full). The workflow must report the failure stage explicitly and not advance to the benchmark stage.
+- Node starts but never reaches a synced tip within the bounded sync timeout. The workflow must abort the run, mark setup as failed (not benchmark as failed), and record the sync wait duration reached.
+- The bounded benchmark timeout expires while a wallet restoration is in flight. The workflow must terminate the benchmark cleanly and report it as a benchmark-stage failure, separate from setup-stage failures.
+- Two matrix legs request the same Mithril snapshot at the same time. The workflow must allow either independent downloads or shared read-only reuse, but must not let one leg's failure or cleanup affect another's database.
+- A successful Mithril snapshot is older than the wallets' birth point used by some matrix legs. The workflow must surface the snapshot hash and snapshot tip so this can be diagnosed; it is out of scope to auto-select a "fresh enough" snapshot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The restoration benchmark workflow MUST provision a node database from a Mithril snapshot at the start of every run, on every matrix leg, instead of relying on any pre-existing node database on the runner.
+- **FR-002**: Each matrix leg (`base`, `seq0`, `seq1`, `rnd5`) MUST operate on an isolated node database, such that two legs running concurrently cannot read or write the same database state.
+- **FR-003**: The workflow MUST start the wallet restoration benchmark measurement only after `cardano-node` has reached a synced/ready tip for that leg's database.
+- **FR-004**: The reported wallet restoration benchmark time MUST NOT include Mithril download, Mithril extraction, node startup, or node sync time. These setup phases MUST be timed and logged independently.
+- **FR-005**: For every run, the workflow logs MUST include, at minimum: (a) Mithril snapshot hash, (b) Mithril client source identifier and version, (c) the node database path used for that leg, (d) the elapsed node-sync wait duration, (e) the wall-clock time at which the wallet benchmark was started.
+- **FR-006**: The workflow MUST enforce a bounded timeout on the combined Mithril-provisioning-and-node-sync setup phase, and a separate bounded timeout on the wallet restoration benchmark phase. A timeout in one MUST NOT consume the budget of the other.
+- **FR-007**: When the setup phase fails or times out (Mithril download, extraction, node startup, or node sync), the workflow MUST classify the failure as a setup failure, distinct from a benchmark failure, in its logs and exit status.
+- **FR-008**: The change MUST be observable end-to-end by linking a successful workflow run in which all four restoration benchmark variants start after Mithril-provisioned node sync and produce the normal benchmark artifacts they produced before this change.
+
+### Key Entities
+
+- **Mithril snapshot**: An immutable, hash-identified node database checkpoint published by the Mithril aggregator and consumed by a Mithril client. Has a snapshot hash, a network (mainnet), and an associated tip.
+- **Per-leg node database**: A filesystem location dedicated to one matrix leg's node instance, populated by extracting a Mithril snapshot, written to only by that leg's node process, and discarded (or treated as discardable) at run end.
+- **Setup phase**: The portion of a run that downloads the Mithril snapshot, extracts it, starts `cardano-node`, and waits for sync. Bounded by its own timeout. Time spent here is recorded but not attributed to the benchmark metric.
+- **Benchmark phase**: The portion of a run that executes the wallet restoration benchmark against an already-synced node. Bounded by its own timeout. Time spent here is the metric of interest.
+- **Run provenance record**: The set of log fields emitted on every run that lets a later reader identify the snapshot, client, database path, sync wait, and benchmark start time without re-running.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After this change, 100% of restoration benchmark workflow runs begin from a Mithril-provisioned node database; 0% depend on a pre-existing on-disk database surviving from a previous run.
+- **SC-002**: The benchmark metric reported by each matrix leg contains zero contribution from Mithril download, extraction, node startup, or node sync time, verifiable by comparing the metric against the separately recorded setup duration in the same run.
+- **SC-003**: All four restoration benchmark variants run in parallel on the same workflow trigger without cross-leg interference, and each completes against its own isolated node database.
+- **SC-004**: Given a failed run, an engineer reading only the workflow logs can identify the failure stage (Mithril download, Mithril extraction, node startup, node sync, or wallet benchmark) and the snapshot hash, Mithril client version, and node database path in use, in under 5 minutes and without consulting the runner host.
+- **SC-005**: A specific workflow run is recorded in the closing PR that shows all four restoration benchmark variants starting after Mithril-provisioned node sync and producing the normal benchmark artifacts.
+
+## Assumptions
+
+- A signed mainnet Mithril snapshot is reliably available at workflow trigger time; transient aggregator outages are tolerated by retry within the setup timeout, but a fully unavailable aggregator is treated as a setup failure rather than a fall-through to stale on-disk state.
+- The self-hosted benchmark runners have sufficient disk and network bandwidth to download and extract a fresh node database per matrix leg per run, within the setup timeout.
+- Issue #5115 (replay-aware handling for existing DBs) is a separate concern; this work does not need to preserve any "reuse existing DB" code path and may remove or bypass it as a consequence.
+- The four matrix legs share a runner pool. Resource isolation between legs is achieved by isolated database paths, not by dedicated runners; concurrent setup phases are an expected and acceptable load on a runner.
+- Reusing existing Mithril provisioning infrastructure already used elsewhere in CI is preferred over introducing a new, parallel implementation; the choice of which is left to planning.
+- Snapshot freshness relative to wallet birth points is out of scope. If a snapshot's tip lies behind a wallet's birth point and the benchmark misbehaves as a result, that is a separate spec.

--- a/specs/005-mithril-bench-snapshots/tasks.md
+++ b/specs/005-mithril-bench-snapshots/tasks.md
@@ -1,0 +1,225 @@
+# Tasks: Mithril-Provisioned Restoration Benchmark Runs
+
+**Input**: Design documents from `/code/cardano-wallet-issue-5278/specs/005-mithril-bench-snapshots/`
+**Issue**: #5278
+**PR**: #5279
+
+## Commit Discipline
+
+Every behavior-changing commit must be a vertical, bisect-safe slice. For this
+feature, each story phase below is a reviewable slice: it includes its
+regression proof, implementation, and verification path in the same slice.
+
+The repository has no dedicated shell test harness for these CI scripts, so the
+proof strategy is:
+
+- RED-style baseline checks against the current workflow/script behavior.
+- Static gates: `bash -n`, `scripts/shellcheck.sh`, and `nix build --quiet .#ci.benchmarks.restore`.
+- Mandatory live boundary proof from a `workflow_dispatch` restoration
+  benchmark run before the PR is marked ready.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches separate files or is a
+  non-mutating check.
+- **[Story]**: Maps to a user story from `spec.md`.
+- Every task names the file path or review artifact it changes or validates.
+
+---
+
+## Phase 1: Setup (Shared PR Infrastructure)
+
+**Purpose**: Establish the local gate and review proof surface before changing
+workflow behavior.
+
+- [x] T001 Create PR gate script in `llm/reviews/5279/gate.sh` covering `bash -n scripts/ci/bench-restore.sh`, `scripts/shellcheck.sh`, and `nix build --quiet .#ci.benchmarks.restore`
+- [x] T002 [P] Record the current branch/task baseline in `/code/cardano-wallet-issue-5278/WIP.md`
+- [x] T003 [P] Decide whether generated agent context should be committed by reviewing `/code/cardano-wallet-issue-5278/AGENTS.md`
+
+**Checkpoint**: The PR has a repeatable local gate and the local handoff notes
+identify any generated non-code files that should be included or dropped.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Prepare shared helpers used by all user stories.
+
+- [x] T004 Extend `run/common/nix/snapshot.sh` to print the Mithril client source, client version, selected snapshot hash, and best-effort snapshot tip without breaking `.github/workflows/linux-mithril-sync.yml`
+- [x] T005 [P] Add comments or usage text for setup and benchmark timeout environment variables in `scripts/ci/bench-restore.sh`
+- [x] T006 Run the PR gate from `llm/reviews/5279/gate.sh` after foundational helper changes
+
+**Checkpoint**: Existing Mithril sync workflow behavior is preserved while the
+snapshot helper exposes the provenance needed by restoration benchmarks.
+
+---
+
+## Phase 3: User Story 1 - Repeatable restoration benchmarks unaffected by stale runner state (Priority: P1) MVP
+
+**Goal**: Every restoration benchmark matrix leg wipes its own database at run
+start, provisions a fresh Mithril snapshot, waits for node readiness, and runs
+the benchmark against an already-running synced node.
+
+**Independent Test**: Trigger the restoration benchmark workflow on a runner
+whose persistent disk is empty, stale, or contains an older-node database. All
+four variants complete and produce normal benchmark artifacts.
+
+### Tests and Proof for User Story 1
+
+- [x] T007 [P] [US1] Capture RED baseline that `.github/workflows/restoration-benchmarks.yml` passes an existing `$HOME/databases/node/<matrix-node-db>` directly to `scripts/ci/bench-restore.sh` without a Mithril setup phase
+- [x] T008 [P] [US1] Capture RED baseline that `scripts/ci/bench-restore.sh` does not call `run/mainnet/nix/snapshot.sh`, does not poll `cardano-cli query tip`, and starts the benchmark with `--node-db` instead of `--running-node`
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Update `.github/workflows/restoration-benchmarks.yml` to remove or ignore `to-tip-timeout`, set `SETUP_TIMEOUT_SECONDS=7200`, `BENCHMARK_TIMEOUT_SECONDS=43200`, `SYNC_POLL_INTERVAL_SECONDS=15`, and `SYNC_STALE_SECONDS=1200`
+- [x] T010 [US1] Update `.github/workflows/restoration-benchmarks.yml` so the restore job Nix shell provides `coreutils`, `gnugrep`, `gawk`, `jq`, `time`, `cardano-node`, `cardano-cli`, and `haskellPackages.hp2pretty`
+- [x] T011 [US1] Implement start-of-run per-leg database cleanup in `scripts/ci/bench-restore.sh` by wiping `${node_db:?}` immediately before Mithril provisioning and never at script exit
+- [x] T012 [US1] Implement Mithril provisioning in `scripts/ci/bench-restore.sh` by sourcing `run/mainnet/nix/.env` and invoking `run/mainnet/nix/snapshot.sh` with `NODE_DB=$node_db`
+- [x] T013 [US1] Implement per-leg node startup in `scripts/ci/bench-restore.sh` using `configs/cardano/mainnet/config.json`, `configs/cardano/mainnet/topology.json`, the isolated `node_db`, and a socket under `$TMPDIR/bench/restore/$bench/`
+- [x] T014 [US1] Implement node readiness polling in `scripts/ci/bench-restore.sh` with `cardano-cli query tip --mainnet --socket-path "$socket"`, 15 second cadence, `syncProgress >= 99.9`, 2 hour setup timeout, and 20 minute stale slot/progress failure
+- [x] T015 [US1] Update `scripts/ci/bench-restore.sh` to run `bench-restore/bin/restore` with `--running-node "$socket"` and a separate GNU `timeout --foreground --kill-after=60s "$BENCHMARK_TIMEOUT_SECONDS"` benchmark budget
+- [x] T016 [US1] Preserve existing result extraction, memory summary, heap profile conversion, and artifact filenames in `scripts/ci/bench-restore.sh`
+
+### Verification for User Story 1
+
+- [x] T017 [US1] Run `llm/reviews/5279/gate.sh` and record the green output in `/code/cardano-wallet-issue-5278/WIP.md`
+- [x] T018 [US1] Run the local dry-run command from `specs/005-mithril-bench-snapshots/quickstart.md` and confirm the script does not silently reuse an existing node database
+
+**Checkpoint**: User Story 1 is complete when the script has a separate setup
+phase, the benchmark phase starts only after a synced already-running node is
+available, and local static gates are green.
+
+---
+
+## Phase 4: User Story 2 - Failed runs are diagnosable from workflow logs alone (Priority: P2)
+
+**Goal**: Workflow logs and artifacts identify the Mithril snapshot, client
+version, database path, sync duration, benchmark start time, and failure stage.
+
+**Independent Test**: Force failures at Mithril list/download/extraction, node
+startup, node sync, and benchmark execution; confirm logs contain the available
+provenance and a specific `FAILURE_STAGE`.
+
+### Tests and Proof for User Story 2
+
+- [x] T019 [P] [US2] Capture RED baseline that `scripts/ci/bench-restore.sh` does not print `MITHRIL_SNAPSHOT_HASH`, `MITHRIL_CLIENT_VERSION`, `NODE_SYNC_WAIT_SECONDS`, `BENCHMARK_STARTED_AT`, or `FAILURE_STAGE`
+- [x] T020 [P] [US2] Add failure-stage smoke commands to `specs/005-mithril-bench-snapshots/quickstart.md` for setup timeout, node-sync timeout, and benchmark timeout validation
+
+### Implementation for User Story 2
+
+- [x] T021 [US2] Add line-oriented provenance logging to `scripts/ci/bench-restore.sh` for `BENCH_NAME`, `NETWORK`, `NODE_DB`, `MITHRIL_CLIENT_SOURCE`, `MITHRIL_CLIENT_VERSION`, `MITHRIL_SNAPSHOT_HASH`, setup timestamps, sync progress, sync wait seconds, and benchmark start time
+- [x] T022 [US2] Add per-leg JSON provenance artifact writing to `scripts/ci/bench-restore.sh` with fields from `specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md`
+- [x] T023 [US2] Add explicit `FAILURE_STAGE=setup:mithril-list`, `setup:mithril-download`, `setup:mithril-extract`, `setup:node-start`, `setup:node-sync`, and `benchmark:restore` classification paths in `scripts/ci/bench-restore.sh`
+- [x] T024 [US2] Update `.github/workflows/restoration-benchmarks.yml` artifact upload patterns to include `*.json` alongside the existing `*.txt`, `*.log`, `*.svg`, and `*.hp` artifacts
+- [x] T025 [US2] Ensure `scripts/ci/bench-restore.sh` writes best-effort provenance on exit even when setup fails before the benchmark starts
+
+### Verification for User Story 2
+
+- [x] T026 [US2] Run `llm/reviews/5279/gate.sh` and record the green output in `/code/cardano-wallet-issue-5278/WIP.md`
+- [ ] T027 [US2] Run the failure-stage smoke commands from `specs/005-mithril-bench-snapshots/quickstart.md` and confirm the expected log fields appear
+
+**Checkpoint**: User Story 2 is complete when an engineer can diagnose setup
+or benchmark failure stage and provenance from logs without shell access to the
+runner.
+
+---
+
+## Phase 5: User Story 3 - Matrix legs run in parallel without sharing mutable node state (Priority: P2)
+
+**Goal**: All four matrix legs can run concurrently without sharing node
+database, socket, or log paths.
+
+**Independent Test**: Trigger the workflow and verify each matrix leg logs a
+different node database path and isolated socket/log paths.
+
+### Tests and Proof for User Story 3
+
+- [x] T028 [P] [US3] Capture RED baseline that `scripts/ci/bench-restore.sh` currently uses only the passed node DB for isolation and does not log per-leg socket or node log paths
+- [x] T029 [P] [US3] Capture RED baseline that `.github/workflows/restoration-benchmarks.yml` has unique `matrix.node-db` values but no logged uniqueness check
+
+### Implementation for User Story 3
+
+- [x] T030 [US3] Ensure `.github/workflows/restoration-benchmarks.yml` keeps unique stable `matrix.node-db` values for `base`, `seq0`, `seq1`, and `rnd5`
+- [x] T031 [US3] Ensure `scripts/ci/bench-restore.sh` derives socket, node log, and temporary work paths from `$TMPDIR/bench/restore/$bench/` so concurrent legs cannot collide
+- [x] T032 [US3] Ensure `scripts/ci/bench-restore.sh` kills only the node process it started and never removes another leg's socket, log, or database path
+- [x] T033 [US3] Add per-leg `NODE_SOCKET_PATH` and `NODE_LOG_PATH` log fields to `scripts/ci/bench-restore.sh`
+
+### Verification for User Story 3
+
+- [x] T034 [US3] Run `llm/reviews/5279/gate.sh` and record the green output in `/code/cardano-wallet-issue-5278/WIP.md`
+- [ ] T035 [US3] Trigger the restoration benchmark workflow with `gh workflow run "Restoration Benchmarks" --ref 005-mithril-bench-snapshots` and verify all four matrix legs log distinct `NODE_DB`, `NODE_SOCKET_PATH`, and `NODE_LOG_PATH` values
+
+**Checkpoint**: User Story 3 is complete when parallel matrix legs have unique
+mutable paths and no cleanup path can affect another leg.
+
+---
+
+## Phase 6: Polish and Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation, and PR readiness.
+
+- [x] T036 [P] Update `specs/005-mithril-bench-snapshots/quickstart.md` with the final local and workflow verification commands if implementation changes them
+- [ ] T037 [P] Update `/code/cardano-wallet-issue-5278/WIP.md` with the final task status, workflow run URL, and CI status
+- [ ] T038 Run `llm/reviews/5279/gate.sh` after all feature slices are complete
+- [ ] T039 Run mandatory workflow-dispatch proof with `gh workflow run "Restoration Benchmarks" --ref 005-mithril-bench-snapshots` and record the successful run URL in `/code/cardano-wallet-issue-5278/WIP.md`
+- [ ] T040 Verify PR #5279 records the successful workflow-dispatch URL showing all four variants start after Mithril-provisioned node sync and upload normal artifacts
+- [ ] T041 Check CI run #25660500468 or its successor and rerun only unrelated flaky jobs from `/code/cardano-wallet-issue-5278/WIP.md` if needed
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational. This is the MVP and should land first.
+- **User Story 2 (Phase 4)**: Depends on the setup/benchmark phase boundaries from US1.
+- **User Story 3 (Phase 5)**: Depends on the node lifecycle from US1 and can be reviewed after US1 or alongside US2 if the diffs stay separate.
+- **Polish (Phase 6)**: Depends on all desired user stories.
+
+### User Story Dependencies
+
+- **US1**: Required first because it creates the Mithril setup, node readiness, and benchmark phase split.
+- **US2**: Requires US1 phase names and lifecycle points for accurate provenance and failure classification.
+- **US3**: Requires US1 node startup and cleanup logic, then hardens path isolation.
+
+### Reviewable Commit Slices
+
+1. **Slice A - Foundation**: T001 through T006.
+2. **Slice B - US1 MVP**: T007 through T018.
+3. **Slice C - US2 Observability**: T019 through T027.
+4. **Slice D - US3 Parallel Isolation**: T028 through T035.
+5. **Slice E - Final Evidence**: T036 through T041.
+
+Each slice should pass `llm/reviews/5279/gate.sh` before review handoff.
+
+---
+
+## Parallel Opportunities
+
+- T002 and T003 can run while T001 is being prepared.
+- T005 can run in parallel with T004.
+- T007 and T008 are independent baseline checks.
+- T019 and T020 are independent US2 proof/documentation tasks.
+- T028 and T029 are independent US3 baseline checks.
+- T036 and T037 can run in parallel during final documentation cleanup.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 for US1.
+3. Stop and validate that the workflow/script no longer depends on stale runner
+   node databases and that local gates are green.
+
+### Incremental Delivery
+
+1. Add US1 to make the benchmark start from a Mithril-provisioned synced node.
+2. Add US2 to make failures diagnosable from logs and artifacts.
+3. Add US3 to harden concurrent matrix isolation.
+4. Run the full restoration benchmark workflow and record the successful run in
+   PR #5279.

--- a/specs/005-mithril-bench-snapshots/tasks.md
+++ b/specs/005-mithril-bench-snapshots/tasks.md
@@ -109,7 +109,7 @@ provenance and a specific `FAILURE_STAGE`.
 
 - [x] T021 [US2] Add line-oriented provenance logging to `scripts/ci/bench-restore.sh` for `BENCH_NAME`, `NETWORK`, `NODE_DB`, `MITHRIL_CLIENT_SOURCE`, `MITHRIL_CLIENT_VERSION`, `MITHRIL_SNAPSHOT_HASH`, setup timestamps, sync progress, sync wait seconds, and benchmark start time
 - [x] T022 [US2] Add per-leg JSON provenance artifact writing to `scripts/ci/bench-restore.sh` with fields from `specs/005-mithril-bench-snapshots/contracts/restoration-benchmarks.md`
-- [x] T023 [US2] Add explicit `FAILURE_STAGE=setup:mithril-list`, `setup:mithril-download`, `setup:mithril-extract`, `setup:node-start`, `setup:node-sync`, and `benchmark:restore` classification paths in `scripts/ci/bench-restore.sh`
+- [x] T023 [US2] Add explicit `FAILURE_STAGE=setup:mithril-list`, `setup:mithril-download`, `setup:mithril-convert`, `setup:mithril-extract`, `setup:node-start`, `setup:node-sync`, and `benchmark:restore` classification paths in `scripts/ci/bench-restore.sh`
 - [x] T024 [US2] Update `.github/workflows/restoration-benchmarks.yml` artifact upload patterns to include `*.json` alongside the existing `*.txt`, `*.log`, `*.svg`, and `*.hp` artifacts
 - [x] T025 [US2] Ensure `scripts/ci/bench-restore.sh` writes best-effort provenance on exit even when setup fails before the benchmark starts
 


### PR DESCRIPTION
Closes #5278.

Reworks `.github/workflows/restoration-benchmarks.yml` so every restoration benchmark run starts from a fresh Mithril-provisioned node database instead of relying on whatever the self-hosted runner happens to have on disk. Each matrix leg (`base`, `seq0`, `seq1`, `rnd5`) gets an isolated node DB so legs can run in parallel without sharing mutable state. Mithril download/extraction/node startup/sync are timed and logged separately from the wallet restoration benchmark.

## Status

Draft. Only the feature spec is in so far (`specs/005-mithril-bench-snapshots/spec.md`). Plan, tasks, and implementation follow as separate commits on this branch.