### PR TITLE
Plumb mint values through ledger tx builders (#5243)

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -243,6 +243,7 @@ test-suite test
     , cardano-ledger-babbage
     , cardano-ledger-core
     , cardano-ledger-core:testlib
+    , cardano-ledger-mary
     , cardano-ledger-shelley
     , cardano-numeric
     , cardano-slotting

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Primitive.Ledger.Convert
       toLedgerAddress
     , toLedgerCoin
     , toLedgerTokenBundle
+    , toLedgerMintValue
     , toLedgerTokenPolicyId
     , toLedgerAssetName
     , toLedgerTokenQuantity
@@ -234,6 +235,31 @@ toLedgerTokenBundle bundle =
         inner
             & Map.mapKeys toLedgerAssetName
             & Map.map toLedgerTokenQuantity
+
+toLedgerMintValue
+    :: TokenMap.TokenMap
+    -> TokenMap.TokenMap
+    -> Ledger.MultiAsset
+toLedgerMintValue mint burn =
+    Ledger.MultiAsset
+        $ Map.mapMaybe nonEmpty
+        $ Map.unionWith
+            (Map.unionWith (+))
+            (signedNested id mint)
+            (signedNested negate burn)
+  where
+    signedNested sign =
+        Map.map (Map.map (sign . toLedgerTokenQuantity))
+            . toLedgerNestedMap
+
+    toLedgerNestedMap =
+        Map.mapKeys toLedgerTokenPolicyId
+            . Map.map (Map.mapKeys toLedgerAssetName)
+            . TokenMap.toNestedMap
+
+    nonEmpty inner =
+        let nonZero = Map.filter (/= 0) inner
+        in  if Map.null nonZero then Nothing else Just nonZero
 
 toWalletTokenBundle :: Ledger.MaryValue -> TokenBundle
 toWalletTokenBundle

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -19,8 +19,17 @@ import Cardano.Ledger.Babbage
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( Convert (..)
+    , toLedgerAssetName
+    , toLedgerMintValue
     , toLedgerTimelockScript
+    , toLedgerTokenPolicyId
+    , toLedgerTokenQuantity
+    , toWalletAssetName
     , toWalletScript
+    , toWalletTokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
     ( AssetName
@@ -37,6 +46,13 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
+    )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap
+    )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genTokenMapSmallRange
+    , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -65,6 +81,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
 import Data.Proxy
     ( Proxy (..)
     )
+import Data.Set
+    ( Set
+    )
 import Data.Typeable
     ( Typeable
     , typeRep
@@ -84,8 +103,10 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , Positive (Positive)
+    , Property
     , arbitrarySizedNatural
     , choose
+    , counterexample
     , elements
     , oneof
     , property
@@ -93,10 +114,15 @@ import Test.QuickCheck
     , sized
     , vectorOf
     , (===)
+    , (==>)
     )
 import Prelude
 
+import qualified Cardano.Ledger.Mary.Value as Ledger
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
@@ -123,6 +149,38 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
                 it "ledger . wallet == id" $ property $ \s -> do
                     ledger (wallet s) === s
 
+        describe "toLedgerMintValue" $ do
+            it "is total for generated mint and burn maps"
+                $ property
+                    prop_mintValue_total
+
+            it "preserves empty mint and burn maps"
+                $ toLedgerMintValue mempty mempty === mempty
+
+            it "translates pure mints as positive quantities"
+                $ property
+                    prop_mintValue_mintOnly
+
+            it "translates pure burns as negative quantities"
+                $ property
+                    prop_mintValue_burnOnly
+
+            it "nets mint and burn quantities per asset"
+                $ property
+                    prop_mintValue_netting
+
+            it "does not introduce phantom asset keys"
+                $ property
+                    prop_mintValue_noPhantomKeys
+
+            it "does not emit empty policy buckets"
+                $ property
+                    prop_mintValue_noEmptyBuckets
+
+            it "roundtrips disjoint mints and burns"
+                $ property
+                    prop_mintValue_roundtripDisjoint
+
 --------------------------------------------------------------------------------
 -- Utilities
 --------------------------------------------------------------------------------
@@ -143,9 +201,141 @@ ledgerRoundtrip proxy = it title
             , "'"
             ]
 
+prop_mintValue_total :: TestTokenMap -> TestTokenMap -> Property
+prop_mintValue_total (TestTokenMap mint) (TestTokenMap burn) =
+    ledgerMintMap (toLedgerMintValue mint burn)
+        === expectedLedgerMintMap mint burn
+
+prop_mintValue_mintOnly :: TestTokenMap -> Property
+prop_mintValue_mintOnly (TestTokenMap mint) =
+    ledgerMintMap (toLedgerMintValue mint mempty)
+        === expectedLedgerMintMap mint mempty
+
+prop_mintValue_burnOnly :: TestTokenMap -> Property
+prop_mintValue_burnOnly (TestTokenMap burn) =
+    ledgerMintMap (toLedgerMintValue mempty burn)
+        === expectedLedgerMintMap mempty burn
+
+prop_mintValue_netting :: TestTokenMap -> TestTokenMap -> Property
+prop_mintValue_netting (TestTokenMap mint) (TestTokenMap burn) =
+    ledgerMintMap (toLedgerMintValue mint burn)
+        === expectedLedgerMintMap mint burn
+
+prop_mintValue_noPhantomKeys
+    :: TestTokenMap -> TestTokenMap -> Property
+prop_mintValue_noPhantomKeys (TestTokenMap mint) (TestTokenMap burn) =
+    outputKeys `Set.isSubsetOf` inputKeys
+        === True
+  where
+    outputKeys = walletAssetKeys $ ledgerMintMap $ toLedgerMintValue mint burn
+    inputKeys = TokenMap.getAssets mint <> TokenMap.getAssets burn
+
+prop_mintValue_noEmptyBuckets
+    :: TestTokenMap -> TestTokenMap -> Property
+prop_mintValue_noEmptyBuckets (TestTokenMap mint) (TestTokenMap burn) =
+    counterexample (show output) $ not (any Map.null output) === True
+  where
+    output = ledgerMintMap $ toLedgerMintValue mint burn
+
+prop_mintValue_roundtripDisjoint
+    :: TestTokenMap -> TestTokenMap -> Property
+prop_mintValue_roundtripDisjoint (TestTokenMap mint) (TestTokenMap burn) =
+    Set.null
+        (TokenMap.getAssets mint `Set.intersection` TokenMap.getAssets burn)
+        ==> fromLedgerMintValue (toLedgerMintValue mint burn) === (mint, burn)
+
+ledgerMintMap
+    :: Ledger.MultiAsset
+    -> Map.Map Ledger.PolicyID (Map.Map Ledger.AssetName Integer)
+ledgerMintMap (Ledger.MultiAsset assets) = assets
+
+expectedLedgerMintMap
+    :: TokenMap
+    -> TokenMap
+    -> Map.Map Ledger.PolicyID (Map.Map Ledger.AssetName Integer)
+expectedLedgerMintMap mint burn =
+    Map.mapMaybe nonEmpty
+        $ Map.unionWith
+            (Map.unionWith (+))
+            (signedNested id mint)
+            (signedNested negate burn)
+  where
+    signedNested sign =
+        Map.map (Map.map (sign . toLedgerTokenQuantity))
+            . toLedgerNestedMap
+
+    nonEmpty inner =
+        let nonZero = Map.filter (/= 0) inner
+        in  if Map.null nonZero then Nothing else Just nonZero
+
+walletAssetKeys
+    :: Map.Map Ledger.PolicyID (Map.Map Ledger.AssetName Integer)
+    -> Set AssetId
+walletAssetKeys =
+    Set.fromList
+        . concatMap
+            ( \(policy, assets) ->
+                [ AssetId
+                    (toWalletTokenPolicyId policy)
+                    (toWalletAssetName asset)
+                | asset <- Map.keys assets
+                ]
+            )
+        . Map.toList
+
+fromLedgerMintValue :: Ledger.MultiAsset -> (TokenMap, TokenMap)
+fromLedgerMintValue (Ledger.MultiAsset assets) =
+    (TokenMap.fromFlatList mints, TokenMap.fromFlatList burns)
+  where
+    (mints, burns) =
+        foldMap
+            splitQuantity
+            [ (policy, asset, quantity)
+            | (policy, inner) <- Map.toList assets
+            , (asset, quantity) <- Map.toList inner
+            ]
+
+    splitQuantity (policy, asset, quantity)
+        | quantity > 0 =
+            ( pure
+                ( walletAssetId policy asset
+                , TokenQuantity $ fromInteger quantity
+                )
+            , []
+            )
+        | quantity < 0 =
+            ( []
+            , pure
+                ( walletAssetId policy asset
+                , TokenQuantity $ fromInteger $ abs quantity
+                )
+            )
+        | otherwise =
+            mempty
+
+    walletAssetId policy asset =
+        AssetId (toWalletTokenPolicyId policy) (toWalletAssetName asset)
+
+toLedgerNestedMap
+    :: TokenMap
+    -> Map.Map Ledger.PolicyID (Map.Map Ledger.AssetName TokenQuantity)
+toLedgerNestedMap =
+    Map.mapKeys toLedgerTokenPolicyId
+        . Map.map (Map.mapKeys toLedgerAssetName)
+        . TokenMap.toNestedMap
+
 --------------------------------------------------------------------------------
 -- Arbitraries
 --------------------------------------------------------------------------------
+
+newtype TestTokenMap = TestTokenMap
+    { getTestTokenMap :: TokenMap
+    }
+    deriving (Eq, Show)
+
+instance Arbitrary TestTokenMap where
+    arbitrary = TestTokenMap <$> genTokenMapSmallRange
+    shrink = fmap TestTokenMap . shrinkTokenMap . getTestTokenMap
 
 instance Arbitrary Coin where
     -- This instance is used to test roundtrip conversions, so it's important

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -87,8 +87,12 @@ import Cardano.Ledger.Api
     , eraProtVerLow
     , witsTxL
     )
+import Cardano.Ledger.Api.Tx.Body
+    ( mintTxBodyL
+    )
 import Cardano.Ledger.BaseTypes
-    ( StrictMaybe (..)
+    ( Network (Testnet)
+    , StrictMaybe (..)
     )
 import Cardano.Ledger.Binary
     ( serialize
@@ -127,6 +131,7 @@ import Cardano.Wallet.Primitive.Ledger.Convert
     ( Convert (..)
     , toConwayTxOut
     , toLedgerCoin
+    , toLedgerMintValue
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
     ( txIntegrity
@@ -227,13 +232,17 @@ import Cardano.Wallet.Shelley.Transaction.Build
     )
 import Cardano.Wallet.Shelley.Transaction.Ledger
     ( TxWitnessTag (..)
+    , buildLedgerTx
+    , buildLedgerTxRaw
     , mkByronWitnessLedger
     , mkShelleyWitnessLedger
     , txConstraints
     )
 import Cardano.Wallet.Transaction
-    ( SelectionOf (..)
+    ( PreSelection (..)
+    , SelectionOf (..)
     , TransactionLayer (..)
+    , Withdrawal (..)
     , WitnessCountCtx (..)
     , selectionDelta
     )
@@ -410,6 +419,7 @@ spec = describe "TransactionSpec" $ do
     decodeSealedTxSpec
     forAllRecentEras feeEstimationRegressionSpec
     forAllRecentEras binaryCalculationsSpec
+    forAllRecentEras ledgerMintPlumbingSpec
     transactionConstraintsSpec
     describe "Sign transaction" $ do
         -- TODO [ADP-2849] The implementation must be restricted to work only in
@@ -1142,6 +1152,113 @@ binaryCalculationsSpec (AnyRecentEra era) =
             describe "binaryCalculationsSpec"
                 $ it "Dijkstra"
                 $ pendingWith "TODO: Dijkstra"
+
+ledgerMintPlumbingSpec :: AnyRecentEra -> Spec
+ledgerMintPlumbingSpec (AnyRecentEra era) =
+    case era of
+        RecentEraConway -> ledgerMintPlumbingSpec' era
+        RecentEraDijkstra ->
+            describe "ledgerMintPlumbingSpec"
+                $ it "Dijkstra"
+                $ pendingWith "TODO: Dijkstra"
+
+ledgerMintPlumbingSpec'
+    :: forall era
+     . (Write.IsRecentEra era, era ~ Write.Conway)
+    => RecentEra era -> Spec
+ledgerMintPlumbingSpec' era =
+    describe ("ledger mint plumbing - " +|| era ||+ "") $ do
+        it "buildLedgerTx writes the explicit mint value"
+            $ txMint
+                ( buildLedgerTx
+                    era
+                    sampleTtl
+                    Testnet
+                    NoWithdrawal
+                    (Coin 0)
+                    Nothing
+                    []
+                    sampleOutputs
+                    sampleSelection
+                    sampleMintValue
+                )
+            `shouldBe` sampleMintValue
+
+        it "buildLedgerTxRaw writes the explicit mint value for selections"
+            $ txMint
+                ( buildLedgerTxRaw
+                    era
+                    sampleTtl
+                    Testnet
+                    NoWithdrawal
+                    (Coin 0)
+                    Nothing
+                    []
+                    sampleOutputs
+                    (Right sampleSelection)
+                    sampleMintValue
+                )
+            `shouldBe` sampleMintValue
+
+        it "buildLedgerTxRaw writes the explicit mint value for preselections"
+            $ txMint
+                ( buildLedgerTxRaw
+                    era
+                    sampleTtl
+                    Testnet
+                    NoWithdrawal
+                    (Coin 0)
+                    Nothing
+                    []
+                    sampleOutputs
+                    (Left samplePreSelection)
+                    sampleMintValue
+                )
+            `shouldBe` sampleMintValue
+  where
+    txMint tx = tx ^. bodyTxL . mintTxBodyL
+
+    sampleTtl = (Nothing, SlotNo 100)
+
+    sampleSelection =
+        Selection
+            { inputs =
+                ( TxIn dummyTxId 0
+                , TxOut (dummyAddress 0) (coinToBundle 10_000_000)
+                )
+                    :| []
+            , collateral = []
+            , extraCoinSource = Coin 0
+            , extraCoinSink = Coin 0
+            , outputs = sampleOutputs
+            , change = []
+            , assetsToMint = sampleMint
+            , assetsToBurn = sampleBurn
+            }
+
+    samplePreSelection = PreSelection{outputs = sampleOutputs}
+
+    sampleOutputs =
+        [TxOut (dummyAddress 1) (coinToBundle 2_000_000)]
+
+    sampleMintValue = toLedgerMintValue sampleMint sampleBurn
+
+    sampleMint =
+        TokenMap.fromFlatList
+            [ (sampleAsset 1 1, TokenQuantity 10)
+            , (sampleAsset 1 2, TokenQuantity 3)
+            ]
+
+    sampleBurn =
+        TokenMap.fromFlatList
+            [ (sampleAsset 1 1, TokenQuantity 4)
+            , (sampleAsset 2 1, TokenQuantity 8)
+            ]
+
+    sampleAsset policyByte assetByte =
+        AssetId
+            (UnsafeTokenPolicyId $ Hash $ BS.pack $ replicate 28 policyByte)
+            (UnsafeAssetName $ BS.pack [assetByte])
 
 -- Up till Mary era we have the following structure of transaction
 --   transaction =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2749,6 +2749,9 @@ buildTransactionPure
                         (view #txMetadata txCtx, allCerts)
                         (txValidityInterval txCtx)
                         (view #txWithdrawal txCtx)
+                        ( fst $ view #txAssetsToMint txCtx
+                        , fst $ view #txAssetsToBurn txCtx
+                        )
                         (Left preSelection)
                         (Coin 0)
             let utxoIndex :: Write.UTxOIndex era
@@ -3553,6 +3556,9 @@ transactionFee
                     (view #txMetadata txCtx, allCerts)
                     (txValidityInterval txCtx)
                     (view #txWithdrawal txCtx)
+                    ( fst $ view #txAssetsToMint txCtx
+                    , fst $ view #txAssetsToBurn txCtx
+                    )
                     (Left preSelection)
                     (Coin 0)
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -18,6 +18,8 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
     ( -- * Transaction construction
       mkTransactionLedger
     , constructUnsignedTxLedger
+    , buildLedgerTx
+    , buildLedgerTxRaw
 
       -- * Sealing
     , sealWriteTx
@@ -105,6 +107,9 @@ import Cardano.Ledger.Keys.Bootstrap
 import Cardano.Ledger.Keys.WitVKey
     ( WitVKey (WitVKey)
     )
+import Cardano.Ledger.Mary.Value
+    ( MultiAsset
+    )
 import Cardano.Ledger.Metadata
     ( Metadatum
     )
@@ -124,6 +129,7 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( Convert (toLedger)
     , toLedgerDelegatee
+    , toLedgerMintValue
     , toLedgerTimelockScript
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
@@ -302,6 +308,10 @@ mkTransactionLedger
                                 (view #txDeposit ctx)
                                 action
         outs <- extractValidatedOutputs (Right cs)
+        let ledgerMint =
+                toLedgerMintValue
+                    (fst $ view #txAssetsToMint ctx)
+                    (fst $ view #txAssetsToBurn ctx)
         let ledgerTx =
                 buildLedgerTx
                     era
@@ -313,6 +323,7 @@ mkTransactionLedger
                     ledgerCerts
                     outs
                     cs
+                    ledgerMint
         let signed =
                 signTransaction
                     keyF
@@ -383,6 +394,7 @@ constructUnsignedTxLedger
        )
     -> (Maybe SlotNo, SlotNo)
     -> Withdrawal
+    -> (TokenMap.TokenMap, TokenMap.TokenMap)
     -> Either PreSelection (SelectionOf TxOut)
     -> W.Coin
     -> Either ErrMkTransaction (Write.Tx era)
@@ -392,9 +404,11 @@ constructUnsignedTxLedger
     (md, lCerts)
     ttl
     wdrl
+    (mint, burn)
     cs
     fee = do
         outs <- extractValidatedOutputs cs
+        let ledgerMint = toLedgerMintValue mint burn
         Right
             $ buildLedgerTxRaw
                 era
@@ -406,6 +420,7 @@ constructUnsignedTxLedger
                 lCerts
                 outs
                 cs
+                ledgerMint
 
 -- | Convert wallet/context types and call 'mkLedgerTx'.
 buildLedgerTx
@@ -420,8 +435,9 @@ buildLedgerTx
     -> [TxCert era]
     -> [TxOut]
     -> SelectionOf TxOut
+    -> MultiAsset
     -> Write.Tx era
-buildLedgerTx era ttl network wdrl fee md certs outs cs =
+buildLedgerTx era ttl network wdrl fee md certs outs cs mint =
     mkLedgerTx
         era
         ins
@@ -430,7 +446,7 @@ buildLedgerTx era ttl network wdrl fee md certs outs cs =
         validity
         wdrls
         ledgerCerts
-        mempty -- TODO: minting support
+        mint
         metadata
   where
     ins :: Set Ledger.TxIn
@@ -474,6 +490,7 @@ buildLedgerTxRaw
     -> [TxCert era]
     -> [TxOut]
     -> Either PreSelection (SelectionOf TxOut)
+    -> MultiAsset
     -> Write.Tx era
 buildLedgerTxRaw
     era
@@ -484,7 +501,8 @@ buildLedgerTxRaw
     md
     certs
     outs
-    cs =
+    cs
+    mint =
         mkLedgerTx
             era
             ins
@@ -493,7 +511,7 @@ buildLedgerTxRaw
             validity
             wdrls
             ledgerCerts
-            mempty -- TODO: minting support
+            mint
             metadata
       where
         ins :: Set Ledger.TxIn

--- a/specs/007-ledger-minting/checklists/requirements.md
+++ b/specs/007-ledger-minting/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Ledger Body Builder Minting Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+This is an internal-API refactor whose "users" are the wallet's own transaction-building code paths and the developers who will maintain them. The spec preserves that framing:
+
+- "User stories" are framed as caller-of-the-ledger-body-builder stories (User Story 1) and follow-up-migration-reviewer stories (User Story 2). Both are independently testable.
+- Functional requirements name *what* the builder must do (accept a mint parameter, translate it faithfully, preserve existing behaviour for the empty case) without naming the Haskell types, modules, or functions involved. The names `mkLedgerTx`, `buildLedgerTx`, `buildLedgerTxRaw`, `MultiAsset`, `TokenBundle`, `mintTxBodyL` deliberately appear only in the Input/Context blocks, never in FRs or success criteria.
+- Success criteria are checkable by inspection of the diff and the test suite. They do not pin a specific Haskell signature.
+- The deferred-to-later script-witness work is documented as an explicit Out-of-Scope item with its consequence (mints produced here will not validate on-chain alone) called out honestly, so planning can size the next slice without re-discovering the constraint.
+
+Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/007-ledger-minting/contracts/ledger-mint-translation.md
+++ b/specs/007-ledger-minting/contracts/ledger-mint-translation.md
@@ -1,0 +1,91 @@
+# Contract: `toLedgerMintValue`
+
+**Module (planned)**: `Cardano.Wallet.Primitive.Ledger.Convert`
+
+**Sketch**:
+
+```haskell
+toLedgerMintValue
+    :: TokenMap   -- ^ mints (unsigned)
+    -> TokenMap   -- ^ burns (unsigned)
+    -> Ledger.MultiAsset
+```
+
+The signature is the public contract. The body is private and may evolve as long as the properties below hold.
+
+## Properties
+
+These are stated as `QuickCheck` properties. They live in the wallet-side spec module — preferred location `lib/primitive/test/.../Ledger/ConvertSpec.hs` (or whichever existing convert spec is conventional in `lib/primitive/test`, to be confirmed by the first task).
+
+### P1 — Totality
+
+`prop_total :: TokenMap -> TokenMap -> Property`
+`toLedgerMintValue m b` evaluates without exception for every `(m, b)` produced by the `Arbitrary TokenMap` generator.
+
+### P2 — Empty preserved
+
+`prop_empty :: Property`
+`toLedgerMintValue mempty mempty === mempty`.
+
+### P3 — Pure mint
+
+`prop_mint_only :: TokenMap -> Property`
+For every key `(p, a)` in a `TokenMap` `m` (disjoint from `mempty`), the result of `toLedgerMintValue m mempty` has the corresponding ledger entry with quantity equal to `+ toInteger (m ! (p, a))`. No other entries.
+
+### P4 — Pure burn
+
+`prop_burn_only :: TokenMap -> Property`
+Same, but with `toLedgerMintValue mempty b`; entries are negative.
+
+### P5 — Mint–burn netting
+
+`prop_netting :: TokenMap -> TokenMap -> Property`
+For every key `(p, a)` appearing in `mint` or `burn` (or both), the quantity in `toLedgerMintValue mint burn` at that key equals `toInteger (mint ! (p, a)) - toInteger (burn ! (p, a))`, **unless** that difference is `0`, in which case the key is absent from the output.
+
+### P6 — No phantom keys
+
+`prop_no_phantom_keys :: TokenMap -> TokenMap -> Property`
+The set of `(p, a)` keys in the output is a subset of `keys mint ∪ keys burn`.
+
+### P7 — No empty policy buckets
+
+`prop_no_empty_buckets :: TokenMap -> TokenMap -> Property`
+For every `policy` in the outer map of the output, the inner map is non-empty.
+
+### P8 — Round-trip with `fromLedgerMintValue`
+
+`prop_roundtrip_disjoint :: TokenMap -> TokenMap -> Property`
+**Precondition**: `mint` and `burn` share no `(policy, asset)` key.
+**Statement**: let `(mint', burn') = fromLedgerMintValue (toLedgerMintValue mint burn)`; then `(mint', burn') === (mint, burn)`.
+
+(Without the disjointness precondition, netting drops information that `fromLedgerMintValue` cannot recover. That is by design; document the precondition explicitly in the property.)
+
+## Builder contracts
+
+These belong in `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`.
+
+### B1 — Mint plumbed through `buildLedgerTx`
+
+For every `RecentEra era` supported by `mkLedgerTx` (currently `RecentEraConway`), for every `(mint, burn)` produced by the wallet generators, with all other inputs fixed:
+
+```text
+view mintTxBodyL (txBody (buildLedgerTx era ttl net wdrl fee md certs outs sel mintVal))
+  ===
+toLedgerMintValue mint burn
+```
+
+where `mintVal = toLedgerMintValue mint burn`.
+
+### B2 — Mint plumbed through `buildLedgerTxRaw`
+
+Same statement, for `buildLedgerTxRaw`, on both branches of its `Either PreSelection (SelectionOf TxOut)` argument.
+
+### B3 — Empty-path stability
+
+When `(mint, burn) == (mempty, mempty)`, the produced transaction body is structurally equal (under `(==)` on `Tx era`) to the body the current `mempty -- TODO`-using builder produces: same mint field (empty), every other field unchanged. Byte-identity of any wire serialisation is not part of this contract — that would depend on serialiser determinism this feature does not own. The regression guarantee is: existing non-minting tests continue to pass without modification.
+
+## Out of contract
+
+- Quantity overflow: `Natural` is unbounded, `Integer` is unbounded; no overflow path exists. The contract has no clamping.
+- Script witnesses: the contract does not constrain script witnesses. A body produced by these builders with a non-empty mint and no witnesses is not on-chain-valid; this is acceptable because no production caller exercises it until a later feature lands.
+- Era beyond `RecentEraConway`: `mkLedgerTx` errors on `RecentEraDijkstra`; the contract for B1/B2 inherits that and is therefore restricted to `RecentEraConway` until the era support gap is closed independently.

--- a/specs/007-ledger-minting/data-model.md
+++ b/specs/007-ledger-minting/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Ledger Mint Translation
+
+**Feature**: `007-ledger-minting`
+
+## Entities
+
+### `WalletMintSet`
+
+The wallet's existing internal representation of mints requested for a transaction. Already populated by upstream code paths.
+
+- **Mint half**: `TokenMap` — flat map of `(TokenPolicyId, TokenAssetName) → TokenQuantity` where `TokenQuantity` is `Natural` (unsigned). Each entry means: "increase the on-chain supply of this asset by this much".
+- **Burn half**: `TokenMap` — same shape. Each entry means: "decrease the on-chain supply of this asset by this much".
+
+Source-of-truth fields in the existing code:
+
+- `Cardano.Wallet.Transaction.TransactionCtx`
+  - `txAssetsToMint :: (TokenMap, Map AssetId ScriptSource)`
+  - `txAssetsToBurn :: (TokenMap, Map AssetId ScriptSource)`
+- `Cardano.Wallet.Transaction.SelectionOf change`
+  - `assetsToMint :: !TokenMap`
+  - `assetsToBurn :: !TokenMap`
+
+The `ScriptSource` half of the `TransactionCtx` pair is **not consumed by this feature** — script witnesses are explicitly out of scope.
+
+### `LedgerMintValue`
+
+The ledger's mint field of a transaction body.
+
+- **Type**: `Cardano.Ledger.Mary.Value.MultiAsset`, structurally `Map PolicyID (Map AssetName Integer)`.
+- **Signed quantity**: positive integers are mints, negative integers are burns, zero entries are admissible but redundant.
+
+### `MintTranslation`
+
+The new total function from the wallet representation to the ledger representation, introduced by this feature.
+
+```text
+toLedgerMintValue
+    :: TokenMap   -- mints (unsigned)
+    -> TokenMap   -- burns (unsigned)
+    -> MultiAsset -- signed
+```
+
+Lives in `Cardano.Wallet.Primitive.Ledger.Convert`, next to `toLedgerTokenBundle`.
+
+## Translation rules
+
+For each `(policy, asset)` key that appears in either input:
+
+1. Let `m = mint[(policy, asset)]` (default `0` if absent), interpreted as `Natural`.
+2. Let `b = burn[(policy, asset)]` (default `0` if absent), interpreted as `Natural`.
+3. Let `q = (toInteger m) - (toInteger b)` — the net signed quantity.
+4. If `q == 0`, **drop** the entry (do not include it in the output).
+5. Otherwise, emit `(policy, asset) ↦ q` in the output `MultiAsset`, with `policy` and `asset` translated by the existing `toLedgerTokenPolicyId` / `toLedgerAssetName` helpers.
+
+The output's `PolicyID` map only contains policies that have at least one non-zero asset after netting (no empty inner maps).
+
+## Invariants
+
+These are the property statements the test suite must encode (see `contracts/ledger-mint-translation.md` for the formal versions).
+
+- **I1 — Totality**: `toLedgerMintValue` terminates for every input pair of `TokenMap`s.
+- **I2 — Identity on empty**: `toLedgerMintValue mempty mempty == mempty`.
+- **I3 — Pure-mint correctness**: for every `(p, a, q)` in `mint` with `burn[(p, a)] == 0` and `q > 0`, the output has the corresponding ledger entry with quantity `+q`.
+- **I4 — Pure-burn correctness**: for every `(p, a, q)` in `burn` with `mint[(p, a)] == 0` and `q > 0`, the output has the corresponding ledger entry with quantity `-q`.
+- **I5 — Mint–burn netting**: when `(p, a)` is in both, the output entry's quantity equals `mint[(p, a)] - burn[(p, a)]`. If that difference is zero, the entry is absent.
+- **I6 — No phantom keys**: no policy or asset appears in the output that didn't appear in at least one input.
+- **I7 — No empty policy buckets**: every `PolicyID` in the output's outer map has a non-empty inner map.
+- **I8 — Round-trip via `fromLedgerMintValue`**: for every input pair where mint and burn have no overlapping keys, applying `fromLedgerMintValue` to the output reconstructs the original `(mint, burn)` pair (modulo empty-bucket trimming). (Reciprocal of the existing read-side function in `Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Mint`.)
+
+## Use in callers
+
+- `mkTransactionLedger` (Ledger.hs:266–349): extract `txAssetsToMint` and `txAssetsToBurn` from its `TransactionCtx`; call `toLedgerMintValue mint burn`; pass the result as the new explicit mint argument to `buildLedgerTx`.
+- `constructUnsignedTxLedger` (Ledger.hs:376–408): grow an explicit `(TokenMap, TokenMap)` parameter (mints, burns); call `toLedgerMintValue` internally; pass the result to `buildLedgerTxRaw`.
+- Wallet-level call site at `Cardano.Wallet.hs:~2746`: pass `txAssetsToMint`'s first component and `txAssetsToBurn`'s first component (the `TokenMap` halves) into the updated `constructUnsignedTxLedger`.
+
+## What this feature does **not** introduce
+
+- No new wallet-domain type. `TokenMap` and the existing field shapes are reused as-is.
+- No script-source threading. The `Map AssetId ScriptSource` halves of `TransactionCtx`'s mint/burn pairs are ignored by this feature.
+- No change to `mkLedgerTx`'s signature. Its `MultiAsset` parameter already exists.

--- a/specs/007-ledger-minting/notes.md
+++ b/specs/007-ledger-minting/notes.md
@@ -1,0 +1,10 @@
+# Notes: 007 ledger minting
+
+## T002
+
+Existing primitive ledger conversion spec module:
+
+`lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs`
+
+No new spec module scaffolding or `primitive.cabal` test-suite wiring is
+needed for Commit 1.

--- a/specs/007-ledger-minting/plan.md
+++ b/specs/007-ledger-minting/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Ledger Body Builder Minting Support
+
+**Branch**: `007-ledger-minting` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification at `/code/cardano-wallet-5243/specs/007-ledger-minting/spec.md`
+
+## Summary
+
+Plumb a mint specification through `buildLedgerTx` and `buildLedgerTxRaw`, translate the wallet's `(mint :: TokenMap, burn :: TokenMap)` pair to a single signed ledger `MultiAsset`, and feed the real value from `mkTransactionLedger` and `constructUnsignedTxLedger`. The two TODO sites in `Ledger.hs` (lines 433, 496) become parameters. No script witnesses, no `mkUnsignedTransaction` migration; those live in follow-up features.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.6, per `cabal.project`).
+**Primary Dependencies**: `cardano-ledger-api`, `cardano-ledger-mary` (`MultiAsset`, `mintTxBodyL`), in-repo `primitive`, `wallet`.
+**Storage**: N/A (transaction body construction, no persistence).
+**Testing**: `hspec` + `QuickCheck`, in `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`.
+**Target Platform**: Linux (musl), Windows (cross), macOS (Intel + Apple Silicon) — unchanged.
+**Project Type**: Haskell library (`cardano-wallet:lib:wallet`).
+**Performance Goals**: Inherits the body-builder's existing cost profile; the translation is O(#policies × #assets) over a typically tiny map, so no new performance concern.
+**Constraints**: Information-preserving translation; empty input → empty mint field; existing callers unchanged on the empty path.
+**Scale/Scope**: ~3 source modules touched (`Ledger.hs`, `Convert.hs`, `Wallet.hs`), one test module extended.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0; re-checked after Phase 1.*
+
+| Principle | Status | Note |
+|---|---|---|
+| I. Maintenance-First Stability | ✓ | Smallest possible plumbing; new behaviour is unreachable in production until the still-blocked `mkUnsignedTransaction` migration lands. |
+| II. Era-Aware Design | ✓ | Follows the existing `IsRecentEra era => RecentEra era ->` shape; only `RecentEraConway` is implemented, matching `mkLedgerTx`'s current support. `Dijkstra` continues to error. |
+| III. Type Safety as Security | ✓ | New translation is a total function; no runtime checks, no partiality, no script-witness handling. |
+| IV. Formal Specification | ✓ | No OpenAPI surface change; no Lean spec affected. |
+| V. Reproducible Builds | ✓ | No new dependencies; no `cabal.project` edits. |
+| VI. Comprehensive Testing | ✓ | New unit + property tests in `TransactionLedgerSpec.hs`; no integration / E2E changes required. |
+| VII. Code Quality Gates | ✓ | Fourmolu / HLint / `-Wall` apply unchanged. |
+
+**Result: PASS. No complexity-tracking entries.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-ledger-minting/
+├── plan.md              # this file
+├── research.md          # Phase 0 findings
+├── data-model.md        # mint-translation contract
+├── contracts/
+│   └── ledger-mint-translation.md   # invariants + property statements
+├── quickstart.md        # reviewer/maintainer walkthrough
+├── spec.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+lib/wallet/src/Cardano/Wallet/Shelley/Transaction/
+├── Ledger.hs            # buildLedgerTx / buildLedgerTxRaw — add mint parameter; drop the two `mempty -- TODO` sites
+└── Build.hs             # unchanged: mkLedgerTx already accepts a MultiAsset (line 104)
+
+lib/wallet/src/Cardano/Wallet.hs
+└── line ~2746            # update the call to constructUnsignedTxLedger to pass mint
+
+lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/
+└── Convert.hs           # add `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset`
+
+lib/unit/test/unit/Cardano/Wallet/Shelley/
+└── TransactionLedgerSpec.hs   # add minting test group (unit + property)
+
+lib/primitive/test/.../Ledger/
+└── ConvertSpec.hs       # add tests for toLedgerMintValue (if a spec module exists; otherwise extend an existing convert spec — confirm during T002)
+```
+
+**Structure Decision**: existing layered layout; the smallest viable change touches the Shelley transaction layer plus a new conversion in the primitive ledger-convert module. The translation lives next to `toLedgerTokenBundle` because it concerns the same `wallet ↔ ledger` boundary.
+
+## Design Decisions (extracted from research.md)
+
+1. **Mint parameter shape**: pass a single `MultiAsset` (already-translated ledger value) as a new positional argument to both `buildLedgerTx` and `buildLedgerTxRaw`. **Not** an extraction from `SelectionOf`, because `buildLedgerTxRaw` accepts `Either PreSelection (SelectionOf TxOut)` and `PreSelection` does not carry mint fields. Explicit parameter keeps the two surfaces symmetric and forces every caller to decide.
+
+2. **Translation location**: add `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset` in `Cardano.Wallet.Primitive.Ledger.Convert`, sitting beside `toLedgerTokenBundle`. Reuses `toLedgerTokenPolicyId`, `toLedgerAssetName`, and a new `toLedgerSignedQuantity` helper that maps `TokenQuantity (Natural) → Integer`. Mint quantities go in positive, burn quantities go in negated.
+
+3. **Mint–burn overlap**: if the same `(policy, asset)` appears in both `assetsToMint` and `assetsToBurn`, net them (`mint − burn`). Drop zero entries (the ledger admits but does not require them, and dropping keeps the body deterministic across equivalent inputs). Make this explicit in `contracts/ledger-mint-translation.md`.
+
+4. **Caller wiring**:
+   - `mkTransactionLedger` (Ledger.hs:306) extracts `txAssetsToMint` and `txAssetsToBurn` from its `TransactionCtx` and passes `toLedgerMintValue mint burn` to `buildLedgerTx`.
+   - `constructUnsignedTxLedger` (Ledger.hs:399) grows an explicit `(TokenMap, TokenMap)` argument; updated at its single call site in `Cardano.Wallet.hs:2746`.
+
+5. **Out-of-scope, explicit**: no change to `mkLedgerTx` (its `MultiAsset` parameter already exists); no script witnesses; no Dijkstra-era work; no change to the `mkUnsignedTransaction` cardano-api path.
+
+## Phase 0: Outline & Research
+
+`research.md` consolidates the Phase 0 Explore findings: exact call sites, line numbers, signatures, the TokenMap/MultiAsset asymmetry, and risks. No unresolved `NEEDS CLARIFICATION` markers remain.
+
+**Output**: `research.md` (present).
+
+## Phase 1: Design & Contracts
+
+- `data-model.md`: defines the two domain types (`TokenMap` mint, `TokenMap` burn) and the translated `MultiAsset`, plus the netting/zero-dropping rule.
+- `contracts/ledger-mint-translation.md`: states the translation's invariants as property-test statements (totality, faithfulness, identity-on-empty, mint–burn netting, zero filter).
+- `quickstart.md`: reviewer walkthrough — five files to read, in order, to verify the slice. Includes the exact `cabal test` command for the affected spec module.
+
+**Output**: `data-model.md`, `contracts/ledger-mint-translation.md`, `quickstart.md` (all present).
+
+**Agent context update**: skipped — the Spec Kit agent-context script is for CLAUDE.md-style files this repo does not maintain; this plan and its supporting documents are the durable hand-off.
+
+## Constitution re-check post-design
+
+Re-evaluated after writing `data-model.md` and `contracts/`. All seven principles still pass. No violations introduced by the chosen translation rule.
+
+## Phase 2 (next)
+
+`/speckit.tasks` will turn this plan into a bisect-safe, TDD-first task list: one RED slice for the translation, one GREEN slice for the translation + its caller plumbing, and one slice for the explicit-parameter rewiring of `constructUnsignedTxLedger`. See `quickstart.md` for the intended commit shape.

--- a/specs/007-ledger-minting/quickstart.md
+++ b/specs/007-ledger-minting/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Reviewing or Resuming `007-ledger-minting`
+
+## What you're looking at
+
+A small, structural plumbing change in the wallet's ledger-based transaction body builder. The change unblocks the migration of `mkUnsignedTransaction` off `cardano-api` (Story 1 of issue [#5285](https://github.com/cardano-foundation/cardano-wallet/issues/5285)) by removing two `mempty -- TODO: minting support` placeholders from `Cardano.Wallet.Shelley.Transaction.Ledger`. Script-witness support is **not** in this slice.
+
+Read these in order if you are reviewing or resuming:
+
+1. `spec.md` — what and why, in spec-kit framing.
+2. `research.md` — Phase 0 findings: exact call sites, line numbers, signatures, the `TokenMap` ↔ `MultiAsset` asymmetry.
+3. `data-model.md` — the new translation function, its inputs, and the mint-burn netting rule.
+4. `contracts/ledger-mint-translation.md` — invariants as property statements.
+5. `plan.md` — the design decisions distilled (D1–D6); read this last to confirm the chosen approach.
+
+## Files the implementation will touch
+
+| File | Change |
+|---|---|
+| `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs` | Add `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset`. |
+| `lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs` | `buildLedgerTx` and `buildLedgerTxRaw` take an explicit `MultiAsset` parameter. The two `mempty -- TODO` sites at lines 433 and 496 vanish. `mkTransactionLedger` and `constructUnsignedTxLedger` translate and pass through. |
+| `lib/wallet/src/Cardano/Wallet.hs` | One call site (around line 2746) updated to pass `(TokenMap, TokenMap)` mint/burn through to `constructUnsignedTxLedger`. |
+| `lib/primitive/test/.../Ledger/ConvertSpec.hs` (or equivalent) | Properties P1–P8 from the contract. |
+| `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs` | Properties B1–B3 from the contract. |
+
+No `cabal.project` changes; no new dependencies; no new packages.
+
+## How to build and test the slice
+
+From the worktree root (`/code/cardano-wallet-5243`), inside `nix develop` (or with direnv loaded):
+
+```bash
+# Build only the affected libraries.
+cabal build cardano-wallet:lib:wallet primitive:lib:primitive -O0 -v0
+
+# Run the convert and builder spec modules.
+cabal test cardano-wallet-unit:unit primitive:test:unit-tests -O0 -v0 \
+  --test-show-details=streaming
+```
+
+For the fast inner loop, narrow further with hspec's `--match`:
+
+```bash
+cabal run cardano-wallet-unit:unit -- --match "TransactionLedger/mint"
+cabal run primitive:test:unit-tests -- --match "Convert/toLedgerMintValue"
+```
+
+Format check before commit:
+
+```bash
+just check-fmt
+```
+
+## Expected commit shape
+
+Three vertical, bisect-safe commits, in this order:
+
+1. **`feat(primitive): toLedgerMintValue (TokenMap, TokenMap) → MultiAsset`** — adds the conversion **and** its property tests in the same commit (RED + GREEN folded, per the PR skill's rule).
+2. **`feat(wallet): plumb mint through buildLedgerTx / buildLedgerTxRaw`** — adds the explicit `MultiAsset` parameter to both builders, removes both `mempty -- TODO` sites, wires `mkTransactionLedger` and `constructUnsignedTxLedger`, and adds the builder-side property tests B1–B3. Same commit holds both the test and the implementation, again to keep the slice bisect-safe.
+3. **`feat(wallet): pass mint/burn from Cardano.Wallet to constructUnsignedTxLedger`** — updates the single call site at `Cardano.Wallet.hs:~2746`.
+
+If a fourth commit appears for "documentation" or "review fixes", reroute the change into the commit that introduced the issue (per the PR skill).
+
+## How to verify minting is plumbed (smoke check)
+
+After the slice lands, the following must hold:
+
+```bash
+# No remaining placeholders.
+rg 'mempty -- TODO: minting support' lib/wallet/src
+# (expect: no matches)
+
+# The new converter exists.
+rg '^toLedgerMintValue' lib/primitive
+# (expect: a definition in Convert.hs)
+
+# Both builders mention the new parameter.
+rg 'buildLedgerTx(Raw)?\b' lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+# (expect: a `MultiAsset` somewhere in their argument lists)
+```
+
+The migration of `mkUnsignedTransaction` itself is a separate feature; it is **not** delivered by this slice and **not** verified by these checks.
+
+## Open questions deferred to next phase
+
+- The exact preferred spec module under `lib/primitive/test/` for the converter properties — to be confirmed by the first task ("locate spec module for `Convert.hs`"). No conversion implementation lives there yet, but the surrounding pattern in that package should drive the choice.
+- Whether `Arbitrary TokenMap` is already exported from the test-only support library or needs a brief re-export — confirm on the first run of `cabal test`.

--- a/specs/007-ledger-minting/research.md
+++ b/specs/007-ledger-minting/research.md
@@ -1,0 +1,95 @@
+# Phase 0 Research: Ledger Body Builder Minting Support
+
+**Feature**: `007-ledger-minting`
+**Date**: 2026-05-13
+**Source**: Explore sub-agent run on `/code/cardano-wallet-5243` at base commit `0821bddb2c` (`origin/master`).
+
+## File index
+
+| Purpose | File | Key lines |
+|---|---|---|
+| Ledger body builder | `lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs` | 411–423 (`buildLedgerTx`), 465–477 (`buildLedgerTxRaw`), 433 + 496 (`mempty -- TODO`) |
+| Transaction assembler | `lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs` | 88–108 (`mkLedgerTx`), 104 (`MultiAsset` param), 131 (`mintTxBodyL .~ mint`) |
+| Transaction context types | `lib/wallet/src/Cardano/Wallet/Transaction.hs` | 218–244 (`TransactionCtx`), 252–271 (`SelectionOf`) |
+| `TokenMap` | `lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs` | 19–79 |
+| Existing wallet→ledger converters | `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs` | 183–192 (class), 216–251 (`toLedgerTokenBundle`) |
+| Existing ledger→wallet mint read path | `lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs` | 226–246 (`fromLedgerMintValue`) |
+| Tests | `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs` | spec entry around line 408 |
+| Indirect caller of `constructUnsignedTxLedger` | `lib/wallet/src/Cardano/Wallet.hs` | ~line 2746 |
+
+## What's there today
+
+### `buildLedgerTx` (Ledger.hs:411–423)
+
+```haskell
+buildLedgerTx
+    :: forall era . IsRecentEra era
+    => RecentEra era
+    -> (Maybe SlotNo, SlotNo)
+    -> Network
+    -> Withdrawal
+    -> W.Coin
+    -> Maybe TxMetadata
+    -> [TxCert era]
+    -> [TxOut]
+    -> SelectionOf TxOut
+    -> Write.Tx era
+```
+
+Line 433 inside its `where`-bound call to `mkLedgerTx` passes `mempty -- TODO: minting support` as the mint argument.
+
+### `buildLedgerTxRaw` (Ledger.hs:465–477)
+
+Same shape, but accepts `Either PreSelection (SelectionOf TxOut)` as its final argument. Line 496 has the same `mempty -- TODO: minting support`.
+
+### `mkLedgerTx` (Build.hs:88–108)
+
+Already accepts `MultiAsset` (`Cardano.Ledger.Mary.Value`) as its 8th parameter (line 104). Applies it via `mintTxBodyL .~ mint` (line 131). No change needed here.
+
+### Wallet's mint representation
+
+- `TokenMap` from `Cardano.Wallet.Primitive.Types.TokenMap` — flat map `(TokenPolicyId, TokenAssetName) → TokenQuantity` where `TokenQuantity = Natural` (unsigned).
+- `TransactionCtx.txAssetsToMint :: (TokenMap, Map AssetId ScriptSource)` and `txAssetsToBurn` analogue.
+- `SelectionOf.assetsToMint :: !TokenMap` and `assetsToBurn :: !TokenMap`.
+- Mints and burns are **two distinct unsigned maps**, not one signed map.
+
+### Ledger's mint representation
+
+- `Cardano.Ledger.Mary.Value.MultiAsset` — `Map PolicyID (Map AssetName Integer)`. Quantity is **signed**: positive = mint, negative = burn.
+- Lens at the body level: `mintTxBodyL :: Lens' (TxBody era) MultiAsset`.
+
+### Existing convert layer
+
+- `toLedgerTokenBundle :: TokenBundle -> MaryValue` (Convert.hs:220) — operates on `TokenBundle` (ada + tokens), not bare `TokenMap`, so not directly reusable for mints.
+- Sub-helpers it relies on (`toLedgerTokenPolicyId`, `toLedgerAssetName`, `toLedgerTokenQuantity`) are reusable for the mint translation.
+- Read-side counterpart `fromLedgerMintValue` (Mint.hs:226) splits a `MultiAsset` into `(mint, burn) :: (TokenMap, TokenMap)`; the new write-side function is its inverse.
+
+## Risks / surprises
+
+1. **`TokenMap → MultiAsset` does not yet exist.** Must be added. Natural home: `Cardano.Wallet.Primitive.Ledger.Convert`, next to `toLedgerTokenBundle`.
+
+2. **Signed / unsigned asymmetry.** `TokenMap` quantities are `Natural`; `MultiAsset` quantities are `Integer`. The new translation must take **two** `TokenMap`s (mint and burn) and produce a single signed `MultiAsset`.
+
+3. **Mint–burn overlap is not impossible.** The same `(policy, asset)` can appear in both `assetsToMint` and `assetsToBurn`. Decision (documented in `data-model.md`): net them (`mint − burn`); drop zero entries.
+
+4. **`PreSelection` does not carry mint fields.** Therefore `buildLedgerTxRaw` cannot recover mints by inspecting its `Either PreSelection (SelectionOf TxOut)` argument. The plan adds an explicit mint parameter — the only design that is symmetric across both builders.
+
+5. **Only `RecentEraConway` is implemented in `mkLedgerTx`.** `Dijkstra` continues to error. The mint feature inherits this; it does not unblock Dijkstra.
+
+6. **No existing minting test on this path.** All current tests pass `mempty`. There is no positive coverage that would regress, but also no fixture to extend — the new property and unit tests come from this feature.
+
+## Decisions (Phase 0 → Phase 1)
+
+- **D1: Pass `MultiAsset` (pre-translated) as an explicit parameter to both builders.** Rationale: uniform across both surfaces, independent of whether the selection happens to carry mint fields.
+- **D2: Add `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset` in `Convert.hs`.** Rationale: same module as `toLedgerTokenBundle`; consistent with read-side `fromLedgerMintValue`.
+- **D3: Net overlapping `(policy, asset)` entries and drop zeros.** Rationale: deterministic body output; matches what callers already arrange to be non-overlapping in practice; documented so reviewers don't have to derive it.
+- **D4: Do not touch `mkLedgerTx`.** Its `MultiAsset` parameter is already there.
+- **D5: Do not change the `cardano-api` path.** This feature is strictly the ledger path's plumbing; the migration is the next feature.
+- **D6: No script-witness work in this slice.** Explicit non-goal; revisit when minting actually becomes reachable through a non-experimental code path.
+
+## Alternatives considered
+
+- **A1: Extract mint from `SelectionOf` inside `buildLedgerTx`** instead of taking a parameter. Rejected — asymmetric with `buildLedgerTxRaw` (whose `PreSelection` branch has no mint), and silently hides the input from the caller-facing signature.
+- **A2: Make the translation type `TokenBundle → MultiAsset` and ignore the ada coin.** Rejected — `TokenBundle` is the wrong domain (mint has no ada coin), and silently dropping the coin is an information-loss footgun if the input ever has one.
+- **A3: Add a `TokenMapWithSign` type and feed that through.** Rejected — gratuitous new type; the existing two-`TokenMap` representation is already universally used in `TransactionCtx` and `SelectionOf`, and netting at the boundary is one line.
+- **A4: Defer the translation and accept `MultiAsset` directly in callers.** Rejected — pushes the wallet→ledger conversion to many call sites instead of one; against the layering principle of the `Convert` module.

--- a/specs/007-ledger-minting/spec.md
+++ b/specs/007-ledger-minting/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Ledger Body Builder Minting Support
+
+**Feature Branch**: `007-ledger-minting`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: "Minting support in Cardano.Wallet.Shelley.Transaction.Ledger body builder. Issue #5243. Follows PR #5286 (branch 006-drop-api-shelley-tx), which documented that the migration of `mkUnsignedTransaction` off cardano-api cannot ship while the ledger-based body builder silently drops minting. Smallest first slice: plumb the mint set through the ledger body builder and translate the wallet's mint representation to the ledger's. Script-witness support is a separate later feature."
+
+## Context
+
+Issue [#5243](https://github.com/cardano-foundation/cardano-wallet/issues/5243) tracks the wallet's migration off `cardano-api` in the Shelley transaction layer. Story 1 of issue [#5285](https://github.com/cardano-foundation/cardano-wallet/issues/5285) — switching `mkUnsignedTransaction` to the ledger-based body builder — was documented in PR [#5286](https://github.com/cardano-foundation/cardano-wallet/pull/5286) as blocked: the ledger body builder hardcodes the transaction's mint field to empty, so the migration would silently drop every mint request that reaches it. This feature removes that structural blocker. It does not perform the migration itself, and it does not add support for the script witnesses that an actual on-chain mint also requires.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Wallet's ledger body builder honours the mint requested by its caller (Priority: P1)
+
+When upstream wallet code asks the ledger-based transaction body builder to construct a transaction body that includes a mint (one or more native-token policies, each with assets and quantities to mint or burn), the resulting transaction body's mint field reflects exactly what the caller asked for, asset-for-asset and quantity-for-quantity.
+
+**Why this priority**: Without this, the migration of `mkUnsignedTransaction` from the `cardano-api` body builder to the ledger body builder cannot proceed — any mint request reaching the new path would be silently dropped, producing a wrong transaction body without warning. This is the single blocker called out by PR [#5286](https://github.com/cardano-foundation/cardano-wallet/pull/5286).
+
+**Independent Test**: Drive the ledger body builder with a representative mint set (one policy with several assets, mixed positive and negative quantities) and inspect the produced transaction body's mint field. The mint field must equal the caller's mint set, translated into the ledger's mint representation, with no assets added, dropped, renamed, or rescaled.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caller that passes an empty mint set, **When** the ledger body builder constructs the transaction body, **Then** the body's mint field is empty (identical to the previous hardcoded behaviour).
+2. **Given** a caller that passes a single-policy, single-asset mint with a positive quantity, **When** the ledger body builder constructs the transaction body, **Then** the body's mint field contains that policy, that asset, with that exact positive quantity, and nothing else.
+3. **Given** a caller that passes a multi-policy mint mixing positive and negative quantities, **When** the ledger body builder constructs the transaction body, **Then** every policy, asset, and signed quantity appears unchanged in the body's mint field.
+4. **Given** the two surface forms of the ledger body builder (the raw form and the higher-level form), **When** both are invoked with the same mint set on the same inputs, **Then** both produce transaction bodies whose mint fields are equal.
+
+---
+
+### User Story 2 — Migration of `mkUnsignedTransaction` to the ledger path is unblocked on minting (Priority: P1)
+
+Once this feature lands, the only remaining minting-related blocker for switching `mkUnsignedTransaction` off `cardano-api` is the separate question of script witnesses. A reviewer of the follow-up migration PR can verify that minting is no longer silently dropped without reading any code outside the migration diff.
+
+**Why this priority**: This is the why-it-matters for User Story 1. Independently testable in the sense that the follow-up migration PR can be opened and have its minting-related risk reviewed without needing further changes to the ledger body builder.
+
+**Independent Test**: Switch `mkUnsignedTransaction` to the ledger body builder on a branch and exercise it with the same mint scenarios as User Story 1. The resulting transaction body's mint field must agree with the input mint set on every scenario from User Story 1.
+
+**Acceptance Scenarios**:
+
+1. **Given** a follow-up branch that wires `mkUnsignedTransaction` to the ledger body builder, **When** it is invoked with a non-empty mint set, **Then** the produced transaction body's mint field reflects that set (rather than being empty as it would be today).
+
+---
+
+### Edge Cases
+
+- **Empty mint set**: Must produce the same transaction body as today's hardcoded-empty behaviour, so that all non-minting flows are unaffected.
+- **Burn-only mint** (all-negative quantities): Must appear in the body's mint field with the negative quantities preserved; not coerced, not filtered.
+- **Zero-quantity entries** in the input mint set: Handled the same way the wallet handles them today in the rest of its pipeline (no new policy on quantity normalisation is introduced by this feature).
+- **Multiple policies in a single mint set**: All policies must appear in the output mint field, none dropped, none merged.
+- **Round-tripping**: The translation from the wallet's mint representation to the ledger's mint representation must not lose information for any input the wallet can produce.
+- **Existing non-minting callers**: The change must not alter callers that pass no mint; their behaviour is preserved exactly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The ledger body builder MUST accept a caller-provided mint specification as a parameter rather than hardcoding the mint field of the transaction body.
+- **FR-002**: The ledger body builder MUST translate the wallet's native mint representation into the ledger's mint representation without losing or altering any policy, asset name, or signed quantity.
+- **FR-003**: When the caller provides an empty mint specification, the resulting transaction body's mint field MUST be empty, matching today's behaviour exactly.
+- **FR-004**: When the caller provides a non-empty mint specification, the resulting transaction body's mint field MUST be equal — under the chosen translation — to the caller's mint specification, with no extra assets and no missing assets.
+- **FR-005**: Both the raw and the higher-level surface of the ledger body builder MUST honour the mint specification consistently; a fixed mint specification must yield equal mint fields on both surfaces.
+- **FR-006**: Existing callers that today rely on the hardcoded empty mint MUST continue to compile and produce unchanged transaction bodies after the change.
+- **FR-007**: The hardcoded "TODO: minting support" placeholder in the ledger body builder MUST be removed; no equivalent silent-drop site may remain.
+- **FR-008**: This feature MUST NOT add script-witness handling for mint scripts; that capability is explicitly deferred to a separate later feature.
+- **FR-009**: The translation from the wallet mint representation to the ledger mint representation MUST be exercised by automated tests covering at minimum: empty input, single-policy single-asset, single-policy multi-asset, multi-policy, and mixed positive/negative quantities.
+
+### Key Entities
+
+- **Wallet mint specification**: The wallet's existing in-process representation of a set of mints — for each policy, the assets and signed quantities to mint or burn. Already produced by upstream code paths today, but currently discarded before reaching the ledger body builder.
+- **Ledger mint field**: The transaction body's native-asset mint field as the ledger sees it. The on-chain contract of the transaction. Currently always empty in bodies produced by the ledger body builder.
+- **Mint translation**: The mapping from the wallet mint specification to the ledger mint field. New artefact introduced by this feature; must be total and information-preserving for all inputs the wallet can produce.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every input mint specification covered by the test scenarios, the ledger body builder's output mint field matches the input under the documented translation. No silent drops.
+- **SC-002**: No call site in the ledger body builder still hardcodes the transaction body's mint field to empty. A repo-wide search for the previous placeholder returns zero hits.
+- **SC-003**: A follow-up PR that switches `mkUnsignedTransaction` to the ledger body builder can be opened with no further changes required in the ledger body builder for minting; the remaining blocker is only script-witness support.
+- **SC-004**: All pre-existing wallet tests that build transactions without minting continue to pass without modification.
+- **SC-005**: A reviewer can read the diff for this feature in under fifteen minutes and verify by inspection that (a) the mint parameter is plumbed end-to-end, (b) the translation is total, and (c) no other behaviour is altered.
+
+## Out of Scope
+
+- **Script-witness support for mints**: A mint that has any effect on-chain requires a Plutus or native-script witness. Producing such witnesses is deferred to a separate later feature and is explicitly not delivered here. Transaction bodies built by this feature with a non-empty mint and no script witnesses will not validate on-chain on their own; that is acceptable, because this feature's only contract is structural plumbing.
+- **Migration of `mkUnsignedTransaction` itself**: Switching `mkUnsignedTransaction` from the `cardano-api` body builder to the ledger body builder is the consumer of this feature; it lives in the follow-up Story 1 work of [#5285](https://github.com/cardano-foundation/cardano-wallet/issues/5285), not here.
+- **New user-facing minting flows or APIs**: This feature does not change any HTTP API, CLI, or wallet behaviour that an external user can observe today.
+
+## Assumptions
+
+- The wallet already produces a mint specification in its existing internal representation at the call sites that reach the ledger body builder; this feature only stops discarding it. (PR [#5286](https://github.com/cardano-foundation/cardano-wallet/pull/5286)'s description confirms the upstream of the ledger body builder is already mint-aware.)
+- The ledger's mint type is a strict superset of what the wallet's mint representation can express, so the translation is total without loss. If a counterexample is found during planning, it becomes a planning-phase decision (e.g., either widen the wallet representation or document the asymmetry).
+- It is acceptable to ship a body builder that produces mints without script witnesses, given that the only consumer today is the still-blocked migration; no production code path will exercise the new mint output until script-witness support also lands.
+- "Script-witness support" is a single, separable follow-up feature and not entangled with this one — i.e., adding witnesses later will not require revisiting the mint-translation introduced here.

--- a/specs/007-ledger-minting/tasks.md
+++ b/specs/007-ledger-minting/tasks.md
@@ -1,0 +1,150 @@
+---
+
+description: "Task list for 007-ledger-minting"
+
+---
+
+# Tasks: Ledger Body Builder Minting Support
+
+**Input**: Design documents in `/code/cardano-wallet-5243/specs/007-ledger-minting/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/ledger-mint-translation.md`, `quickstart.md`
+
+**Tests**: Required for every behaviour-changing slice. Per the PR skill, the RED tests and GREEN implementation fold into **one** reviewed commit (no test-only behaviour commits, no impl-only behaviour commits). Each task below states the commit it belongs to. The three-commit shape comes from `quickstart.md`.
+
+**Organization**: User Story 1 (the builders) and User Story 2 (downstream unblocker) are both P1. US2 has no implementation work in this feature; it is a verification-only phase whose acceptance is "the next migration PR can be opened without further changes to the builders."
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: independent file, parallelisable.
+- **[Story]**: maps task to a user story.
+- File paths are absolute below; commit boundaries are explicit.
+
+---
+
+## Phase 1: Setup (Shared)
+
+**Purpose**: confirm green baseline before any change.
+
+- [ ] T001 Confirm baseline test green on `origin/master` HEAD in `/code/cardano-wallet-5243`: run `cabal build cardano-wallet:lib:wallet primitive:lib:primitive -O0 -v0` then `cabal test cardano-wallet-unit:unit primitive:test:unit-tests -O0 -v0 --test-show-details=streaming`. **No commit.** If red, stop and report — never start a feature over a red baseline.
+- [ ] T002 [P] Locate the convert-side spec module: `find /code/cardano-wallet-5243/lib/primitive/test -name 'ConvertSpec.hs' -o -path '*Primitive/Ledger/*Spec*.hs'`. In `specs/007-ledger-minting/notes.md`, record either (a) the canonical path of an existing spec module to extend, or (b) the explicit observation "no spec module found — Commit 1 must scaffold `Cardano.Wallet.Primitive.Ledger.ConvertSpec` and register it in `primitive.cabal`'s `test-suite` stanza". Case (b) folds into Commit 1 (does not become a new commit), but T010/T011 must explicitly include the scaffolding + cabal-stanza edit; flag this dependency in the commit body. **No commit yet.**
+
+---
+
+## Phase 2: Foundational (Commit 1: converter)
+
+**Purpose**: introduce the `toLedgerMintValue` translation with its full property suite. Blocks Phase 3 because Phase 3 callers translate via this function.
+
+**Folding rule**: T010 (RED, properties) and T011 (GREEN, implementation) are authored in one editing session and committed together as a single reviewed commit titled
+`feat(primitive): toLedgerMintValue (TokenMap, TokenMap) → MultiAsset`.
+Do not push T010 alone; do not push T011 alone. Bisect-safety requires the property suite and the function to land atomically.
+
+- [ ] T010 [US1] Write properties P1–P8 (`prop_total`, `prop_empty`, `prop_mint_only`, `prop_burn_only`, `prop_netting`, `prop_no_phantom_keys`, `prop_no_empty_buckets`, `prop_roundtrip_disjoint`) from `contracts/ledger-mint-translation.md` in the spec module identified by T002 (`/code/cardano-wallet-5243/lib/primitive/test/.../Ledger/ConvertSpec.hs`). Reuse `Arbitrary TokenMap` from existing primitive generators; if missing, add a re-export rather than re-rolling. Run the spec; properties must FAIL because `toLedgerMintValue` does not exist. Capture the failure output as evidence in the commit body of the eventual commit (see folding rule).
+- [ ] T011 [US1] Implement `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset` in `/code/cardano-wallet-5243/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs`, placed adjacent to `toLedgerTokenBundle`. Reuse `toLedgerTokenPolicyId`, `toLedgerAssetName`, and a new private `toLedgerSignedQuantity` (or inline `toInteger`). Implement the netting rule from `data-model.md` §"Translation rules": `q = toInteger m - toInteger b`, drop entries with `q == 0`, drop empty policy buckets. Export the symbol from the module's export list. Re-run the spec; all P1–P8 must PASS. Run `just check-fmt`. Stage **both** T010 and T011's edits and commit once with title `feat(primitive): toLedgerMintValue (TokenMap, TokenMap) → MultiAsset`; commit body must reference issue #5243 and quote the property names covered.
+
+**Checkpoint**: Commit 1 is bisect-safe — the converter exists with full property coverage.
+
+---
+
+## Phase 3: User Story 1 (Commits 2 + 3: builder plumbing + Wallet.hs wiring)
+
+**Story**: US1 — "Wallet's ledger body builder honours the mint requested by its caller."
+**Independent test**: drive `buildLedgerTx` and `buildLedgerTxRaw` with a representative `(TokenMap, TokenMap)` and inspect `view mintTxBodyL` of the produced body; equal to `toLedgerMintValue mint burn`.
+
+### Commit 2: `feat(wallet): plumb mint through buildLedgerTx / buildLedgerTxRaw`
+
+**Folding rule**: T020 (RED, builder properties B1–B3) and T021–T024 (GREEN, builder + caller edits) fold into one commit.
+
+- [ ] T020 [US1] In `/code/cardano-wallet-5243/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs` add a "Mint plumbing" describe block with properties B1, B2, B3 from `contracts/ledger-mint-translation.md`:
+  - B1: `view mintTxBodyL (buildLedgerTx … mintVal) === mintVal` for `RecentEraConway`.
+  - B2: same for `buildLedgerTxRaw` on both `Left PreSelection` and `Right (SelectionOf TxOut)` branches.
+  - B3: empty-input regression — passing `mempty` for the new parameter yields a transaction body structurally equal (under `(==)` on `Tx era`) to the body the current `mempty -- TODO` builder produces. Compare structurally, not via wire-byte equality.
+  Run the spec; B1/B2/B3 must FAIL because the builders still hardcode `mempty`.
+- [ ] T021 [US1] In `/code/cardano-wallet-5243/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs`, add an explicit `MultiAsset` parameter to `buildLedgerTx` (signature at lines 411–423). Thread it to the `mkLedgerTx` call site, replacing the `mempty -- TODO: minting support` at line 433. Do **not** invent a new caller-side translation; the parameter is already-translated.
+- [ ] T022 [US1] In the same file, add the same `MultiAsset` parameter to `buildLedgerTxRaw` (signature at lines 465–477), replacing the `mempty -- TODO: minting support` at line 496. Both builders must end up with the parameter in the same positional slot — keep the surfaces symmetric.
+- [ ] T023 [US1] Update `mkTransactionLedger` (around line 266, call site at line 306 in `Ledger.hs`) to extract `txAssetsToMint` and `txAssetsToBurn` from its `TransactionCtx` (`fst` of each pair — drop the `ScriptSource` map; script witnesses are out of scope) and call `toLedgerMintValue mint burn` to produce the new argument to `buildLedgerTx`.
+- [ ] T024 [US1] Update `constructUnsignedTxLedger` (around lines 376–408 in `Ledger.hs`, call site at line 399) to take an explicit `(TokenMap, TokenMap)` parameter (mints, burns), translate via `toLedgerMintValue`, and pass the result to `buildLedgerTxRaw`. Stage T020–T024 together, run the spec — B1/B2/B3 must PASS — run `just check-fmt`, and commit once with title `feat(wallet): plumb mint through buildLedgerTx / buildLedgerTxRaw`.
+
+**Checkpoint after Commit 2**: the builders accept and honour mint; the only remaining hardcoded site is the top-level wallet caller.
+
+### Commit 3: `feat(wallet): pass mint/burn from Cardano.Wallet to constructUnsignedTxLedger`
+
+- [ ] T030 [US1] In `/code/cardano-wallet-5243/lib/wallet/src/Cardano/Wallet.hs` around line 2746, the single call site of `constructUnsignedTxLedger`, locate the in-scope `TransactionCtx` (or equivalent) and pass `(fst txAssetsToMint, fst txAssetsToBurn)` to the new parameter added in T024. Rebuild; run the full unit suite — no regressions. Commit as a single reviewed commit titled `feat(wallet): pass mint/burn from Cardano.Wallet to constructUnsignedTxLedger`.
+
+**Checkpoint after Commit 3**: every reachable call path into the ledger builder carries the real mint set; the two `mempty -- TODO: minting support` strings no longer exist in `lib/wallet/src`.
+
+---
+
+## Phase 4: User Story 2 (verification only — no implementation)
+
+**Story**: US2 — "Migration of `mkUnsignedTransaction` to the ledger path is unblocked on minting." Acceptance is **observational**: after this feature, the follow-up migration PR can be opened with no further mint-related blockers in the ledger builder. There are no source edits in this phase.
+
+- [ ] T040 [US2] Run the smoke commands from `quickstart.md` §"How to verify minting is plumbed":
+  - `rg 'mempty -- TODO: minting support' lib/wallet/src` → must return zero matches.
+  - `rg '^toLedgerMintValue' lib/primitive` → must return at least one definition match in `Convert.hs`.
+  - `rg 'buildLedgerTx(Raw)?\b' lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs` → output must show the new `MultiAsset` parameter in the signatures.
+  - **FR-008 guard**: `git diff origin/master -- lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs | rg -i 'ScriptSource'` → must return zero matches. The slice must not introduce script-witness handling; if any line appears, fix it before the next commit.
+  Record the output in the PR description. **No commit.**
+- [ ] T041 [US2] Sanity-only: paste a one-paragraph note in the PR description confirming that script-witness work remains the documented next blocker, citing the relevant Out-of-Scope item in `spec.md`. This satisfies User Story 2's acceptance scenario ("a reviewer of the follow-up migration PR can verify that minting is no longer silently dropped without reading any code outside the migration diff"). **No commit.**
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: housekeeping that does not change behaviour. Fold into commit 2 if reviewer prefers, but standalone is acceptable here because these are not behaviour-bearing.
+
+- [ ] T050 [P] Run `just check-fmt` and `just check-hlint` across the touched files; fold any required edits into the commit that introduced the offending line (per the PR skill).
+- [ ] T051 [P] Verify era coverage: `rg 'RecentEraConway' /code/cardano-wallet-5243/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs` — confirm `mkLedgerTx`'s era restriction is unchanged and that the new code does not pretend to support Dijkstra. If a new era check is needed it is **out of scope** — open a follow-up issue.
+- [ ] T052 Run the full unit suite once more end-to-end: `cabal test cardano-wallet-unit:unit primitive:test:unit-tests -O0 -v0`. **Before pushing**, run the flake gate locally: `nix build .#checks.* --quiet` — `just ci` and `cabal test` are not equivalent to the flake checks, and pushing past a red flake gate predictably surfaces as red CI (memory `feedback_local_ci_gap`). Only after the flake gate is green: push the branch and open a draft PR linked to issue #5243 (per the `feedback_always_open_pr` memory).
+- [ ] T053 After CI runs, loop-check it green (per the `feedback_ci_loop` memory). Address any failures in the commit that introduced them; do not add fixup commits.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: no dependencies.
+- **Phase 2 (Commit 1, converter)**: depends on Phase 1. Blocks Phase 3.
+- **Phase 3 (Commits 2 + 3, builders + Wallet.hs)**: depends on Phase 2. Commit 2 blocks Commit 3 because Commit 3 calls into the parameter added in Commit 2 (T024).
+- **Phase 4 (US2 verification)**: depends on Phase 3 complete.
+- **Phase 5 (Polish)**: depends on Phase 3 complete; runs alongside Phase 4.
+
+### Within each commit
+
+- RED test task is authored first, observed to fail, **then** GREEN implementation is added.
+- Both are staged and committed together (folding rule). The commit message body cites which properties the commit makes pass.
+
+### Parallel opportunities
+
+- T001, T002 in Phase 1 are mutually independent ([P]).
+- Inside Commit 2: T021 and T022 touch the same file (`Ledger.hs`) and cannot be parallelised. T023 and T024 also touch `Ledger.hs`. Author them sequentially.
+- T050 and T051 in Phase 5 are independent of each other ([P]).
+
+---
+
+## Parallel Example: Phase 1
+
+```bash
+# T001 and T002 run independently:
+cabal build cardano-wallet:lib:wallet primitive:lib:primitive -O0 -v0 \
+  && cabal test cardano-wallet-unit:unit primitive:test:unit-tests -O0 -v0
+find /code/cardano-wallet-5243/lib/primitive/test \
+  \( -name 'ConvertSpec.hs' -o -path '*Primitive/Ledger/*Spec*.hs' \)
+```
+
+## Implementation Strategy
+
+The three-commit shape and its rationale live in `quickstart.md` §"Expected commit shape" — that is the single source of truth. The phase headers in this file map onto it (Phase 2 = Commit 1, Phase 3 = Commits 2 + 3, Phases 4–5 introduce no behaviour commits). See `quickstart.md` for the canonical commit titles, bodies, and bisect contract.
+
+### MVP scope
+
+US1 is the MVP — Phase 1 + Phase 2 + Phase 3 deliver the entire feature. US2 is verification-only.
+
+---
+
+## Notes
+
+- The PR skill's RED+GREEN fold rule applies to every behaviour-changing commit in this feature. Commits 1 and 2 are behaviour-changing; commit 3 is a one-line wiring change that exercises code already covered by Commit 2's properties (no new RED required, the existing builder properties carry forward).
+- T040 and T041 produce no commits; they produce text for the PR description.
+- The `feedback_pr_descriptions` memory applies: the PR body must reflect the final merged state, not the journey.
+- Out of scope, never sneak in: script witnesses, `mkUnsignedTransaction` migration, Dijkstra era support, any changes to the `cardano-api` body builder path.


### PR DESCRIPTION
## Summary

Implements the smallest first slice toward unblocking [#5285](https://github.com/cardano-foundation/cardano-wallet/issues/5285) Story 1: the ledger-native transaction builders no longer silently drop minting.

This PR now includes both the spec artifacts and implementation for [#5243](https://github.com/cardano-foundation/cardano-wallet/issues/5243):

- adds `toLedgerMintValue :: TokenMap -> TokenMap -> MultiAsset`, netting wallet mint/burn maps into signed ledger quantities and dropping zero entries and empty policy buckets
- threads explicit `MultiAsset` mint values through `buildLedgerTx` and `buildLedgerTxRaw`
- extracts `txAssetsToMint` / `txAssetsToBurn` from `TransactionCtx` for `mkTransactionLedger`
- extends `constructUnsignedTxLedger` to accept mint/burn maps and updates the `Cardano.Wallet` call sites
- keeps script-witness support out of scope; that remains the documented next blocker before non-empty mint transactions can validate on-chain

Follows PR [#5286](https://github.com/cardano-foundation/cardano-wallet/pull/5286), which documented why #5285 Story 2 has to land before Story 1.

## Artifacts

- `specs/007-ledger-minting/spec.md` — user stories, requirements, success criteria, out-of-scope
- `specs/007-ledger-minting/plan.md` — design decisions and implementation plan
- `specs/007-ledger-minting/research.md` — existing builder/converter findings
- `specs/007-ledger-minting/data-model.md` — mint/burn netting rules and invariants
- `specs/007-ledger-minting/contracts/ledger-mint-translation.md` — converter and builder contracts
- `specs/007-ledger-minting/tasks.md` — planned task breakdown
- `specs/007-ledger-minting/quickstart.md` — reviewer commands

## Verification

- [x] `cabal test cardano-wallet-primitive:test -O0 -v0 --test-show-details=streaming --test-options='--match toLedgerMintValue'` — 8 examples, 0 failures; each property passed 1000 tests
- [x] `cabal test cardano-wallet-unit:unit -O0 -v0 --test-show-details=streaming --test-options='--match explicit'` — 3 examples, 0 failures
- [x] `fourmolu --mode check` on touched Haskell files
- [x] `git diff --check`
- [x] `rg 'mempty -- TODO: minting support' lib/wallet/src` returns zero matches
- [x] `rg '^toLedgerMintValue' lib/primitive` returns matches in `Convert.hs`
- [x] FR-008 guard: `git diff origin/master -- lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs | rg -i 'ScriptSource'` returns zero matches

## Out of Scope

- Script witnesses for mint scripts
- The `mkUnsignedTransaction` migration itself, tracked under #5285
- Dijkstra-era support in `mkLedgerTx`, unchanged from the existing Conway-only behaviour