### PR TITLE
fix(release): require manual publish, fix Latest pointer, pin Windows runners, trim signatures

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,72 @@
+name: Publish Release
+
+# Fires when a maintainer clicks "Publish release" on a draft in the GitHub UI
+# (or otherwise un-drafts a non-prerelease release). The release.yml workflow
+# builds, verifies, and uploads assets to a draft; this workflow runs the
+# public-facing side-effects (docker push + gh-pages redirect) after a human
+# has reviewed and published the release notes.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push-docker:
+    name: "Push Docker Image"
+    # Skip for prereleases (nightly/test are published as prereleases and
+    # already had their docker image pushed by release.yml).
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Download docker-image asset
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
+        run: |
+          mkdir -p docker-image
+          gh release download "$TAG" \
+            --repo cardano-foundation/cardano-wallet \
+            --pattern "cardano-wallet-${TAG}-docker-image.tgz" \
+            --dir docker-image
+
+      - name: Login to Docker Hub
+        run: docker login -u cfhal -p "${{ secrets.DOCKER_HUB_TOKEN }}"
+
+      - name: Load and push Docker image
+        run: |
+          REPO="cardanofoundation/cardano-wallet"
+          image_file=$(find docker-image -type f | head -1)
+          echo "Loading docker image from: $image_file ($(stat -c%s "$image_file") bytes)"
+          load_output=$(docker load -i "$image_file")
+          echo "$load_output"
+
+          LOADED_IMAGE=$(echo "$load_output" | grep -oP 'Loaded image: \K.*')
+          echo "Loaded image: $LOADED_IMAGE"
+          docker tag "$LOADED_IMAGE" "$REPO:$TAG"
+          docker push "$REPO:$TAG"
+
+          docker tag "$REPO:$TAG" "$REPO:latest"
+          docker push "$REPO:latest"
+
+  update-docs:
+    name: "Update Documentation Links"
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Update redirects
+        run: |
+          cd releases
+          ./make_redirects.sh "$TAG"
+
+      - name: Push updates
+        run: git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,11 +388,13 @@ jobs:
       - name: Create GitHub release
         shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         run: |
-          gh release create \
-            -d \
-            -F release-body.md \
-            -t "${{ steps.tag.outputs.title }}" \
-            "${{ steps.tag.outputs.tag }}"
+          # Mark nightly/test as prereleases so they don't overtake the most
+          # recent semver release as GitHub's "Latest" pointer.
+          args=(-d -F release-body.md -t "${{ steps.tag.outputs.title }}")
+          if [ "$IS_RELEASE" != "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}" "${{ steps.tag.outputs.tag }}"
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
@@ -453,26 +455,37 @@ jobs:
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
     steps:
-      - name: Un-draft release
+      - name: Un-draft nightly/test release
+        if: env.IS_RELEASE != 'true'
         shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
         run: |
           TAG="${{ needs.create-release.outputs.tag }}"
-          echo "Publishing release $TAG"
+          echo "Un-drafting $TAG"
           gh release edit "$TAG" \
             --repo cardano-foundation/cardano-wallet \
             --draft=false
 
+      - name: Notify release ready for manual review
+        if: env.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          URL="https://github.com/cardano-foundation/cardano-wallet/releases/tag/$TAG"
+          echo "::notice::Draft release $TAG built and verified."
+          echo "::notice::Edit notes (Docker link, changelog, signatures) and click Publish in the UI."
+          echo "::notice::$URL"
+          echo "::notice::On Publish, .github/workflows/publish-release.yml handles docker + docs."
+
   push-docker:
-    name: "Push Docker Image"
+    name: "Push Docker Image (nightly/test)"
     needs: [prepare, create-release, publish-release]
-    if: ${{ !cancelled() && needs.publish-release.result == 'success' }}
+    # Skip for real releases — .github/workflows/publish-release.yml pushes
+    # version + latest docker tags on the release.published event instead.
+    if: ${{ !cancelled() && inputs.release_type != 'release' && needs.publish-release.result == 'success' }}
     runs-on: [self-hosted, linux, x86_64, cardano-wallet]
     env:
-      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
-      RELEASE_CABAL_VERSION: ${{ needs.prepare.outputs.release-cabal-version }}
       TEST_RC: ${{ needs.prepare.outputs.test-rc }}
-      IS_RELEASE: ${{ inputs.release_type == 'release' && 'true' || 'false' }}
     steps:
       - name: Download Docker image
         uses: actions/download-artifact@v8
@@ -483,9 +496,7 @@ jobs:
       - name: Determine tag
         id: tag
         run: |
-          if [ "$IS_RELEASE" == "true" ]; then
-            echo "tag=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-          elif [ "$TEST_RC" == "TRUE" ]; then
+          if [ "$TEST_RC" == "TRUE" ]; then
             echo "tag=test" >> "$GITHUB_OUTPUT"
           else
             echo "tag=nightly" >> "$GITHUB_OUTPUT"
@@ -504,35 +515,7 @@ jobs:
           load_output=$(docker load -i "$image_file")
           echo "$load_output"
 
-          # Extract actual image name from docker load output
           LOADED_IMAGE=$(echo "$load_output" | grep -oP 'Loaded image: \K.*')
           echo "Loaded image: $LOADED_IMAGE"
           docker tag "$LOADED_IMAGE" "$REPO:$TAG"
           docker push "$REPO:$TAG"
-
-          if [ "$IS_RELEASE" == "true" ]; then
-            docker tag "$REPO:$TAG" "$REPO:latest"
-            docker push "$REPO:latest"
-          fi
-
-  update-docs:
-    name: "Update Documentation Links"
-    needs: [prepare, create-release, publish-release]
-    if: ${{ !cancelled() && inputs.release_type == 'release' && needs.publish-release.result == 'success' }}
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-          fetch-depth: 0
-
-      - name: Update redirects
-        run: |
-          cd releases
-          ./make_redirects.sh "${{ needs.prepare.outputs.release-version }}"
-
-      - name: Push updates
-        run: git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
     name: "E2E Windows"
     if: inputs.release_type == 'release'
     needs: [prepare, build-e2e-windows]
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     timeout-minutes: 240
     steps:
       - name: Download E2E bundle

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -109,7 +109,7 @@ jobs:
 
   verify-windows:
     name: "Verify Windows"
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
       - name: Download and verify
         env:

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -29,7 +29,7 @@ jobs:
   e2e-tests:
     name: "Windows E2E Tests"
     needs: build-e2e
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
   unit-tests:
     name: ${{ matrix.name }}
     needs: upload-win-test
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     env:
       LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
     strategy:

--- a/scripts/release/release-template.md
+++ b/scripts/release/release-template.md
@@ -34,9 +34,5 @@ $API_CHANGES
 
 | Name                                | Role              | Approval |
 | ----------------------------------- | ----------------- | -------- |
-| Heinrich Apfelmus @HeinrichApfelmus | Software Engineer |          |
 | Paolo Veronelli @paolino            | Software Engineer |          |
 | Pawel Jakubas @paweljakubas         | Software Engineer |          |
-| Johannes Lund @Anviking             | Software Engineer |          |
-| David Clark @david-a-clark          | Product Manager   |          |
-| Arnaud Bailly @abailly              | Software Engineer |          |


### PR DESCRIPTION
Closes #5281.

Three related fixes to the release pipeline, each in its own commit.

## 1. `chore(release): trim signatures template to current maintainers`

`scripts/release/release-template.md` shipped a 6-row signature table. The
only currently-active wallet maintainers signing releases are Paolo
Veronelli (@paolino) and Pawel Jakubas (@paweljakubas). Removed the other
rows so the templated release body no longer needs hand-editing for the
signature section.

## 2. `ci: pin Windows runners to windows-2025-vs2026`

Windows jobs emit a deprecation notice on `windows-latest`:

```
NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by May 12, 2026
```

Pinned the four Windows job sites to the new explicit label:
- `.github/workflows/release.yml` (release e2e-windows)
- `.github/workflows/verify-release.yml` (verify-windows)
- `.github/workflows/windows-e2e.yml` (e2e-tests)
- `.github/workflows/windows.yml` (unit-tests)

`windows-2025-vs2026` is GA on GitHub-hosted runners (per
`actions/runner-images#14016`, May 7, 2026). `actionlint` does not yet
know the label; the warning it prints is a tooling lag, not a real
problem.

## 3. `fix(release): require manual publish for real releases`

This addresses two distinct bugs that share the same root cause: the
pipeline publishes too eagerly.

### Bug A — releases auto-undrafted before notes are reviewed

The `publish-release` job called `gh release edit --draft=false`
automatically once `verify-assets` passed. That published
v2026-05-11 as a prerelease with the raw template body — Docker link
placeholder still saying `FIX THIS LINK BY INSPECTING DOCKERHUB !`,
`Fixed/Added/Changed/Removed` sections empty, defunct signers
listed. Notes had to be rewritten in place after the release was
already public.

### Bug B — `releases/latest` API followed `nightly`

```
$ gh api repos/cardano-foundation/cardano-wallet/releases/latest --jq .tag_name
nightly
```

`nightly` is published as a non-prerelease, non-draft release. With
the default `make_latest=legacy` rule, GitHub picks the most recently
published non-prerelease release as Latest — which is `nightly`
every morning, until the next real release. So the "Latest" pointer
on the repo silently followed nightly builds.

### Fixes

`release.yml`:

- `create-release`: `gh release create` now passes `--prerelease` when
  `IS_RELEASE != 'true'`. Nightly/test stop overtaking semver releases as
  GitHub's "Latest".
- `publish-release`: auto-un-drafts only nightly/test. For real
  releases it logs a notice ("Edit notes and click Publish in the UI")
  and leaves the draft in place. The maintainer reviews + publishes
  manually.
- `push-docker`: skipped on the release path. Tags renamed to
  reflect it now only handles nightly/test. The `latest` tag push is
  removed (it was already conditional on `IS_RELEASE`, which is now
  always false here).
- `update-docs`: removed from `release.yml`.

New `.github/workflows/publish-release.yml`:

- Triggered on `release.published` (filter: `!github.event.release.prerelease`).
- `push-docker`: downloads the `cardano-wallet-<tag>-docker-image.tgz`
  asset from the release, pushes `cardanofoundation/cardano-wallet:<tag>`
  and `:latest`.
- `update-docs`: checks out `gh-pages`, runs
  `releases/make_redirects.sh "<tag>"`, pushes.

### Flow after this PR

- **Nightly cron**: same UX as before — workflow runs end-to-end,
  release un-drafts as a prerelease, docker `nightly` tag pushed. No
  human action needed. GitHub "Latest" pointer no longer changes.
- **Real release**: workflow builds, verifies, uploads assets to a
  draft. Stops there. Maintainer edits the release notes, then
  clicks "Publish release" in the GitHub UI. That fires
  `release.published`, which runs `publish-release.yml` to push the
  docker image (`<tag>` and `latest`) and update gh-pages redirects.

## Test plan

- [ ] Nightly cron run: release is created as draft prerelease, un-drafted
      by publish-release, `releases/latest` still points to the most recent
      semver release.
- [ ] Manual release run: draft is created, publish-release logs the
      notice URL, draft stays as draft, docker is NOT pushed yet, gh-pages
      not updated.
- [ ] Click "Publish release" in the UI: `publish-release.yml` runs,
      docker `<tag>` and `:latest` pushed to Docker Hub, gh-pages
      redirects added.
- [ ] Windows jobs no longer emit the `windows-2025 -> vs2026` redirect
      notice.
- [ ] Templated release body's signature table contains only Paolo and
      Pawel.
