### PR TITLE
feat: upgrade root-key storage to v2 (Argon2id+PBKDF2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,7 +725,12 @@ jobs:
     needs: [build-gate-quality, build-gate-artifacts, build-gate-windows]
     runs-on: nix-enabled-runners
     timeout-minutes: 180
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    # Fork PRs run without repository secrets, so ATTIC_TOKEN is empty
+    # there and the push can only fail; skip the job for them.
+    if: >-
+      (github.event_name == 'pull_request'
+       && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/intersectmbo/cardano-base
-  tag: 610e24137eef96e6f43e866bce7b212cb409ada0
-  --sha256: sha256-Ru1TbLPP4/5t5NaWSFEiv7ontQBy8vGpkxpZmYfvjHg=
+  tag: b3d5405e4b33b6afedd321e6f7dc46c5fe1b5357
+  --sha256: sha256-8UBsnVOM3WaTW/A5J9i9fZp8IbbinqBdSO5HskW++lg=
   subdir:
     cardano-crypto-wallet
 

--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ index-state: 2026-03-26T20:21:33Z
 
 index-state:
   , hackage.haskell.org 2026-03-26T20:21:33Z
-  , cardano-haskell-packages 2026-07-09T14:13:51Z
+  , cardano-haskell-packages 2026-07-20T14:49:58Z
 
 packages:
   lib/address-derivation-discovery
@@ -146,18 +146,6 @@ source-repository-package
 
 -- END cardano-balance-tx
 --------------------------------------------------------------------------------
-
--- BEGIN cardano-crypto-wallet
-
-source-repository-package
-  type: git
-  location: https://github.com/intersectmbo/cardano-base
-  tag: 35260c9c1cd487f753496b00976d86431f3b4cca
-  --sha256: sha256-kBgEEJ3LjBybViCHmnP85mud0i5ya46z0b6oGANbTvo=
-  subdir:
-    cardano-crypto-wallet
-
--- END cardano-crypto-wallet
 
 --------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section

--- a/cabal.project
+++ b/cabal.project
@@ -153,9 +153,18 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/intersectmbo/cardano-base
-  tag: e531b81a0fe2f3584f5c151a0eafc6f57354d391
-  --sha256: sha256-jRm04FYRZN5/SKIuW8AYzmVe+txVGOqy3YvW3E+NEfw=
-  subdir: cardano-crypto-wallet
+  tag: 610e24137eef96e6f43e866bce7b212cb409ada0
+  --sha256: sha256-Ru1TbLPP4/5t5NaWSFEiv7ontQBy8vGpkxpZmYfvjHg=
+  subdir:
+    cardano-crypto-wallet
+
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/cardano-base
+  tag: bcd0bcc96efd0b48080ff9bf60e1cfe0c5710e4b
+  --sha256: sha256-4iyc549FGlJjaVAIjeBvtv+aVakxwhYlj1PDx8gfWJQ=
+  subdir:
+    cardano-crypto-class
 
 -- END cardano-crypto-wallet
 --------------------------------------------------------------------------------

--- a/cabal.project
+++ b/cabal.project
@@ -152,8 +152,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/intersectmbo/cardano-base
-  tag: 94bf0f1b4961470f6172ab20a7df2ff540b0096e
-  --sha256: sha256-SKhBl29Fm0Mhd9Zsz695q2Er5wATDFsGR/2We6+Ri80=
+  tag: 35260c9c1cd487f753496b00976d86431f3b4cca
+  --sha256: sha256-kBgEEJ3LjBybViCHmnP85mud0i5ya46z0b6oGANbTvo=
   subdir:
     cardano-crypto-wallet
 

--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/intersectmbo/cardano-base
-  tag: 592fc8d2e236a8bd24147323ac3282272adbae38
-  --sha256: sha256-FwXrSjX6AOnRiH3LnL3YKkff9flb1UeuUZ4gEuiTm8g=
+  tag: e531b81a0fe2f3584f5c151a0eafc6f57354d391
+  --sha256: sha256-jRm04FYRZN5/SKIuW8AYzmVe+txVGOqy3YvW3E+NEfw=
   subdir: cardano-crypto-wallet
 
 -- END cardano-crypto-wallet

--- a/cabal.project
+++ b/cabal.project
@@ -148,6 +148,19 @@ source-repository-package
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
+-- BEGIN cardano-crypto-wallet-v2
+
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/cardano-base
+  tag: b0941c4168d2fbc00253a8f955ce0063d710b7e0
+  --sha256: sha256-vuBiy4ix8QiEB6hdOM8PQtNFBaSjxKJWEV6W4yaiEGU=
+  subdir: cardano-crypto-wallet-v2
+
+-- END cardano-crypto-wallet-v2
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section
 
 allow-newer:

--- a/cabal.project
+++ b/cabal.project
@@ -147,6 +147,18 @@ source-repository-package
 -- END cardano-balance-tx
 --------------------------------------------------------------------------------
 
+-- BEGIN cardano-crypto-wallet
+
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/cardano-base
+  tag: 94bf0f1b4961470f6172ab20a7df2ff540b0096e
+  --sha256: sha256-SKhBl29Fm0Mhd9Zsz695q2Er5wATDFsGR/2We6+Ri80=
+  subdir:
+    cardano-crypto-wallet
+
+-- END cardano-crypto-wallet
+
 --------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section
 

--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ index-state: 2026-03-26T20:21:33Z
 
 index-state:
   , hackage.haskell.org 2026-03-26T20:21:33Z
-  , cardano-haskell-packages 2026-05-02T16:21:41Z
+  , cardano-haskell-packages 2026-07-09T14:13:51Z
 
 packages:
   lib/address-derivation-discovery
@@ -148,30 +148,6 @@ source-repository-package
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
--- BEGIN cardano-crypto-wallet
-
-source-repository-package
-  type: git
-  location: https://github.com/intersectmbo/cardano-base
-  tag: b3d5405e4b33b6afedd321e6f7dc46c5fe1b5357
-  --sha256: sha256-8UBsnVOM3WaTW/A5J9i9fZp8IbbinqBdSO5HskW++lg=
-  subdir:
-    cardano-crypto-wallet
-
-source-repository-package
-  type: git
-  -- Keep the second cardano-base URL syntactically distinct so Cabal
-  -- does not reference-clone from the first shallow checkout.
-  location: https://github.com/intersectmbo/cardano-base.git
-  tag: bcd0bcc96efd0b48080ff9bf60e1cfe0c5710e4b
-  --sha256: sha256-4iyc549FGlJjaVAIjeBvtv+aVakxwhYlj1PDx8gfWJQ=
-  subdir:
-    cardano-crypto-class
-
--- END cardano-crypto-wallet
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section
 
 allow-newer:
@@ -213,7 +189,7 @@ constraints:
   , cardano-binary ==1.8.0.0
   , cardano-cli ==11.0.0.0
   , cardano-crypto ==1.3.0
-  , cardano-crypto-class ==2.3.2.0
+  , cardano-crypto-class ==2.3.3.0
   , cardano-crypto-praos ==2.2.2.0
   , cardano-crypto-wrapper ==1.7.0.0
   , cardano-data ==1.3.0.0

--- a/cabal.project
+++ b/cabal.project
@@ -160,7 +160,9 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/intersectmbo/cardano-base
+  -- Keep the second cardano-base URL syntactically distinct so Cabal
+  -- does not reference-clone from the first shallow checkout.
+  location: https://github.com/intersectmbo/cardano-base.git
   tag: bcd0bcc96efd0b48080ff9bf60e1cfe0c5710e4b
   --sha256: sha256-4iyc549FGlJjaVAIjeBvtv+aVakxwhYlj1PDx8gfWJQ=
   subdir:
@@ -375,4 +377,3 @@ package bitvec
    flags: -simd
 
 -- -------------------------------------------------------------------------
-

--- a/cabal.project
+++ b/cabal.project
@@ -148,16 +148,16 @@ source-repository-package
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
--- BEGIN cardano-crypto-wallet-v2
+-- BEGIN cardano-crypto-wallet
 
 source-repository-package
   type: git
   location: https://github.com/intersectmbo/cardano-base
-  tag: b0941c4168d2fbc00253a8f955ce0063d710b7e0
-  --sha256: sha256-vuBiy4ix8QiEB6hdOM8PQtNFBaSjxKJWEV6W4yaiEGU=
-  subdir: cardano-crypto-wallet-v2
+  tag: 592fc8d2e236a8bd24147323ac3282272adbae38
+  --sha256: sha256-FwXrSjX6AOnRiH3LnL3YKkff9flb1UeuUZ4gEuiTm8g=
+  subdir: cardano-crypto-wallet
 
--- END cardano-crypto-wallet-v2
+-- END cardano-crypto-wallet
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1777742585,
-        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
+        "lastModified": 1780436322,
+        "narHash": "sha256-3YDsDhjAcm5QatdluTKuQ9WeDdwrxZMnKH587pVyv9o=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
+        "rev": "bc93f1caabfdc4d38c5b44e6eea8f5b8f535775a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1780436322,
-        "narHash": "sha256-3YDsDhjAcm5QatdluTKuQ9WeDdwrxZMnKH587pVyv9o=",
+        "lastModified": 1783608062,
+        "narHash": "sha256-b7vCPkrTeKFDfJ3x9TMB9pwUm0eqrR28mxvunZMi/0c=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bc93f1caabfdc4d38c5b44e6eea8f5b8f535775a",
+        "rev": "28088c447cffe5dce9816c3a1ea5df693b350dba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1783608062,
-        "narHash": "sha256-b7vCPkrTeKFDfJ3x9TMB9pwUm0eqrR28mxvunZMi/0c=",
+        "lastModified": 1784570152,
+        "narHash": "sha256-eOcU6GF5Skq/WkBdfCgKIyTzgAjWo1WjbVsR5xDzunI=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "28088c447cffe5dce9816c3a1ea5df693b350dba",
+        "rev": "f77658bfbf42886478e7a34a1522949cdfc639a3",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ unit-tests-cabal-match match:
   LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
   cabal test \
     cardano-wallet-application-tls:unit \
-    cardano-balance-tx:test \
+    cardano-balance-tx:unit \
     cardano-numeric:unit \
     cardano-wallet-blackbox-benchmarks:unit \
     cardano-wallet-launcher:unit \

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -462,7 +462,7 @@ isShared addrRaw st = case ready st of
 
 instance SupportsDiscovery n k => IsOurs (SharedState n k) Address where
     isOurs addr st =
-        first (fmap (decoratePath st utxoExternal . fst)) (isShared addr st)
+        first (fmap (\(ix, role') -> decoratePath st (toEnum (fromEnum role')) ix)) (isShared addr st)
 
 -- | Decorate an index with the derivation prefix corresponding to the state.
 decoratePath

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -462,7 +462,9 @@ isShared addrRaw st = case ready st of
 
 instance SupportsDiscovery n k => IsOurs (SharedState n k) Address where
     isOurs addr st =
-        first (fmap (\(ix, role') -> decoratePath st (toEnum (fromEnum role')) ix)) (isShared addr st)
+        first
+            (fmap (\(ix, role') -> decoratePath st (toEnum (fromEnum role')) ix))
+            (isShared addr st)
 
 -- | Decorate an index with the derivation prefix corresponding to the state.
 decoratePath

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -194,7 +194,9 @@ import Cardano.Wallet
     , ErrGetPolicyId (..)
     , ErrNoSuchWallet (..)
     , ErrReadRewardAccount (..)
+    , ErrMkTransaction (..)
     , ErrSignPayment (..)
+    , ErrSignTx (..)
     , ErrSubmitTransaction (..)
     , ErrSubmitTransactionMissingWitnessCounts (..)
     , ErrUpdatePassphrase (..)
@@ -731,6 +733,7 @@ import Control.Monad.Trans.Except
 import Control.Tracer
     ( Tracer
     , contramap
+    , nullTracer
     )
 import Cryptography.Core
     ( genSalt
@@ -1704,7 +1707,7 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
     matchEmptyPassphrase db =
         liftIO
             $ runExceptT
-            $ W.withRootKey @s db wid mempty Prelude.id (\_ -> pure ())
+            $ W.withRootKey nullTracer @s db wid mempty Prelude.id (\_ -> pure ())
 
     hideInfoForEmptyPassphrase info =
         withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
@@ -2491,12 +2494,10 @@ signTransaction ctx (ApiT wid) body = do
             tl = wrk ^. W.transactionLayer @k
             nl = wrk ^. W.networkLayer
         db & \W.DBLayer{atomically, readCheckpoint} ->
-            W.withRootKey @s db wid pwd ErrWitnessTxWithRootKey
+            W.withRootKey nullTracer @s db wid pwd ErrWitnessTxWithRootKey
                 $ \case
                     W.RootKeyAccessV2{} ->
-                        liftIO
-                            $ error
-                                "signTransaction: V2 key signing not yet implemented"
+                        throwE $ ErrWitnessTxSignTx ErrSignTxUnimplemented
                     W.RootKeyAccessV1 rootK scheme -> lift $ do
                         cp <- atomically readCheckpoint
                         let
@@ -5066,12 +5067,12 @@ rndStateChange
     -> Handler (ArgGenChange s)
 rndStateChange ctx (ApiT wid) pwd =
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> liftHandler
-        $ W.withRootKey (wrk ^. dbLayer) wid pwd ErrSignPaymentWithRootKey
+        $ W.withRootKey nullTracer (wrk ^. dbLayer) wid pwd ErrSignPaymentWithRootKey
         $ \case
             W.RootKeyAccessV2{} ->
-                liftIO
-                    $ error
-                        "rndStateChange: V2 key not yet supported for Byron wallets"
+                throwE $ ErrSignPaymentMkTx
+                    $ ErrMkTransactionTxBodyError
+                        "V2 key signing is not yet supported for Byron wallets."
             W.RootKeyAccessV1 xprv scheme ->
                 pure (xprv, preparePassphrase scheme pwd)
 

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1704,7 +1704,7 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
     matchEmptyPassphrase db =
         liftIO
             $ runExceptT
-            $ W.withRootKey @s db wid mempty Prelude.id (\_ _ -> pure ())
+            $ W.withRootKey @s db wid mempty Prelude.id (\_ -> pure ())
 
     hideInfoForEmptyPassphrase info =
         withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
@@ -2492,40 +2492,45 @@ signTransaction ctx (ApiT wid) body = do
             nl = wrk ^. W.networkLayer
         db & \W.DBLayer{atomically, readCheckpoint} ->
             W.withRootKey @s db wid pwd ErrWitnessTxWithRootKey
-                $ \rootK scheme -> lift $ do
-                    cp <- atomically readCheckpoint
-                    let
-                        pwdP :: Passphrase "encryption"
-                        pwdP = preparePassphrase scheme pwd
+                $ \case
+                    W.RootKeyAccessV2{} ->
+                        liftIO
+                            $ error
+                                "signTransaction: V2 key signing not yet implemented"
+                    W.RootKeyAccessV1 rootK scheme -> lift $ do
+                        cp <- atomically readCheckpoint
+                        let
+                            pwdP :: Passphrase "encryption"
+                            pwdP = preparePassphrase scheme pwd
 
-                        utxo :: UTxO.UTxO
-                        utxo = totalUTxO mempty cp
+                            utxo :: UTxO.UTxO
+                            utxo = totalUTxO mempty cp
 
-                        keyLookup = isOwned wF (getState cp) (rootK, pwdP)
+                            keyLookup = isOwned wF (getState cp) (rootK, pwdP)
 
-                        accIxForStakingM :: Maybe (Index 'Hardened 'AccountK)
-                        accIxForStakingM = getAccountIx @s (getState cp)
+                            accIxForStakingM :: Maybe (Index 'Hardened 'AccountK)
+                            accIxForStakingM = getAccountIx @s (getState cp)
 
-                        witCountCtx = shelleyOrShared
-                            wF
-                            AnyWitnessCountCtx
-                            $ \flavor ->
-                                toWitnessCountCtx flavor (getState cp)
+                            witCountCtx = shelleyOrShared
+                                wF
+                                AnyWitnessCountCtx
+                                $ \flavor ->
+                                    toWitnessCountCtx flavor (getState cp)
 
-                    era <- liftIO $ NW.currentNodeEra nl
-                    let sealedTx = body ^. #transaction . #getApiT
-                    pure
-                        $ W.signTransaction
-                            (keyFlavorFromState @s)
-                            tl
-                            era
-                            witCountCtx
-                            keyLookup
-                            Nothing
-                            (RootCredentials rootK pwdP)
-                            utxo
-                            accIxForStakingM
-                            sealedTx
+                        era <- liftIO $ NW.currentNodeEra nl
+                        let sealedTx = body ^. #transaction . #getApiT
+                        pure
+                            $ W.signTransaction
+                                (keyFlavorFromState @s)
+                                tl
+                                era
+                                witCountCtx
+                                keyLookup
+                                Nothing
+                                (RootCredentials rootK pwdP)
+                                utxo
+                                accIxForStakingM
+                                sealedTx
 
     -- TODO: The body+witnesses seem redundant with the sealedTx already. What's
     -- the use-case for having them provided separately? In the end, the client
@@ -5062,7 +5067,13 @@ rndStateChange
 rndStateChange ctx (ApiT wid) pwd =
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> liftHandler
         $ W.withRootKey (wrk ^. dbLayer) wid pwd ErrSignPaymentWithRootKey
-        $ \xprv scheme -> pure (xprv, preparePassphrase scheme pwd)
+        $ \case
+            W.RootKeyAccessV2{} ->
+                liftIO
+                    $ error
+                        "rndStateChange: V2 key not yet supported for Byron wallets"
+            W.RootKeyAccessV1 xprv scheme ->
+                pure (xprv, preparePassphrase scheme pwd)
 
 type RewardAccountBuilder k =
     ClearCredentials k

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1156,12 +1156,14 @@ mkShelleyWallet ctx@ApiLayer{..} wid cp meta delegation pending progress = do
             , delegation = apiDelegation
             , id = ApiT wid
             , name = ApiT $ meta ^. #name
-            , passphrase =
-                ApiWalletPassphraseInfo
-                    <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
+            , passphrase = toApiPassphraseInfo <$> meta ^. #passphraseInfo
             , state = ApiT progress
             , tip
             }
+
+toApiPassphraseInfo :: WalletPassphraseInfo -> ApiWalletPassphraseInfo
+toApiPassphraseInfo WalletPassphraseInfo{lastUpdatedAt, passphraseScheme} =
+    ApiWalletPassphraseInfo lastUpdatedAt (ApiT passphraseScheme)
 
 toApiWalletDelegation
     :: W.WalletDelegation -> TimeInterpreter IO -> IO ApiWalletDelegation
@@ -1497,9 +1499,7 @@ mkSharedWallet ctx wid cp meta delegation pending progress =
                     , name = ApiT $ meta ^. #name
                     , accountIndex = ApiT $ DerivationIndex $ getIndex accIx
                     , addressPoolGap = ApiT $ Shared.poolGap st
-                    , passphrase =
-                        ApiWalletPassphraseInfo
-                            <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
+                    , passphrase = toApiPassphraseInfo <$> meta ^. #passphraseInfo
                     , paymentScriptTemplate =
                         ApiScriptTemplate
                             $ Shared.paymentTemplate st
@@ -1583,7 +1583,7 @@ patchSharedWallet ctx liftKey cred (ApiT wid) body = do
             $ withWorkerCtx @_ @s ctx wid liftE liftE
             $ \wrk ->
                 handler
-                    $ W.attachPrivateKeyFromPwdHashShelley wrk (fromJust prvKeyM)
+                    $ liftIO $ W.reattachPrivateKey wrk (fromJust prvKeyM)
 
     fst <$> getWallet ctx (mkSharedWallet @_ @s) (ApiT wid)
   where
@@ -1641,6 +1641,7 @@ mkLegacyWallet
        , HasNetworkLayer IO ctx
        , IsOurs s Address
        , IsOurs s RewardAccount
+       , WalletFlavor s
        )
     => ctx
     -> WalletId
@@ -1662,13 +1663,15 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
     pwdInfo <- case meta ^. #passphraseInfo of
         Nothing ->
             pure Nothing
-        Just (WalletPassphraseInfo time EncryptWithPBKDF2) ->
-            pure $ Just $ ApiWalletPassphraseInfo time
-        Just (WalletPassphraseInfo time EncryptWithScrypt) ->
+        Just info@(WalletPassphraseInfo _ EncryptWithPBKDF2) ->
+            pure $ Just $ toApiPassphraseInfo info
+        Just info@(WalletPassphraseInfo _ EncryptWithArgon2idV2) ->
+            pure $ Just $ toApiPassphraseInfo info
+        Just info@(WalletPassphraseInfo _ EncryptWithScrypt) ->
             withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
                 matchEmptyPassphrase (wrk ^. typed) <&> \case
                     Right{} -> Nothing
-                    Left{} -> Just $ ApiWalletPassphraseInfo time
+                    Left{} -> Just $ toApiPassphraseInfo info
 
     tip' <- liftIO $ getWalletTip (expectAndThrowFailures ti) cp
     let available = availableBalance pending cp

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -192,9 +192,9 @@ import Cardano.Wallet
     , ErrCreateMigrationPlan (..)
     , ErrDecodeTx (..)
     , ErrGetPolicyId (..)
+    , ErrMkTransaction (..)
     , ErrNoSuchWallet (..)
     , ErrReadRewardAccount (..)
-    , ErrMkTransaction (..)
     , ErrSignPayment (..)
     , ErrSubmitTransaction (..)
     , ErrSubmitTransactionMissingWitnessCounts (..)
@@ -5085,10 +5085,16 @@ rndStateChange
     -> Handler (ArgGenChange s)
 rndStateChange ctx (ApiT wid) pwd =
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> liftHandler
-        $ W.withRootKey nullTracer (wrk ^. dbLayer) wid pwd ErrSignPaymentWithRootKey
+        $ W.withRootKey
+            nullTracer
+            (wrk ^. dbLayer)
+            wid
+            pwd
+            ErrSignPaymentWithRootKey
         $ \case
             W.RootKeyAccessV2{} ->
-                throwE $ ErrSignPaymentMkTx
+                throwE
+                    $ ErrSignPaymentMkTx
                     $ ErrMkTransactionTxBodyError
                         "V2 key signing is not yet supported for Byron wallets."
             W.RootKeyAccessV1 xprv scheme ->

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1667,12 +1667,9 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
         Just info@(WalletPassphraseInfo _ EncryptWithPBKDF2) ->
             pure $ Just $ toApiPassphraseInfo info
         Just info@(WalletPassphraseInfo _ EncryptWithArgon2idV2) ->
-            pure $ Just $ toApiPassphraseInfo info
+            hideInfoForEmptyPassphrase info
         Just info@(WalletPassphraseInfo _ EncryptWithScrypt) ->
-            withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
-                matchEmptyPassphrase (wrk ^. typed) <&> \case
-                    Right{} -> Nothing
-                    Left{} -> Just $ toApiPassphraseInfo info
+            hideInfoForEmptyPassphrase info
 
     tip' <- liftIO $ getWalletTip (expectAndThrowFailures ti) cp
     let available = availableBalance pending cp
@@ -1708,6 +1705,12 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
         liftIO
             $ runExceptT
             $ W.withRootKey @s db wid mempty Prelude.id (\_ _ -> pure ())
+
+    hideInfoForEmptyPassphrase info =
+        withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
+            matchEmptyPassphrase (wrk ^. typed) <&> \case
+                Right{} -> Nothing
+                Left{} -> Just $ toApiPassphraseInfo info
 
 -- | A 64-bit seed for the Byron HD-random address generator, drawn from the
 -- system CSPRNG rather than the process-global 'StdGen'.

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -196,7 +196,6 @@ import Cardano.Wallet
     , ErrReadRewardAccount (..)
     , ErrMkTransaction (..)
     , ErrSignPayment (..)
-    , ErrSignTx (..)
     , ErrSubmitTransaction (..)
     , ErrSubmitTransactionMissingWitnessCounts (..)
     , ErrUpdatePassphrase (..)
@@ -219,6 +218,7 @@ import Cardano.Wallet
     , networkLayer
     , readPrivateKey
     , readWalletMeta
+    , signTransactionV2
     , txWitnessTagForKey
     )
 import Cardano.Wallet.Address.Book
@@ -682,6 +682,7 @@ import Cardano.Wallet.TokenMetadata
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , DelegationAction (..)
+    , ErrSignTx (..)
     , PreSelection (..)
     , SelectionOf (..)
     , TransactionCtx (..)
@@ -1707,7 +1708,7 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
     matchEmptyPassphrase db =
         liftIO
             $ runExceptT
-            $ W.withRootKey nullTracer @s db wid mempty Prelude.id (\_ -> pure ())
+            $ W.withRootKey @s nullTracer db wid mempty Prelude.id (\_ -> pure ())
 
     hideInfoForEmptyPassphrase info =
         withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk ->
@@ -2494,10 +2495,27 @@ signTransaction ctx (ApiT wid) body = do
             tl = wrk ^. W.transactionLayer @k
             nl = wrk ^. W.networkLayer
         db & \W.DBLayer{atomically, readCheckpoint} ->
-            W.withRootKey nullTracer @s db wid pwd ErrWitnessTxWithRootKey
+            W.withRootKey @s nullTracer db wid pwd ErrWitnessTxWithRootKey
                 $ \case
-                    W.RootKeyAccessV2{} ->
-                        throwE $ ErrWitnessTxSignTx ErrSignTxUnimplemented
+                    W.RootKeyAccessV2 ekey _mPayload userPwd -> do
+                        cp <- lift $ atomically readCheckpoint
+                        era <- liftIO $ NW.currentNodeEra nl
+                        let sealedTxIn = body ^. #transaction . #getApiT
+                            utxo = totalUTxO mempty cp
+                        mSigned <-
+                            liftIO
+                                $ signTransactionV2
+                                    era
+                                    sealedTxIn
+                                    cp
+                                    utxo
+                                    ekey
+                                    userPwd
+                        case mSigned of
+                            Nothing ->
+                                throwE
+                                    $ ErrWitnessTxSignTx ErrSignTxUnimplemented
+                            Just signed -> pure signed
                     W.RootKeyAccessV1 rootK scheme -> lift $ do
                         cp <- atomically readCheckpoint
                         let

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1583,7 +1583,8 @@ patchSharedWallet ctx liftKey cred (ApiT wid) body = do
             $ withWorkerCtx @_ @s ctx wid liftE liftE
             $ \wrk ->
                 handler
-                    $ liftIO $ W.reattachPrivateKey wrk (fromJust prvKeyM)
+                    $ liftIO
+                    $ W.reattachPrivateKey wrk (fromJust prvKeyM)
 
     fst <$> getWallet ctx (mkSharedWallet @_ @s) (ApiT wid)
   where

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -405,6 +405,7 @@ import Cardano.Wallet.Primitive.NetworkId
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
     , PassphraseHash (..)
+    , PassphraseScheme (..)
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..)
@@ -1000,13 +1001,20 @@ data ApiWalletAssetsBalance = ApiWalletAssetsBalance
     deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletAssetsBalance
     deriving anyclass (NFData)
 
-newtype ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
+data ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
     { lastUpdatedAt :: UTCTime
+    , encryptionMethod :: ApiT PassphraseScheme
     }
     deriving (Eq, Generic)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletPassphraseInfo
     deriving anyclass (NFData)
     deriving (Show) via (Quiet ApiWalletPassphraseInfo)
+
+instance ToJSON (ApiT PassphraseScheme) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT PassphraseScheme) where
+    parseJSON = fromTextApiT "PassphraseScheme"
 
 data ApiWalletDelegation = ApiWalletDelegation
     { active :: !ApiWalletDelegationNext

--- a/lib/application/cardano-wallet-application.cabal
+++ b/lib/application/cardano-wallet-application.cabal
@@ -74,6 +74,7 @@ library shelley
   build-depends:
     , address-derivation-discovery
     , base
+    , cardano-crypto-class
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application

--- a/lib/application/shelley/Cardano/Wallet/Application.hs
+++ b/lib/application/shelley/Cardano/Wallet/Application.hs
@@ -25,6 +25,9 @@ module Cardano.Wallet.Application
     , module Tracers
     ) where
 
+import Cardano.Crypto.Init
+    ( cryptoInit
+    )
 import Cardano.Wallet
     ( WalletException
     )
@@ -308,6 +311,7 @@ serveWallet
     tokenMetaUri
     block0
     beforeMainLoop = withSNetworkId network $ \sNetwork -> evalContT $ do
+        lift cryptoInit
         let netId = networkIdVal sNetwork
         lift $ case blockchainSource of
             NodeSource nodeConn _ _ ->

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -52,6 +52,7 @@ library framework
     , bech32-th
     , bytestring
     , cardano-addresses
+    , cardano-crypto
     , cardano-ledger-shelley
     , cardano-wallet
     , cardano-wallet-api
@@ -73,6 +74,7 @@ library framework
     , either
     , extra
     , faucet
+    , filepath
     , flat
     , fmt
     , generic-lens

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -11,13 +11,23 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Integration.Framework.Setup where
+module Test.Integration.Framework.Setup
+    ( TestingCtx (..)
+    , legacyV1ApiWalletId
+    , legacyV1CliWalletId
+    , legacyV1Passphrase
+    , withContext
+    , withTestsSetup
+    ) where
 
 import Cardano.Address
     ( NetworkTag (..)
     )
 import Cardano.Address.Style.Shelley
     ( shelleyTestnet
+    )
+import Cardano.BM.Data.Tracer
+    ( nullTracer
     )
 import Cardano.BM.Extra
     ( bracketTracer
@@ -26,15 +36,45 @@ import Cardano.BM.Extra
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     )
+import Cardano.Crypto.Wallet
+    ( XPrv
+    )
+import Cardano.Faucet.Mnemonics
+    ( unsafeMnemonic
+    )
 import Cardano.Launcher
     ( ProcessHasExited (..)
     )
 import Cardano.Ledger.Shelley.Genesis
     ( sgNetworkMagic
     )
+import Cardano.Mnemonic
+    ( SomeMnemonic (..)
+    )
 import Cardano.Startup
     ( installSignalHandlersNoLogging
     , setDefaultFilePermissions
+    )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (RootK)
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( ShelleyKey
+    )
+import Cardano.Wallet.Address.Discovery
+    ( ChangeAddressMode (IncreasingChangeAddresses)
+    )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( SeqState
+    , defaultAddressPoolGap
+    , purposeCIP1852
+    )
+import Cardano.Wallet.Address.Keys.SequentialAny
+    ( mkSeqStateFromRootXPrv
+    )
+import Cardano.Wallet.Address.Keys.WalletKey
+    ( digest
+    , publicKey
     )
 import Cardano.Wallet.Api.Types
     ( ApiPoolSpecifier (..)
@@ -55,9 +95,20 @@ import Cardano.Wallet.Application.CLI
 import Cardano.Wallet.Application.Server
     ( walletListenFromEnv
     )
+import Cardano.Wallet.DB
+    ( DBLayer (..)
+    , DBLayerParams (..)
+    )
+import Cardano.Wallet.DB.Layer
+    ( withBootDBLayerFromFile
+    )
 import Cardano.Wallet.Faucet
     ( FaucetM
     , runFaucetM
+    )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (ShelleyKeyS)
+    , WalletFlavorS (ShelleyWallet)
     )
 import Cardano.Wallet.Launch.Cluster
     ( ClusterEra (..)
@@ -89,24 +140,52 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
 import Cardano.Wallet.Network.Ports
     ( portFromURL
     )
+import Cardano.Wallet.Network.RestorationMode
+    ( RestorationPoint (RestorationPointAtGenesis)
+    )
 import Cardano.Wallet.Pools
     ( StakePool
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( fromGenesisData
     )
+import Cardano.Wallet.Primitive.Model
+    ( initWallet
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkDiscriminant (Testnet)
     , NetworkId (..)
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( encryptPassphrase
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..)
+    , PassphraseScheme (EncryptWithPBKDF2)
+    , WalletPassphraseInfo (..)
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( hoistTimeInterpreter
+    , mkSingleEraInterpreter
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( NetworkParameters
+    ( Block
+    , GenesisParameters (getGenesisBlockDate)
+    , NetworkParameters (..)
+    , WalletId (..)
+    , WalletMetadata (..)
+    , WalletName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (HashedCredentialsV1)
+    , RootCredentials (..)
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
@@ -147,6 +226,12 @@ import Data.Text
     )
 import Data.Text.Class
     ( ToText (..)
+    )
+import Data.Text.Encoding
+    ( encodeUtf8
+    )
+import Data.Time.Clock
+    ( getCurrentTime
     )
 import Main.Utf8
     ( withUtf8
@@ -227,10 +312,149 @@ import Prelude
 
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Layer as Pool
+import qualified Cardano.Wallet as Wallet
+import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Application.CLI as CLI
 import qualified Cardano.Wallet.Faucet as Faucet
+import qualified Data.ByteArray as BA
+import qualified Data.Functor.Identity as Identity
 import qualified Data.Text as T
+import qualified System.FilePath as FilePath
+
+-- | A persisted V1 root key, prepared before the wallet server starts.
+--
+-- Separate API and CLI fixtures mean both scenarios independently exercise
+-- the migration, including when run in parallel.
+legacyV1ApiWalletId :: WalletId
+legacyV1ApiWalletId = legacyV1WalletId legacyV1ApiMnemonic
+
+legacyV1Passphrase :: Text
+legacyV1Passphrase = "legacy-root-key-passphrase"
+
+legacyV1ApiMnemonic :: [Text]
+legacyV1ApiMnemonic =
+    [ "pulp"
+    , "ten"
+    , "light"
+    , "rhythm"
+    , "replace"
+    , "vessel"
+    , "slow"
+    , "drift"
+    , "kingdom"
+    , "amazing"
+    , "negative"
+    , "join"
+    , "auction"
+    , "ugly"
+    , "symptom"
+    ]
+
+legacyV1CliMnemonic :: [Text]
+legacyV1CliMnemonic =
+    [ "vintage"
+    , "poem"
+    , "topic"
+    , "machine"
+    , "hazard"
+    , "cement"
+    , "dune"
+    , "glimpse"
+    , "fix"
+    , "brief"
+    , "account"
+    , "badge"
+    , "mass"
+    , "silly"
+    , "business"
+    ]
+
+legacyV1CliWalletId :: WalletId
+legacyV1CliWalletId = legacyV1WalletId legacyV1CliMnemonic
+
+legacyV1WalletId :: [Text] -> WalletId
+legacyV1WalletId mnemonic =
+    WalletId
+        $ digest ShelleyKeyS
+        $ publicKey ShelleyKeyS
+        $ legacyV1RootKey mnemonic
+
+legacyV1RootKey :: [Text] -> ShelleyKey 'RootK XPrv
+legacyV1RootKey mnemonic =
+    Shelley.generateKeyFromSeed
+        (SomeMnemonic $ unsafeMnemonic @15 mnemonic, Just legacyV1SecondFactor)
+        (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
+
+-- | Keep the persisted fixtures' IDs distinct from the fixed mnemonics used
+-- by the regular integration scenarios.
+legacyV1SecondFactor :: SomeMnemonic
+legacyV1SecondFactor =
+    SomeMnemonic $ unsafeMnemonic @15 legacyV1ApiMnemonic
+
+legacyV1Passphrase' :: Passphrase "user"
+legacyV1Passphrase' =
+    Passphrase $ BA.convert $ encodeUtf8 legacyV1Passphrase
+
+seedLegacyV1Wallets
+    :: FilePath
+    -> Block
+    -> NetworkParameters
+    -> IO ()
+seedLegacyV1Wallets dbDir block0 networkParameters = do
+    forM_ [legacyV1ApiMnemonic, legacyV1CliMnemonic] $ \mnemonic -> do
+        now <- getCurrentTime
+        (_, passphraseHash) <- encryptPassphrase legacyV1Passphrase'
+        let wid = legacyV1WalletId mnemonic
+        let rootKey = legacyV1RootKey mnemonic
+        let state :: SeqState ('Testnet 42) ShelleyKey
+            state =
+                mkSeqStateFromRootXPrv
+                    ShelleyKeyS
+                    ( RootCredentials
+                        rootKey
+                        (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
+                    )
+                    purposeCIP1852
+                    defaultAddressPoolGap
+                    IncreasingChangeAddresses
+        let params =
+                DBLayerParams
+                    (snd $ initWallet block0 state)
+                    RestorationPointAtGenesis
+                    WalletMetadata
+                        { name = WalletName "Legacy V1 migration fixture"
+                        , creationTime = now
+                        , passphraseInfo =
+                            Just
+                                $ WalletPassphraseInfo
+                                    { lastUpdatedAt = now
+                                    , passphraseScheme = EncryptWithPBKDF2
+                                    }
+                        }
+                    mempty
+                    (genesisParameters networkParameters)
+        let dbFile =
+                dbDir
+                    FilePath.</> ("she." <> T.unpack (toText wid) <> ".sqlite")
+        let timeInterpreter =
+                hoistTimeInterpreter (pure . Identity.runIdentity)
+                    $ mkSingleEraInterpreter
+                        (getGenesisBlockDate $ genesisParameters networkParameters)
+                        (slottingParameters networkParameters)
+        withBootDBLayerFromFile
+            ShelleyWallet
+            nullTracer
+            timeInterpreter
+            wid
+            Nothing
+            params
+            dbFile
+            $ \DBLayer{atomically, walletState} ->
+                atomically
+                    $ Wallet.putPrivateKey
+                        walletState
+                        (HashedCredentialsV1 rootKey passphraseHash)
 
 -- | Do all the program setup required for integration tests, create a temporary
 -- directory, and pass this info to the main hspec action.
@@ -376,6 +600,11 @@ onClusterStart
                     fromGenesisData genesisData
             let db = absDirOf testDir </> relDir "wallets"
             liftIO $ createDirectory $ toFilePath db
+            liftIO
+                $ seedLegacyV1Wallets
+                    (toFilePath db)
+                    block0
+                    networkParameters
             listen <- liftIO $ walletListenFromEnv envFromText
             let testMetadata = absDirOf testDataDir </> relFile "token-metadata.json"
             tokenMetaUrl <-

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -15,6 +15,7 @@ module Test.Integration.Framework.Setup
     ( TestingCtx (..)
     , legacyV1ApiWalletId
     , legacyV1CliWalletId
+    , legacyV1SharedWalletId
     , legacyV1Passphrase
     , withContext
     , withTestsSetup
@@ -22,6 +23,11 @@ module Test.Integration.Framework.Setup
 
 import Cardano.Address
     ( NetworkTag (..)
+    )
+import Cardano.Address.Script
+    ( Cosigner (..)
+    , Script (RequireSignatureOf)
+    , ScriptTemplate (..)
     )
 import Cardano.Address.Style.Shelley
     ( shelleyTestnet
@@ -57,6 +63,10 @@ import Cardano.Startup
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (RootK)
+    , HardDerivation (deriveAccountPrivateKey)
+    )
+import Cardano.Wallet.Address.Derivation.Shared
+    ( SharedKey
     )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey
@@ -69,11 +79,18 @@ import Cardano.Wallet.Address.Discovery.Sequential
     , defaultAddressPoolGap
     , purposeCIP1852
     )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( SharedState
+    )
 import Cardano.Wallet.Address.Keys.SequentialAny
     ( mkSeqStateFromRootXPrv
     )
+import Cardano.Wallet.Address.Keys.Shared
+    ( mkSharedStateFromRootXPrv
+    )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( digest
+    , getRawKey
     , publicKey
     )
 import Cardano.Wallet.Api.Types
@@ -107,8 +124,8 @@ import Cardano.Wallet.Faucet
     , runFaucetM
     )
 import Cardano.Wallet.Flavor
-    ( KeyFlavorS (ShelleyKeyS)
-    , WalletFlavorS (ShelleyWallet)
+    ( KeyFlavorS (SharedKeyS, ShelleyKeyS)
+    , WalletFlavorS (SharedWallet, ShelleyWallet)
     )
 import Cardano.Wallet.Launch.Cluster
     ( ClusterEra (..)
@@ -313,19 +330,21 @@ import Prelude
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet as Wallet
+import qualified Cardano.Wallet.Address.Derivation.Shared as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Application.CLI as CLI
 import qualified Cardano.Wallet.Faucet as Faucet
 import qualified Data.ByteArray as BA
 import qualified Data.Functor.Identity as Identity
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified System.FilePath as FilePath
 
--- | A persisted V1 root key, prepared before the wallet server starts.
+-- | Persisted V1 root keys, prepared before the wallet server starts.
 --
--- Separate API and CLI fixtures mean both scenarios independently exercise
--- the migration, including when run in parallel.
+-- Separate Shelley API, Shelley CLI, and Shared API fixtures mean all
+-- migratable wallet kinds exercise the migration independently.
 legacyV1ApiWalletId :: WalletId
 legacyV1ApiWalletId = legacyV1WalletId legacyV1ApiMnemonic
 
@@ -373,6 +392,12 @@ legacyV1CliMnemonic =
 legacyV1CliWalletId :: WalletId
 legacyV1CliWalletId = legacyV1WalletId legacyV1CliMnemonic
 
+legacyV1SharedWalletId :: WalletId
+legacyV1SharedWalletId =
+    WalletId
+        $ digest SharedKeyS
+        $ publicKey SharedKeyS legacyV1SharedRootKey
+
 legacyV1WalletId :: [Text] -> WalletId
 legacyV1WalletId mnemonic =
     WalletId
@@ -383,7 +408,9 @@ legacyV1WalletId mnemonic =
 legacyV1RootKey :: [Text] -> ShelleyKey 'RootK XPrv
 legacyV1RootKey mnemonic =
     Shelley.generateKeyFromSeed
-        (SomeMnemonic $ unsafeMnemonic @15 mnemonic, Just legacyV1SecondFactor)
+        ( SomeMnemonic $ unsafeMnemonic @15 mnemonic
+        , Just legacyV1SecondFactor
+        )
         (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
 
 -- | Keep the persisted fixtures' IDs distinct from the fixed mnemonics used
@@ -391,6 +418,14 @@ legacyV1RootKey mnemonic =
 legacyV1SecondFactor :: SomeMnemonic
 legacyV1SecondFactor =
     SomeMnemonic $ unsafeMnemonic @15 legacyV1ApiMnemonic
+
+legacyV1SharedRootKey :: SharedKey 'RootK XPrv
+legacyV1SharedRootKey =
+    Shared.generateKeyFromSeed
+        ( SomeMnemonic $ unsafeMnemonic @15 legacyV1CliMnemonic
+        , Just legacyV1SecondFactor
+        )
+        (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
 
 legacyV1Passphrase' :: Passphrase "user"
 legacyV1Passphrase' =
@@ -455,6 +490,69 @@ seedLegacyV1Wallets dbDir block0 networkParameters = do
                     $ Wallet.putPrivateKey
                         walletState
                         (HashedCredentialsV1 rootKey passphraseHash)
+
+    now <- getCurrentTime
+    (_, passphraseHash) <- encryptPassphrase legacyV1Passphrase'
+    let rootKey = legacyV1SharedRootKey
+    let accountXPub =
+            publicKey SharedKeyS
+                $ deriveAccountPrivateKey
+                    (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
+                    rootKey
+                    minBound
+    let state :: SharedState ('Testnet 42) SharedKey
+        state =
+            mkSharedStateFromRootXPrv
+                SharedKeyS
+                ( RootCredentials
+                    rootKey
+                    (preparePassphrase EncryptWithPBKDF2 legacyV1Passphrase')
+                )
+                minBound
+                IncreasingChangeAddresses
+                defaultAddressPoolGap
+                ( ScriptTemplate
+                    (Map.singleton (Cosigner 0) $ getRawKey SharedKeyS accountXPub)
+                    (RequireSignatureOf $ Cosigner 0)
+                )
+                Nothing
+    let params =
+            DBLayerParams
+                (snd $ initWallet block0 state)
+                RestorationPointAtGenesis
+                WalletMetadata
+                    { name = WalletName "Legacy V1 shared migration fixture"
+                    , creationTime = now
+                    , passphraseInfo =
+                        Just
+                            $ WalletPassphraseInfo
+                                { lastUpdatedAt = now
+                                , passphraseScheme = EncryptWithPBKDF2
+                                }
+                    }
+                mempty
+                (genesisParameters networkParameters)
+    let dbFile =
+            dbDir
+                FilePath.</> ("sha." <> T.unpack (toText legacyV1SharedWalletId) <> ".sqlite")
+    let timeInterpreter =
+            hoistTimeInterpreter (pure . Identity.runIdentity)
+                $ mkSingleEraInterpreter
+                    (getGenesisBlockDate $ genesisParameters networkParameters)
+                    (slottingParameters networkParameters)
+    withBootDBLayerFromFile
+        SharedWallet
+        nullTracer
+        timeInterpreter
+        legacyV1SharedWalletId
+        Nothing
+        params
+        dbFile
+        $ \DBLayer{atomically, walletState} ->
+            atomically
+                $ Wallet.putPrivateKey
+                    walletState
+                    (HashedCredentialsV1 rootKey passphraseHash)
 
 -- | Do all the program setup required for integration tests, create a temporary
 -- directory, and pass this info to the main hspec action.

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -165,6 +165,10 @@ import Test.Integration.Framework.DSL
     , walletId
     , (</>)
     )
+import Test.Integration.Framework.Setup
+    ( legacyV1Passphrase
+    , legacyV1SharedWalletId
+    )
 import Test.Integration.Framework.TestData
     ( errMsg403CreateIllegal
     , errMsg403KeyAlreadyPresent
@@ -191,6 +195,29 @@ spec
      . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHARED_WALLETS" $ do
+    it
+        "SHARED_WALLETS_ROOT_KEY_MIGRATION_01 - \
+        \HTTP can use a persisted V1 root key after upgrading"
+        $ \ctx -> runResourceT $ do
+            let w = ApiT legacyV1SharedWalletId
+            let payload =
+                    Json
+                        [json|{
+                        "passphrase": #{legacyV1Passphrase},
+                        "format": "extended"
+                        }|]
+            forM_ [1 :: Int, 2] $ \_ -> do
+                r <-
+                    request @ApiAccountKeyShared
+                        ctx
+                        ( Link.postAccountKey @'Shared
+                            w
+                            (DerivationIndex 2_147_483_648)
+                        )
+                        Default
+                        payload
+                verify r [expectResponseCode HTTP.status202]
+
     it
         "SHARED_WALLETS_CREATE_01 - \
         \Create an active shared wallet from root xprv"

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -5776,7 +5776,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         [json|{
                 "validity_interval": {
                     "invalid_hereafter": {
-                        "quantity": #{sl + 10},
+                        "quantity": #{sl + 100},
                         "unit": "slot"
                     }
                 },
@@ -5784,7 +5784,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     "policy_script_template":
                         { "all":
                            [ "cosigner#0",
-                             { "active_until": #{sl + 11} }
+                             { "active_until": #{sl + 101} }
                            ]
                         },
                     "asset_name": #{toText assetName'},
@@ -5800,7 +5800,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             let scriptUsed policyKeyHash =
                     RequireAllOf
                         [ RequireSignatureOf policyKeyHash
-                        , ActiveUntilSlot (fromIntegral $ sl + 11)
+                        , ActiveUntilSlot (fromIntegral $ sl + 101)
                         ]
 
             mintAssetsCheck ctx wa assetName' payload scriptUsed

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -179,6 +179,10 @@ import Test.Integration.Framework.DSL
     , walletId
     , (</>)
     )
+import Test.Integration.Framework.Setup
+    ( legacyV1ApiWalletId
+    , legacyV1Passphrase
+    )
 import Test.Integration.Framework.TestData
     ( arabicWalletName
     , errMsg403WrongMnemonic
@@ -214,6 +218,30 @@ spec
      . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHELLEY_WALLETS" $ do
+    it
+        "WALLETS_ROOT_KEY_MIGRATION_01 - \
+        \HTTP can use a persisted V1 root key after upgrading"
+        $ \ctx -> runResourceT $ do
+            let w = ApiT legacyV1ApiWalletId
+            let payload =
+                    Json
+                        [json|
+                        { "passphrase": #{legacyV1Passphrase}
+                        , "metadata": {"0": { "string": "migration fixture" }}
+                        }|]
+            forM_ [1 :: Int, 2] $ \_ -> do
+                r <-
+                    rawRequest
+                        ctx
+                        (Link.signMetadata w MutableAccount (DerivationIndex 0))
+                        ( Headers
+                            [ (HTTP.hAccept, "*/*")
+                            , (HTTP.hContentType, "application/json")
+                            ]
+                        )
+                        payload
+                expectResponseCode HTTP.status200 r
+
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> runResourceT $ do
         m15 <- Mnemonics.generateSome Mnemonics.M15
         m12 <- Mnemonics.generateSome Mnemonics.M12

--- a/lib/integration/scenarios/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -70,6 +70,9 @@ import Data.Proxy
 import Data.Text
     ( Text
     )
+import Data.Text.Class
+    ( toText
+    )
 import Data.Word
     ( Word32
     )
@@ -127,6 +130,10 @@ import Test.Integration.Framework.DSL
     , verify
     , walletId
     )
+import Test.Integration.Framework.Setup
+    ( legacyV1CliWalletId
+    , legacyV1Passphrase
+    )
 import Test.Integration.Framework.TestData
     ( arabicWalletName
     , cmdOk
@@ -146,6 +153,33 @@ spec
      . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHELLEY_CLI_WALLETS" $ do
+    it
+        "WALLETS_ROOT_KEY_MIGRATION_01 - \
+        \CLI can use a persisted V1 root key after upgrading"
+        $ \ctx -> runResourceT $ do
+            let wid = T.unpack $ toText legacyV1CliWalletId
+            let oldPassphrase = T.unpack legacyV1Passphrase
+            let newPassphrase = oldPassphrase
+            (c1, _out1, err1) <-
+                updateWalletPassphraseViaCLI
+                    ctx
+                    wid
+                    oldPassphrase
+                    newPassphrase
+                    newPassphrase
+            c1 `shouldBe` ExitSuccess
+            T.unpack err1 `shouldContain` cmdOk
+
+            (c2, _out2, err2) <-
+                updateWalletPassphraseViaCLI
+                    ctx
+                    wid
+                    newPassphrase
+                    oldPassphrase
+                    oldPassphrase
+            c2 `shouldBe` ExitSuccess
+            T.unpack err2 `shouldContain` cmdOk
+
     it "BYRON_GET_03 - Shelley CLI does not show Byron wallet" $ \ctx -> runResourceT $ do
         wid <- emptyRandomWallet' ctx
         (Exit c, Stdout out, Stderr err) <- getWalletViaCLI ctx wid

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -64,6 +64,10 @@ preparePassphrase
 preparePassphrase = \case
     EncryptWithPBKDF2 -> PBKDF2.preparePassphrase
     EncryptWithScrypt -> Scrypt.preparePassphrase
+    -- v2 keys are stored as CBOR envelopes; the in-memory XPrv holds the
+    -- plaintext scalar, so the C layer is invoked with an empty passphrase
+    -- (memcpy / no-op path, no PBKDF2 round-trip).
+    EncryptWithArgon2idV2 -> \_ -> Passphrase mempty
 
 -- | Check whether a 'Passphrase' matches with a stored 'Hash'
 checkPassphrase
@@ -77,6 +81,10 @@ checkPassphrase scheme received stored = case scheme of
         if Scrypt.checkPassphrase prepared stored
             then Right ()
             else Left ErrWrongPassphrase
+    EncryptWithArgon2idV2 ->
+        -- v2 keys are self-authenticating via AEAD; this path should not be
+        -- reached, but fail safely if it is.
+        Left ErrWrongPassphrase
   where
     prepared = preparePassphrase scheme received
 

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -42,6 +42,12 @@ import Prelude
 import qualified Cardano.Wallet.Primitive.Passphrase.Current as PBKDF2
 import qualified Cardano.Wallet.Primitive.Passphrase.Legacy as Scrypt
 
+-- | The PBKDF2 scheme used for V1 key hashing and as the intermediate
+-- derivation step when creating V2 credentials.
+--
+-- This intentionally remains 'EncryptWithPBKDF2' even though new wallets are
+-- stored as V2 envelopes: 'mkV2Credentials' calls @xPrvChangePass prepared
+-- mempty@ to extract the plaintext scalar, which requires PBKDF2 preparation.
 currentPassphraseScheme :: PassphraseScheme
 currentPassphraseScheme = EncryptWithPBKDF2
 
@@ -64,9 +70,9 @@ preparePassphrase
 preparePassphrase = \case
     EncryptWithPBKDF2 -> PBKDF2.preparePassphrase
     EncryptWithScrypt -> Scrypt.preparePassphrase
-    -- v2 keys are stored as CBOR envelopes; the in-memory XPrv holds the
-    -- plaintext scalar, so the C layer is invoked with an empty passphrase
-    -- (memcpy / no-op path, no PBKDF2 round-trip).
+    -- V2 passphrase validation goes through 'encryptedValidatePassphrase',
+    -- not 'checkPassphrase'; returning mempty here is a safe default that
+    -- prevents accidental use of this V1 XPrv passphrase-preparation path.
     EncryptWithArgon2idV2 -> \_ -> Passphrase mempty
 
 -- | Check whether a 'Passphrase' matches with a stored 'Hash'

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -177,10 +177,10 @@ data PassphraseScheme
       EncryptWithScrypt
     | -- | Encryption scheme used since cardano-wallet
       EncryptWithPBKDF2
-    | -- | v2 envelope (Argon2id + XChaCha20-Poly1305). Keys encrypted
-      -- with this scheme are stored as CBOR-encoded v2 blobs; the
-      -- in-memory XPrv holds the plaintext scalar so the C layer is
-      -- called with an empty passphrase (memcpy / no-op path).
+    | -- | v2 envelope (Argon2id + XChaCha20-Poly1305 AEAD, raw bytes).
+      -- Secret material is decrypted on demand by
+      -- 'withDecryptedExtKeyMaterial', which keeps it in
+      -- @sodium_malloc@-backed memory and zeroes it when the bracket exits.
       EncryptWithArgon2idV2
     deriving (Generic, Eq, Ord, Show, Read)
 

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -192,10 +192,11 @@ instance ToText PassphraseScheme where
     toText EncryptWithArgon2idV2 = "argon2id-v2"
 
 instance FromText PassphraseScheme where
-    fromText "scrypt"             = Right EncryptWithScrypt
+    fromText "scrypt" = Right EncryptWithScrypt
     fromText "pbkdf2-hmac-sha512" = Right EncryptWithPBKDF2
-    fromText "argon2id-v2"        = Right EncryptWithArgon2idV2
-    fromText t = Left $ TextDecodingError $ "Unknown passphrase scheme: " <> T.unpack t
+    fromText "argon2id-v2" = Right EncryptWithArgon2idV2
+    fromText t =
+        Left $ TextDecodingError $ "Unknown passphrase scheme: " <> T.unpack t
 
 newtype PassphraseHash = PassphraseHash {getPassphraseHash :: ScrubbedBytes}
     deriving stock (Show)

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -177,6 +177,11 @@ data PassphraseScheme
       EncryptWithScrypt
     | -- | Encryption scheme used since cardano-wallet
       EncryptWithPBKDF2
+    | -- | v2 envelope (Argon2id + XChaCha20-Poly1305). Keys encrypted
+      -- with this scheme are stored as CBOR-encoded v2 blobs; the
+      -- in-memory XPrv holds the plaintext scalar so the C layer is
+      -- called with an empty passphrase (memcpy / no-op path).
+      EncryptWithArgon2idV2
     deriving (Generic, Eq, Ord, Show, Read)
 
 instance NFData PassphraseScheme
@@ -184,6 +189,13 @@ instance NFData PassphraseScheme
 instance ToText PassphraseScheme where
     toText EncryptWithScrypt = "scrypt"
     toText EncryptWithPBKDF2 = "pbkdf2-hmac-sha512"
+    toText EncryptWithArgon2idV2 = "argon2id-v2"
+
+instance FromText PassphraseScheme where
+    fromText "scrypt"             = Right EncryptWithScrypt
+    fromText "pbkdf2-hmac-sha512" = Right EncryptWithPBKDF2
+    fromText "argon2id-v2"        = Right EncryptWithArgon2idV2
+    fromText t = Left $ TextDecodingError $ "Unknown passphrase scheme: " <> T.unpack t
 
 newtype PassphraseHash = PassphraseHash {getPassphraseHash :: ScrubbedBytes}
     deriving stock (Show)

--- a/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
+++ b/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.UI.Shelley.Html.Pages.Wallet where
@@ -122,7 +123,7 @@ renderPassphrase
     -> Maybe ApiWalletPassphraseInfo
     -> HtmlT m ()
 renderPassphrase _ Nothing = ""
-renderPassphrase showTime (Just ApiWalletPassphraseInfo{..}) =
+renderPassphrase showTime (Just ApiWalletPassphraseInfo{lastUpdatedAt}) =
     toHtml $ showTime lastUpdatedAt
 
 renderPoolGap :: Monad m => ApiT AddressPoolGap -> HtmlT m ()

--- a/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
+++ b/lib/ui/src/shelley/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.UI.Shelley.Html.Pages.Wallet where

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -76,7 +76,7 @@ test-suite unit
     , cardano-balance-tx
     , cardano-crypto
     , cardano-crypto-class
-    , cardano-crypto-wallet-v2
+    , cardano-crypto-wallet
     , cardano-diffusion:api
     , cardano-ledger-allegra
     , cardano-ledger-alonzo

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -199,11 +199,11 @@ test-suite unit
     Cardano.Wallet.Address.Derivation.IcarusSpec
     Cardano.Wallet.Address.Derivation.MintBurnSpec
     Cardano.Wallet.Address.DerivationSpec
-    Cardano.Wallet.Address.Keys.PersistPrivateKeySpec
     Cardano.Wallet.Address.Discovery.RandomSpec
     Cardano.Wallet.Address.Discovery.SequentialSpec
     Cardano.Wallet.Address.Discovery.SharedSpec
     Cardano.Wallet.Address.DiscoverySpec
+    Cardano.Wallet.Address.Keys.PersistPrivateKeySpec
     Cardano.Wallet.Address.PoolSpec
     Cardano.Wallet.Api.Malformed
     Cardano.Wallet.Api.ServerSpec

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -76,6 +76,7 @@ test-suite unit
     , cardano-balance-tx
     , cardano-crypto
     , cardano-crypto-class
+    , cardano-crypto-wallet-v2
     , cardano-diffusion:api
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
@@ -198,6 +199,7 @@ test-suite unit
     Cardano.Wallet.Address.Derivation.IcarusSpec
     Cardano.Wallet.Address.Derivation.MintBurnSpec
     Cardano.Wallet.Address.DerivationSpec
+    Cardano.Wallet.Address.Keys.PersistPrivateKeySpec
     Cardano.Wallet.Address.Discovery.RandomSpec
     Cardano.Wallet.Address.Discovery.SequentialSpec
     Cardano.Wallet.Address.Discovery.SharedSpec

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiActiveSharedWallet.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiActiveSharedWallet.json
@@ -1,1113 +1,188 @@
 {
     "samples": [
         {
-            "account_index": "1549",
-            "address_pool_gap": 58024,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 43
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 27
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 5
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 20
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 223,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 182,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 37,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1j7hnrwmjku27k26lngwvdctmjefqhwr4njred4rgq3skvtym7mw"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 13019,
-                            "epoch_start_time": "1898-07-02T02:22:24Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1wvxs3h7dcul5sf32p7a3vmz54lqll5r3qs7yvnpyk7qakv2vvfe"
-                    },
-                    {
-                        "changes_at": {
-                            "epoch_number": 1708,
-                            "epoch_start_time": "1888-09-02T15:31:14Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1mp2pe0rlh8hrqm7k3s435a74val4wlkdnrhqggy5cfk7jh226n8"
-                    }
-                ]
-            },
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1eyv64tn3s5kpryqec62fpxkq60gln6gad3ha5yq4mfwejyhhg0fqgmx8e4yz27r3xnshulpc8yf67nhld405mkx9wpp20xtk7z5tuhcee0sun",
-                    "cosigner#1": "acct_shared_xvk19vqs8k4vxc30d3u9jr24y708xgnam93lc78zzu4eths2fwuad9kvltya8xupc0jlv60x8dwt49prjmx4uvmyhrjc96xp7uyxpql92jcx47x3x"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 1,
-                        "from": [
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        {
-                                            "all": [
-                                                {
-                                                    "active_from": 0
-                                                },
-                                                "cosigner#0",
-                                                {
-                                                    "active_until": 8
-                                                },
-                                                "cosigner#1",
-                                                {
-                                                    "active_from": 0
-                                                },
-                                                "cosigner#1",
-                                                {
-                                                    "active_from": 1
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    "cosigner#1",
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_from": 1
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 8
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "id": "d2009ed20d2f66d44e2aaea4197f14972c618212",
-            "name": "<726D4> [U8",
-            "passphrase": {
-                "last_updated_at": "1885-06-27T10:00:00Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1eg56uttw697xl85ggws0c2aak0wdsdr8d5esnup7tnsuun2n9dhwayk0q0snpulvz3pxryu6xmahsrkgqqdx8kcl0f7x77uuv9y672g97077c",
-                    "cosigner#6": "acct_shared_xvk1wnm0r8cfuh4jqgv47mfeu3jqj9f9yrlcu8k5zly72nc7nnjjtgcdqx9qnlp98rw5p0fmxcfcwdwn5hzgvknfvvxh0hfjm4j68npp7vgydth58",
-                    "cosigner#7": "acct_shared_xvk1tnxrtet7gj6hvj8ncrcgpyj9fuwucrv492c9cj2kzmgzqjytkya6fzz7dgtadz04q02x7dvngkfesye90rns0c4a8lv0ku4gsq540vct7h04d"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 5,
-                        "from": [
-                            {
-                                "some": {
-                                    "at_least": 6,
-                                    "from": [
-                                        {
-                                            "active_from": 4
-                                        },
-                                        "cosigner#0",
-                                        "cosigner#4",
-                                        {
-                                            "active_from": 0
-                                        },
-                                        {
-                                            "active_from": 3
-                                        },
-                                        {
-                                            "active_until": 8
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 9
-                                    },
-                                    "cosigner#4",
-                                    {
-                                        "active_until": 8
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 2
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 9
-                                    },
-                                    {
-                                        "active_until": 9
-                                    },
-                                    "cosigner#3",
-                                    {
-                                        "active_from": 0
-                                    },
-                                    {
-                                        "active_until": 8
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        {
-                                            "active_from": 7
-                                        },
-                                        "cosigner#1"
-                                    ]
-                                }
-                            },
-                            {
-                                "all": [
-                                    "cosigner#0",
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 9
-                                    },
-                                    {
-                                        "active_from": 8
-                                    },
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#6",
-                                    {
-                                        "active_from": 2
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        "cosigner#6",
-                                        {
-                                            "active_from": 6
-                                        },
-                                        "cosigner#4"
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 3,
-                                    "from": [
-                                        {
-                                            "active_until": 7
-                                        },
-                                        {
-                                            "active_until": 5
-                                        },
-                                        {
-                                            "active_until": 6
-                                        },
-                                        "cosigner#7",
-                                        "cosigner#6",
-                                        {
-                                            "active_until": 3
-                                        },
-                                        "cosigner#6",
-                                        "cosigner#2",
-                                        {
-                                            "active_from": 9
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 3926020,
-                "epoch_number": 12650,
-                "height": {
-                    "quantity": 15154,
-                    "unit": "block"
-                },
-                "slot_number": 13140,
-                "time": "1875-07-25T00:12:55.779704778596Z"
-            }
-        },
-        {
-            "account_index": "8455",
-            "address_pool_gap": 46014,
+            "account_index": "2",
+            "address_pool_gap": 38454,
             "assets": {
                 "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 17
-                    }
-                ]
+                "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 71,
+                    "quantity": 22739151133183843,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 150,
+                    "quantity": 13394012858665252,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 44,
+                    "quantity": 42430293144825648,
                     "unit": "lovelace"
                 }
             },
             "delegation": {
                 "active": {
                     "status": "delegating",
-                    "target": "pool18ez99fqnleq8ur0a69afrkwazfsesytunukx0c9wh8v36a9yanf"
+                    "target": "pool1qqqqqqqzqqqsqqqqqyqqyqgpqqpqyqszqypqqqszqqpqzw6pg8r"
                 },
                 "next": [
                     {
                         "changes_at": {
-                            "epoch_number": 5049,
-                            "epoch_start_time": "1874-06-10T08:00:00Z"
+                            "epoch_number": 2,
+                            "epoch_start_time": "1874-07-20T01:40:18.212035690377Z"
                         },
-                        "status": "delegating",
-                        "target": "pool12dmuh6y6qgt8knz7vd2dzls7mfcvvr9phtuzlu2ymjlevhe65tm"
+                        "status": "not_delegating"
                     }
                 ]
             },
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1fglj8czr6zjed0pwn23x8kk0r2r8e242dg3axrf7sr95ut0mjjpndcpahqm5dw8y89g2dr7usm3ux4ce9c2pvxylld09vfxtj3lsghq4ne6z7",
-                    "cosigner#4": "acct_shared_xvk1299p0zyav5n8c69gvyxm26gmdgfm6nny6tdr5na5lpck0pmk405mnrnqh0p04asxaqs6376xdz3psmahgmtc0dmdgm8s57gm8v8zlssckfweu",
-                    "cosigner#5": "acct_shared_xvk1yw6vkeacm8n3lw6dlq8aq0n25eftzhkgael35tdeeefawlsh2xg2myf4kyfxfkjxwpzryfgrc45g0ecc94wy4gdy75c3lfavckgx3zq27da6f",
-                    "cosigner#7": "acct_shared_xvk1hkgq0fv8vj7vpugd8e4z7gjhr7n8y8c3vp40tt600fejvyut5mtme6y49s2rxnl2k6zqx2jern9jkka5cat4qx8p29zvmh0canr3vxcahczxy",
-                    "cosigner#8": "acct_shared_xvk1pjywwpt42pnep9yvpd0yq2n5u6fmg20a7wyyl2w57g4qd86e285sh4z5c0jruusgkyyawxydpt2a4eq79fev50cf2rmvn77fcgrm3ag5n4vz0",
-                    "cosigner#9": "acct_shared_xvk1ascmdk5ax786ysql67wmxhantwjju2xvwrfhzk3pjxvu2jrulhj6v7xaqm8vrcw5q0ewanpfzflmn7zq4vq574sz56ke0mq2mpfxckgsh36k9"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "any": [
-                                {
-                                    "active_from": 6
-                                },
-                                {
-                                    "active_until": 3
-                                },
-                                {
-                                    "active_from": 2
-                                },
-                                {
-                                    "active_until": 4
-                                },
-                                {
-                                    "active_from": 9
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                "cosigner#3",
-                                {
-                                    "active_until": 1
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                "cosigner#9",
-                                "cosigner#9"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_from": 7
-                                },
-                                {
-                                    "active_until": 9
-                                },
-                                {
-                                    "active_from": 0
-                                },
-                                {
-                                    "active_until": 9
-                                },
-                                {
-                                    "active_from": 6
-                                },
-                                {
-                                    "active_from": 2
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    "cosigner#9",
-                                    {
-                                        "active_until": 3
-                                    },
-                                    "cosigner#8",
-                                    {
-                                        "active_from": 8
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    "cosigner#7",
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_until": 1
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_from": 1
-                                    },
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_until": 3
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "any": [
-                                "cosigner#0",
-                                "cosigner#0",
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_until": 8
-                                },
-                                {
-                                    "active_from": 3
-                                },
-                                {
-                                    "active_until": 2
-                                },
-                                "cosigner#4",
-                                "cosigner#5",
-                                {
-                                    "active_until": 2
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_from": 7
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                "cosigner#5",
-                                {
-                                    "active_until": 8
-                                },
-                                {
-                                    "active_from": 5
-                                },
-                                {
-                                    "active_from": 0
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "d0244711665f8f4c1bebf6dc5db7affa926f3806",
-            "name": " TSG1:X𬳃$",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#3": "acct_shared_xvk1w0q4lpcrs4e955j6t29375e4tm76h8tffz656gczh8mafvya88x9c8dn3x7lu5vu2f8g2ujrw9rp4vwrvw45909aenwevdtjecl354g6v4fyh",
-                    "cosigner#4": "acct_shared_xvk1j5f2mj4k6k4sae7hfmepusytx8vvwmy3kuh7kpjdhper2k93340v0vvuntpxh3exmryumykm3ycz9sqgsn8av7kglvwlzwykvzhdwxqrs6rlr",
-                    "cosigner#5": "acct_shared_xvk1v4wygwqxm2tr0fkgldl0dge5hx9kry745jlsrumu3y7qefz0amd6hzme7f9zaks0p5jm5ltrtxjenzcngupj4qplxvr2t08emfkwysqnpr58x",
-                    "cosigner#8": "acct_shared_xvk1ddlkh356uwynwre3x9ugpj0nq0zqthpnj4fed6uyj4ptmt4m2cc54nfq0pt5pz5jsw30nwppu38zvyq2n8nkxv45scs6vv72sye96ksplr6gp"
+                    "cosigner#0": "acct_shared_xvk1qqqqzqqpqgqqyqgpqqqsyqqqqgqqzqqpqqqqzqszqqpqyqgzqqqsyqgqqqpqzqqpqqqqzqszqypqyqqzqqqqzqgpqyqsqqsqqgpqzqskx66z8"
                 },
                 "template": {
                     "some": {
                         "at_least": 2,
                         "from": [
+                            "cosigner#0",
                             {
-                                "any": [
-                                    "cosigner#8",
-                                    {
-                                        "active_from": 7
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        "cosigner#6",
-                                        "cosigner#4",
-                                        {
-                                            "active_until": 3
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 9
-                                    },
-                                    {
-                                        "active_from": 4
-                                    },
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_until": 4
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#8"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 4,
-                                    "from": [
-                                        {
-                                            "active_until": 5
-                                        },
-                                        "cosigner#5",
-                                        "cosigner#3",
-                                        {
-                                            "active_until": 5
-                                        },
-                                        {
-                                            "active_from": 4
-                                        },
-                                        {
-                                            "active_from": 7
-                                        },
-                                        "cosigner#8"
-                                    ]
-                                }
+                                "active_until": 0
                             }
                         ]
                     }
                 }
             },
-            "state": {
-                "progress": {
-                    "quantity": 86.7,
-                    "unit": "percent"
-                },
-                "status": "syncing"
-            },
-            "tip": {
-                "absolute_slot_number": 904166,
-                "epoch_number": 9351,
-                "height": {
-                    "quantity": 12494,
-                    "unit": "block"
-                },
-                "slot_number": 584,
-                "time": "1879-08-23T22:00:00Z"
-            }
-        },
-        {
-            "account_index": "10717",
-            "address_pool_gap": 94168,
-            "assets": {
-                "available": [],
-                "total": []
-            },
-            "balance": {
-                "available": {
-                    "quantity": 204,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 128,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 161,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": []
-            },
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1s9xmdug6q6xyjfggqm6xxxhrreza0aze9u70400tukdrvppgl60mg9g6f452n7u7cjzf68vsu9ynhzscua48gmrmvpyelpwzdvy8nvqz38mzp",
-                    "cosigner#2": "acct_shared_xvk1530uhwthzpx8yfp20da3qcxqwe0rs406xhedmqfymtuguw8xyckh7txacs0p83uhzyn9uzlzznrkr2pgpqaah8gz6wtdk6k0knfgyks4vp90e"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 5,
-                        "from": [
-                            {
-                                "all": [
-                                    {
-                                        "active_from": 9
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 2
-                                    },
-                                    {
-                                        "active_until": 6
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#3",
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 1
-                                    },
-                                    "cosigner#2",
-                                    "cosigner#1",
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_from": 3
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        {
-                                            "active_until": 5
-                                        },
-                                        "cosigner#4"
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 4,
-                                    "from": [
-                                        "cosigner#0",
-                                        "cosigner#1",
-                                        {
-                                            "active_from": 8
-                                        },
-                                        {
-                                            "active_until": 4
-                                        },
-                                        {
-                                            "active_until": 7
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        "cosigner#0",
-                                        "cosigner#0",
-                                        {
-                                            "active_from": 4
-                                        },
-                                        {
-                                            "active_until": 2
-                                        },
-                                        {
-                                            "active_until": 1
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 4
-                                    },
-                                    "cosigner#0"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "id": "8bdf420b9372864bba65753781a206fb55316296",
-            "name": "𘀯%魂;",
+            "id": "e4fbfc6c48586c566f5143baafb7e3d4389b95ab",
+            "name": "(",
             "passphrase": {
-                "last_updated_at": "1889-08-09T08:00:00Z"
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1896-10-06T15:00:00Z"
             },
             "payment_script_template": {
                 "cosigners": {
-                    "cosigner#1": "acct_shared_xvk1anj6cgznz5a470ftspctnjl7agspcfcku9tq57nn3hva442xqdysh6ny4tyxh7d0uj5xm656g0hup6eu6kshxy40fwjzgugrl8na8rq66cjpd",
-                    "cosigner#2": "acct_shared_xvk1scmsctxv97cc0arc3d2sezpn9hlp88sshp6fxtn62n9fd8t2h3ayll9gkdw64jecuhaqmv6r0mwr30paadysvcud5jtepgjl6equ88s86xtcq"
+                    "cosigner#1": "acct_shared_xvk1qqqsqqszqgqqyqqpqgpqqqgpqqqsyqqqqyqqqqgqqgpqyqszqyqqyqqqqgpqzqqzqgqqyqqpqyqsqqspqgqsqqqqqypqyqgqqypqzqs3y6ewj"
                 },
                 "template": {
                     "all": [
+                        "cosigner#1",
                         {
-                            "all": [
-                                {
-                                    "some": {
-                                        "at_least": 3,
-                                        "from": [
-                                            {
-                                                "active_from": 4
-                                            },
-                                            "cosigner#1",
-                                            "cosigner#0",
-                                            {
-                                                "active_from": 3
-                                            },
-                                            {
-                                                "active_until": 4
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "any": [
-                                "cosigner#0",
-                                "cosigner#1",
-                                "cosigner#2",
-                                {
-                                    "active_from": 8
-                                },
-                                {
-                                    "active_from": 6
-                                }
-                            ]
+                            "active_from": 0
                         }
                     ]
-                }
-            },
-            "state": {
-                "progress": {
-                    "quantity": 1.48,
-                    "unit": "percent"
-                },
-                "status": "syncing"
-            },
-            "tip": {
-                "absolute_slot_number": 8114632,
-                "epoch_number": 5641,
-                "height": {
-                    "quantity": 2379,
-                    "unit": "block"
-                },
-                "slot_number": 3739,
-                "time": "1874-11-23T00:00:00Z"
-            }
-        },
-        {
-            "account_index": "13998",
-            "address_pool_gap": 5313,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 5
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 25
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 9
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 40
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 144,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 90,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 210,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 3357,
-                            "epoch_start_time": "1898-10-21T16:21:04.979027299136Z"
-                        },
-                        "status": "not_delegating"
-                    }
-                ]
-            },
-            "id": "bfeefdc8ee641b594ae8fcb69452ff0942926cad",
-            "name": ",|vY𩗷!D52|LqbU`",
-            "passphrase": {
-                "last_updated_at": "1864-12-12T08:03:14.324049312283Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#2": "acct_shared_xvk1zflr2fytquqe2gfal6tzsl0svjm9g5hrs4eeqsf7vhhe6pf6adcdjr0g8m08cwgx835psr3dhdfje7cvwpgxqyrehan87njml4wanyc4k9867",
-                    "cosigner#6": "acct_shared_xvk1pl9e5lf6cr2xetzzr4sjh24u4t59394xpegqqv5j87wwds42xltu796vmhrxmd5u5d9dhlzldhzgy7p9983gpl2ldl5k8pcu4rtfqjqztwd9h",
-                    "cosigner#7": "acct_shared_xvk1xcr6t7a4txfkrjuwyk8g6du0hezfqc7qerupdvjdvhyxj6r9a6d2y7tuwypyp3tv5krx7af29mdw6a7d23lupwyq6kpthvqz8jzkmmqpnx0kp",
-                    "cosigner#9": "acct_shared_xvk1e9uk282y3lnfzt49f9tw4hk92uhy9mh5zlprjat8p5v2eaee29htzstwqzkdnx60frjvkgw50457nhnak9urdvxc23gmd3w88u6zp6ge0mgve"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 6,
-                        "from": [
-                            {
-                                "all": [
-                                    "cosigner#6",
-                                    "cosigner#1",
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 9
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 6,
-                                    "from": [
-                                        "cosigner#6",
-                                        "cosigner#7",
-                                        {
-                                            "active_from": 4
-                                        },
-                                        {
-                                            "active_until": 6
-                                        },
-                                        "cosigner#5",
-                                        {
-                                            "active_from": 8
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "all": [
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 5
-                                    },
-                                    "cosigner#3",
-                                    {
-                                        "active_from": 0
-                                    },
-                                    "cosigner#1"
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 3
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_until": 8
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#9",
-                                    "cosigner#4",
-                                    {
-                                        "active_until": 5
-                                    },
-                                    "cosigner#7",
-                                    {
-                                        "active_from": 8
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#4"
-                                ]
-                            }
-                        ]
-                    }
                 }
             },
             "state": {
                 "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 253228,
-                "epoch_number": 14071,
+                "absolute_slot_number": 3,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 1465,
+                    "quantity": 0,
                     "unit": "block"
                 },
-                "slot_number": 10472,
-                "time": "1890-05-30T22:05:11Z"
+                "slot_number": 1,
+                "time": "1869-04-24T21:15:17Z"
             }
         },
         {
-            "account_index": "10235",
-            "address_pool_gap": 12618,
+            "account_index": "0",
+            "address_pool_gap": 46503,
             "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 15
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 24
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 8
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 2
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 21
-                    }
-                ],
+                "available": [],
                 "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 124,
+                    "quantity": 0,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 50,
+                    "quantity": 20503226642026023,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 185,
+                    "quantity": 11834624457701774,
                     "unit": "lovelace"
                 }
             },
             "delegation": {
                 "active": {
                     "status": "delegating",
-                    "target": "pool166vrrj99kxmks2ckvqdta7zly6ykq9ahuhkfdcfywml8qmzzzth"
+                    "target": "pool1qypqyqsqqqqqyqsqqqqqzqszqyqszqgpqgqqqqqzqyqsq4zvvm0"
                 },
                 "next": [
                     {
                         "changes_at": {
-                            "epoch_number": 12381,
-                            "epoch_start_time": "1890-04-29T10:00:00Z"
+                            "epoch_number": 1,
+                            "epoch_start_time": "1873-10-21T07:00:00Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qyqszqqqqgqqqqspqyqqzqszqqqqyqgzqqqsqqgpqyqqy6cwdje"
+                    }
+                ]
+            },
+            "id": "d6f331bd4d603f20400d390ac8b328f43a8e07e7",
+            "name": "S",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1882-04-23T06:00:00Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#0": "acct_shared_xvk1qgpqqqqqqgqsyqqqqqpqqqsqqyqszqqpqqqsyqgpqgqsqqqqqgqqyqqpqqpqzqgqqgqsyqszqgqqqqqqqypqyqgpqyqsyqszqqqsyqgqgrnwd"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#0"
+                    ]
+                }
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 6,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1899-11-20T07:00:00Z"
+            }
+        },
+        {
+            "account_index": "1",
+            "address_pool_gap": 24399,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 14453157902159776,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 7353331028412808,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qgqszqsqqyqsqqspqgpqzqgzqyqsyqqpqypqqqgpqgqsq6kmtd7"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1881-02-12T18:40:21Z"
                         },
                         "status": "not_delegating"
                     }
@@ -1115,145 +190,69 @@
             },
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#1": "acct_shared_xvk199tstrd38w576m5fczpswx76d9t65d0hu3fauen0sj002q5u53ghfn63985vncm0cjgswucdjvc43ugvpnehhvy69lncvr9wvr2w3rslte6u0"
+                    "cosigner#8": "acct_shared_xvk1qgpqqqqqqgqqqqgqqqpqzqgpqgpqqqszqgqqyqszqgqqzqgqqypqqqgpqyqsqqqqqqqqqqszqgqsqqspqqpqyqqzqypqqqsqqqqqzqs2c8svp"
                 },
                 "template": {
-                    "any": [
-                        "cosigner#1",
-                        {
-                            "active_from": 2
-                        },
-                        {
-                            "active_from": 5
-                        },
-                        {
-                            "active_until": 3
-                        },
-                        {
-                            "active_until": 6
-                        },
-                        {
-                            "active_from": 3
-                        },
-                        {
-                            "active_from": 1
-                        },
-                        "cosigner#6",
+                    "some": {
+                        "at_least": 1,
+                        "from": [
+                            "cosigner#8"
+                        ]
+                    }
+                }
+            },
+            "id": "55c523d156edf48e799647cb9dfe802363ffadd9",
+            "name": "@",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1860-03-09T05:33:33.629826483201Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqsqqqpqqqqqqgpqgqsqqgqqgqsyqgzqqqqyqqzqyqsyqszqyqsyqgqqgpqzqszqqpqyqqzqypqqqspqgpqzqgzqyqsyqqzqgqsqqs0sq7k4"
+                },
+                "template": {
+                    "all": [
                         "cosigner#1"
                     ]
                 }
             },
-            "id": "6c6c8e70e474cdf653e4b4bdbc62ad940345b61a",
-            "name": "8BUtR𠰎ID_cWE@+P",
-            "passphrase": {
-                "last_updated_at": "1871-10-19T22:14:28Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#1": "acct_shared_xvk168tskyc8tsh4hgspwjurjauq2g579c3m7lksddjnqjt9rgj93vltvltuatwpl9jg8w86ydwskj3uztdcwzz92stzczd7gn934ncpkrqqm4v0g"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 2,
-                        "from": [
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#1",
-                                    {
-                                        "active_from": 6
-                                    },
-                                    {
-                                        "active_until": 4
-                                    },
-                                    "cosigner#1",
-                                    {
-                                        "active_until": 9
-                                    },
-                                    "cosigner#0",
-                                    "cosigner#1",
-                                    "cosigner#1",
-                                    {
-                                        "active_from": 3
-                                    },
-                                    "cosigner#1"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 4,
-                                    "from": [
-                                        "cosigner#1",
-                                        "cosigner#0",
-                                        {
-                                            "active_until": 8
-                                        },
-                                        {
-                                            "active_until": 5
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_from": 5
-                                    },
-                                    {
-                                        "active_until": 4
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "state": {
-                "status": "not_responding"
+                "progress": {
+                    "quantity": 3.79,
+                    "unit": "percent"
+                },
+                "status": "syncing"
             },
             "tip": {
-                "absolute_slot_number": 6052391,
-                "epoch_number": 7986,
+                "absolute_slot_number": 4,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 7402,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 15753,
-                "time": "1879-02-24T12:21:06.647629879757Z"
+                "slot_number": 0,
+                "time": "1882-02-08T04:30:57Z"
             }
         },
         {
-            "account_index": "14342",
-            "address_pool_gap": 72873,
+            "account_index": "0",
+            "address_pool_gap": 87956,
             "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 3
-                    }
-                ],
+                "available": [],
                 "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 253,
+                    "quantity": 22831808281497637,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 166,
+                    "quantity": 9335381767036421,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 119,
+                    "quantity": 22087359274613315,
                     "unit": "lovelace"
                 }
             },
@@ -1264,177 +263,98 @@
                 "next": [
                     {
                         "changes_at": {
-                            "epoch_number": 11591,
-                            "epoch_start_time": "1865-06-23T06:00:00Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1x8j3j4d6d9ha38hug98rdl5f44qpnxfaq62ej3e9jxthcnyt7ts"
-                    }
-                ]
-            },
-            "id": "e7abeb2ed0980338e6d1fbb8993cdec41fd9ca29",
-            "name": "%]!𨙟*7OkM=𱆂$𬳭ja]CIM",
-            "passphrase": {
-                "last_updated_at": "1882-08-06T14:00:00Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#2": "acct_shared_xvk1dwxejemlaukj84rxf4pfkdvsxvfd0zgun859cgahq2pv280dvj59v5hwmq3pj9a2rs669phpz3ljrnj2v76fdqa9aaadz8kd2qluquqe2geu3",
-                    "cosigner#5": "acct_shared_xvk1eqep42u5mmlk6j7njm0kuur2wstay6lvqq8nnun030lspztmevqqp9v7hrxfzyneede3tmu7a5v5qrh747ffsyp5yljgdy0s35tcckq3l0mes"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 2,
-                        "from": [
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 1
-                                    },
-                                    "cosigner#5",
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_from": 1
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "any": [
-                                            {
-                                                "active_until": 8
-                                            },
-                                            {
-                                                "active_from": 1
-                                            },
-                                            {
-                                                "active_until": 2
-                                            },
-                                            {
-                                                "active_until": 5
-                                            },
-                                            {
-                                                "active_from": 0
-                                            },
-                                            {
-                                                "active_from": 3
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "some": {
-                                            "at_least": 6,
-                                            "from": [
-                                                {
-                                                    "active_from": 5
-                                                },
-                                                "cosigner#2",
-                                                "cosigner#2",
-                                                {
-                                                    "active_until": 8
-                                                },
-                                                {
-                                                    "active_from": 4
-                                                },
-                                                "cosigner#2",
-                                                {
-                                                    "active_from": 4
-                                                },
-                                                "cosigner#5"
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 6947658,
-                "epoch_number": 12763,
-                "height": {
-                    "quantity": 6670,
-                    "unit": "block"
-                },
-                "slot_number": 12860,
-                "time": "1860-10-24T21:56:31Z"
-            }
-        },
-        {
-            "account_index": "8403",
-            "address_pool_gap": 2714,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 13
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 13
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 22
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 163,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 222,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 102,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 5894,
-                            "epoch_start_time": "1881-05-18T03:00:00Z"
+                            "epoch_number": 1,
+                            "epoch_start_time": "1864-11-12T19:42:07Z"
                         },
                         "status": "not_delegating"
                     },
                     {
                         "changes_at": {
-                            "epoch_number": 9036,
-                            "epoch_start_time": "1898-06-10T23:00:00Z"
+                            "epoch_number": 1,
+                            "epoch_start_time": "1880-04-29T00:00:00Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qqqsyqgzqqqqzqqqqyqqzqspqqqqqqqqqqqqzqgzqypqy2yxngw"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#6": "acct_shared_xvk1qyqqzqqzqqqszqqqqgqszqqzqqqsqqqpqqpqyqspqqqsyqgzqgqsqqsqqgpqyqsqqyqqzqszqqpqqqqqqgpqzqsqqypqqqqqqyqqzqg9q9la5"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#6"
+                    ]
+                }
+            },
+            "id": "552d58dc792d225bdd1240eb8e8ee5d0b30c0620",
+            "name": "Z",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1897-12-16T22:20:24Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#0": "acct_shared_xvk1qgqsqqsqqypqyqgqqqqqyqqzqypqzqgqqqqszqspqqqqqqqpqgpqyqqpqqqqyqqqqgqqqqspqgqsqqgzqqqszqspqyqsyqgpqypqyqqr4dq7s",
+                    "cosigner#3": "acct_shared_xvk1qgqszqgpqqqsqqgqqypqzqsqqypqzqgpqqqsyqszqqpqzqgpqypqyqszqgqqyqqpqqpqzqqqqgpqyqgpqgqsqqqqqqpqzqgqqgqqqqq3l332w"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#3",
+                        "cosigner#0"
+                    ]
+                }
+            },
+            "state": {
+                "progress": {
+                    "quantity": 9.24,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1903-10-13T18:00:00Z"
+            }
+        },
+        {
+            "account_index": "1",
+            "address_pool_gap": 15437,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 38364442615946625,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 6077195734617115,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qgpqqqszqgqqqqspqqqsqqsqqgqsyqspqgqszqspqgpqqrmg8gj"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 1,
+                            "epoch_start_time": "1907-06-13T11:04:43Z"
                         },
                         "status": "not_delegating"
                     }
@@ -1442,551 +362,61 @@
             },
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1y77fz7q6sp6fd4q26pt5rs0m2ra7ucczz2sks3dv0c4ze803w9txl49529a9l4gy8hrtzlwrwqagc9vgz9eqrrpceq778dy8gpdl6lcx6x98j",
-                    "cosigner#2": "acct_shared_xvk1ukzcl96pdfnm5l8dx9wfu40cxat8kfzjvz38aarkq89rsyj56p367mkv0em9entzvsdc77ksgemkx8ker644uh870yqwd3524eqf6xqn2ayxx",
-                    "cosigner#5": "acct_shared_xvk1y7nu0jrcuxfeg79vzqvt3cx96jrzzlkgh03v49a33zs85t69n05deg950qak0k06v7fvayzhglfttmckguufjafxg3xe7el2n9mdjacsflz3s",
-                    "cosigner#8": "acct_shared_xvk1x6mz05gw4uass4csc9363g7zr0fxvesx3a3dsd4npluy0e8c57s7mu5ax0p2lqthhz2n9z77h0jgtk7fzawgnqxcxlt06yyj4zdhffsvyjs6k"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "all": [
-                                {
-                                    "active_from": 4
-                                },
-                                "cosigner#2",
-                                "cosigner#0"
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_from": 6
-                                },
-                                "cosigner#7"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 5
-                                },
-                                "cosigner#8",
-                                "cosigner#1",
-                                {
-                                    "active_from": 8
-                                },
-                                {
-                                    "active_from": 5
-                                },
-                                "cosigner#4",
-                                "cosigner#2",
-                                "cosigner#2"
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_from": 5
-                                },
-                                "cosigner#4",
-                                "cosigner#5",
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_from": 2
-                                }
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_from": 5
-                                },
-                                {
-                                    "active_from": 6
-                                },
-                                {
-                                    "active_until": 3
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                "cosigner#2"
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    "cosigner#2"
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_until": 1
-                                },
-                                "cosigner#0"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_until": 1
-                                },
-                                "cosigner#2"
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "f4afddca1f0cf80de3fa0ee75a36b08792e55c64",
-            "name": "剭!匣!裌M^3E92>𘩗UK_E",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#5": "acct_shared_xvk14kfct8ddfhn2g8fqn2yct5max8pds7c2tm8293tvt3v3hkcrjp2sccewwl52a4ecz72hajxu5l7mtyyzv3razk3x43v9czyew22x4xgtt75g2"
+                    "cosigner#1": "acct_shared_xvk1qqpqyqqzqqpqqqgqqqqqyqqzqgpqqqszqypqzqqpqqpqzqqzqyqsyqszqgqqyqgpqypqzqqpqqqqqqqqqypqqqgqqyqsyqgzqgpqzqghmngv2"
                 },
                 "template": {
                     "some": {
                         "at_least": 1,
                         "from": [
-                            {
-                                "all": [
-                                    {
-                                        "any": [
-                                            {
-                                                "active_from": 8
-                                            },
-                                            {
-                                                "active_from": 9
-                                            },
-                                            {
-                                                "active_until": 9
-                                            },
-                                            {
-                                                "active_until": 5
-                                            },
-                                            {
-                                                "active_until": 1
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_from": 2
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        {
-                                            "active_from": 1
-                                        },
-                                        {
-                                            "active_from": 4
-                                        },
-                                        "cosigner#5",
-                                        {
-                                            "active_until": 4
-                                        }
-                                    ]
-                                }
-                            }
+                            "cosigner#1"
                         ]
                     }
                 }
             },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 3805995,
-                "epoch_number": 2513,
-                "height": {
-                    "quantity": 483,
-                    "unit": "block"
-                },
-                "slot_number": 8892,
-                "time": "1864-10-23T06:02:33.275770727305Z"
-            }
-        },
-        {
-            "account_index": "186",
-            "address_pool_gap": 77296,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 12
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 2
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 43,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 79,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 101,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 3957,
-                            "epoch_start_time": "1908-08-24T18:00:00Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1yp26vsnhmphdy5s7u85vmhsps67mjf2j5w25vl6k0l9zjk94kq6"
-                    }
-                ]
-            },
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1zxnn0v43hn852x2cp8ya73pcp2pvdrg6vcn5wjd9wr32xjq5u690qxqt7keeng4xmjwf2n79scnxuljp9lkzxe70ja87xhq2apz2tucn2chnf",
-                    "cosigner#1": "acct_shared_xvk1g3fazryzwx4qlc5xz9398ekxu3farhdz27f7mcw9qm9v3fe90evxd85jj0s3f9vryzagmqfca8tk223zu39r99lfyw90z8sucvqat4chn7m9c",
-                    "cosigner#2": "acct_shared_xvk1mwxzavccxy4j5p0p7feat0c7v8rn7nzn5z49sjpm9wxwd3d9g3sjnug4qhkxh4p9pgmm47j0d8qjaf7w8n7kymtpq9x9dan6tx6y0pgpne8na"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 4,
-                        "from": [
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 1
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_from": 7
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    {
-                                        "active_from": 8
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    "cosigner#4"
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_from": 5
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_from": 10
-                                    },
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_from": 8
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_until": 9
-                                    },
-                                    "cosigner#3"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        "cosigner#0",
-                                        {
-                                            "active_from": 6
-                                        },
-                                        {
-                                            "active_from": 9
-                                        },
-                                        "cosigner#0",
-                                        "cosigner#1",
-                                        {
-                                            "active_from": 8
-                                        },
-                                        "cosigner#1",
-                                        {
-                                            "active_until": 5
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 6
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "id": "49442d3fc5367dd67e7536752b2c2e26256c64ba",
-            "name": "DF,F]'𰀙肭\\𤅃vb𥚔楀菉樕bY",
+            "id": "e64dc27a5323863c0f9d7eb170bfeb0e59021d7b",
+            "name": "O",
             "passphrase": {
-                "last_updated_at": "1881-07-23T16:03:01Z"
+                "encryption_method": "scrypt",
+                "last_updated_at": "1859-10-29T00:14:11.784505557153Z"
             },
             "payment_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1ucvll8kk98artm0y8f44tjwlu33zdaq0gwmz8lu06w2sv3j50ad77nhrmw7ysazqxdsxqs2aptvjsl4eafux24l0l0vxeqm230mut4cjt6x7f",
-                    "cosigner#2": "acct_shared_xvk1uvj2dnp9gk483melfqn73e2l8sd8dnw94m3c0mwuma6t9k2hsfqa423xkpexv5aphj4spyfeek4zsdcc5f7r6xt3xh2r6muzz57p5fct9e0aw",
-                    "cosigner#5": "acct_shared_xvk1lu8ftt2yzht3c8f9jdanfe8gzrhnpzregk62xrx2k5mmxsa50lvt3naayfz6qm878n76hned3g9z3l4n30lt000yllpnn8e6cgaxq6glqcccd",
-                    "cosigner#6": "acct_shared_xvk1kkmvjzgf8pcry9kqgp2k48nmj4jg8syh9257pa2647vp6xv96tpynu8hn85wqsgrdqhds7j8jew7f08qmehuru8kxq5a4zapg7jpamgnfwnkv",
-                    "cosigner#7": "acct_shared_xvk1wfuj26633mhzt7nl30nqkkvvmhagnfrrjglacev23sxld70f8yv8m5d789u3hqlte0wsd4cf9hp0ukt0gf3ym38muxtqxef79k8kflsp5mht9",
-                    "cosigner#8": "acct_shared_xvk1y2pfshm5xg8y5jxgzww0k40vm70pfatde8l7jpa8hyxrhgz7j02x9xfcua0hg8vrvpazly90q4zk445jcx9yr6uptxqftuqyepmvzhcmv27k9"
+                    "cosigner#4": "acct_shared_xvk1qgqqqqsqqyqqyqqqqyqsqqqpqgqsyqsqqyqsyqqzqqqsqqqqqyqszqspqgqsqqsqqqqqqqszqyqszqgpqqqsqqszqgqqqqqqqgpqzqg82msyl"
                 },
-                "template": {
-                    "some": {
-                        "at_least": 8,
-                        "from": [
-                            {
-                                "all": [
-                                    "cosigner#6"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        {
-                                            "active_until": 0
-                                        },
-                                        {
-                                            "active_from": 2
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#7",
-                                    "cosigner#3"
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#8"
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 7
-                                    },
-                                    {
-                                        "active_from": 4
-                                    },
-                                    "cosigner#5",
-                                    {
-                                        "active_from": 5
-                                    },
-                                    "cosigner#8",
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 5
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    "cosigner#6",
-                                    "cosigner#0",
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_from": 5
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 5
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 0
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
+                "template": "cosigner#4"
             },
             "state": {
                 "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 6599658,
-                "epoch_number": 5864,
+                "absolute_slot_number": 2,
+                "epoch_number": 0,
                 "height": {
-                    "quantity": 3058,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 347,
-                "time": "1883-01-05T21:30:37.241386416693Z"
+                "slot_number": 0,
+                "time": "1873-12-23T05:50:21Z"
             }
         },
         {
-            "account_index": "2004",
-            "address_pool_gap": 28551,
+            "account_index": "0",
+            "address_pool_gap": 96052,
             "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 2
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 16
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 23
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 15
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 4
-                    }
-                ]
+                "available": [],
+                "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 202,
+                    "quantity": 45000000000000000,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 46,
+                    "quantity": 38969396930005418,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 219,
+                    "quantity": 0,
                     "unit": "lovelace"
                 }
             },
@@ -1997,16 +427,15 @@
                 "next": [
                     {
                         "changes_at": {
-                            "epoch_number": 16020,
-                            "epoch_start_time": "1863-05-23T05:25:09Z"
+                            "epoch_number": 1,
+                            "epoch_start_time": "1886-03-25T07:00:00Z"
                         },
-                        "status": "delegating",
-                        "target": "pool1fhl5fhx0g5rxzawqyp8d7p0y0sg5llye9lngjqmmqk32yp880uw"
+                        "status": "not_delegating"
                     },
                     {
                         "changes_at": {
-                            "epoch_number": 8147,
-                            "epoch_start_time": "1868-12-11T00:00:00Z"
+                            "epoch_number": 0,
+                            "epoch_start_time": "1867-01-12T08:09:37Z"
                         },
                         "status": "not_delegating"
                     }
@@ -2014,377 +443,54 @@
             },
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1jyp5vj4zk9s87xjvdl2lzygh0dqccdek9wklark7txrfvzl0wj09u8wpg5qltm8dm3m609kx9zdgltylvlrrp4sdt0vt90r7ffgl3sqdudupk",
-                    "cosigner#2": "acct_shared_xvk1lvgmazfxfxper20kz3uklq5c5hll3t9grxzqxn4n02as8k36hl4qaan7c6d260ecksepfaugn00c997nhf7f5mnzl2q3f5sqxu9vmss47d07d",
-                    "cosigner#4": "acct_shared_xvk1vfukq2prumy3hgt22g08jc3073f6vva0lp92sfmu2kpyr57a68uqmfazz5gmhvns2yml5jq5rd683ezslmlwn4zg5jadc9wlt7gaseguxashe",
-                    "cosigner#5": "acct_shared_xvk1snf988ymndmjz2cj3ph42428rwrnmmphq0fllan7g3w4rgexnhgjp7r6z23xdm6klpcu4q5cuv0lgz3t6fd24l59juqd5q97vlyvppggkhyfh",
-                    "cosigner#6": "acct_shared_xvk1tpmvzhz0kr959ajakve0yjdye8ky7wvufluw5wjchmazy9pulpc062mqjjpzktt2uh569a988anv9x65dxj7wh0vydg54hahvf5uwycwcf7rt"
+                    "cosigner#9": "acct_shared_xvk1qgpqqqszqgqszqgqqgqsqqgqqgpqzqqqqgqqqqsqqgqqyqqpqgqszqspqqpqzqqpqgpqyqgzqyqqzqsqqqqszqgzqyqsyqsqqyqszqs58mped"
                 },
-                "template": {
-                    "some": {
-                        "at_least": 4,
-                        "from": [
-                            {
-                                "all": [
-                                    "cosigner#4",
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_from": 4
-                                    },
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_from": 0
-                                    },
-                                    {
-                                        "active_until": 1
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#4"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 4,
-                                    "from": [
-                                        {
-                                            "active_until": 9
-                                        },
-                                        "cosigner#5",
-                                        {
-                                            "active_until": 1
-                                        },
-                                        "cosigner#0",
-                                        {
-                                            "active_from": 0
-                                        },
-                                        "cosigner#3",
-                                        {
-                                            "active_from": 5
-                                        },
-                                        {
-                                            "active_from": 5
-                                        },
-                                        {
-                                            "active_until": 1
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 4
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_from": 1
-                                    },
-                                    "cosigner#5",
-                                    {
-                                        "active_until": 3
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    "cosigner#4"
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#5",
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 6
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_from": 0
-                                    },
-                                    {
-                                        "active_until": 9
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 1
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#4",
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#3",
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    "cosigner#2"
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_from": 6
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 9
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 7
-                                    }
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        "cosigner#6",
-                                        "cosigner#5"
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
+                "template": "cosigner#9"
             },
-            "id": "fccca9942fc54b4b2a10a78bd9e299a0b9c76b3c",
-            "name": "=𣯯`&衛1⌵)A𮊕𮓣V똻/_F3a",
+            "id": "cce951ba5f8a946f877d1ff590bad30ab6947fd9",
+            "name": "T(",
             "passphrase": {
-                "last_updated_at": "1898-08-24T09:19:56Z"
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1865-03-18T00:09:48.368998853648Z"
             },
             "payment_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1ks3eygqdnhk68w9vtjktxt7lzdlv5fvrkp54s70pwtr66p8600t644ejpz5mprgzfmz9akvs8zfqe8r4agn0y94zf9pahtsgq3d0tcqvdldaa",
-                    "cosigner#3": "acct_shared_xvk1tyc0ysgku7zlh0flg4mws8h9z4xln78sn4rgftfscupufvl2plmxv9lqehm0nykrh2ddqgmvtmxa057nds77fv0cluxn94sjttmru8cnjz50t",
-                    "cosigner#4": "acct_shared_xvk1879efddhp5nju92k33cup75fxz3mpnwhlkqrwyw52s20ldecxusa3cpmg7uuye62cm3w66yl9h4ddmtdjzjek0uat8tcplatar9d4aszey2q0"
+                    "cosigner#4": "acct_shared_xvk1qqpqqqqpqqqsqqqqqyqqyqgqqypqzqszqyqqyqgqqgqsqqqpqqqszqgzqgpqzqgpqqqqqqsqqypqqqgzqgpqzqqpqgpqqqszqgqqyqgz5ajyr"
                 },
-                "template": {
-                    "any": [
-                        {
-                            "any": [
-                                {
-                                    "active_until": 4
-                                },
-                                {
-                                    "active_from": 9
-                                },
-                                {
-                                    "active_from": 9
-                                },
-                                {
-                                    "active_until": 1
-                                },
-                                {
-                                    "active_until": 4
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                {
-                                    "active_until": 4
-                                }
-                            ]
-                        },
-                        {
-                            "any": [
-                                "cosigner#3",
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_until": 6
-                                },
-                                "cosigner#0"
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    "cosigner#3",
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 7
-                                    },
-                                    {
-                                        "active_from": 0
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 9,
-                                "from": [
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_from": 6
-                                    },
-                                    {
-                                        "active_until": 3
-                                    },
-                                    {
-                                        "active_until": 7
-                                    },
-                                    {
-                                        "active_from": 0
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_until": 4
-                                    },
-                                    {
-                                        "active_from": 8
-                                    },
-                                    "cosigner#4"
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    {
-                                        "active_until": 6
-                                    },
-                                    "cosigner#0",
-                                    "cosigner#1"
-                                ]
-                            }
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_until": 9
-                                },
-                                {
-                                    "active_from": 2
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 6
-                                    },
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_from": 0
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#2",
-                                    {
-                                        "active_from": 8
-                                    },
-                                    "cosigner#4"
-                                ]
-                            }
-                        }
-                    ]
-                }
+                "template": "cosigner#4"
             },
             "state": {
-                "status": "not_responding"
+                "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 5041549,
-                "epoch_number": 14528,
+                "absolute_slot_number": 1,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 7098,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 12984,
-                "time": "1870-05-30T02:00:13.232736962238Z"
+                "slot_number": 0,
+                "time": "1899-06-28T08:25:30.646536387303Z"
             }
         },
         {
-            "account_index": "7814",
-            "address_pool_gap": 53214,
+            "account_index": "0",
+            "address_pool_gap": 57626,
             "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 17
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 34
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 16
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 20
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 8
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 13
-                    }
-                ]
+                "available": [],
+                "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 205,
+                    "quantity": 2192616603292858,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 209,
+                    "quantity": 43460199670690924,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 25,
+                    "quantity": 17156722054932474,
                     "unit": "lovelace"
                 }
             },
@@ -2392,157 +498,298 @@
                 "active": {
                     "status": "not_delegating"
                 },
-                "next": []
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1894-01-26T04:32:11.284512843881Z"
+                        },
+                        "status": "not_delegating"
+                    },
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1867-04-04T02:04:29.270137836383Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qqqsqqgpqypqzqgpqgqszqqzqgqsyqqpqqqqqqgzqyqsygulf6n"
+                    }
+                ]
             },
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1sshvuzae9uh04ru6xarmwavq4v686x6r00ee5wn2zea9lhfezpq3y8vsf2kqfyxv0xzsnp4pwzqwr3mr3qq2wxjy9cqwhdy3zyl8tvg7tlx2y",
-                    "cosigner#1": "acct_shared_xvk1vryuavg3m5medpah9ru98q48pkyu6kr6s5wvxupskpgumfed87clu7yplt5cs2nd88tlcsn9t7jh5d8zv3xf6n3ur7jay667h3preeshpeykj"
+                    "cosigner#2": "acct_shared_xvk1qgqqzqgzqqpqqqgqqypqyqgzqqpqzqspqgpqyqgqqyqqzqgpqqqszqspqypqzqgqqyqqzqgqqgpqyqgqqgqsyqgqqgpqyqszqgqszqsmypa76"
                 },
                 "template": {
-                    "all": [
+                    "any": [
+                        "cosigner#2",
                         {
-                            "all": [
-                                "cosigner#1",
-                                {
-                                    "active_from": 6
-                                },
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_from": 7
-                                },
-                                "cosigner#1",
-                                "cosigner#1"
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    {
-                                        "active_from": 7
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 0
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 2
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                "cosigner#0",
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_from": 8
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                "cosigner#0",
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_until": 3
-                                },
-                                "cosigner#0"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 7
-                                }
-                            ]
+                            "active_from": 1
                         }
                     ]
                 }
             },
-            "id": "fcf03ffcb0c82e8aafb4a2aca24d1a22a67f1537",
-            "name": "EA eX𪃙VX`~𥦨0~0蚍𝖸wPh9y6&5",
+            "id": "0f1d1c8d8ca598ed35fec26ebcafdcb49a3ffc9e",
+            "name": "🤈",
             "passphrase": {
-                "last_updated_at": "1877-03-16T19:00:00Z"
+                "encryption_method": "scrypt",
+                "last_updated_at": "1861-09-30T02:33:41Z"
             },
             "payment_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1kqjwkcwx6kmky5ne60dc4ttexqx06n2l2a74snvg53r0sqgjc3yepwsw8jd9hntk4rzskcd7z259ytr6emue82wcvcs3ghvelrydvus8kr52j",
-                    "cosigner#3": "acct_shared_xvk1mz4x9lxfx4wwtmmgejqm3pefrgk20crcph2f9km0mgj85k8z682lpxy73a4t9vvupqzuttv7kap9ac7vu6d2w5jnp2fh0sg67w5hmncz0d963",
-                    "cosigner#4": "acct_shared_xvk1x6n3s7lkavrr74m49rra6k5ku4n0ncad66x7r7tsd8zjqmqxjzax9f7wmg4ps7tqwmtkt5k0fyuha2lyljwg0zgvfu4fv9hzqmnvr0qe73kh0",
-                    "cosigner#5": "acct_shared_xvk1l3dfkfwx9m4jk5zcusjdd2n842608s2qwp45plmre4t8tz78c0xtjnh3km79nmp7yqmd9tmf7ptvgqg375ey5emzm9zwvpudmerv0zg46a4nm"
+                    "cosigner#2": "acct_shared_xvk1qgqqqqqpqqqsqqqpqqpqqqqzqyqqqqqpqqqsqqqqqgqqzqszqyqsyqspqqqqyqqqqqqsqqqqqypqqqgqqqqqqqgqqqqqqqsqqgpqqqq7pk0j3"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#2"
+                    ]
+                }
+            },
+            "state": {
+                "progress": {
+                    "quantity": 52.43,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1901-04-13T12:56:44.034488530491Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 10548,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 22428715469788082,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 4723155875681432,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1901-03-05T22:40:00.50782770441Z"
+                        },
+                        "status": "not_delegating"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#0": "acct_shared_xvk1qgqszqsqqqqqzqgpqgqsyqqpqyqqqqqqqqqsqqgpqqpqzqgqqqpqzqgzqgpqzqspqypqqqgpqgqszqqqqgqsqqgqqgqszqgzqgqsqqqdrh6aw"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#1",
+                        "cosigner#0"
+                    ]
+                }
+            },
+            "id": "45d31c3f4bcb5087c9ad0c7b491b1dc9d54d7681",
+            "name": "x2",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1868-09-09T21:03:26.967507999393Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#6": "acct_shared_xvk1qyqqyqqqqqqszqqzqypqyqgzqyqqzqqpqyqqyqsqqgqqqqgzqqqsqqgzqqqsyqspqgqqqqqqqyqqyqgzqgpqqqgpqypqqqgpqgqszqg866kyd"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#6",
+                        {
+                            "active_until": 0
+                        }
+                    ]
+                }
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 6,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1860-08-23T22:00:00Z"
+            }
+        },
+        {
+            "account_index": "2",
+            "address_pool_gap": 65086,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 12829523347131097,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qyqqyqqqqgqsqqgqqypqyqszqqqsqqgzqgpqzqszqgqsztty933"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 1,
+                            "epoch_start_time": "1907-11-22T17:00:00Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qypqzqgzqqpqzqszqyqsqqqzqgqsyqgpqqqqzqqzqgpqq62v688"
+                    },
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1894-02-11T03:57:13.286045061743Z"
+                        },
+                        "status": "not_delegating"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#4": "acct_shared_xvk1qqpqzqqpqgpqzqqqqqpqqqqpqqpqqqgzqqqszqgpqqqqzqqqqypqyqgqqqqszqgqqqqszqspqgpqyqgqqgqsqqgqqgqqyqszqyqsqqstcs5tv"
                 },
                 "template": {
                     "some": {
-                        "at_least": 4,
+                        "at_least": 1,
                         "from": [
+                            "cosigner#4",
                             {
-                                "all": [
-                                    "cosigner#0",
-                                    "cosigner#3"
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 9
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_from": 5
-                                    },
-                                    {
-                                        "active_from": 0
-                                    },
-                                    "cosigner#5",
-                                    "cosigner#4",
-                                    "cosigner#3",
-                                    "cosigner#3",
-                                    "cosigner#5",
-                                    {
-                                        "active_from": 8
-                                    }
-                                ]
-                            },
-                            {
-                                "any": [
-                                    "cosigner#0"
-                                ]
+                                "active_until": 1
                             }
                         ]
                     }
                 }
             },
+            "id": "13e91fdcd1664c241af8eeb9445074da29bbde8a",
+            "name": "䙒p",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1871-03-04T02:33:00Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#4": "acct_shared_xvk1qyqszqspqypqyqqzqyqsqqqpqypqzqspqgqqqqspqgqqyqszqqpqzqsqqgqqyqqpqqqqyqqzqyqqzqqqqgpqyqgqqqpqyqqpqgqsqqgmktu0c"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#4"
+                    ]
+                }
+            },
             "state": {
-                "status": "not_responding"
+                "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 430819,
-                "epoch_number": 8582,
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 10538,
+                    "quantity": 0,
                     "unit": "block"
                 },
-                "slot_number": 5851,
-                "time": "1871-03-25T22:29:18Z"
+                "slot_number": 1,
+                "time": "1869-09-18T02:00:00Z"
+            }
+        },
+        {
+            "account_index": "2",
+            "address_pool_gap": 1736,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 36109912306408874,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 16454895379533912,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qqpqzqgqqqpqzqgqqqqsyqspqypqzqgqqyqszqgzqqpqyvll8v6"
+                },
+                "next": []
+            },
+            "id": "a9b196e0d0feb3c2369143e08ae0705add05d77d",
+            "name": "TN",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1862-12-03T02:00:00Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#4": "acct_shared_xvk1qgqsqqszqgqsqqqqqyqsyqgqqqqszqspqgqsyqsqqgqszqqpqqpqzqgqqyqsqqspqqpqqqqqqgpqzqgpqqqqqqsqqqpqyqszqgqsyqsgtuvne"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#4"
+                    ]
+                }
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1907-08-28T01:08:14Z"
             }
         }
     ],
-    "seed": 2007925166
+    "seed": 1151751788
 }

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiByronWallet.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiByronWallet.json
@@ -2,465 +2,268 @@
     "samples": [
         {
             "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 16
-                    }
-                ],
+                "available": [],
                 "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 115,
+                    "quantity": 45000000000000000,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 188,
+                    "quantity": 14132423031800289,
                     "unit": "lovelace"
                 }
             },
             "discovery": "sequential",
-            "id": "4f7f3fa509ae653d7aec76f272879fb0241775d6",
-            "name": "ऽⲠGhE𥝃ySORdZ~$;걆𑿯t",
+            "id": "c575800eec184d3e2586b08c9f86971090ee3805",
+            "name": "LU",
             "passphrase": {
-                "last_updated_at": "1894-05-19T00:00:00Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 6946055,
-                "epoch_number": 5587,
-                "height": {
-                    "quantity": 11084,
-                    "unit": "block"
-                },
-                "slot_number": 14002,
-                "time": "1873-12-03T09:00:00Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 11
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 221,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 182,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "sequential",
-            "id": "c109d9a005eaf8c5c51e1f0f4001f651b8ff9f4e",
-            "name": "M",
-            "passphrase": {
-                "last_updated_at": "1868-05-30T09:08:22Z"
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 2280265,
-                "epoch_number": 1031,
-                "height": {
-                    "quantity": 1980,
-                    "unit": "block"
-                },
-                "slot_number": 3138,
-                "time": "1864-09-12T02:48:33Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 5
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 11
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 20
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 49
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 8
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 8
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 23
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 23
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 13
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 13
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 9
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 13
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 23
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 144,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 252,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "random",
-            "id": "4f6c8593f6559ea72aefc628079bf957850cd0e2",
-            "name": "D𱀴",
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 558677,
-                "epoch_number": 9781,
-                "height": {
-                    "quantity": 5319,
-                    "unit": "block"
-                },
-                "slot_number": 2091,
-                "time": "1859-06-06T20:25:08Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 13
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 39
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 23
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 35
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 25
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 13
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 251,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 27,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "sequential",
-            "id": "1231972d61bb227f8f0bec3e0b25fb84ddb91844",
-            "name": "𤃖y밊𔐴~i=z>[h𬃲𪶎hxa𡦟꠷k\\mUMs䷃癰5e",
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 4698242,
-                "epoch_number": 8822,
-                "height": {
-                    "quantity": 12593,
-                    "unit": "block"
-                },
-                "slot_number": 2185,
-                "time": "1889-10-30T07:12:49.067737226418Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 20
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 155,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 105,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "sequential",
-            "id": "e6d8ab070a69df4d5c95859adff610538804175c",
-            "name": "c31]𪰹=om𰦮JD𥢧z6U,@C",
-            "passphrase": {
-                "last_updated_at": "1908-02-08T18:30:46.065848596679Z"
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1876-11-16T04:12:00Z"
             },
             "state": {
                 "progress": {
-                    "quantity": 45.48,
+                    "quantity": 4.92,
                     "unit": "percent"
                 },
                 "status": "syncing"
             },
             "tip": {
-                "absolute_slot_number": 5988477,
-                "epoch_number": 8053,
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
                 "height": {
-                    "quantity": 14527,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 7960,
-                "time": "1871-09-21T12:35:08Z"
+                "slot_number": 1,
+                "time": "1894-09-13T07:00:00Z"
             }
         },
         {
             "assets": {
                 "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 24
-                    }
-                ]
+                "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 238,
+                    "quantity": 1472734577163611,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 193,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "random",
-            "id": "9599847df99bb28ef04e5f0be136ddb436768c49",
-            "name": "T<fBG& &8O]wm",
-            "passphrase": {
-                "last_updated_at": "1865-11-18T18:00:00Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 4185198,
-                "epoch_number": 10418,
-                "height": {
-                    "quantity": 11012,
-                    "unit": "block"
-                },
-                "slot_number": 3343,
-                "time": "1874-04-04T03:42:23.948391844709Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 24
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 14
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 214,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 148,
+                    "quantity": 10351220290697674,
                     "unit": "lovelace"
                 }
             },
             "discovery": "sequential",
-            "id": "2f04c2f52080ffd28036a3c7efb7c1cc10edbdf0",
-            "name": "𝦊)s𢧍7𬥮]y𪟤tyg/d넾p_J𩕚IFBsH𪪣67",
+            "id": "1a0719491bbc63d00c370ee45266e9230afee9c3",
+            "name": "窑𪚄[",
             "passphrase": {
-                "last_updated_at": "1891-10-21T21:03:53Z"
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1894-06-20T13:00:00Z"
             },
             "state": {
                 "progress": {
-                    "quantity": 68.97,
+                    "quantity": 82.61,
                     "unit": "percent"
                 },
                 "status": "syncing"
             },
             "tip": {
-                "absolute_slot_number": 7076848,
-                "epoch_number": 6944,
+                "absolute_slot_number": 1,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 9475,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 4034,
-                "time": "1896-02-17T02:19:44Z"
+                "slot_number": 0,
+                "time": "1899-02-26T08:00:00Z"
             }
         },
         {
             "assets": {
                 "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 5
-                    }
-                ]
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "sequential",
+            "id": "bb7e3417b051446100d8b9fc0510dadd3343d050",
+            "name": "5x齊",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1904-09-21T06:00:00Z"
+            },
+            "state": {
+                "status": "not_responding"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1887-04-07T00:00:00Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 3411249018662397,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 9531046080973651,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "sequential",
+            "id": "dd36ec7f9c72c582a67b84e4483d151c7444b055",
+            "name": "𣥔G",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1891-07-11T19:35:50.585785321051Z"
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 1,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1862-08-05T07:00:00Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 10821974063515824,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "random",
+            "id": "528163857e58e969ae24e437dcea1adcfc1cea48",
+            "name": "l𢈏0",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1907-04-11T05:11:05Z"
+            },
+            "state": {
+                "status": "not_responding"
+            },
+            "tip": {
+                "absolute_slot_number": 8,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1884-03-02T09:00:00Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 27292804915728356,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "random",
+            "id": "b1c944eb799b09d3f78da638d9c4568b24e8ccf4",
+            "name": "Pl",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1869-04-22T16:52:12.280948522186Z"
+            },
+            "state": {
+                "status": "not_responding"
+            },
+            "tip": {
+                "absolute_slot_number": 4,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 1,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1887-08-17T07:00:00Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 15027112509629680,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 33543673035706441,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "sequential",
+            "id": "3eb5b8d77851c38cd1ef2a58b739a0d9d9e992df",
+            "name": "y",
+            "state": {
+                "progress": {
+                    "quantity": 9.17,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 7,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1896-06-18T10:00:00Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
             },
             "balance": {
                 "available": {
@@ -468,143 +271,103 @@
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 159,
+                    "quantity": 8196801454459190,
                     "unit": "lovelace"
                 }
             },
             "discovery": "random",
-            "id": "18c2b88a8bc54d57e547360ecab2617667a1931c",
-            "name": "$2A𮂊𗤼F'DxvWS-弮5L7x",
+            "id": "c921a416c4958b44d3c7676fe7e267823997a205",
+            "name": "即",
             "passphrase": {
-                "last_updated_at": "1906-04-11T04:00:48.857756679235Z"
+                "encryption_method": "scrypt",
+                "last_updated_at": "1867-07-17T17:04:15Z"
             },
             "state": {
-                "progress": {
-                    "quantity": 19.08,
-                    "unit": "percent"
-                },
-                "status": "syncing"
+                "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 5147830,
-                "epoch_number": 82,
+                "absolute_slot_number": 4,
+                "epoch_number": 0,
                 "height": {
-                    "quantity": 2904,
+                    "quantity": 0,
                     "unit": "block"
                 },
-                "slot_number": 16282,
-                "time": "1869-03-14T07:42:59.461937046034Z"
+                "slot_number": 0,
+                "time": "1865-10-31T01:31:01Z"
             }
         },
         {
             "assets": {
                 "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 5
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 2,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 112,
-                    "unit": "lovelace"
-                }
-            },
-            "discovery": "random",
-            "id": "bbcb17eff1704a902653323a25bc71cf715fcf24",
-            "name": "5\"O%%i4𥓡|O]D!^X,ﴀ碧p<nSZ9f`",
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 8025884,
-                "epoch_number": 9017,
-                "height": {
-                    "quantity": 11646,
-                    "unit": "block"
-                },
-                "slot_number": 8844,
-                "time": "1875-05-04T19:36:50Z"
-            }
-        },
-        {
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 37
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 8
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 40
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 22
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 2
-                    }
-                ],
                 "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 82,
+                    "quantity": 3407001230553603,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 74,
+                    "quantity": 42428871290654173,
                     "unit": "lovelace"
                 }
             },
-            "discovery": "sequential",
-            "id": "1bf03295f5f84f259d1bf683ef879983216dd56c",
-            "name": "-|𬳟l.=H3iRia:.Qp𮈖ᨯHo𬤾l뀌.숯Kj",
+            "discovery": "random",
+            "id": "fff09fb5b3d5e1b384cf0cc4b10528b37d346573",
+            "name": "EB",
             "passphrase": {
-                "last_updated_at": "1882-11-19T01:13:41.362352984652Z"
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1900-02-25T01:33:19.221135135061Z"
             },
             "state": {
                 "status": "not_responding"
             },
             "tip": {
-                "absolute_slot_number": 1046200,
-                "epoch_number": 5277,
+                "absolute_slot_number": 3,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 13459,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 7129,
-                "time": "1864-06-29T17:45:38Z"
+                "slot_number": 0,
+                "time": "1889-01-01T21:13:42Z"
+            }
+        },
+        {
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 9141308257060297,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "discovery": "sequential",
+            "id": "955ff867034a16a1c4438640bc2186d4e387d7bf",
+            "name": "d",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1900-04-14T19:00:00Z"
+            },
+            "state": {
+                "status": "not_responding"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1874-04-26T10:00:00Z"
             }
         }
     ],
-    "seed": 1921983423
+    "seed": 2029164924
 }

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiSharedWallet.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiSharedWallet.json
@@ -1,1642 +1,11 @@
 {
     "samples": [
         {
-            "account_index": "13323",
-            "address_pool_gap": 43941,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 21
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 5
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 36
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 15
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 22
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 67,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 18,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 207,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": []
-            },
-            "id": "c103cee4f80710c19279a71616c884587bccf1cd",
-            "name": "GoEU.№E",
-            "passphrase": {
-                "last_updated_at": "1867-09-14T16:08:55Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#4": "acct_shared_xvk109ur9m62e4tgqz229gyaq4yhtqwkqt3eqp4f4dfmlrkyyq4nyax7ezzgdr88vkr3z0aka8qsa6dp2ep5tet3za3vjl3x060l59lsdnsrengr8",
-                    "cosigner#5": "acct_shared_xvk10ae0h383qak9w9sm8utu2tgwumkpy0jlhwu7j57egmelngqgh0kdwmsx6fpz4r9mza3d4evsnpye42mhfe0ggw88t6vhz5034ychj3cjdtq9p",
-                    "cosigner#6": "acct_shared_xvk1apct9m0d29z7erjkj9l5fw9jyc0mmsdg8nufdfr3qa8ph73z30myls54675xdyk7mf0acxmkecv8pqcuxg0gtcxy6khrnj79zpdzm2gme0ujj"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 2,
-                        "from": [
-                            {
-                                "any": [
-                                    "cosigner#5",
-                                    "cosigner#5",
-                                    "cosigner#4",
-                                    {
-                                        "active_from": 6
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 3
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 0
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    "cosigner#4"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        {
-                                            "active_until": 7
-                                        },
-                                        {
-                                            "active_from": 8
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "any": [
-                                    {
-                                        "active_from": 7
-                                    },
-                                    "cosigner#5",
-                                    "cosigner#6",
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_until": 8
-                                    },
-                                    {
-                                        "active_until": 8
-                                    }
-                                ]
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_from": 4
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "state": {
-                "progress": {
-                    "quantity": 85.59,
-                    "unit": "percent"
-                },
-                "status": "syncing"
-            },
-            "tip": {
-                "absolute_slot_number": 5161026,
-                "epoch_number": 5289,
-                "height": {
-                    "quantity": 7501,
-                    "unit": "block"
-                },
-                "slot_number": 12576,
-                "time": "1860-04-06T02:00:00Z"
-            }
-        },
-        {
-            "account_index": "13655",
-            "address_pool_gap": 28519,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 15
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 16
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 149,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 110,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 180,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": []
-            },
-            "id": "dad8c6f0ecb01ec3c8f0af6334d6340bec27539c",
-            "name": "~!",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#1": "acct_shared_xvk1jfr3cty2cy2eqxnamd76s4m9p8zzajcql5l03k6ywxjjxghhpadsutr22wlykszs7swxrhl39ce9wufssstt7ps0xedqgmgf60sxffchm4lfg",
-                    "cosigner#3": "acct_shared_xvk1mpfqgfmnp9f6kp54g3wrj0gk8aheaej2e3cq9gyk638peq5xwspj4nkf5x9zg5jcstfncxznvvf8r827p5luggure9x5rzrd5t7vyggk4233e",
-                    "cosigner#6": "acct_shared_xvk1l0ztwzdx6lpv50xr5jrkqefz8gqzr4taskeum4rvw5jqdkpk3nncuddafnumlnvd6m7ep38krkqy5ngzepe6cyycd2t6tyn7ag845tgphjlek",
-                    "cosigner#8": "acct_shared_xvk1r7z7ahwx48su0j0kcdz47h5lrhulvn5l0z3y6kvavugd0v0jzfsge8uzkeg0r9tc2asrzkpuzr3zx8f8teh5sq7ytz2skfq0v0xa3ecd02ysy"
-                },
-                "template": {
-                    "some": {
-                        "at_least": 7,
-                        "from": [
-                            {
-                                "all": [
-                                    "cosigner#6",
-                                    {
-                                        "active_from": 2
-                                    },
-                                    "cosigner#8"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 4,
-                                    "from": [
-                                        {
-                                            "active_from": 3
-                                        },
-                                        {
-                                            "active_from": 9
-                                        },
-                                        {
-                                            "active_until": 8
-                                        },
-                                        "cosigner#1",
-                                        {
-                                            "active_from": 5
-                                        },
-                                        "cosigner#1",
-                                        {
-                                            "active_from": 0
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 3,
-                                    "from": [
-                                        "cosigner#2",
-                                        {
-                                            "active_from": 0
-                                        },
-                                        {
-                                            "active_from": 5
-                                        },
-                                        "cosigner#6"
-                                    ]
-                                }
-                            },
-                            {
-                                "all": [
-                                    {
-                                        "active_until": 1
-                                    },
-                                    "cosigner#3"
-                                ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 3,
-                                    "from": [
-                                        {
-                                            "active_until": 2
-                                        },
-                                        "cosigner#6",
-                                        {
-                                            "active_from": 3
-                                        },
-                                        {
-                                            "active_from": 9
-                                        },
-                                        "cosigner#4",
-                                        {
-                                            "active_from": 4
-                                        },
-                                        {
-                                            "active_from": 0
-                                        },
-                                        {
-                                            "active_from": 1
-                                        },
-                                        {
-                                            "active_until": 2
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        {
-                                            "active_until": 6
-                                        },
-                                        "cosigner#3"
-                                    ]
-                                }
-                            },
-                            {
-                                "some": {
-                                    "at_least": 1,
-                                    "from": [
-                                        {
-                                            "active_from": 9
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 6617597,
-                "epoch_number": 4959,
-                "height": {
-                    "quantity": 9155,
-                    "unit": "block"
-                },
-                "slot_number": 16064,
-                "time": "1889-07-13T20:21:36Z"
-            }
-        },
-        {
-            "account_index": "14887",
-            "address_pool_gap": 74142,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 18
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 10
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 254,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 197,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 21,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1v8pgeegylj276dxvef5r5a2pqjuwek7gumpa9fmn8pa9vg8p30z"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 10798,
-                            "epoch_start_time": "1877-12-25T00:00:00Z"
-                        },
-                        "status": "not_delegating"
-                    },
-                    {
-                        "changes_at": {
-                            "epoch_number": 14385,
-                            "epoch_start_time": "1896-04-06T20:00:00Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1mg8ew8s7rqrck8c263xmvqyqq9eh942qxrtmmrn4y3pkxkfc5hn"
-                    }
-                ]
-            },
+            "account_index": "1",
+            "address_pool_gap": 32004,
             "delegation_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1f3mqp7s6nx7yasgy2u5r7738mt6rr9veetn4jtlv2awdk7hmuhf7rrqcdte34ytsdk5rqetc6yn098kmhnknquhwxhhjdn6f49afk9c0gnvx9",
-                    "cosigner#1": "acct_shared_xvk1ayx49w9pdutrfzgzanrkwv3p9w32289504396w3m5jh9gfjl4lu2vfagm0kea4j4lasqw6k59733wqttxryn36yer6p7sadazghyj2cd6qn3g"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "any": [
-                                "cosigner#1",
-                                {
-                                    "active_until": 9
-                                },
-                                "cosigner#1",
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_until": 9
-                                },
-                                {
-                                    "active_until": 3
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 3,
-                                "from": [
-                                    "cosigner#1",
-                                    "cosigner#0",
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_until": 4
-                                    },
-                                    {
-                                        "active_from": 6
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 6,
-                                "from": [
-                                    {
-                                        "active_from": 3
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 2
-                                    },
-                                    {
-                                        "active_until": 0
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 5
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_from": 3
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 2
-                                },
-                                {
-                                    "active_from": 2
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    "cosigner#0"
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#1",
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 0
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "any": [
-                                "cosigner#0",
-                                "cosigner#1",
-                                {
-                                    "active_until": 7
-                                },
-                                "cosigner#0",
-                                {
-                                    "active_until": 7
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "89559c89ac52f1f276d30b5d31718d131e6857d4",
-            "name": "𪻎o`~z",
-            "passphrase": {
-                "last_updated_at": "1903-06-08T04:00:00Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#3": "acct_shared_xvk18ar2xzl6xsa2qt9w4kzeqetryg7ny4s4pe22l2fw3lf63kzvykrhvfnhkugnjv3qyqw0ar5nuq4zkxaeylzfczuysavv03kp43p4wtqnsnnnl",
-                    "cosigner#4": "acct_shared_xvk1l7m8q5yq620esf57dlx3awsmuyfjfrskkq5q8nz8707w3j66e2ezqetgep76wavjdgmvlgxvcm04hjt53fvmpwxk8pju89ks5rrt5yq97ehay"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "all": [
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_until": 1
-                                },
-                                {
-                                    "active_from": 7
-                                },
-                                {
-                                    "active_from": 4
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                "cosigner#5"
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_from": 4
-                                },
-                                "cosigner#3",
-                                {
-                                    "active_from": 6
-                                },
-                                {
-                                    "active_until": 1
-                                },
-                                {
-                                    "active_from": 6
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                "cosigner#4",
-                                {
-                                    "active_from": 9
-                                },
-                                {
-                                    "active_from": 1
-                                },
-                                {
-                                    "active_until": 5
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 6
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 8099225,
-                "epoch_number": 5203,
-                "height": {
-                    "quantity": 3403,
-                    "unit": "block"
-                },
-                "slot_number": 5107,
-                "time": "1890-02-16T10:01:55Z"
-            }
-        },
-        {
-            "account_index": "2182",
-            "address_pool_gap": 11626,
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#1": "acct_shared_xvk15px6djxlqq3fa4tr4suw97fwhu645hczn0e033kd6js5pcrjdaqhr3hesf780ndggajglljtmqj0yznsqlnvnfrrwcechv2wf4gecvsx4allr",
-                    "cosigner#4": "acct_shared_xvk1tyzqx65u5sdzavjdsv3wskclqr2rxwhn8p7nu5eup0cshhjhhmuk9tjtm4mkjhh8jlzazdvveynd8c7q8j7cyhryzq5mn0fy5q9g46s0lahag"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "all": [
-                                "cosigner#0",
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_until": 1
-                                },
-                                {
-                                    "active_from": 1
-                                },
-                                "cosigner#4",
-                                "cosigner#1",
-                                "cosigner#0"
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "90b84593cdf9f4e77c811eac00bb1cd6c4a7b41a",
-            "name": "I)jGɌ3p",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#1": "acct_shared_xvk1n7fhv0p9qa7tjwm6a3vekt776euaae7mnvc269fm78g87rrfssypfw6acz5ce05ffgxfleawx27d4wr4lpf8p9pj0hx7ymac4mqd7gq5l7ret",
-                    "cosigner#3": "acct_shared_xvk18523n366hqag5vxqy2sf3yxmrjdp7wfuhn5jvmtrypywkfqy5972yx3xegpgv8zgquy0c4p3gzx02ykyuj5h0zaj2fj4rcylxlscf2sn5wem4",
-                    "cosigner#4": "acct_shared_xvk1vl900k827aetem9dmt57defzr95ewn7x83kxj4xytypc7sw66pc00tkw3jc7w9qtgecscdu5rvtxy4vheye5mm4a7mm8640ydna28fq3su7vm"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "all": [
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                {
-                                    "active_from": 0
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 3
-                                },
-                                {
-                                    "active_until": 7
-                                },
-                                "cosigner#1",
-                                {
-                                    "active_until": 0
-                                },
-                                "cosigner#1",
-                                "cosigner#4",
-                                "cosigner#3"
-                            ]
-                        },
-                        {
-                            "all": [
-                                "cosigner#3"
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 5,
-                                "from": [
-                                    {
-                                        "active_from": 4
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    "cosigner#5",
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 9
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 3,
-                                "from": [
-                                    {
-                                        "active_until": 5
-                                    },
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 3
-                                    },
-                                    "cosigner#1"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "incomplete"
-            }
-        },
-        {
-            "account_index": "2159",
-            "address_pool_gap": 13218,
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk16sma20jcap4erq6ykp4qz4h7ge9e5r32mrgg5a2n8dfvalxjstqy6r92vz4w66l7wm86t56lfy4r9my8dm7w9qz0wa8yfg5t56gtvpqetrsvr"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "all": [
-                                {
-                                    "some": {
-                                        "at_least": 2,
-                                        "from": [
-                                            "cosigner#1",
-                                            "cosigner#1",
-                                            {
-                                                "active_until": 2
-                                            },
-                                            {
-                                                "active_from": 2
-                                            },
-                                            {
-                                                "active_from": 4
-                                            },
-                                            "cosigner#0",
-                                            "cosigner#0"
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "bad55c336d23b8731774cdc2410dccb49b86febd",
-            "name": "娂!OફAzH1tby1𫖿",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1kuw3rvcxjjcxaknfmm2rd2yjvqqvr9zp7fy58ysmw63cdvvsvsstdctfejtul03pjhmhkl99z9jyr9atsx9utf4zuetj2tt7vrge2psxhmxc3",
-                    "cosigner#1": "acct_shared_xvk1vfpp2r865smr5escwnvantmhsd2afxv9zqx2rdg64phtt6tl9unfzphjlfja33zakh570fw5fzms6xnrfyzrjqu2pcm7kspwvnevqxqdn0g23",
-                    "cosigner#2": "acct_shared_xvk10lz4n2ht7lrf7gkja6qcgtxnv20k8pl9e03guu2eu8lx9rajdsxyarcmt2fwjxrpm32us54z0l7lt0uhvvykd4fcm4ggchmduuhhz8qkntkju"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    {
-                                        "active_until": 2
-                                    },
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_from": 3
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    "cosigner#1"
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 3,
-                                "from": [
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_until": 2
-                                    },
-                                    "cosigner#2"
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                "cosigner#0",
-                                "cosigner#1",
-                                {
-                                    "active_until": 3
-                                },
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_from": 7
-                                },
-                                {
-                                    "active_until": 3
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                {
-                                    "active_from": 9
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_from": 3
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "some": {
-                                "at_least": 3,
-                                "from": [
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_until": 7
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_from": 9
-                                    },
-                                    {
-                                        "active_from": 2
-                                    },
-                                    "cosigner#0",
-                                    "cosigner#0"
-                                ]
-                            }
-                        },
-                        {
-                            "any": [
-                                "cosigner#2",
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                "cosigner#2",
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                "cosigner#0"
-                            ]
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "incomplete"
-            }
-        },
-        {
-            "account_index": "3787",
-            "address_pool_gap": 13507,
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#3": "acct_shared_xvk1mygrnpcvwdv2aqlz0dmqm74d6w7qxsfzrglc5yaxxwar7ltpwafftl0dfcpu7l4gpj8eka5vuujphyjgggkdllsvu9h2jafvkwqc33s29efrv"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "active_from": 3
-                        },
-                        {
-                            "active_from": 4
-                        },
-                        "cosigner#3",
-                        "cosigner#1",
-                        "cosigner#2",
-                        "cosigner#5",
-                        {
-                            "active_from": 9
-                        },
-                        {
-                            "active_from": 5
-                        },
-                        {
-                            "active_from": 7
-                        }
-                    ]
-                }
-            },
-            "id": "ba46765908e3ca4aed5b267f08289d217b907f3d",
-            "name": "𧅎M|9技Sퟺ𝄙qi㇃들QDl",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#2": "acct_shared_xvk1s3gjvm6uqa2a58832swjkhzl0ta4aqfc6wa638amw8q35x7sms09entedwn6xz2gekvdv0yml7mjsydaj4gsz0smnj8za3ulls2skvg9rvlyl"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_until": 0
-                                    },
-                                    {
-                                        "active_from": 7
-                                    },
-                                    {
-                                        "active_until": 2
-                                    },
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    "cosigner#2",
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_from": 4
-                                    },
-                                    {
-                                        "active_until": 4
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "incomplete"
-            }
-        },
-        {
-            "account_index": "7695",
-            "address_pool_gap": 9789,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 9
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 10
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 6
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 5
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 63
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 17
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 20
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 19
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 13
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 249,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 34,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 149,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 11556,
-                            "epoch_start_time": "1881-04-21T15:13:33.64207264508Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1pktztm5fpr46ewenkk0j25pz4m94fa2mxml4t7j69zv376nedjj"
-                    }
-                ]
-            },
-            "id": "8b41606355884e4cdeabba1206784a4165125f24",
-            "name": "덑RGb",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1rmdav4ea0j96es47kxkczg5sr20gz223vfmk2t92lrs38apgfhkpsx6gma0vtcsrm3em6vm678ml6vvpfxvxg6pvargy7qqvmjcfucgmm95zy",
-                    "cosigner#3": "acct_shared_xvk1kc59gnmjq948j68r26fc69z2v792qzw2wuly9m08jq6pg3m9su35c6g8ztsqzq742knrm9m3zht77flqq2nr0mcsylufz664j764c9gwn4fwn",
-                    "cosigner#4": "acct_shared_xvk1j0a4qwvdqmp3wya4wtwqlanxmc4cgmqwpqmykaq5hm4dsyk2asgur953t8ljkmw8r990uqpghw3kj096pznsne6d9kn3du7g6fscx7q940gcw",
-                    "cosigner#7": "acct_shared_xvk16msypxjaqp4ftl9mfehdy77t78luk7jpkt9ayrxds5ctfw6m8l6svtz8vfkar2drplzvsklhh2zjxy6ajps7pkmxaduz9v26rpuljyc52mku3"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "all": [
-                                {
-                                    "active_from": 1
-                                },
-                                "cosigner#9"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 3
-                                },
-                                "cosigner#7",
-                                {
-                                    "active_from": 9
-                                },
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_from": 8
-                                },
-                                {
-                                    "active_until": 8
-                                },
-                                "cosigner#0"
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_until": 8
-                                },
-                                "cosigner#4",
-                                "cosigner#7"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 2
-                                },
-                                {
-                                    "active_from": 1
-                                },
-                                "cosigner#8",
-                                "cosigner#0",
-                                "cosigner#8",
-                                {
-                                    "active_until": 7
-                                }
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_until": 5
-                                },
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_until": 6
-                                },
-                                "cosigner#4",
-                                "cosigner#3"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_from": 3
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                {
-                                    "active_from": 5
-                                },
-                                {
-                                    "active_from": 0
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                "cosigner#9",
-                                {
-                                    "active_from": 8
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "progress": {
-                    "quantity": 76.45,
-                    "unit": "percent"
-                },
-                "status": "syncing"
-            },
-            "tip": {
-                "absolute_slot_number": 3838404,
-                "epoch_number": 11120,
-                "height": {
-                    "quantity": 9211,
-                    "unit": "block"
-                },
-                "slot_number": 728,
-                "time": "1893-04-28T02:00:00Z"
-            }
-        },
-        {
-            "account_index": "7604",
-            "address_pool_gap": 95415,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 23
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 29
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 21
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 41
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 13
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 247,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 22,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 70,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool18gmgc7latd42ytmkkh2vdfsnc6lr5mye28nn2czv022q7gu2wh4"
-                },
-                "next": []
-            },
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1ht628sm5an676g35kaw27xtxwp0hsjjllz7ddhwp4cgk92jz3x34g6mlaxmpy094705phs8npngpkj93czpusmsalezg2zcc04u6d8gzhrpl2",
-                    "cosigner#1": "acct_shared_xvk179vs977azs7x9lgt2rgdsj8ksxpv098uxq6qz4cldzt8xzahp2ezww8ajd5ds2lrefps7x98c63qqx2wjvm5rl8m4lekkwphwasnh6cavvwy8"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "all": [
-                                "cosigner#0",
-                                {
-                                    "active_until": 0
-                                },
-                                "cosigner#1",
-                                {
-                                    "active_until": 3
-                                },
-                                {
-                                    "active_from": 8
-                                }
-                            ]
-                        },
-                        {
-                            "any": [
-                                "cosigner#1"
-                            ]
-                        },
-                        {
-                            "any": [
-                                {
-                                    "active_from": 9
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_until": 8
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 2
-                                    },
-                                    "cosigner#3",
-                                    {
-                                        "active_until": 2
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "id": "f87b579f56601bd50f5b6e026c06a0aa98e95995",
-            "name": "꼋PWF4whu𤗈.%!e%Lk잻𧒧E^㖭U@E",
-            "passphrase": {
-                "last_updated_at": "1884-09-10T23:38:21Z"
-            },
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#3": "acct_shared_xvk1ppzxrfp7l0mqn2h73eddf3c6g0pf6lflsxrptgpzw36mkl0p8rk53a82v6w96hj63dm93dt0z2a9epyg4mx0k4umkn2l2r34qv0x2acrurm3x",
-                    "cosigner#5": "acct_shared_xvk1m3ljg8znc4qzwgl7jrqsnvfrjqqjkwxv37v80jy6fhsnl9lstqr96285y7hgadnxr6fe4z4wmsmv7te0je92lnlmtyt7tces84d684cmm2en8"
-                },
-                "template": {
-                    "any": [
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    "cosigner#3",
-                                    "cosigner#2",
-                                    "cosigner#3"
-                                ]
-                            }
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_until": 9
-                                },
-                                "cosigner#5"
-                            ]
-                        },
-                        {
-                            "all": [
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_until": 8
-                                },
-                                "cosigner#3",
-                                {
-                                    "active_until": 9
-                                },
-                                {
-                                    "active_from": 3
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                {
-                                    "active_until": 7
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 2,
-                                "from": [
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#3"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 1747327,
-                "epoch_number": 5957,
-                "height": {
-                    "quantity": 3413,
-                    "unit": "block"
-                },
-                "slot_number": 2355,
-                "time": "1868-01-03T11:00:00Z"
-            }
-        },
-        {
-            "account_index": "493",
-            "address_pool_gap": 71281,
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#4": "acct_shared_xvk12gep48g47xhdt8rs4twg4ktw8u2xq30qczrkmg6jszvtg2zq7r8danctnquenhljsk6krwhjs6dkrhu3p6cjswdrxv7vx5qvcpmqljctk3a25",
-                    "cosigner#5": "acct_shared_xvk150tn9me2y6ahzqyn5zznpfx5cxlp2e7edlgyhcpwnlcvpqk5tjlxzca5x6nsnj2pn57lx3tuhax5xkma0swv6q6sngxszzelr3uv9rs43cd20"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "all": [
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_from": 3
-                                },
-                                "cosigner#5",
-                                {
-                                    "active_from": 0
-                                },
-                                "cosigner#5",
-                                {
-                                    "active_until": 4
-                                },
-                                {
-                                    "active_from": 4
-                                },
-                                {
-                                    "active_from": 8
-                                }
-                            ]
-                        },
-                        {
-                            "all": [
-                                "cosigner#4",
-                                {
-                                    "active_until": 0
-                                },
-                                {
-                                    "active_from": 5
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 1,
-                                "from": [
-                                    {
-                                        "active_from": 1
-                                    },
-                                    {
-                                        "active_from": 2
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "id": "b8c4ccf09ae5970d4c4c82efe719892cae662f3a",
-            "name": "9p㠯2*F?C\\xK8𐅦W8𪼷6r聠8J?䧣k",
-            "payment_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1870xsck9083704sza9ja5ygu6936q77wtvw9yfy4u39nujalsz32005mfgthd3lxey7c0ptu3tcyaus22c5gvws7g9l0f5dqxcqlsrgjgrtut"
-                },
-                "template": {
-                    "all": [
-                        {
-                            "all": [
-                                {
-                                    "any": [
-                                        "cosigner#1",
-                                        {
-                                            "active_until": 6
-                                        },
-                                        {
-                                            "active_until": 7
-                                        },
-                                        {
-                                            "active_from": 3
-                                        },
-                                        {
-                                            "active_until": 7
-                                        },
-                                        "cosigner#0",
-                                        {
-                                            "active_from": 7
-                                        },
-                                        {
-                                            "active_until": 8
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "some": {
-                                "at_least": 4,
-                                "from": [
-                                    "cosigner#0",
-                                    {
-                                        "active_until": 1
-                                    },
-                                    {
-                                        "active_until": 7
-                                    },
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 4
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "state": {
-                "status": "incomplete"
-            }
-        },
-        {
-            "account_index": "14494",
-            "address_pool_gap": 1664,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 16
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 21
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 21
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 18
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 219,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 77,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 69,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool165yy0t9ddke5p2pl0sder227e2ezreyx5s29gn3ndt6dght797l"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 14677,
-                            "epoch_start_time": "1899-09-09T05:18:02Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1vvv9nt04la2kzgx6nxkerpn0sakznk4l3pmcxdhs6kmhj2xk6dr"
-                    }
-                ]
-            },
-            "delegation_script_template": {
-                "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1udr5dszx8qvjdg482vhx9r9utrjcusw5vhukrghq6xs3lmlf7skczcert8rawxn5n63fszjxt6jrf6xkz9gkvevsgejq40kgs0ykmegz4nwva",
-                    "cosigner#1": "acct_shared_xvk142spuxgsyhe87vzrqtupvz3tckh77ppz90nmcqfd4a4d3wj56cuvs7scxd9jslsnwen3qa8dat9pt4ynejaeh2zmd5m83d9xq5shkfs0jruyh"
+                    "cosigner#0": "acct_shared_xvk1qszqyqqqqvqsgqqyqqqsgqsrqypsqqsrqgpqyqczqgzqqqgrqqpqgpqqqqqsqqgyqspsxqqzqqpsgpqqqyqszqqyqvpsyqqyqypqgqsgewh3r"
                 },
                 "template": {
                     "some": {
@@ -1644,125 +13,515 @@
                         "from": [
                             {
                                 "any": [
-                                    "cosigner#1",
                                     {
                                         "active_until": 2
                                     },
-                                    "cosigner#0",
-                                    "cosigner#0",
-                                    {
-                                        "active_from": 3
-                                    },
-                                    {
-                                        "active_until": 6
-                                    },
-                                    {
-                                        "active_from": 1
-                                    }
+                                    "cosigner#0"
                                 ]
-                            },
-                            {
-                                "some": {
-                                    "at_least": 2,
-                                    "from": [
-                                        "cosigner#0",
-                                        "cosigner#0",
-                                        {
-                                            "active_from": 3
-                                        },
-                                        "cosigner#1",
-                                        {
-                                            "active_from": 5
-                                        },
-                                        "cosigner#1"
-                                    ]
-                                }
                             }
                         ]
                     }
                 }
             },
-            "id": "7ab4c5459ad4f423b2954d360794fa8e345fcc06",
-            "name": "ycJo𗇭٦@j),g,m=/Ice",
+            "id": "ec7ea7d3261932106b3581dfae655dc584731c0f",
+            "name": "8LGS𧡨",
             "payment_script_template": {
                 "cosigners": {
-                    "cosigner#0": "acct_shared_xvk1l284kpnlkeynplu7t4rx42h279sps9qehszdxjayg5zaaezgkdh77mz9gnmkkyv05xftsn4hmusvxr8yp9ldtn3l4udx89gazqrq8tqdn35hs",
-                    "cosigner#1": "acct_shared_xvk1mzeuqevwr6h5tmmlucnuxthpplh0dga2ew9t26508lwn05wwktpyx4yzgssmhmctgfd7f4y7sc5pct6ydv9lzc5lltsd395pffhqzuspzlzsf"
+                    "cosigner#2": "acct_shared_xvk1qvpsxqcyqqqqxqcpqypsxqszqqqqzpqqqqqsgqspqqpsyqqpqgpsypqpqsqqyqqrqszqzpqrqqpqqqcqqvzqyqcyqspsqqqqqvpsyqcellayn"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#2"
+                    ]
+                }
+            },
+            "state": {
+                "status": "incomplete"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 71881,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 16981996248933888,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 1134716833472424,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qqqsqqqqqqqqqqqzqypqyqqqqgqsqqgzqqpqqqgqqqpqyckhaep"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1861-10-15T10:34:34.412451471315Z"
+                        },
+                        "status": "not_delegating"
+                    },
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1899-02-13T13:00:00Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qqpqyqqzqyqqyqsqqyqsyqqqqgqszqqqqgqsqqgpqgqqq27kd4z"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#6": "acct_shared_xvk1qyqqyqgzqgpqzqqzqqqqyqqqqgpqzqqpqypqyqspqyqqzqsqqgpqzqszqqpqzqspqqqszqqzqyqqqqqpqgqqyqgpqqqqyqsqqyqsqqq8w8swd"
+                },
+                "template": "cosigner#6"
+            },
+            "id": "823034d6e7e126748e9068345f3b9b04e2f7c690",
+            "name": "[&",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1889-09-23T00:00:00Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qyqqzqgpqgpqqqszqqqqqqqqqgqqzqqpqqqqqqqpqqqszqgqqypqqqspqgqsyqqpqqqqyqszqqqqzqgzqqqqyqgzqypqqqszqyqsyqqln4l6v"
+                },
+                "template": "cosigner#1"
+            },
+            "state": {
+                "progress": {
+                    "quantity": 56.37,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 1,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1898-04-07T02:00:00Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 68693,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 7998934729011804,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 26030747940547196,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 32081322301089508,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qgpqqqqpqgqsqqqzqypqqqgpqqqqyqgzqypqqqqqqyqqyz2fd2m"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 1,
+                            "epoch_start_time": "1878-10-08T19:20:33.201626803014Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qqqqqqgqqqqsqqqqqgqqqqgzqqpqqqgzqgqqqqqzqyqqynpfvs2"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#4": "acct_shared_xvk1qgpqqqgpqgpqzqqqqypqqqgzqypqqqqpqqqsyqspqyqsqqgqqypqqqqpqqqszqgpqgqsyqspqqqsqqsqqyqsyqspqyqqqqgpqyqqqqsm7v5p2"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#4"
+                    ]
+                }
+            },
+            "id": "681ecf1ba31f9499a9d55ed2723ed30d814c111d",
+            "name": "y",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1878-05-03T17:17:37.857586719815Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqsyqgzqgqsqqqzqqqsyqszqqpqzqgqqqpqyqsqqyqszqgzqyqqyqsqqypqzqgpqgpqqqqpqqqszqgpqgpqyqszqgqqyqgqqyqsyqgqxc5fu"
                 },
                 "template": {
                     "any": [
                         {
-                            "all": [
-                                {
-                                    "active_from": 1
-                                },
-                                "cosigner#0",
-                                {
-                                    "active_until": 9
-                                },
-                                "cosigner#1",
-                                {
-                                    "active_from": 5
-                                },
-                                {
-                                    "active_until": 7
-                                },
-                                {
-                                    "active_until": 4
-                                },
-                                {
-                                    "active_until": 0
-                                }
-                            ]
+                            "active_from": 1
                         },
+                        "cosigner#1"
+                    ]
+                }
+            },
+            "state": {
+                "progress": {
+                    "quantity": 26.89,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 1,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1879-03-18T23:21:48Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 96084,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 32204788913769744,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 42448543827073907,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": []
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqsyqspqgqszqgpqypqzqspqypqqqgzqgqqyqszqgpqzqgpqgqqzqqzqypqqqgpqypqyqgpqqqszqqqqypqqqgpqqpqyqqqqqqsqqs6yql9y"
+                },
+                "template": "cosigner#1"
+            },
+            "id": "4ae5c71f09ae2f6b2ec8cca2b5ce8c2b8b44d197",
+            "name": "𪣣𗆁",
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qgpqqqqqqqqqyqqqqypqyqqqqgpqyqqzqqpqzqgqqgqqzqgzqgqszqgzqqqsyqqzqqqqqqqpqgqqqqszqgqqqqqpqgqsqqqzqypqqqg8arrr2"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#1"
+                    ]
+                }
+            },
+            "state": {
+                "status": "not_responding"
+            },
+            "tip": {
+                "absolute_slot_number": 3,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1878-05-06T15:00:00Z"
+            }
+        },
+        {
+            "account_index": "1",
+            "address_pool_gap": 61070,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 18354242100844811,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 2359130235822698,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qqqsqqqpqgpqqqspqypqyqqpqyqsqqqqqqqqzqqpqqqszsch08v"
+                },
+                "next": []
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#4": "acct_shared_xvk1qqqsqqgpqyqsqqspqgqqqqgpqyqqyqqzqypqqqszqgpqyqqzqqqszqsqqqqqzqqqqqqqzqgqqgpqqqqzqyqszqqzqgqsqqspqgpqzqs4p9qw2"
+                },
+                "template": {
+                    "all": [
+                        "cosigner#4"
+                    ]
+                }
+            },
+            "id": "82cf6baf3ce60a491d463b4ca30092793ebe7714",
+            "name": "k,",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1900-09-14T00:00:00Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#8": "acct_shared_xvk1qgpqqqsqqqqszqgzqgqqqqsqqgpqzqgzqqqqzqspqqqszqqzqyqsyqqqqyqqqqqzqyqszqgqqyqqyqqqqgqsqqqqqypqzqqpqqpqyqqqerxtq"
+                },
+                "template": "cosigner#8"
+            },
+            "state": {
+                "progress": {
+                    "quantity": 82.98,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1896-09-19T20:00:00Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 2219,
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#8": "acct_shared_xvk1qszqqqcrqvzqqqcrqypsgqcpqypqgqqpqspsqqqqqvzqxqszqgpsyqcrqqpqxqszqspsqqgyqqpqyqgqqqqsyqsyqyqsqqsyqsqsqqc0vddsc"
+                },
+                "template": {
+                    "any": [
                         {
                             "some": {
                                 "at_least": 1,
                                 "from": [
                                     {
-                                        "all": [
-                                            {
-                                                "active_until": 4
-                                            },
-                                            {
-                                                "active_until": 5
-                                            },
-                                            {
-                                                "active_from": 8
-                                            },
-                                            "cosigner#0"
-                                        ]
-                                    }
+                                        "active_from": 0
+                                    },
+                                    "cosigner#8"
                                 ]
                             }
-                        },
-                        {
-                            "all": [
-                                "cosigner#1",
-                                {
-                                    "active_from": 5
-                                },
-                                {
-                                    "active_from": 7
-                                },
-                                {
-                                    "active_until": 6
-                                },
-                                {
-                                    "active_until": 2
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                {
-                                    "active_until": 5
-                                },
-                                {
-                                    "active_until": 0
-                                },
-                                "cosigner#1"
-                            ]
                         }
+                    ]
+                }
+            },
+            "id": "b3ed640cf65b912d78e3c1671bdf86c43a9fd13a",
+            "name": "YQ䑱텞7",
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qvzqgqqyqqpsgqqzqqpqyqqpqszqyqqpqsqsxqqqqvqsqqcrqgqqqqgyqsqsgpqpqvzqqqqpqvqqzqcqqqpsyqsyqgqsyqspqgzqzqcna3ned"
+                },
+                "template": {
+                    "some": {
+                        "at_least": 1,
+                        "from": [
+                            {
+                                "any": [
+                                    {
+                                        "active_until": 1
+                                    },
+                                    "cosigner#1"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "state": {
+                "status": "incomplete"
+            }
+        },
+        {
+            "account_index": "2",
+            "address_pool_gap": 76027,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 7634016996974216,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 32220093377725980,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 37410644345060116,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": []
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#3": "acct_shared_xvk1qyqqyqqzqgqsyqgqqypqyqqzqgqszqgqqqpqqqgpqqqqyqspqgqqzqqzqyqqyqszqgpqyqgpqgqqyqqqqyqszqsqqgqqzqgzqqpqqqg9lzdps"
+                },
+                "template": {
+                    "some": {
+                        "at_least": 1,
+                        "from": [
+                            "cosigner#3",
+                            {
+                                "active_from": 1
+                            }
+                        ]
+                    }
+                }
+            },
+            "id": "88f549e22b2eacc141e8872723a9844235b5120f",
+            "name": "!",
+            "passphrase": {
+                "encryption_method": "scrypt",
+                "last_updated_at": "1886-03-19T02:31:06Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqsqqszqqqsqqsqqgqqzqspqgqqyqsqqypqzqspqqpqqqqpqypqzqgpqyqszqgqqgpqqqqpqgqqyqqqqgqqzqsqqgqqzqgzqqqsyqqvlztsj"
+                },
+                "template": {
+                    "some": {
+                        "at_least": 1,
+                        "from": [
+                            "cosigner#1"
+                        ]
+                    }
+                }
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 1,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1898-08-06T19:22:01.864228176631Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 13789,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 32539741285591088,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1869-10-29T18:28:01.444409645353Z"
+                        },
+                        "status": "not_delegating"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qgqsyqgpqqqqzqgzqqpqyqqqqgqsqqgqqgqszqszqypqzqszqgpqzqqqqyqsyqgpqgqsqqgzqyqqzqsqqgpqyqsqqypqqqsqqypqzqqyzxptd"
+                },
+                "template": {
+                    "some": {
+                        "at_least": 2,
+                        "from": [
+                            "cosigner#1",
+                            {
+                                "active_from": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "id": "c9e507e1c19e38a12c9f63b42879f8d3bb469ed0",
+            "name": "Q",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1900-06-29T16:00:42.12669903758Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqqqqgqqgpqzqqzqyqsyqgpqypqyqsqqgqqzqspqgqqzqqqqypqzqsqqqpqzqsqqypqyqqpqqpqzqqpqypqzqqpqqqqzqqzqqqsqqsnxc6l2"
+                },
+                "template": {
+                    "all": [
+                        {
+                            "active_until": 1
+                        },
+                        "cosigner#1"
                     ]
                 }
             },
@@ -1770,16 +529,115 @@
                 "status": "ready"
             },
             "tip": {
-                "absolute_slot_number": 5302703,
-                "epoch_number": 13177,
+                "absolute_slot_number": 1,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 652,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 315,
-                "time": "1906-07-06T11:00:00Z"
+                "slot_number": 1,
+                "time": "1905-10-20T22:01:58.034804890833Z"
+            }
+        },
+        {
+            "account_index": "0",
+            "address_pool_gap": 13546,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 30281634727828452,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 2,
+                            "epoch_start_time": "1874-06-03T08:00:00Z"
+                        },
+                        "status": "not_delegating"
+                    }
+                ]
+            },
+            "delegation_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqqqzqsqqgqqzqszqqpqzqqpqypqyqgzqqpqyqgzqqpqzqgqqyqqyqspqyqsyqqpqqqqyqszqypqqqsqqqqsqqgpqqpqyqgzqqqqqqs3rgdke"
+                },
+                "template": "cosigner#1"
+            },
+            "id": "d7712e11e6c5503417b9a7ad71f7dabcf6fbbad7",
+            "name": "~",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1861-02-13T21:03:02Z"
+            },
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#1": "acct_shared_xvk1qqpqyqspqgqqzqgpqgqszqqzqgpqyqszqgqqqqqpqqqqzqgpqgqqzqszqypqzqgpqgqqyqgqqgpqyqgpqgpqyqqqqypqyqgpqqqqqqqz20jd4"
+                },
+                "template": {
+                    "any": [
+                        "cosigner#1"
+                    ]
+                }
+            },
+            "state": {
+                "progress": {
+                    "quantity": 4.77,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1867-12-01T09:00:00Z"
+            }
+        },
+        {
+            "account_index": "2",
+            "address_pool_gap": 95790,
+            "id": "b254887e44889485bda8b95bb3e7d226b5e7ee25",
+            "name": "*6𱐿_",
+            "payment_script_template": {
+                "cosigners": {
+                    "cosigner#2": "acct_shared_xvk1qvqqypqrqsqsxqqqqqzqzqsqqgpqqqczqvpsqqszqypqzqczqvqsyqcrqgqsqqqrqvpszqqqqvpqgpqpqszqgqgqqyqqgqsqqszqgqcgphgdn"
+                },
+                "template": {
+                    "any": [
+                        {
+                            "all": [
+                                "cosigner#5",
+                                "cosigner#2"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "state": {
+                "status": "incomplete"
             }
         }
     ],
-    "seed": -1397094827
+    "seed": -1500034355
 }

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiWallet.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiWallet.json
@@ -1,676 +1,69 @@
 {
     "samples": [
         {
-            "address_pool_gap": 28630,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 10
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 156,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 115,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 254,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 15427,
-                            "epoch_start_time": "1871-03-12T01:00:00Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1z0h0p2yauueteq4mk4keahlnjg4zke5sfp9cvu36np45w4l7lqn"
-                    }
-                ]
-            },
-            "id": "52815252d7c58ef32122fd45565cef65f2012c3a",
-            "name": "9𩨂B:9_a𬲠9c딞녳^9$e4G0Xv?",
-            "passphrase": {
-                "last_updated_at": "1893-08-28T08:00:00Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 4473166,
-                "epoch_number": 2403,
-                "height": {
-                    "quantity": 12764,
-                    "unit": "block"
-                },
-                "slot_number": 3047,
-                "time": "1874-03-07T11:02:33Z"
-            }
-        },
-        {
-            "address_pool_gap": 51118,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 7
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 1
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 25
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 21
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 25
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 18
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 12
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 17,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 241,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 111,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1klmt5mysdn65376m42m6h8tga4g3j94x5sx70ndyhw5q5kw66a8"
-                },
-                "next": []
-            },
-            "id": "c8f2b50c6fa143530cf12155b296487d1ca0b274",
-            "name": "=𥱗t:",
-            "passphrase": {
-                "last_updated_at": "1892-07-09T12:25:14.828438044945Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 2348567,
-                "epoch_number": 5776,
-                "height": {
-                    "quantity": 11286,
-                    "unit": "block"
-                },
-                "slot_number": 15869,
-                "time": "1892-06-05T23:43:14.41446163682Z"
-            }
-        },
-        {
-            "address_pool_gap": 49402,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 6
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 2
-                    }
-                ],
-                "total": []
-            },
-            "balance": {
-                "available": {
-                    "quantity": 88,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 196,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 113,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1tad9ghyl6n9z7p4v7gvhzhavnpdxpc5jn3hem0nhql9rchu5kqe"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 13537,
-                            "epoch_start_time": "1882-09-20T01:00:00Z"
-                        },
-                        "status": "not_delegating"
-                    },
-                    {
-                        "changes_at": {
-                            "epoch_number": 3091,
-                            "epoch_start_time": "1863-05-11T08:22:01.47920926161Z"
-                        },
-                        "status": "not_delegating"
-                    }
-                ]
-            },
-            "id": "9b9a90c457726f83d7208156899241cdd29066d5",
-            "name": "b횝槽T(8q𢒯o𱇝La",
-            "passphrase": {
-                "last_updated_at": "1882-09-03T03:39:37Z"
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 7295340,
-                "epoch_number": 6508,
-                "height": {
-                    "quantity": 104,
-                    "unit": "block"
-                },
-                "slot_number": 7723,
-                "time": "1899-03-01T20:34:13Z"
-            }
-        },
-        {
-            "address_pool_gap": 63344,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 6
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 26,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 55,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 252,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1tzcy5nmjfdvwk8hszndu3k4dmy454d0r9vetnmgddfqqv38hmqh"
-                },
-                "next": []
-            },
-            "id": "42b1f5edb9a7c6e2f42fc1dea360723362136eb4",
-            "name": "OK세#Pp7*+O9",
-            "passphrase": {
-                "last_updated_at": "1897-09-05T16:00:00Z"
-            },
-            "state": {
-                "progress": {
-                    "quantity": 36.27,
-                    "unit": "percent"
-                },
-                "status": "syncing"
-            },
-            "tip": {
-                "absolute_slot_number": 2304621,
-                "epoch_number": 1666,
-                "height": {
-                    "quantity": 10138,
-                    "unit": "block"
-                },
-                "slot_number": 1637,
-                "time": "1872-11-28T20:38:29.509012608403Z"
-            }
-        },
-        {
-            "address_pool_gap": 4978,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 52
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 27
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 42
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 24
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 25
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 39
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 4
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 244,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 51,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 219,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "not_delegating"
-                },
-                "next": []
-            },
-            "id": "a7bb2535c16a80adfb3eb9bcd5bb220f8658c261",
-            "name": ">k6",
-            "passphrase": {
-                "last_updated_at": "1877-02-06T16:00:00Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 3088159,
-                "epoch_number": 9338,
-                "height": {
-                    "quantity": 14867,
-                    "unit": "block"
-                },
-                "slot_number": 8360,
-                "time": "1889-07-30T19:57:04Z"
-            }
-        },
-        {
-            "address_pool_gap": 44556,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 1
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 27
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 36,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 74,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 58,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1qs3lymey7s89fhgp39wnnw469aterjka85qe6590qldjg5c6eyy"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 10793,
-                            "epoch_start_time": "1887-12-01T08:08:29.173931750584Z"
-                        },
-                        "status": "not_delegating"
-                    },
-                    {
-                        "changes_at": {
-                            "epoch_number": 164,
-                            "epoch_start_time": "1905-04-18T13:00:00Z"
-                        },
-                        "status": "not_delegating"
-                    }
-                ]
-            },
-            "id": "3d950ad13d7f3f8109fe444aa3299cc50f547f78",
-            "name": "v[*틾kI𧕾Db𘙨X밁\"",
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 516889,
-                "epoch_number": 8760,
-                "height": {
-                    "quantity": 12499,
-                    "unit": "block"
-                },
-                "slot_number": 10083,
-                "time": "1865-05-24T22:34:44.628855115253Z"
-            }
-        },
-        {
-            "address_pool_gap": 61797,
-            "assets": {
-                "available": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 4
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 9
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 11
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 3
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 29
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 19
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 20
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 2
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "44444444444444444444444444444444444444444444444444444444",
-                        "quantity": 26
-                    }
-                ],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 22
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "00000000000000000000000000000000000000000000000000000000",
-                        "quantity": 28
-                    },
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 14
-                    },
-                    {
-                        "asset_name": "546f6b656e44",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 6
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 16
-                    },
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 16
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "22222222222222222222222222222222222222222222222222222222",
-                        "quantity": 27
-                    },
-                    {
-                        "asset_name": "546f6b656e43",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 12
-                    },
-                    {
-                        "asset_name": "546f6b656e45",
-                        "policy_id": "33333333333333333333333333333333333333333333333333333333",
-                        "quantity": 3
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 137,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 182,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 224,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1nxz36dljt3fs3nalp9l6vvnz88gx2kvd465vm7vcv6k7xqwpn76"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 10951,
-                            "epoch_start_time": "1901-03-31T12:37:44Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool1hm4c3ftvjza3ueyv93rrfc6g57qjtnaujdhyjdvfhyr3j7t9crs"
-                    }
-                ]
-            },
-            "id": "44a5398c8aaa53c9bfcff2107129860a8663abfa",
-            "name": "D?;U.2]i𦨓3&dNV9+\\~0𧦒𘭭>)7",
-            "passphrase": {
-                "last_updated_at": "1889-07-10T00:23:35Z"
-            },
-            "state": {
-                "status": "ready"
-            },
-            "tip": {
-                "absolute_slot_number": 3070548,
-                "epoch_number": 12150,
-                "height": {
-                    "quantity": 8712,
-                    "unit": "block"
-                },
-                "slot_number": 10771,
-                "time": "1863-11-21T15:00:00Z"
-            }
-        },
-        {
-            "address_pool_gap": 73030,
-            "assets": {
-                "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e42",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 13
-                    }
-                ]
-            },
-            "balance": {
-                "available": {
-                    "quantity": 142,
-                    "unit": "lovelace"
-                },
-                "reward": {
-                    "quantity": 159,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 246,
-                    "unit": "lovelace"
-                }
-            },
-            "delegation": {
-                "active": {
-                    "status": "delegating",
-                    "target": "pool16ytz2kmh7plm763lg0anlf2fxhlcgkpurvmaaaru75uug998vvh"
-                },
-                "next": [
-                    {
-                        "changes_at": {
-                            "epoch_number": 3587,
-                            "epoch_start_time": "1901-06-15T11:05:13Z"
-                        },
-                        "status": "delegating",
-                        "target": "pool10e5krun5q9psq7c66teck66m9ltgkx4sne2q6ts06y3u2msvcas"
-                    }
-                ]
-            },
-            "id": "21a6135c0a5e62d052ccb579181c397d528c56cf",
-            "name": "^,𫊫&&6m볲𬁇4",
-            "passphrase": {
-                "last_updated_at": "1899-10-20T05:30:31.388655691274Z"
-            },
-            "state": {
-                "status": "not_responding"
-            },
-            "tip": {
-                "absolute_slot_number": 4683755,
-                "epoch_number": 11417,
-                "height": {
-                    "quantity": 1973,
-                    "unit": "block"
-                },
-                "slot_number": 12412,
-                "time": "1896-05-20T14:58:51.390252407918Z"
-            }
-        },
-        {
-            "address_pool_gap": 75178,
+            "address_pool_gap": 65749,
             "assets": {
                 "available": [],
                 "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 18,
+                    "quantity": 18007287804391550,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 218,
+                    "quantity": 30459419090888971,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 191,
+                    "quantity": 40450694970802992,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qyqsyqqqqgqqyqspqypqyqgpqgpqqqgqqgqqqqspqyqszuhx7g9"
+                },
+                "next": []
+            },
+            "id": "5a4e800b0232acef22bf564df341cd96a31c0d71",
+            "name": "H",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1876-06-09T16:59:51.772459457027Z"
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1895-12-18T15:10:18Z"
+            }
+        },
+        {
+            "address_pool_gap": 51885,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 9116243534147245,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 1732674774005218,
                     "unit": "lovelace"
                 }
             },
@@ -680,86 +73,448 @@
                 },
                 "next": []
             },
-            "id": "fac2e6e8917412f35db916ed555eab5f2ce515be",
-            "name": "𠫗U[vvT𦫢𢲼~",
+            "id": "85c5c6af0bfa8b3a19748dd0273a64ed5ba364ad",
+            "name": "P𜷉:",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1874-12-18T00:00:00Z"
+            },
             "state": {
-                "status": "ready"
+                "status": "not_responding"
             },
             "tip": {
-                "absolute_slot_number": 701640,
-                "epoch_number": 10193,
+                "absolute_slot_number": 4,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 9392,
+                    "quantity": 1,
                     "unit": "block"
                 },
-                "slot_number": 16016,
-                "time": "1906-11-11T10:19:09Z"
+                "slot_number": 0,
+                "time": "1870-10-04T11:00:00Z"
             }
         },
         {
-            "address_pool_gap": 62294,
+            "address_pool_gap": 89746,
             "assets": {
                 "available": [],
-                "total": [
-                    {
-                        "asset_name": "546f6b656e41",
-                        "policy_id": "11111111111111111111111111111111111111111111111111111111",
-                        "quantity": 14
-                    }
-                ]
+                "total": []
             },
             "balance": {
                 "available": {
-                    "quantity": 138,
+                    "quantity": 0,
                     "unit": "lovelace"
                 },
                 "reward": {
-                    "quantity": 221,
+                    "quantity": 0,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 239,
+                    "quantity": 45000000000000000,
                     "unit": "lovelace"
                 }
             },
             "delegation": {
                 "active": {
                     "status": "delegating",
-                    "target": "pool1g4juxxcrk2t9vam245a5qw7vskus36cn8pyxzxcvqgf2wjn482s"
+                    "target": "pool1qqqqyqqqqgpqzqspqgqsyqsqqgqszqgpqypqzqgqqgpqzaklyg6"
                 },
                 "next": [
                     {
                         "changes_at": {
-                            "epoch_number": 5335,
-                            "epoch_start_time": "1893-04-02T14:05:37.410920484986Z"
+                            "epoch_number": 0,
+                            "epoch_start_time": "1859-04-21T15:14:24.639376668127Z"
                         },
                         "status": "not_delegating"
                     }
                 ]
             },
-            "id": "3428d5c4b6a121a057decf2a5a9bde7a6b84d495",
-            "name": "T8켔 𒇠(f2JOzo︉𣉅➾𭀸W-?-yj𫍲",
-            "passphrase": {
-                "last_updated_at": "1901-12-12T03:39:38Z"
+            "id": "8833785c86a69ebc1750a106e97588c9132c1d07",
+            "name": "zJ(",
+            "state": {
+                "status": "ready"
             },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1873-10-13T19:51:39Z"
+            }
+        },
+        {
+            "address_pool_gap": 821,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 9497906478058449,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 23539095724506673,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "not_delegating"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1869-08-13T21:42:30.006193670228Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qypqzqszqgpqyqqpqgqqqqspqypqqqqqqyqsyqgpqqpqq2kcwj9"
+                    }
+                ]
+            },
+            "id": "b2678d1a0d5cf139154b8a3d8156cf045453848c",
+            "name": "[",
             "state": {
                 "progress": {
-                    "quantity": 23.49,
+                    "quantity": 42.9,
                     "unit": "percent"
                 },
                 "status": "syncing"
             },
             "tip": {
-                "absolute_slot_number": 5051953,
-                "epoch_number": 7214,
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
                 "height": {
-                    "quantity": 13963,
+                    "quantity": 2,
                     "unit": "block"
                 },
-                "slot_number": 1411,
-                "time": "1885-11-07T00:30:05Z"
+                "slot_number": 1,
+                "time": "1894-10-17T16:00:00Z"
+            }
+        },
+        {
+            "address_pool_gap": 59811,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 43095128271654024,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 39011953127353212,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 1834719237471463,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qyqszqqpqgpqqqqzqgpqzqgzqqpqqqspqyqqzqspqqpqyg0twlr"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1874-02-12T02:00:00Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qqpqqqspqqqqqqqzqyqqyqgpqgqsqqsqqgpqqqszqgqqqts8c08"
+                    }
+                ]
+            },
+            "id": "fe4ebdf4dcb5e4f08a5b6a4b9c73bbab5782b538",
+            "name": "𲋩",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1890-04-15T09:02:03.855382978792Z"
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 5,
+                "epoch_number": 0,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1898-08-25T09:00:00Z"
+            }
+        },
+        {
+            "address_pool_gap": 64112,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 41635777239386214,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 8662644529464536,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 8596857913142743,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qyqqyqgzqqqqzqgzqyqqzqszqyqqyqszqgqsyqsqqqqqyhfvsqf"
+                },
+                "next": []
+            },
+            "id": "7e5a90288b75c2136941c50c5f7f5fb5354f1441",
+            "name": "8_+",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1903-11-08T20:45:47Z"
+            },
+            "state": {
+                "progress": {
+                    "quantity": 48.15,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 3,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1879-07-16T22:41:44.697924463602Z"
+            }
+        },
+        {
+            "address_pool_gap": 72068,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 13038844840985330,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 34907695013739813,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qgqqzqgzqqpqqqgqqgpqqqsqqqqqyqszqgqqyqgqqyqqqenll0w"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 0,
+                            "epoch_start_time": "1880-02-21T05:11:33Z"
+                        },
+                        "status": "not_delegating"
+                    }
+                ]
+            },
+            "id": "dea1acf7fe4bf6b3b50410e23a64feefaaad79ff",
+            "name": "$94",
+            "passphrase": {
+                "encryption_method": "pbkdf2-hmac-sha512",
+                "last_updated_at": "1869-06-02T00:00:00Z"
+            },
+            "state": {
+                "progress": {
+                    "quantity": 5.26,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 4,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1863-06-10T01:58:39.489343753749Z"
+            }
+        },
+        {
+            "address_pool_gap": 82192,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 16106595729312384,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 31797505172565534,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qgpqzqqpqgpqqqgzqqqqyqspqqqszqqzqyqqyqgpqyqqzlxhkjp"
+                },
+                "next": []
+            },
+            "id": "c644065dc741bd5c2db6269c3b3fa0690db2d2ce",
+            "name": "r𘉠[",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1899-04-06T00:00:00Z"
+            },
+            "state": {
+                "progress": {
+                    "quantity": 70.36,
+                    "unit": "percent"
+                },
+                "status": "syncing"
+            },
+            "tip": {
+                "absolute_slot_number": 8,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 0,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1876-03-10T01:14:02Z"
+            }
+        },
+        {
+            "address_pool_gap": 62656,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 26414927367841679,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 0,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qypqyqgzqgqqqqqzqypqzqgpqyqqqqgpqqqsyqszqypqytu3p9v"
+                },
+                "next": []
+            },
+            "id": "bc76f088f6cba529467b479d9e28785620c55537",
+            "name": "i9𓰁",
+            "passphrase": {
+                "encryption_method": "argon2id-v2",
+                "last_updated_at": "1882-03-23T05:06:15.754153541639Z"
+            },
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 2,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 0,
+                "time": "1876-09-29T12:05:09.113052370335Z"
+            }
+        },
+        {
+            "address_pool_gap": 21513,
+            "assets": {
+                "available": [],
+                "total": []
+            },
+            "balance": {
+                "available": {
+                    "quantity": 29679997647091152,
+                    "unit": "lovelace"
+                },
+                "reward": {
+                    "quantity": 45000000000000000,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 5690229594988077,
+                    "unit": "lovelace"
+                }
+            },
+            "delegation": {
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1qqqqyqqzqgpqzqgpqyqqqqszqyqqyqspqqqszqgpqgqsq6n7pkt"
+                },
+                "next": [
+                    {
+                        "changes_at": {
+                            "epoch_number": 1,
+                            "epoch_start_time": "1884-02-29T07:16:56.345941376607Z"
+                        },
+                        "status": "delegating",
+                        "target": "pool1qypqqqgpqgpqyqsqqqpqyqgzqypqqqszqgqqyqsqqyqsy66telx"
+                    }
+                ]
+            },
+            "id": "ca7fda64fdb40d1bdc20556b9c6525519dfeb6e7",
+            "name": "H\\",
+            "state": {
+                "status": "ready"
+            },
+            "tip": {
+                "absolute_slot_number": 1,
+                "epoch_number": 1,
+                "height": {
+                    "quantity": 2,
+                    "unit": "block"
+                },
+                "slot_number": 1,
+                "time": "1881-06-07T19:23:53.874065841666Z"
             }
         }
     ],
-    "seed": 2143575409
+    "seed": -228475280
 }

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiWalletPassphraseInfo.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiWalletPassphraseInfo.json
@@ -1,35 +1,45 @@
 {
     "samples": [
         {
-            "last_updated_at": "1882-12-28T02:12:47.874305327384Z"
+            "encryption_method": "argon2id-v2",
+            "last_updated_at": "1884-01-08T07:31:52.11520238318Z"
         },
         {
-            "last_updated_at": "1897-06-05T13:30:18.146650561464Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1873-06-01T01:26:24Z"
         },
         {
-            "last_updated_at": "1903-12-22T19:01:07Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1890-07-21T22:00:00Z"
         },
         {
-            "last_updated_at": "1862-12-04T04:51:46Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1873-01-31T16:39:35Z"
         },
         {
-            "last_updated_at": "1904-07-26T09:22:53Z"
+            "encryption_method": "argon2id-v2",
+            "last_updated_at": "1870-09-21T00:00:00Z"
         },
         {
-            "last_updated_at": "1874-04-25T03:49:28Z"
+            "encryption_method": "pbkdf2-hmac-sha512",
+            "last_updated_at": "1899-05-10T02:20:54Z"
         },
         {
-            "last_updated_at": "1869-10-20T21:19:17.923907186484Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1864-02-10T20:00:00Z"
         },
         {
-            "last_updated_at": "1859-09-13T04:00:00Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1904-08-18T17:59:11Z"
         },
         {
-            "last_updated_at": "1877-02-18T11:57:13.43350526975Z"
+            "encryption_method": "argon2id-v2",
+            "last_updated_at": "1891-09-20T05:05:21.367543494023Z"
         },
         {
-            "last_updated_at": "1877-07-23T01:01:22.602053916091Z"
+            "encryption_method": "scrypt",
+            "last_updated_at": "1861-04-11T08:31:33Z"
         }
     ],
-    "seed": -853528238
+    "seed": 1517553496
 }

--- a/lib/unit/test/unit/Cardano/Wallet/Address/DerivationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/DerivationSpec.hs
@@ -42,6 +42,9 @@ import Cardano.Wallet.Address.Keys.PersistPrivateKey
     ( serializeXPrv
     , unsafeDeserializeXPrv
     )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
+    )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey
     , publicKey
@@ -411,10 +414,11 @@ prop_roundtripXPrv
     => KeyFlavorS k
     -> (k 'RootK XPrv, PassphraseHash)
     -> Property
-prop_roundtripXPrv keyF xpriv =
-    xpriv' === xpriv
+prop_roundtripXPrv keyF (xpriv, hash) =
+    creds' === creds
   where
-    xpriv' = unsafeDeserializeXPrv keyF . serializeXPrv keyF $ xpriv
+    creds = HashedCredentialsV1 xpriv hash
+    creds' = unsafeDeserializeXPrv keyF . serializeXPrv keyF $ creds
 
 prop_roundtripXPub
     :: ( PersistPublicKey (k 'AccountK)

--- a/lib/unit/test/unit/Cardano/Wallet/Address/DerivationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/DerivationSpec.hs
@@ -42,9 +42,6 @@ import Cardano.Wallet.Address.Keys.PersistPrivateKey
     ( serializeXPrv
     , unsafeDeserializeXPrv
     )
-import Cardano.Wallet.Primitive.Types.Credentials
-    ( HashedCredentials (..)
-    )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey
     , publicKey
@@ -64,6 +61,9 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
     , PassphraseScheme (..)
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
     )
 import Control.Monad
     ( replicateM

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -143,11 +144,10 @@ genV1ByronCreds =
 -- Must be called within 'withFastKdfForTesting'.
 mkTestEncryptedKey :: IO EncryptedKey
 mkTestEncryptedKey =
-    case
-        encryptedCreate
-            (BS.replicate 32 0x02 :: BS.ByteString)
-            ("test-passphrase-0123456789" :: BS.ByteString)
-            (BS.replicate 32 0xAB :: BS.ByteString)
-    of
-        Left err -> error $ "mkTestEncryptedKey: " <> show err
-        Right k -> pure k
+    encryptedCreate
+        (BS.replicate 32 0x02 :: BS.ByteString)
+        ("test-passphrase-0123456789" :: BS.ByteString)
+        (BS.replicate 32 0xAB :: BS.ByteString)
+        >>= \case
+            Left err -> error $ "mkTestEncryptedKey: " <> show err
+            Right k -> pure k

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -42,8 +42,7 @@ import Cardano.Wallet.Flavor
     ( KeyFlavorS (..)
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..)
-    , PassphraseHash
+    ( PassphraseHash
     )
 import Cardano.Wallet.Primitive.Types.Credentials
     ( HashedCredentials (..)
@@ -58,11 +57,11 @@ import Test.QuickCheck
     ( Gen
     , arbitrary
     , forAll
+    , generate
     , property
     )
 import Prelude
 
-import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 
 {-------------------------------------------------------------------------------
@@ -88,12 +87,13 @@ spec = describe "PersistPrivateKey" $ do
                     ByronKeyS
                     (serializeXPrv ByronKeyS creds)
                     `shouldBe` creds
-        it "V2 Shelley key (no payload) roundtrips"
+        it "V2 Shelley key roundtrips"
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
+                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 ekey Nothing
+                    creds = HashedCredentialsV2 key ekey
                     creds' =
                         unsafeDeserializeXPrv
                             ShelleyKeyS
@@ -103,13 +103,9 @@ spec = describe "PersistPrivateKey" $ do
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
-                let payload =
-                        Passphrase
-                            ( BA.convert @BS.ByteString
-                                "payload-bytes-0123456789abcdef0"
-                            )
-                    creds :: HashedCredentials ByronKey
-                    creds = HashedCredentialsV2 ekey (Just payload)
+                key <- generate (arbitrary @(ByronKey 'RootK XPrv))
+                let creds :: HashedCredentials ByronKey
+                    creds = HashedCredentialsV2 key ekey
                     creds' =
                         unsafeDeserializeXPrv
                             ByronKeyS
@@ -119,16 +115,18 @@ spec = describe "PersistPrivateKey" $ do
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
+                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 ekey Nothing
+                    creds = HashedCredentialsV2 key ekey
                     (keyCol, _) = serializeXPrv ShelleyKeyS creds
                 BS.length keyCol > 256 `shouldBe` True
         it "V2 hash column is empty"
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
+                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 ekey Nothing
+                    creds = HashedCredentialsV2 key ekey
                     (_, hashCol) = serializeXPrv ShelleyKeyS creds
                 hashCol `shouldBe` ""
 

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -134,22 +134,23 @@ spec = describe "PersistPrivateKey" $ do
     describe "Malformed input throws" $ do
         it "garbled Shelley key column throws"
             $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("garbage", ""))
-                `shouldThrow` anyException
+            `shouldThrow` anyException
         it "V2-prefix with invalid hex payload throws"
             $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("V2:notvalidhex!", ""))
-                `shouldThrow` anyException
+            `shouldThrow` anyException
         it "short key column (neither V1 nor V2) throws"
             $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("aabbcc", ""))
-                `shouldThrow` anyException
+            `shouldThrow` anyException
         it "garbled Byron key column throws"
             $ evaluate (unsafeDeserializeXPrv ByronKeyS ("garbage", ""))
-                `shouldThrow` anyException
+            `shouldThrow` anyException
         it "V2-prefix with invalid hex payload throws for Byron"
             $ evaluate (unsafeDeserializeXPrv ByronKeyS ("V2:notvalidhex!", ""))
-                `shouldThrow` anyException
+            `shouldThrow` anyException
     describe "Cross-version rejection" $ do
         it "V2 Shelley column deserializes as HashedCredentialsV2, not V1"
-            $ withFastKdfForTesting $ do
+            $ withFastKdfForTesting
+            $ do
                 ekey <- mkTestEncryptedKey
                 let creds :: HashedCredentials ShelleyKey
                     creds = HashedCredentialsV2 ekey Nothing
@@ -165,7 +166,8 @@ spec = describe "PersistPrivateKey" $ do
                     HashedCredentialsV2{} -> fail "V1 Shelley column misidentified as V2"
                     HashedCredentialsV1{} -> pure () :: IO ()
         it "V2 Byron column deserializes as HashedCredentialsV2, not V1"
-            $ withFastKdfForTesting $ do
+            $ withFastKdfForTesting
+            $ do
                 ekey <- mkTestEncryptedKey
                 ByronKey _ _ payload <- generate (arbitrary @(ByronKey 'RootK XPrv))
                 let creds :: HashedCredentials ByronKey

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -47,11 +47,16 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Types.Credentials
     ( HashedCredentials (..)
     )
+import Control.Exception
+    ( evaluate
+    )
 import Test.Hspec
     ( Spec
+    , anyException
     , describe
     , it
     , shouldBe
+    , shouldThrow
     )
 import Test.QuickCheck
     ( Gen
@@ -126,6 +131,22 @@ spec = describe "PersistPrivateKey" $ do
                     creds = HashedCredentialsV2 ekey Nothing
                     (_, hashCol) = serializeXPrv ShelleyKeyS creds
                 hashCol `shouldBe` ""
+    describe "Malformed input throws" $ do
+        it "garbled Shelley key column throws"
+            $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("garbage", ""))
+                `shouldThrow` anyException
+        it "V2-prefix with invalid hex payload throws"
+            $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("V2:notvalidhex!", ""))
+                `shouldThrow` anyException
+        it "short key column (neither V1 nor V2) throws"
+            $ evaluate (unsafeDeserializeXPrv ShelleyKeyS ("aabbcc", ""))
+                `shouldThrow` anyException
+        it "garbled Byron key column throws"
+            $ evaluate (unsafeDeserializeXPrv ByronKeyS ("garbage", ""))
+                `shouldThrow` anyException
+        it "V2-prefix with invalid hex payload throws for Byron"
+            $ evaluate (unsafeDeserializeXPrv ByronKeyS ("V2:notvalidhex!", ""))
+                `shouldThrow` anyException
 
 {-------------------------------------------------------------------------------
     Generators

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -16,7 +16,7 @@ where
 import Cardano.Address.Derivation
     ( XPrv
     )
-import Cardano.Crypto.WalletV2.Encrypted
+import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     , encryptedCreate
     , withFastKdfForTesting

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -36,7 +36,8 @@ import Cardano.Wallet.Address.Keys.PersistPrivateKey
     , unsafeDeserializeXPrv
     )
 import Cardano.Wallet.DB.Arbitrary
-    ()
+    (
+    )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS (..)
     )
@@ -75,14 +76,16 @@ spec = describe "PersistPrivateKey" $ do
             $ property
             $ forAll genV1ShelleyCreds
             $ \creds ->
-                unsafeDeserializeXPrv ShelleyKeyS
+                unsafeDeserializeXPrv
+                    ShelleyKeyS
                     (serializeXPrv ShelleyKeyS creds)
                     `shouldBe` creds
         it "V1 Byron key roundtrips through serialize/deserialize"
             $ property
             $ forAll genV1ByronCreds
             $ \creds ->
-                unsafeDeserializeXPrv ByronKeyS
+                unsafeDeserializeXPrv
+                    ByronKeyS
                     (serializeXPrv ByronKeyS creds)
                     `shouldBe` creds
         it "V2 Shelley key (no payload) roundtrips"
@@ -91,8 +94,10 @@ spec = describe "PersistPrivateKey" $ do
                 ekey <- mkTestEncryptedKey
                 let creds :: HashedCredentials ShelleyKey
                     creds = HashedCredentialsV2 ekey Nothing
-                    creds' = unsafeDeserializeXPrv ShelleyKeyS
-                        (serializeXPrv ShelleyKeyS creds)
+                    creds' =
+                        unsafeDeserializeXPrv
+                            ShelleyKeyS
+                            (serializeXPrv ShelleyKeyS creds)
                 creds' `shouldBe` creds
         it "V2 Byron key (with payload) roundtrips"
             $ withFastKdfForTesting
@@ -100,12 +105,15 @@ spec = describe "PersistPrivateKey" $ do
                 ekey <- mkTestEncryptedKey
                 let payload =
                         Passphrase
-                            (BA.convert @BS.ByteString
-                                "payload-bytes-0123456789abcdef0")
+                            ( BA.convert @BS.ByteString
+                                "payload-bytes-0123456789abcdef0"
+                            )
                     creds :: HashedCredentials ByronKey
                     creds = HashedCredentialsV2 ekey (Just payload)
-                    creds' = unsafeDeserializeXPrv ByronKeyS
-                        (serializeXPrv ByronKeyS creds)
+                    creds' =
+                        unsafeDeserializeXPrv
+                            ByronKeyS
+                            (serializeXPrv ByronKeyS creds)
                 creds' `shouldBe` creds
         it "V2 key column is longer than 256 hex chars"
             $ withFastKdfForTesting

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Address.Derivation
     ( Depth (..)
     )
 import Cardano.Wallet.Address.Derivation.Byron
-    ( ByronKey
+    ( ByronKey (..)
     )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey
@@ -91,9 +91,8 @@ spec = describe "PersistPrivateKey" $ do
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
-                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 key ekey
+                    creds = HashedCredentialsV2 ekey Nothing
                     creds' =
                         unsafeDeserializeXPrv
                             ShelleyKeyS
@@ -103,9 +102,9 @@ spec = describe "PersistPrivateKey" $ do
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
-                key <- generate (arbitrary @(ByronKey 'RootK XPrv))
+                ByronKey _ _ payload <- generate (arbitrary @(ByronKey 'RootK XPrv))
                 let creds :: HashedCredentials ByronKey
-                    creds = HashedCredentialsV2 key ekey
+                    creds = HashedCredentialsV2 ekey (Just payload)
                     creds' =
                         unsafeDeserializeXPrv
                             ByronKeyS
@@ -115,18 +114,16 @@ spec = describe "PersistPrivateKey" $ do
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
-                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 key ekey
+                    creds = HashedCredentialsV2 ekey Nothing
                     (keyCol, _) = serializeXPrv ShelleyKeyS creds
                 BS.length keyCol > 256 `shouldBe` True
         it "V2 hash column is empty"
             $ withFastKdfForTesting
             $ do
                 ekey <- mkTestEncryptedKey
-                key <- generate (arbitrary @(ShelleyKey 'RootK XPrv))
                 let creds :: HashedCredentials ShelleyKey
-                    creds = HashedCredentialsV2 key ekey
+                    creds = HashedCredentialsV2 ekey Nothing
                     (_, hashCol) = serializeXPrv ShelleyKeyS creds
                 hashCol `shouldBe` ""
 

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -147,6 +147,40 @@ spec = describe "PersistPrivateKey" $ do
         it "V2-prefix with invalid hex payload throws for Byron"
             $ evaluate (unsafeDeserializeXPrv ByronKeyS ("V2:notvalidhex!", ""))
                 `shouldThrow` anyException
+    describe "Cross-version rejection" $ do
+        it "V2 Shelley column deserializes as HashedCredentialsV2, not V1"
+            $ withFastKdfForTesting $ do
+                ekey <- mkTestEncryptedKey
+                let creds :: HashedCredentials ShelleyKey
+                    creds = HashedCredentialsV2 ekey Nothing
+                    result = unsafeDeserializeXPrv ShelleyKeyS (serializeXPrv ShelleyKeyS creds)
+                case result of
+                    HashedCredentialsV1{} -> fail "V2 Shelley column misidentified as V1"
+                    HashedCredentialsV2{} -> pure ()
+        it "V1 Shelley column deserializes as HashedCredentialsV1, not V2"
+            $ property
+            $ forAll genV1ShelleyCreds
+            $ \v1Creds ->
+                case unsafeDeserializeXPrv ShelleyKeyS (serializeXPrv ShelleyKeyS v1Creds) of
+                    HashedCredentialsV2{} -> fail "V1 Shelley column misidentified as V2"
+                    HashedCredentialsV1{} -> pure () :: IO ()
+        it "V2 Byron column deserializes as HashedCredentialsV2, not V1"
+            $ withFastKdfForTesting $ do
+                ekey <- mkTestEncryptedKey
+                ByronKey _ _ payload <- generate (arbitrary @(ByronKey 'RootK XPrv))
+                let creds :: HashedCredentials ByronKey
+                    creds = HashedCredentialsV2 ekey (Just payload)
+                    result = unsafeDeserializeXPrv ByronKeyS (serializeXPrv ByronKeyS creds)
+                case result of
+                    HashedCredentialsV1{} -> fail "V2 Byron column misidentified as V1"
+                    HashedCredentialsV2{} -> pure ()
+        it "V1 Byron column deserializes as HashedCredentialsV1, not V2"
+            $ property
+            $ forAll genV1ByronCreds
+            $ \v1Creds ->
+                case unsafeDeserializeXPrv ByronKeyS (serializeXPrv ByronKeyS v1Creds) of
+                    HashedCredentialsV2{} -> fail "V1 Byron column misidentified as V2"
+                    HashedCredentialsV1{} -> pure () :: IO ()
 
 {-------------------------------------------------------------------------------
     Generators

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Tests for V1 and V2 key serialization roundtrips in
+-- "Cardano.Wallet.Address.Keys.PersistPrivateKey".
+module Cardano.Wallet.Address.Keys.PersistPrivateKeySpec
+    ( spec
+    )
+where
+
+import Cardano.Address.Derivation
+    ( XPrv
+    )
+import Cardano.Crypto.WalletV2.Encrypted
+    ( EncryptedKey
+    , encryptedCreate
+    , withFastKdfForTesting
+    )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..)
+    )
+import Cardano.Wallet.Address.Derivation.Byron
+    ( ByronKey
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( ShelleyKey
+    )
+import Cardano.Wallet.Address.Keys.PersistPrivateKey
+    ( serializeXPrv
+    , unsafeDeserializeXPrv
+    )
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (..)
+    )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..)
+    , PassphraseHash
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Gen
+    , arbitrary
+    , forAll
+    , property
+    )
+import Prelude
+
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+
+{-------------------------------------------------------------------------------
+    Spec
+-------------------------------------------------------------------------------}
+
+spec :: Spec
+spec = describe "PersistPrivateKey" $ do
+    describe "V1/V2 serialization roundtrips" $ do
+        it "V1 Shelley key roundtrips through serialize/deserialize"
+            $ property
+            $ forAll genV1ShelleyCreds
+            $ \creds ->
+                unsafeDeserializeXPrv ShelleyKeyS
+                    (serializeXPrv ShelleyKeyS creds)
+                    `shouldBe` creds
+        it "V1 Byron key roundtrips through serialize/deserialize"
+            $ property
+            $ forAll genV1ByronCreds
+            $ \creds ->
+                unsafeDeserializeXPrv ByronKeyS
+                    (serializeXPrv ByronKeyS creds)
+                    `shouldBe` creds
+        it "V2 Shelley key (no payload) roundtrips"
+            $ withFastKdfForTesting
+            $ do
+                ekey <- mkTestEncryptedKey
+                let creds :: HashedCredentials ShelleyKey
+                    creds = HashedCredentialsV2 ekey Nothing
+                    creds' = unsafeDeserializeXPrv ShelleyKeyS
+                        (serializeXPrv ShelleyKeyS creds)
+                creds' `shouldBe` creds
+        it "V2 Byron key (with payload) roundtrips"
+            $ withFastKdfForTesting
+            $ do
+                ekey <- mkTestEncryptedKey
+                let payload =
+                        Passphrase
+                            (BA.convert @BS.ByteString
+                                "payload-bytes-0123456789abcdef0")
+                    creds :: HashedCredentials ByronKey
+                    creds = HashedCredentialsV2 ekey (Just payload)
+                    creds' = unsafeDeserializeXPrv ByronKeyS
+                        (serializeXPrv ByronKeyS creds)
+                creds' `shouldBe` creds
+        it "V2 key column is longer than 256 hex chars"
+            $ withFastKdfForTesting
+            $ do
+                ekey <- mkTestEncryptedKey
+                let creds :: HashedCredentials ShelleyKey
+                    creds = HashedCredentialsV2 ekey Nothing
+                    (keyCol, _) = serializeXPrv ShelleyKeyS creds
+                BS.length keyCol > 256 `shouldBe` True
+        it "V2 hash column is empty"
+            $ withFastKdfForTesting
+            $ do
+                ekey <- mkTestEncryptedKey
+                let creds :: HashedCredentials ShelleyKey
+                    creds = HashedCredentialsV2 ekey Nothing
+                    (_, hashCol) = serializeXPrv ShelleyKeyS creds
+                hashCol `shouldBe` ""
+
+{-------------------------------------------------------------------------------
+    Generators
+-------------------------------------------------------------------------------}
+
+genV1ShelleyCreds :: Gen (HashedCredentials ShelleyKey)
+genV1ShelleyCreds =
+    HashedCredentialsV1
+        <$> arbitrary @(ShelleyKey 'RootK XPrv)
+        <*> arbitrary @PassphraseHash
+
+genV1ByronCreds :: Gen (HashedCredentials ByronKey)
+genV1ByronCreds =
+    HashedCredentialsV1
+        <$> arbitrary @(ByronKey 'RootK XPrv)
+        <*> arbitrary @PassphraseHash
+
+-- | Create a test 'EncryptedKey' from fixed-byte inputs.
+-- Must be called within 'withFastKdfForTesting'.
+mkTestEncryptedKey :: IO EncryptedKey
+mkTestEncryptedKey =
+    case
+        encryptedCreate
+            (BS.replicate 32 0x02 :: BS.ByteString)
+            ("test-passphrase-0123456789" :: BS.ByteString)
+            (BS.replicate 32 0xAB :: BS.ByteString)
+    of
+        Left err -> error $ "mkTestEncryptedKey: " <> show err
+        Right k -> pure k

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -898,14 +898,17 @@ spec = do
 
     describe "PassphraseScheme JSON encoding (FR-004 stable identifiers)" $ do
         it "EncryptWithScrypt encodes as \"scrypt\""
-            $ Aeson.encode (ApiT EncryptWithScrypt) `shouldBe` "\"scrypt\""
+            $ Aeson.encode (ApiT EncryptWithScrypt)
+            `shouldBe` "\"scrypt\""
         it "EncryptWithPBKDF2 encodes as \"pbkdf2-hmac-sha512\""
-            $ Aeson.encode (ApiT EncryptWithPBKDF2) `shouldBe` "\"pbkdf2-hmac-sha512\""
+            $ Aeson.encode (ApiT EncryptWithPBKDF2)
+            `shouldBe` "\"pbkdf2-hmac-sha512\""
         it "EncryptWithArgon2idV2 encodes as \"argon2id-v2\""
-            $ Aeson.encode (ApiT EncryptWithArgon2idV2) `shouldBe` "\"argon2id-v2\""
+            $ Aeson.encode (ApiT EncryptWithArgon2idV2)
+            `shouldBe` "\"argon2id-v2\""
         it "unknown encryption_method string is rejected"
             $ Aeson.eitherDecode @(ApiT PassphraseScheme) "\"unknown-scheme\""
-                `shouldSatisfy` isLeft
+            `shouldSatisfy` isLeft
 
     describe "SealedTx JSON decoding" $ do
         -- NOTE(AB): I tried to factor more of the properties as their structure only

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -340,6 +340,7 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     , PassphraseHash (PassphraseHash)
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
+    , PassphraseScheme (..)
     , passphraseMaxLength
     , passphraseMinLength
     )
@@ -517,7 +518,8 @@ import Data.Data
     , showConstr
     )
 import Data.Either
-    ( lefts
+    ( isLeft
+    , lefts
     )
 import Data.FileEmbed
     ( embedFile
@@ -626,6 +628,7 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
+    , shouldSatisfy
     )
 import Test.Hspec.QuickCheck
     ( prop
@@ -892,6 +895,17 @@ spec = do
         textRoundtrip $ Proxy @SortOrder
         textRoundtrip $ Proxy @Coin
         textRoundtrip $ Proxy @TokenFingerprint
+
+    describe "PassphraseScheme JSON encoding (FR-004 stable identifiers)" $ do
+        it "EncryptWithScrypt encodes as \"scrypt\""
+            $ Aeson.encode (ApiT EncryptWithScrypt) `shouldBe` "\"scrypt\""
+        it "EncryptWithPBKDF2 encodes as \"pbkdf2-hmac-sha512\""
+            $ Aeson.encode (ApiT EncryptWithPBKDF2) `shouldBe` "\"pbkdf2-hmac-sha512\""
+        it "EncryptWithArgon2idV2 encodes as \"argon2id-v2\""
+            $ Aeson.encode (ApiT EncryptWithArgon2idV2) `shouldBe` "\"argon2id-v2\""
+        it "unknown encryption_method string is rejected"
+            $ Aeson.eitherDecode @(ApiT PassphraseScheme) "\"unknown-scheme\""
+                `shouldSatisfy` isLeft
 
     describe "SealedTx JSON decoding" $ do
         -- NOTE(AB): I tried to factor more of the properties as their structure only

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1899,7 +1899,7 @@ instance Arbitrary WalletName where
         | otherwise = [WalletName $ T.take walletNameMinLength t]
 
 instance Arbitrary ApiWalletPassphraseInfo where
-    arbitrary = ApiWalletPassphraseInfo <$> genUniformTime
+    arbitrary = ApiWalletPassphraseInfo <$> genUniformTime <*> arbitrary
 
 instance Arbitrary ApiMaintenanceAction where
     arbitrary = genericArbitrary

--- a/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -53,9 +53,6 @@ import Cardano.BM.Setup
 import Cardano.BM.Trace
     ( traceInTVarIO
     )
-import Cardano.Crypto.Wallet
-    ( XPrv
-    )
 import Cardano.DB.Sqlite
     ( DBLog (..)
     )

--- a/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -65,7 +65,8 @@ import Cardano.Mnemonic
     ( SomeMnemonic (..)
     )
 import Cardano.Wallet
-    ( putPrivateKey
+    ( RootKeyAccess (..)
+    , putPrivateKey
     , readPrivateKey
     , readWalletMeta
     , withRootKey
@@ -694,7 +695,9 @@ fileModeSpec = do
                     unlocked <-
                         runExceptT
                             $ withRootKey db testWid migrationPwd id
-                            $ \_ scheme -> pure scheme
+                            $ \case
+                                RootKeyAccessV1 _ s -> pure s
+                                RootKeyAccessV2{} -> pure EncryptWithArgon2idV2
                     unlocked `shouldBeRight` EncryptWithPBKDF2
                     (credsAfter, metaAfter) <- readPrivateKeyAndMeta' db
                     assertHashedCredentialsV2 credsAfter
@@ -708,12 +711,14 @@ fileModeSpec = do
                     unlockedAgain <-
                         runExceptT
                             $ withRootKey db testWid migrationPwd id
-                            $ \_ scheme -> pure scheme
-                    unlockedAgain `shouldBeRight` EncryptWithPBKDF2
+                            $ \case
+                                RootKeyAccessV1 _ s -> pure s
+                                RootKeyAccessV2{} -> pure EncryptWithArgon2idV2
+                    unlockedAgain `shouldBeRight` EncryptWithArgon2idV2
                     rejected <-
                         runExceptT
                             $ withRootKey db testWid wrongMigrationPwd id
-                            $ \_ _ -> pure ()
+                            $ \_ -> pure ()
                     rejected `shouldSatisfy` isLeft
 
             it "put and read tx history (Ascending)" $ \f -> do

--- a/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -68,6 +68,7 @@ import Cardano.Wallet
     ( putPrivateKey
     , readPrivateKey
     , readWalletMeta
+    , withRootKey
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
@@ -241,6 +242,9 @@ import Control.Monad.IO.Class
     ( MonadIO
     , liftIO
     )
+import Control.Monad.Trans.Except
+    ( runExceptT
+    )
 import Control.Tracer
     ( Tracer
     )
@@ -252,6 +256,9 @@ import Data.ByteString
     )
 import Data.Coerce
     ( coerce
+    )
+import Data.Either
+    ( isLeft
     )
 import Data.Generics.Internal.VL.Lens
     ( over
@@ -343,6 +350,7 @@ import Test.Hspec
     , before
     , beforeWith
     , describe
+    , expectationFailure
     , it
     , shouldBe
     , shouldContain
@@ -677,6 +685,36 @@ fileModeSpec = do
             it "create and get private key" $ \f -> do
                 creds <- withShelleyFileBootDBLayer f attachPrivateKey
                 testReopening f readPrivateKey' (Just creds)
+
+            it "withRootKey migrates V1 private key to V2 on disk" $ \f -> do
+                withShelleyFileBootDBLayer f attachV1PrivateKeyWithMeta
+                withShelleyFileLoadedDBLayer @TestState f $ \db -> do
+                    beforeMigration <- readPrivateKey' db
+                    assertHashedCredentialsV1 beforeMigration
+                    unlocked <-
+                        runExceptT
+                            $ withRootKey db testWid migrationPwd id
+                            $ \_ scheme -> pure scheme
+                    unlocked `shouldBeRight` EncryptWithPBKDF2
+                    (credsAfter, metaAfter) <- readPrivateKeyAndMeta' db
+                    assertHashedCredentialsV2 credsAfter
+                    (passphraseScheme <$> passphraseInfo metaAfter)
+                        `shouldBe` Just EncryptWithArgon2idV2
+                withShelleyFileLoadedDBLayer @TestState f $ \db -> do
+                    (credsAfterReopen, metaAfterReopen) <- readPrivateKeyAndMeta' db
+                    assertHashedCredentialsV2 credsAfterReopen
+                    (passphraseScheme <$> passphraseInfo metaAfterReopen)
+                        `shouldBe` Just EncryptWithArgon2idV2
+                    unlockedAgain <-
+                        runExceptT
+                            $ withRootKey db testWid migrationPwd id
+                            $ \_ scheme -> pure scheme
+                    unlockedAgain `shouldBeRight` EncryptWithPBKDF2
+                    rejected <-
+                        runExceptT
+                            $ withRootKey db testWid wrongMigrationPwd id
+                            $ \_ _ -> pure ()
+                    rejected `shouldSatisfy` isLeft
 
             it "put and read tx history (Ascending)" $ \f -> do
                 withShelleyFileBootDBLayer f $ \DBLayer{atomically, putTxHistory} ->
@@ -1181,6 +1219,13 @@ readPrivateKey'
     -> m (Maybe (HashedCredentials (KeyOf s)))
 readPrivateKey' DBLayer{..} = atomically $ readPrivateKey walletState
 
+readPrivateKeyAndMeta'
+    :: DBLayer m s
+    -> m (Maybe (HashedCredentials (KeyOf s)), WalletMetadata)
+readPrivateKeyAndMeta' DBLayer{..} =
+    atomically
+        $ (,) <$> readPrivateKey walletState <*> readWalletMeta walletState
+
 -- | Attach an arbitrary private key to a wallet
 attachPrivateKey
     :: KeyOf s ~ ShelleyKey
@@ -1194,6 +1239,67 @@ attachPrivateKey DBLayer{..} = do
         creds = HashedCredentialsV1 k h
     atomically $ putPrivateKey walletState creds
     return creds
+
+attachV1PrivateKeyWithMeta
+    :: DBLayer IO TestState
+    -> IO ()
+attachV1PrivateKeyWithMeta DBLayer{..} = do
+    seed <- liftIO $ generate $ SomeMnemonic <$> genMnemonic @15
+    now <- getCurrentTime
+    (scheme, h) <- liftIO $ encryptPassphrase migrationPwd
+    let k =
+            generateKeyFromSeed
+                (seed, Nothing)
+                (preparePassphrase scheme migrationPwd)
+        creds = HashedCredentialsV1 k h
+    atomically $ do
+        putPrivateKey walletState creds
+        meta <- readWalletMeta walletState
+        Delta.onDBVar walletState
+            $ Delta.update
+            $ \_ ->
+                [ WalletState.UpdateInfo
+                    $ WalletInfo.UpdateWalletMetadata
+                    $ meta
+                        { passphraseInfo =
+                            Just
+                                $ WalletPassphraseInfo
+                                    { lastUpdatedAt = now
+                                    , passphraseScheme = scheme
+                                    }
+                        }
+                ]
+
+assertHashedCredentialsV1
+    :: Maybe (HashedCredentials ShelleyKey)
+    -> Expectation
+assertHashedCredentialsV1 = \case
+    Just HashedCredentialsV1{} -> pure ()
+    _ -> expectationFailure "expected HashedCredentialsV1"
+
+assertHashedCredentialsV2
+    :: Maybe (HashedCredentials ShelleyKey)
+    -> Expectation
+assertHashedCredentialsV2 = \case
+    Just HashedCredentialsV2{} -> pure ()
+    _ -> expectationFailure "expected HashedCredentialsV2"
+
+shouldBeRight
+    :: (Eq a, Show a)
+    => Either e a
+    -> a
+    -> Expectation
+shouldBeRight result expected = case result of
+    Right actual -> actual `shouldBe` expected
+    Left _ -> expectationFailure "expected Right"
+
+migrationPwd :: Passphrase "user"
+migrationPwd =
+    Passphrase $ BA.convert @BS.ByteString "simplevalidphrase"
+
+wrongMigrationPwd :: Passphrase "user"
+wrongMigrationPwd =
+    Passphrase $ BA.convert @BS.ByteString "wrongvalidphrase"
 
 cutRandomly :: [a] -> IO [[a]]
 cutRandomly = iter []

--- a/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -694,7 +694,7 @@ fileModeSpec = do
                     assertHashedCredentialsV1 beforeMigration
                     unlocked <-
                         runExceptT
-                            $ withRootKey db testWid migrationPwd id
+                            $ withRootKey nullTracer db testWid migrationPwd id
                             $ \case
                                 RootKeyAccessV1 _ s -> pure s
                                 RootKeyAccessV2{} -> pure EncryptWithArgon2idV2
@@ -710,14 +710,14 @@ fileModeSpec = do
                         `shouldBe` Just EncryptWithArgon2idV2
                     unlockedAgain <-
                         runExceptT
-                            $ withRootKey db testWid migrationPwd id
+                            $ withRootKey nullTracer db testWid migrationPwd id
                             $ \case
                                 RootKeyAccessV1 _ s -> pure s
                                 RootKeyAccessV2{} -> pure EncryptWithArgon2idV2
                     unlockedAgain `shouldBeRight` EncryptWithArgon2idV2
                     rejected <-
                         runExceptT
-                            $ withRootKey db testWid wrongMigrationPwd id
+                            $ withRootKey nullTracer db testWid wrongMigrationPwd id
                             $ \_ -> pure ()
                     rejected `shouldSatisfy` isLeft
 

--- a/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -174,7 +174,6 @@ import Cardano.Wallet.Primitive.Passphrase
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
-    , PassphraseHash (..)
     , PassphraseScheme (..)
     , WalletPassphraseInfo (..)
     )
@@ -198,7 +197,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.Credentials
-    ( RootCredentials (..)
+    ( HashedCredentials (..)
+    , RootCredentials (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -678,8 +678,8 @@ fileModeSpec = do
                 testReopening f getWalletId' testWid
 
             it "create and get private key" $ \f -> do
-                (k, h) <- withShelleyFileBootDBLayer f attachPrivateKey
-                testReopening f readPrivateKey' (Just (k, h))
+                creds <- withShelleyFileBootDBLayer f attachPrivateKey
+                testReopening f readPrivateKey' (Just creds)
 
             it "put and read tx history (Ascending)" $ \f -> do
                 withShelleyFileBootDBLayer f $ \DBLayer{atomically, putTxHistory} ->
@@ -1181,21 +1181,22 @@ readTransactions' DBLayer{..} a1 a2 mstatus =
 
 readPrivateKey'
     :: DBLayer m s
-    -> m (Maybe (KeyOf s 'RootK XPrv, PassphraseHash))
+    -> m (Maybe (HashedCredentials (KeyOf s)))
 readPrivateKey' DBLayer{..} = atomically $ readPrivateKey walletState
 
 -- | Attach an arbitrary private key to a wallet
 attachPrivateKey
     :: KeyOf s ~ ShelleyKey
     => DBLayer IO s
-    -> IO (KeyOf s 'RootK XPrv, PassphraseHash)
+    -> IO (HashedCredentials (KeyOf s))
 attachPrivateKey DBLayer{..} = do
     let pwd = Passphrase $ BA.convert $ T.encodeUtf8 "simplevalidphrase"
     seed <- liftIO $ generate $ SomeMnemonic <$> genMnemonic @15
     (scheme, h) <- liftIO $ encryptPassphrase pwd
     let k = generateKeyFromSeed (seed, Nothing) (preparePassphrase scheme pwd)
-    atomically $ putPrivateKey walletState (k, h)
-    return (k, h)
+        creds = HashedCredentialsV1 k h
+    atomically $ putPrivateKey walletState creds
+    return creds
 
 cutRandomly :: [a] -> IO [[a]]
 cutRandomly = iter []

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
@@ -42,8 +42,7 @@ import Cardano.Wallet.Flavor
     ( KeyFlavorS (..)
     )
 import Cardano.Wallet.Primitive.Types.Credentials
-    ( HashedCredentials
-    , RootCredentials (RootCredentials)
+    ( HashedCredentials (..)
     )
 import Data.Delta
     ( Replace (..)
@@ -90,7 +89,7 @@ prop_StorePrivateKeyLaws kF db wid = do
 
 genPrivateKey
     :: Arbitrary (k 'RootK XPrv) => Gen (Maybe (HashedCredentials k))
-genPrivateKey = fmap Just $ RootCredentials <$> arbitrary <*> arbitrary
+genPrivateKey = fmap Just $ HashedCredentialsV1 <$> arbitrary <*> arbitrary
 
 instance Buildable (DeltaPrivateKey k) where
     build _ = "DeltaPrivateKey"

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -76,6 +76,14 @@ import Cardano.Balance.Tx.SizeEstimation
     ( TxSkeleton (..)
     , estimateTxSize
     )
+import Cardano.Crypto.Wallet.Types
+    ( DerivationScheme (DerivationScheme2)
+    )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( encryptedCreateDirectWithTweak
+    , withDecryptedExtKeyMaterial
+    , withFastKdfForTesting
+    )
 import Cardano.Ledger.Address
     ( Withdrawals (..)
     )
@@ -295,14 +303,6 @@ import Control.Monad.Trans.Except
     ( except
     , runExceptT
     )
-import Cardano.Crypto.Wallet.Types
-    ( DerivationScheme (DerivationScheme2)
-    )
-import Cardano.Crypto.WalletHD.Encrypted
-    ( encryptedCreateDirectWithTweak
-    , withDecryptedExtKeyMaterial
-    , withFastKdfForTesting
-    )
 import Cryptography.Hash.Blake
     ( blake2b224
     )
@@ -469,10 +469,11 @@ spec = describe "TransactionSpec" $ do
     forAllRecentEras ledgerScriptWitnessParitySpec
     transactionConstraintsSpec
     describe "V2 key witness" $ do
-        prop "V2 root witness matches V1 for same key material" $
-            forAll genShelleyKeyAndPwd (uncurry prop_v2WitnessMatchesV1)
-        prop "V2 derived child witness matches V1" $
-            forAll ((,) <$> genShelleyKeyAndPwd <*> arbitrary)
+        prop "V2 root witness matches V1 for same key material"
+            $ forAll genShelleyKeyAndPwd (uncurry prop_v2WitnessMatchesV1)
+        prop "V2 derived child witness matches V1"
+            $ forAll
+                ((,) <$> genShelleyKeyAndPwd <*> arbitrary)
                 (\((key, pwd), ix) -> prop_v2DerivedWitnessMatchesV1 key pwd ix)
     describe "Sign transaction" $ do
         -- TODO [ADP-2849] The implementation must be restricted to work only in
@@ -2557,13 +2558,20 @@ prop_v2WitnessMatchesV1 xprvKey encPwd = ioProperty $ withFastKdfForTesting $ do
         plaintextXprv = CC.xPrvChangePass encPwd (mempty :: BS.ByteString) rawXprv
         raw128 = CC.unXPrv plaintextXprv
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
-        v1Wit = mkShelleyWitnessLedger RecentEraConway minimalConwayTxBody
-            (plaintextXprv, mempty)
-    ekeyE <- encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
+        v1Wit =
+            mkShelleyWitnessLedger
+                RecentEraConway
+                minimalConwayTxBody
+                (plaintextXprv, mempty)
+    ekeyE <-
+        encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
     ekey <- either (error . show) pure ekeyE
     witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
-        Right <$> mkShelleyWitnessFromExtKeyMaterial RecentEraConway
-            minimalConwayTxBody km
+        Right
+            <$> mkShelleyWitnessFromExtKeyMaterial
+                RecentEraConway
+                minimalConwayTxBody
+                km
     v2Wit <- either (error . show) pure witE
     pure $ v1Wit == v2Wit
 
@@ -2582,15 +2590,25 @@ prop_v2DerivedWitnessMatchesV1 xprvKey encPwd ix =
             raw128 = CC.unXPrv plaintextXprv
             masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
             childXprv =
-                CC.deriveXPrv DerivationScheme2 (mempty :: BS.ByteString)
-                    plaintextXprv ix
-            v1Wit = mkShelleyWitnessLedger RecentEraConway minimalConwayTxBody
-                (childXprv, mempty)
-        ekeyE <- encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
+                CC.deriveXPrv
+                    DerivationScheme2
+                    (mempty :: BS.ByteString)
+                    plaintextXprv
+                    ix
+            v1Wit =
+                mkShelleyWitnessLedger
+                    RecentEraConway
+                    minimalConwayTxBody
+                    (childXprv, mempty)
+        ekeyE <-
+            encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
         ekey <- either (error . show) pure ekeyE
         witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
             EncHD.deriveExtKeyMaterial EncHD.DerivationScheme2 km ix $ \childKm ->
-                Right <$> mkShelleyWitnessFromExtKeyMaterial RecentEraConway
-                    minimalConwayTxBody childKm
+                Right
+                    <$> mkShelleyWitnessFromExtKeyMaterial
+                        RecentEraConway
+                        minimalConwayTxBody
+                        childKm
         v2Wit <- either (error . show) pure witE
         pure $ v1Wit == v2Wit

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -2566,12 +2566,10 @@ prop_v2WitnessMatchesV1 xprvKey encPwd = ioProperty $ withFastKdfForTesting $ do
     ekeyE <-
         encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
     ekey <- either (error . show) pure ekeyE
-    witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
-        Right
-            <$> mkShelleyWitnessFromExtKeyMaterial
-                RecentEraConway
-                minimalConwayTxBody
-                km
+    witE <-
+        withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString)
+            $ fmap Right
+                . mkShelleyWitnessFromExtKeyMaterial RecentEraConway minimalConwayTxBody
     v2Wit <- either (error . show) pure witE
     pure $ v1Wit == v2Wit
 
@@ -2604,11 +2602,8 @@ prop_v2DerivedWitnessMatchesV1 xprvKey encPwd ix =
             encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
         ekey <- either (error . show) pure ekeyE
         witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
-            EncHD.deriveExtKeyMaterial EncHD.DerivationScheme2 km ix $ \childKm ->
-                Right
-                    <$> mkShelleyWitnessFromExtKeyMaterial
-                        RecentEraConway
-                        minimalConwayTxBody
-                        childKm
+            EncHD.deriveExtKeyMaterial EncHD.DerivationScheme2 km ix
+                $ fmap Right
+                    . mkShelleyWitnessFromExtKeyMaterial RecentEraConway minimalConwayTxBody
         v2Wit <- either (error . show) pure witE
         pure $ v1Wit == v2Wit

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -256,6 +256,7 @@ import Cardano.Wallet.Shelley.Transaction.Ledger
     , buildLedgerTxRaw
     , certificateFromDelegationActionLedger
     , mkByronWitnessLedger
+    , mkShelleyWitnessFromExtKeyMaterial
     , mkShelleyWitnessLedger
     , noScriptWitnesses
     , txConstraints
@@ -293,6 +294,14 @@ import Control.Monad.Random
 import Control.Monad.Trans.Except
     ( except
     , runExceptT
+    )
+import Cardano.Crypto.Wallet.Types
+    ( DerivationScheme (DerivationScheme2)
+    )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( encryptedCreateDirectWithTweak
+    , withDecryptedExtKeyMaterial
+    , withFastKdfForTesting
     )
 import Cryptography.Hash.Blake
     ( blake2b224
@@ -344,6 +353,7 @@ import Data.Type.Equality
     )
 import Data.Word
     ( Word16
+    , Word32
     , Word64
     , Word8
     )
@@ -385,6 +395,7 @@ import Test.QuickCheck
     , forAll
     , forAllShow
     , frequency
+    , ioProperty
     , oneof
     , property
     , resize
@@ -421,9 +432,15 @@ import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Primitive as BT
 import qualified Cardano.Balance.Tx.Tx as Write
     ( Tx
+    , TxBody
     )
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
 import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Crypto.Wallet as CC
+import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
+    ( DerivationScheme (..)
+    , deriveExtKeyMaterial
+    )
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
@@ -451,6 +468,12 @@ spec = describe "TransactionSpec" $ do
     forAllRecentEras ledgerMintPlumbingSpec
     forAllRecentEras ledgerScriptWitnessParitySpec
     transactionConstraintsSpec
+    describe "V2 key witness" $ do
+        prop "V2 root witness matches V1 for same key material" $
+            forAll genShelleyKeyAndPwd (uncurry prop_v2WitnessMatchesV1)
+        prop "V2 derived child witness matches V1" $
+            forAll ((,) <$> genShelleyKeyAndPwd <*> arbitrary)
+                (\((key, pwd), ix) -> prop_v2DerivedWitnessMatchesV1 key pwd ix)
     describe "Sign transaction" $ do
         -- TODO [ADP-2849] The implementation must be restricted to work only in
         -- 'RecentEra's, not just the tests.
@@ -2490,3 +2513,84 @@ newtype ShowOrd a = ShowOrd {unShowOrd :: a}
 
 instance (Eq a, Show a) => Ord (ShowOrd a) where
     compare = comparing show
+
+--------------------------------------------------------------------------------
+-- V2 key witness parity properties
+--------------------------------------------------------------------------------
+
+-- | Generate a Shelley root key together with the passphrase it was created
+-- with, so parity tests can correctly strip the passphrase.
+genShelleyKeyAndPwd
+    :: Gen (ShelleyKey 'RootK XPrv, Passphrase "encryption")
+genShelleyKeyAndPwd = do
+    pwd <- genPassphrase (0, 16)
+    key <- genRootKeysSeqWithPass pwd
+    pure (key, pwd)
+
+-- | Build a minimal Conway tx body for use in witness parity tests.
+minimalConwayTxBody :: Write.TxBody Write.Conway
+minimalConwayTxBody =
+    mkLedgerTx
+        RecentEraConway
+        Set.empty
+        (fromList [])
+        (Ledger.Coin 1_000_000)
+        (ValidityInterval SNothing SNothing)
+        (Withdrawals Map.empty)
+        mempty
+        mempty
+        Map.empty
+        ^. bodyTxL
+
+-- | V2 and V1 produce the same witness for the same root key material.
+--
+-- Mirrors the 'mkV2Credentials' logic: strips the passphrase from the V1
+-- 'ShelleyKey', extracts the 96-byte plaintext scalar+chain-code, wraps it
+-- in a V2 Argon2id envelope, and compares the resulting 'WitVKey' with the
+-- one produced by the V1 'mkShelleyWitnessLedger' path.
+prop_v2WitnessMatchesV1
+    :: ShelleyKey 'RootK XPrv
+    -> Passphrase "encryption"
+    -> Property
+prop_v2WitnessMatchesV1 xprvKey encPwd = ioProperty $ withFastKdfForTesting $ do
+    let rawXprv = getRawKey ShelleyKeyS xprvKey
+        plaintextXprv = CC.xPrvChangePass encPwd (mempty :: BS.ByteString) rawXprv
+        raw128 = CC.unXPrv plaintextXprv
+        masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        v1Wit = mkShelleyWitnessLedger RecentEraConway minimalConwayTxBody
+            (plaintextXprv, mempty)
+    ekeyE <- encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
+    ekey <- either (error . show) pure ekeyE
+    witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
+        Right <$> mkShelleyWitnessFromExtKeyMaterial RecentEraConway
+            minimalConwayTxBody km
+    v2Wit <- either (error . show) pure witE
+    pure $ v1Wit == v2Wit
+
+-- | V2 child key and V1 child key produce the same witness for the same
+-- derivation index.
+prop_v2DerivedWitnessMatchesV1
+    :: ShelleyKey 'RootK XPrv
+    -> Passphrase "encryption"
+    -> Word32
+    -> Property
+prop_v2DerivedWitnessMatchesV1 xprvKey encPwd ix =
+    ioProperty $ withFastKdfForTesting $ do
+        let rawXprv = getRawKey ShelleyKeyS xprvKey
+            plaintextXprv =
+                CC.xPrvChangePass encPwd (mempty :: BS.ByteString) rawXprv
+            raw128 = CC.unXPrv plaintextXprv
+            masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+            childXprv =
+                CC.deriveXPrv DerivationScheme2 (mempty :: BS.ByteString)
+                    plaintextXprv ix
+            v1Wit = mkShelleyWitnessLedger RecentEraConway minimalConwayTxBody
+                (childXprv, mempty)
+        ekeyE <- encryptedCreateDirectWithTweak masterKey96 (mempty :: BS.ByteString)
+        ekey <- either (error . show) pure ekeyE
+        witE <- withDecryptedExtKeyMaterial ekey (mempty :: BS.ByteString) $ \km ->
+            EncHD.deriveExtKeyMaterial EncHD.DerivationScheme2 km ix $ \childKm ->
+                Right <$> mkShelleyWitnessFromExtKeyMaterial RecentEraConway
+                    minimalConwayTxBody childKm
+        v2Wit <- either (error . show) pure witE
+        pure $ v1Wit == v2Wit

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -42,9 +42,12 @@ import Cardano.Wallet
     , LocalTxSubmissionConfig (..)
     , SelectionWithoutChange
     , WalletLayer (..)
+    , dbLayer
     , migrationPlanToSelectionWithdrawals
+    , readPrivateKey
     , submitTx
     , throttle
+    , withRootKey
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
@@ -121,7 +124,14 @@ import Cardano.Wallet.Primitive.Passphrase
     , Passphrase (..)
     )
 import Cardano.Wallet.Primitive.Passphrase.Current
-    ( preparePassphrase
+    ( encryptPassphrase
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( PassphraseHash
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
@@ -206,7 +216,8 @@ import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..)
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeRunExceptT
+    ( someDummyMnemonic
+    , unsafeRunExceptT
     )
 import Cardano.Wallet.Util
     ( HasCallStack
@@ -269,6 +280,9 @@ import Cryptography.Hash.Core
 import Data.ByteString
     ( ByteString
     )
+import Data.Either
+    ( isLeft
+    )
 import Data.Coerce
     ( coerce
     )
@@ -282,6 +296,9 @@ import Data.Generics.Internal.VL
     ( iso
     , view
     , (^.)
+    )
+import Data.Proxy
+    ( Proxy (..)
     )
 import Data.List
     ( nubBy
@@ -330,6 +347,7 @@ import System.Random
 import Test.Hspec
     ( Spec
     , describe
+    , expectationFailure
     , it
     , shouldBe
     , shouldSatisfy
@@ -462,6 +480,14 @@ spec = describe "Cardano.WalletSpec" $ do
         it
             "Wallet won't list unrelated assets used in related transactions"
             (property walletListsOnlyRelatedAssets)
+
+    describe "V1 → V2 root key migration" $ do
+        it "V1 key is upgraded to V2 on successful unlock"
+            walletRootKeyV1toV2Migration
+        it "Wrong passphrase leaves key at V1"
+            walletRootKeyMigrationRejectedOnWrongPassphrase
+        it "V2 key is not re-encrypted on successful unlock (idempotent)"
+            walletRootKeyV2Idempotent
 
     describe "Tx fee estimation spread"
         $ it
@@ -630,6 +656,115 @@ walletKeyIsReencrypted
     -> Passphrase "user"
     -> Property
 walletKeyIsReencrypted (_wid, _wname) (_xprv, _pwd) _newPwd = property True
+
+-- | Assert that a V1 (PBKDF2-hashed) root key is silently upgraded to V2 the
+-- first time the wallet is unlocked with the correct passphrase.
+walletRootKeyV1toV2Migration :: IO ()
+walletRootKeyV1toV2Migration = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    -- Store a V1 credential set.
+    W.attachPrivateKeyFromPwdHashShelley wl (testKey, testHash)
+    -- Confirm V1 is stored.
+    mCreds0 <- atomically $ readPrivateKey walletState
+    case mCreds0 of
+        Just (HashedCredentialsV1 _ _) -> pure ()
+        _ -> expectationFailure "expected HashedCredentialsV1 before migration"
+    -- Unlock the wallet (triggers opportunistic migration).
+    result <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                testPwd
+                id
+                (\_ _ -> pure ())
+    result `shouldBe` Right ()
+    -- Confirm V2 is now stored.
+    mCreds1 <- atomically $ readPrivateKey walletState
+    case mCreds1 of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ -> expectationFailure "expected HashedCredentialsV2 after migration"
+
+-- | A wrong passphrase must not trigger migration: the stored key stays V1.
+walletRootKeyMigrationRejectedOnWrongPassphrase :: IO ()
+walletRootKeyMigrationRejectedOnWrongPassphrase = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    W.attachPrivateKeyFromPwdHashShelley wl (testKey, testHash)
+    let wrongPwd = Passphrase @"user" (BA.convert @BS.ByteString "wrong-passphrase-0000")
+    result <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                wrongPwd
+                id
+                (\_ _ -> pure ())
+    result `shouldSatisfy` isLeft
+    mCreds <- atomically $ readPrivateKey walletState
+    case mCreds of
+        Just (HashedCredentialsV1 _ _) -> pure ()
+        _ ->
+            expectationFailure
+                "expected key to remain HashedCredentialsV1 after failed unlock"
+
+-- | Unlocking a V2 wallet must not trigger re-encryption: the stored key bytes
+-- must remain identical.
+walletRootKeyV2Idempotent :: IO ()
+walletRootKeyV2Idempotent = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    -- attachPrivateKeyFromPwd stores V2.
+    W.attachPrivateKeyFromPwd wl (testKey, testPwd)
+    mCreds0 <- atomically $ readPrivateKey walletState
+    case mCreds0 of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ -> expectationFailure "expected HashedCredentialsV2 after initial store"
+    -- Unlock again.
+    _ <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                testPwd
+                id
+                (\_ _ -> pure ())
+    mCreds1 <- atomically $ readPrivateKey walletState
+    -- Still V2 after the second unlock.
+    case mCreds1 of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ ->
+            expectationFailure
+                "expected key to remain HashedCredentialsV2 after re-unlock"
+
+-- | A fixed (WalletId, WalletName, DummyState) used by the migration tests.
+testWallet :: (WalletId, WalletName, DummyState)
+testWallet =
+    ( WalletId (hash @BS.ByteString "migration-test-wallet")
+    , WalletName "Migration Test Wallet"
+    , TestState mempty
+    )
+
+-- | A fixed test passphrase (>= 10 chars to satisfy 'validatePassphrase').
+testPwd :: Passphrase "user"
+testPwd = Passphrase @"user" (BA.convert @BS.ByteString "migration-test-pass01")
+
+-- | The test key generated from 'testPwd' via PBKDF2 (V1 scheme).
+testKey :: ShelleyKey 'RootK XPrv
+testKey =
+    generateKeyFromSeed
+        (someDummyMnemonic (Proxy @15), Nothing)
+        (preparePassphrase testPwd)
+
+-- | A PBKDF2 hash of 'testPwd' created with a fixed 16-byte salt, compatible
+-- with 'checkPassphrase EncryptWithPBKDF2 testPwd'.
+testHash :: PassphraseHash
+testHash = encryptPassphrase (preparePassphrase testPwd) fixedSalt
+  where
+    fixedSalt :: Passphrase "salt"
+    fixedSalt =
+        Passphrase (BA.convert @BS.ByteString "0123456789abcdef")
 
 walletListTransactionsSorted
     :: (WalletId, WalletName, DummyState)

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -34,15 +35,25 @@ import Cardano.Balance.Tx.SizeEstimation
     )
 import Cardano.Crypto.Wallet
     ( toXPub
+    , xpub
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (..)
+    )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( DerivationScheme (..)
+    , chainCodeByteString
+    , encryptedChainCode
+    , encryptedDerivePrivate
+    , encryptedPublic
+    , publicKeyByteString
     )
 import Cardano.Wallet
     ( ErrUpdatePassphrase (..)
     , ErrWithRootKey (..)
     , InitialState (..)
     , LocalTxSubmissionConfig (..)
+    , RootKeyAccess (..)
     , SelectionWithoutChange
     , WalletLayer (..)
     , dbLayer
@@ -65,11 +76,15 @@ import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey (..)
     , generateKeyFromSeed
     )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( purposeCIP1852
+    )
 import Cardano.Wallet.Address.Discovery
     ( CompareDiscovery (..)
     , GenChange (..)
     , IsOurs (..)
     , KnownAddresses (..)
+    , coinTypeAda
     )
 import Cardano.Wallet.Address.States.Features
     ( TestFeatures (..)
@@ -229,7 +244,8 @@ import Control.DeepSeq
     ( NFData (..)
     )
 import Control.Monad
-    ( forM_
+    ( foldM
+    , forM_
     , guard
     , replicateM
     , void
@@ -690,7 +706,7 @@ walletRootKeyV1toV2Migration = do
                 wid
                 testPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     result `shouldBe` Right ()
     -- Confirm V2 is now stored.
     mCreds1 <- atomically $ readPrivateKey walletState
@@ -713,7 +729,7 @@ walletRootKeyMigrationRejectedOnWrongPassphrase = do
                 wid
                 wrongPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     result `shouldSatisfy` isLeft
     mCreds <- atomically $ readPrivateKey walletState
     case mCreds of
@@ -734,7 +750,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
                 wid
                 testEmptyPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     result `shouldBe` Right ()
     mCreds <- atomically $ readPrivateKey walletState
     case mCreds of
@@ -749,7 +765,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
                 wid
                 testEmptyPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     unlockAgain `shouldBe` Right ()
     rejected <-
         runExceptT
@@ -758,7 +774,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
                 wid
                 testNonEmptyPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     rejected `shouldSatisfy` isLeft
 
 -- | Unlocking a V2 wallet must not trigger re-encryption: the stored key bytes
@@ -782,7 +798,7 @@ walletRootKeyV2Idempotent = do
                 wid
                 testPwd
                 id
-                (\_ _ -> pure ())
+                (\_ -> pure ())
     mCreds1 <- atomically $ readPrivateKey walletState
     -- Still V2 after the second unlock.
     case mCreds1 of
@@ -834,8 +850,32 @@ walletPasswordChangeV1ToV2PreservesPublicKey = do
     pubKeyAfterResult <-
         runExceptT
             $ withRootKey (wl ^. dbLayer) wid newPwd id
-            $ \rootK _scheme ->
-                pure $ derivedPub (preparePassphrase newPwd) rootK
+            $ \case
+                RootKeyAccessV1 rootK _scheme ->
+                    pure $ derivedPub (preparePassphrase newPwd) rootK
+                RootKeyAccessV2 ekey _ userPwd -> liftIO $ do
+                    let path =
+                            [ getIndex (purposeCIP1852 :: Index 'Hardened 'PurposeK)
+                            , getIndex (coinTypeAda :: Index 'Hardened 'CoinTypeK)
+                            , getIndex (minBound :: Index 'Hardened 'AccountK)
+                            , 0
+                            , 0
+                            ]
+                    addrEkey <-
+                        foldM
+                            ( \ek ix ->
+                                encryptedDerivePrivate DerivationScheme2 ek userPwd ix
+                                    >>= either (error . show) pure
+                            )
+                            ekey
+                            path
+                    let pub = publicKeyByteString (encryptedPublic addrEkey)
+                        cc = chainCodeByteString (encryptedChainCode addrEkey)
+                    case xpub (pub <> cc) of
+                        Left e ->
+                            error
+                                $ "walletPasswordChangeV1ToV2: xpub: " <> e
+                        Right xpub' -> pure xpub'
     pubKeyAfter <- case pubKeyAfterResult of
         Left err ->
             expectationFailure

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -130,9 +130,6 @@ import Cardano.Wallet.Primitive.Passphrase.Current
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( PassphraseHash
     )
-import Cardano.Wallet.Primitive.Types.Credentials
-    ( HashedCredentials (..)
-    )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , NetworkParameters (..)
@@ -157,6 +154,9 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinPositive
+    )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -280,11 +280,11 @@ import Cryptography.Hash.Core
 import Data.ByteString
     ( ByteString
     )
-import Data.Either
-    ( isLeft
-    )
 import Data.Coerce
     ( coerce
+    )
+import Data.Either
+    ( isLeft
     )
 import Data.Function
     ( on
@@ -296,9 +296,6 @@ import Data.Generics.Internal.VL
     ( iso
     , view
     , (^.)
-    )
-import Data.Proxy
-    ( Proxy (..)
     )
 import Data.List
     ( nubBy
@@ -320,6 +317,9 @@ import Data.Maybe
     )
 import Data.Ord
     ( Down (..)
+    )
+import Data.Proxy
+    ( Proxy (..)
     )
 import Data.Quantity
     ( Quantity (..)
@@ -482,11 +482,14 @@ spec = describe "Cardano.WalletSpec" $ do
             (property walletListsOnlyRelatedAssets)
 
     describe "V1 → V2 root key migration" $ do
-        it "V1 key is upgraded to V2 on successful unlock"
+        it
+            "V1 key is upgraded to V2 on successful unlock"
             walletRootKeyV1toV2Migration
-        it "Wrong passphrase leaves key at V1"
+        it
+            "Wrong passphrase leaves key at V1"
             walletRootKeyMigrationRejectedOnWrongPassphrase
-        it "V2 key is not re-encrypted on successful unlock (idempotent)"
+        it
+            "V2 key is not re-encrypted on successful unlock (idempotent)"
             walletRootKeyV2Idempotent
 
     describe "Tx fee estimation spread"
@@ -692,7 +695,8 @@ walletRootKeyMigrationRejectedOnWrongPassphrase = do
     WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
         setupFixture dummyStateF testWallet
     W.attachPrivateKeyFromPwdHashShelley wl (testKey, testHash)
-    let wrongPwd = Passphrase @"user" (BA.convert @BS.ByteString "wrong-passphrase-0000")
+    let wrongPwd =
+            Passphrase @"user" (BA.convert @BS.ByteString "wrong-passphrase-0000")
     result <-
         runExceptT
             $ withRootKey
@@ -720,7 +724,8 @@ walletRootKeyV2Idempotent = do
     mCreds0 <- atomically $ readPrivateKey walletState
     case mCreds0 of
         Just (HashedCredentialsV2 _ _) -> pure ()
-        _ -> expectationFailure "expected HashedCredentialsV2 after initial store"
+        _ ->
+            expectationFailure "expected HashedCredentialsV2 after initial store"
     -- Unlock again.
     _ <-
         runExceptT
@@ -748,7 +753,8 @@ testWallet =
 
 -- | A fixed test passphrase (>= 10 chars to satisfy 'validatePassphrase').
 testPwd :: Passphrase "user"
-testPwd = Passphrase @"user" (BA.convert @BS.ByteString "migration-test-pass01")
+testPwd =
+    Passphrase @"user" (BA.convert @BS.ByteString "migration-test-pass01")
 
 -- | The test key generated from 'testPwd' via PBKDF2 (V1 scheme).
 testKey :: ShelleyKey 'RootK XPrv

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -32,6 +32,10 @@ import Cardano.Balance.Tx.Balance
 import Cardano.Balance.Tx.SizeEstimation
     ( TxWitnessTag (..)
     )
+import Cardano.Crypto.Wallet
+    ( XPub
+    , toXPub
+    )
 import Cardano.Mnemonic
     ( SomeMnemonic (..)
     )
@@ -491,6 +495,9 @@ spec = describe "Cardano.WalletSpec" $ do
         it
             "V2 key is not re-encrypted on successful unlock (idempotent)"
             walletRootKeyV2Idempotent
+        it
+            "password change V1→V2 preserves derived public keys"
+            walletPasswordChangeV1ToV2PreservesPublicKey
 
     describe "Tx fee estimation spread"
         $ it
@@ -742,6 +749,58 @@ walletRootKeyV2Idempotent = do
         _ ->
             expectationFailure
                 "expected key to remain HashedCredentialsV2 after re-unlock"
+
+-- | Changing a wallet passphrase from the old V1 format (PBKDF2 /
+-- cardano-crypto hard-coded-salt KDF) to the new V2 format (Argon2id /
+-- cardano-base) must not change the child public keys derivable from the
+-- root key.  The same mnemonic always produces the same HD tree regardless
+-- of how the root key happens to be encrypted at rest.
+walletPasswordChangeV1ToV2PreservesPublicKey :: IO ()
+walletPasswordChangeV1ToV2PreservesPublicKey = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    -- 1. Store the root key in the old V1 (PBKDF2 / cardano-crypto) format.
+    W.attachPrivateKeyFromPwdHashShelley wl (testKey, testHash)
+    -- 2. Derive an address public key from the V1 root key (before migration).
+    let encOld = preparePassphrase testPwd
+        derivedPub encPwd k =
+            toXPub . getKey
+                $ deriveAddressPrivateKey encPwd
+                    (deriveAccountPrivateKey encPwd k minBound)
+                    UtxoExternal
+                    minBound
+        pubKeyBefore = derivedPub encOld testKey
+    -- 3. Change passphrase: V1 PBKDF2 (cardano-crypto) → V2 Argon2id (cardano-base).
+    let newPwd = Passphrase @"user" (BA.convert @BS.ByteString "new-migration-pass01")
+    changeResult <-
+        runExceptT
+            $ W.updateWalletPassphraseWithOldPassphrase
+                dummyStateF
+                wl
+                wid
+                (testPwd, newPwd)
+    changeResult `shouldBe` Right ()
+    -- 4. Confirm V2 credentials are now stored.
+    mCreds <- atomically $ readPrivateKey walletState
+    case mCreds of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ ->
+            expectationFailure
+                "expected HashedCredentialsV2 after password change"
+    -- 5. Unlock with the new passphrase and derive the same address public key.
+    pubKeyAfterResult <-
+        runExceptT
+            $ withRootKey (wl ^. dbLayer) wid newPwd id
+            $ \rootK _scheme ->
+                pure $ derivedPub (preparePassphrase newPwd) rootK
+    pubKeyAfter <- case pubKeyAfterResult of
+        Left err ->
+            expectationFailure
+                ("withRootKey after password change failed: " <> show err)
+                >> error "unreachable"
+        Right pk -> pure pk
+    -- 6. The derived public key must be identical regardless of encryption format.
+    pubKeyAfter `shouldBe` pubKeyBefore
 
 -- | A fixed (WalletId, WalletName, DummyState) used by the migration tests.
 testWallet :: (WalletId, WalletName, DummyState)

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -702,6 +702,7 @@ walletRootKeyV1toV2Migration = do
     result <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 testPwd
@@ -725,6 +726,7 @@ walletRootKeyMigrationRejectedOnWrongPassphrase = do
     result <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 wrongPwd
@@ -746,6 +748,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
     result <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 testEmptyPwd
@@ -761,6 +764,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
     unlockAgain <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 testEmptyPwd
@@ -770,6 +774,7 @@ walletRootKeyEmptyPassphraseV1toV2Migration = do
     rejected <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 testNonEmptyPwd
@@ -794,6 +799,7 @@ walletRootKeyV2Idempotent = do
     _ <-
         runExceptT
             $ withRootKey
+                nullTracer
                 (wl ^. dbLayer)
                 wid
                 testPwd
@@ -849,7 +855,7 @@ walletPasswordChangeV1ToV2PreservesPublicKey = do
     -- 5. Unlock with the new passphrase and derive the same address public key.
     pubKeyAfterResult <-
         runExceptT
-            $ withRootKey (wl ^. dbLayer) wid newPwd id
+            $ withRootKey nullTracer (wl ^. dbLayer) wid newPwd id
             $ \case
                 RootKeyAccessV1 rootK _scheme ->
                     pure $ derivedPub (preparePassphrase newPwd) rootK

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -764,13 +764,15 @@ walletPasswordChangeV1ToV2PreservesPublicKey = do
     let encOld = preparePassphrase testPwd
         derivedPub encPwd k =
             toXPub . getKey
-                $ deriveAddressPrivateKey encPwd
+                $ deriveAddressPrivateKey
+                    encPwd
                     (deriveAccountPrivateKey encPwd k minBound)
                     UtxoExternal
                     minBound
         pubKeyBefore = derivedPub encOld testKey
     -- 3. Change passphrase: V1 PBKDF2 (cardano-crypto) → V2 Argon2id (cardano-base).
-    let newPwd = Passphrase @"user" (BA.convert @BS.ByteString "new-migration-pass01")
+    let newPwd =
+            Passphrase @"user" (BA.convert @BS.ByteString "new-migration-pass01")
     changeResult <-
         runExceptT
             $ W.updateWalletPassphraseWithOldPassphrase

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -492,6 +492,9 @@ spec = describe "Cardano.WalletSpec" $ do
             "Wrong passphrase leaves key at V1"
             walletRootKeyMigrationRejectedOnWrongPassphrase
         it
+            "empty-passphrase V1 key migrates to V2 and remains unlockable"
+            walletRootKeyEmptyPassphraseV1toV2Migration
+        it
             "V2 key is not re-encrypted on successful unlock (idempotent)"
             walletRootKeyV2Idempotent
         it
@@ -719,6 +722,45 @@ walletRootKeyMigrationRejectedOnWrongPassphrase = do
             expectationFailure
                 "expected key to remain HashedCredentialsV1 after failed unlock"
 
+walletRootKeyEmptyPassphraseV1toV2Migration :: IO ()
+walletRootKeyEmptyPassphraseV1toV2Migration = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    W.attachPrivateKeyFromPwdHashShelley wl (testEmptyKey, testEmptyHash)
+    result <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                testEmptyPwd
+                id
+                (\_ _ -> pure ())
+    result `shouldBe` Right ()
+    mCreds <- atomically $ readPrivateKey walletState
+    case mCreds of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ ->
+            expectationFailure
+                "expected empty-passphrase key to migrate to HashedCredentialsV2"
+    unlockAgain <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                testEmptyPwd
+                id
+                (\_ _ -> pure ())
+    unlockAgain `shouldBe` Right ()
+    rejected <-
+        runExceptT
+            $ withRootKey
+                (wl ^. dbLayer)
+                wid
+                testNonEmptyPwd
+                id
+                (\_ _ -> pure ())
+    rejected `shouldSatisfy` isLeft
+
 -- | Unlocking a V2 wallet must not trigger re-encryption: the stored key bytes
 -- must remain identical.
 walletRootKeyV2Idempotent :: IO ()
@@ -816,6 +858,13 @@ testPwd :: Passphrase "user"
 testPwd =
     Passphrase @"user" (BA.convert @BS.ByteString "migration-test-pass01")
 
+testEmptyPwd :: Passphrase "user"
+testEmptyPwd = Passphrase @"user" mempty
+
+testNonEmptyPwd :: Passphrase "user"
+testNonEmptyPwd =
+    Passphrase @"user" (BA.convert @BS.ByteString "not-empty-pass01")
+
 -- | The test key generated from 'testPwd' via PBKDF2 (V1 scheme).
 testKey :: ShelleyKey 'RootK XPrv
 testKey =
@@ -823,10 +872,23 @@ testKey =
         (someDummyMnemonic (Proxy @15), Nothing)
         (preparePassphrase testPwd)
 
+testEmptyKey :: ShelleyKey 'RootK XPrv
+testEmptyKey =
+    generateKeyFromSeed
+        (someDummyMnemonic (Proxy @15), Nothing)
+        (preparePassphrase testEmptyPwd)
+
 -- | A PBKDF2 hash of 'testPwd' created with a fixed 16-byte salt, compatible
 -- with 'checkPassphrase EncryptWithPBKDF2 testPwd'.
 testHash :: PassphraseHash
 testHash = encryptPassphrase (preparePassphrase testPwd) fixedSalt
+  where
+    fixedSalt :: Passphrase "salt"
+    fixedSalt =
+        Passphrase (BA.convert @BS.ByteString "0123456789abcdef")
+
+testEmptyHash :: PassphraseHash
+testEmptyHash = encryptPassphrase (preparePassphrase testEmptyPwd) fixedSalt
   where
     fixedSalt :: Passphrase "salt"
     fixedSalt =

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -514,6 +514,9 @@ spec = describe "Cardano.WalletSpec" $ do
             "V2 key is not re-encrypted on successful unlock (idempotent)"
             walletRootKeyV2Idempotent
         it
+            "Wrong passphrase is rejected for V2 key"
+            walletRootKeyV2RejectedOnWrongPassphrase
+        it
             "password change V1→V2 preserves derived public keys"
             walletPasswordChangeV1ToV2PreservesPublicKey
 
@@ -812,6 +815,30 @@ walletRootKeyV2Idempotent = do
         _ ->
             expectationFailure
                 "expected key to remain HashedCredentialsV2 after re-unlock"
+
+walletRootKeyV2RejectedOnWrongPassphrase :: IO ()
+walletRootKeyV2RejectedOnWrongPassphrase = do
+    WalletLayerFixture DBLayer{walletState, atomically} wl wid <-
+        setupFixture dummyStateF testWallet
+    W.attachPrivateKeyFromPwd wl (testKey, testPwd)
+    let wrongPwd =
+            Passphrase @"user" (BA.convert @BS.ByteString "wrong-passphrase-0000")
+    result <-
+        runExceptT
+            $ withRootKey
+                nullTracer
+                (wl ^. dbLayer)
+                wid
+                wrongPwd
+                id
+                (\_ -> pure ())
+    result `shouldSatisfy` isLeft
+    mCreds <- atomically $ readPrivateKey walletState
+    case mCreds of
+        Just (HashedCredentialsV2 _ _) -> pure ()
+        _ ->
+            expectationFailure
+                "expected key to remain HashedCredentialsV2 after failed unlock"
 
 -- | Changing a wallet passphrase from the old V1 format (PBKDF2 /
 -- cardano-crypto hard-coded-salt KDF) to the new V2 format (Argon2id /

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -33,8 +33,7 @@ import Cardano.Balance.Tx.SizeEstimation
     ( TxWitnessTag (..)
     )
 import Cardano.Crypto.Wallet
-    ( XPub
-    , toXPub
+    ( toXPub
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (..)

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -37,9 +37,6 @@ import Cardano.Crypto.Wallet
     ( toXPub
     , xpub
     )
-import Cardano.Mnemonic
-    ( SomeMnemonic (..)
-    )
 import Cardano.Crypto.WalletHD.Encrypted
     ( DerivationScheme (..)
     , chainCodeByteString
@@ -47,6 +44,9 @@ import Cardano.Crypto.WalletHD.Encrypted
     , encryptedDerivePrivate
     , encryptedPublic
     , publicKeyByteString
+    )
+import Cardano.Mnemonic
+    ( SomeMnemonic (..)
     )
 import Cardano.Wallet
     ( ErrUpdatePassphrase (..)
@@ -76,15 +76,15 @@ import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey (..)
     , generateKeyFromSeed
     )
-import Cardano.Wallet.Address.Discovery.Sequential
-    ( purposeCIP1852
-    )
 import Cardano.Wallet.Address.Discovery
     ( CompareDiscovery (..)
     , GenChange (..)
     , IsOurs (..)
     , KnownAddresses (..)
     , coinTypeAda
+    )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( purposeCIP1852
     )
 import Cardano.Wallet.Address.States.Features
     ( TestFeatures (..)

--- a/lib/unit/test/unit/core-unit-test.hs
+++ b/lib/unit/test/unit/core-unit-test.hs
@@ -3,6 +3,9 @@ module Main where
 import Cardano.Crypto.Init
     ( cryptoInit
     )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( withFastKdfForTesting
+    )
 import Main.Utf8
     ( withUtf8
     )
@@ -19,5 +22,6 @@ import qualified Spec
 main :: IO ()
 main = withUtf8 $ do
     cryptoInit
-    hspecMain Spec.spec
-    performMajorGC
+    withFastKdfForTesting $ do
+        hspecMain Spec.spec
+        performMajorGC

--- a/lib/unit/test/unit/core-unit-test.hs
+++ b/lib/unit/test/unit/core-unit-test.hs
@@ -1,7 +1,13 @@
 module Main where
 
+import Cardano.Crypto.Init
+    ( cryptoInit
+    )
 import Main.Utf8
     ( withUtf8
+    )
+import System.Mem
+    ( performMajorGC
     )
 import Test.Hspec.Extra
     ( hspecMain
@@ -11,4 +17,7 @@ import Prelude
 import qualified Spec
 
 main :: IO ()
-main = withUtf8 $ hspecMain Spec.spec
+main = withUtf8 $ do
+    cryptoInit
+    hspecMain Spec.spec
+    performMajorGC

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -322,6 +322,7 @@ test-suite wallet-key-export-test
     , bytestring
     , cardano-addresses
     , cardano-crypto
+    , cardano-crypto-wallet
     , cardano-wallet
     , cardano-wallet-primitive
     , cardano-wallet-secrets

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -54,7 +54,7 @@ library
     , cardano-binary
     , cardano-crypto
     , cardano-crypto-class
-    , cardano-crypto-wallet-v2
+    , cardano-crypto-wallet
     , cardano-crypto-wrapper
     , cardano-ledger-allegra
     , cardano-ledger-alonzo

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -54,6 +54,7 @@ library
     , cardano-binary
     , cardano-crypto
     , cardano-crypto-class
+    , cardano-crypto-wallet-v2
     , cardano-crypto-wrapper
     , cardano-ledger-allegra
     , cardano-ledger-alonzo

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -394,23 +394,16 @@ prop_wrongSchemeByron exe =
 prop_v2ShelleyUnsupported :: FilePath -> Property
 prop_v2ShelleyUnsupported exe =
     forAll
-        ( (,,)
-            <$> genShelleyMnemonic
-            <*> genUserPassphrase
+        ( (,)
+            <$> genUserPassphrase
             <*> genWalletId
         )
-        $ \(mnemonic, userPass, wid) ->
+        $ \(userPass, wid) ->
             ioProperty $ do
-                let encPass =
-                        preparePassphrase EncryptWithPBKDF2 userPass
-                    key =
-                        generateKeyFromSeed
-                            (mnemonic, Nothing)
-                            encPass
-                    (rootHex, hashHex) =
+                let (rootHex, hashHex) =
                         serializeXPrv
                             ShelleyKeyS
-                            (HashedCredentialsV2 key testEncryptedKey)
+                            (HashedCredentialsV2 testEncryptedKey Nothing)
                 runUnsupportedV2Test
                     exe
                     wid

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -18,6 +18,10 @@ import Cardano.Crypto.Wallet
     ( unXPrv
     , xPrvChangePass
     )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( EncryptedKey
+    , mkEncryptedKey
+    )
 import Cardano.DB.Sqlite
     ( runQuery
     , withSqliteContextFile
@@ -81,6 +85,9 @@ import Cardano.Wallet.Unsafe
     )
 import Control.Tracer
     ( nullTracer
+    )
+import Data.List
+    ( isInfixOf
     )
 import Data.Text.Class
     ( toText
@@ -155,6 +162,7 @@ main = do
             , withMaxSuccess 20 $ prop_wrongPassphraseByron exe
             , withMaxSuccess 20 $ prop_wrongSchemeShelley exe
             , withMaxSuccess 20 $ prop_wrongSchemeByron exe
+            , withMaxSuccess 20 $ prop_v2ShelleyUnsupported exe
             ]
     if all isSuccess results
         then putStrLn "All tests passed."
@@ -381,6 +389,35 @@ prop_wrongSchemeByron exe =
                     hashHex
                     userPass
 
+-- | V2 Shelley keys contain ':' separators but must not be routed to
+-- the Byron deserializer.
+prop_v2ShelleyUnsupported :: FilePath -> Property
+prop_v2ShelleyUnsupported exe =
+    forAll
+        ( (,,)
+            <$> genShelleyMnemonic
+            <*> genUserPassphrase
+            <*> genWalletId
+        )
+        $ \(mnemonic, userPass, wid) ->
+            ioProperty $ do
+                let encPass =
+                        preparePassphrase EncryptWithPBKDF2 userPass
+                    key =
+                        generateKeyFromSeed
+                            (mnemonic, Nothing)
+                            encPass
+                    (rootHex, hashHex) =
+                        serializeXPrv
+                            ShelleyKeyS
+                            (HashedCredentialsV2 key testEncryptedKey)
+                runUnsupportedV2Test
+                    exe
+                    wid
+                    rootHex
+                    hashHex
+                    userPass
+
 emptyPass :: Passphrase "encryption"
 emptyPass = mempty
 
@@ -480,6 +517,57 @@ runWrongPassTest exe wid rootHex hashHex wrongPass =
                             ("stdout: " <> stdout_)
                         $ exitCode
                             === ExitFailure 1
+
+-- | Test that a V2 key reports the intentional unsupported-key error.
+runUnsupportedV2Test
+    :: FilePath
+    -> WalletId
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Passphrase "user"
+    -> IO Property
+runUnsupportedV2Test exe wid rootHex hashHex userPass =
+    withSystemTempFile "wallet-export-test.db"
+        $ \dbPath handle -> do
+            hClose handle
+            dbResult <-
+                withSqliteContextFile
+                    nullTracer
+                    dbPath
+                    noManualMigration
+                    migrateAll
+                    $ \db ->
+                        runQuery db $ do
+                            insertWallet wid
+                            insert_
+                                $ PrivateKey wid rootHex hashHex
+            case dbResult of
+                Left err ->
+                    pure
+                        $ counterexample
+                            ("DB migration error: " <> show err)
+                        $ False === True
+                Right () -> do
+                    let widHex = T.unpack (toText wid)
+                        passText = passphraseToText userPass
+                    (exitCode, stdout_, stderr_) <-
+                        readCreateProcessWithExitCode
+                            (proc exe [dbPath, widHex])
+                            (T.unpack passText ++ "\n")
+                    pure
+                        $ counterexample
+                            ("stdout: " <> stdout_ <> "\nstderr: " <> stderr_)
+                        $ (exitCode === ExitFailure 1)
+                        .&&. (unsupportedMessage `isInfixOf` stdout_ === True)
+  where
+    unsupportedMessage =
+        "Error: V2 (Argon2id) keys cannot be exported in XPrv format"
+
+testEncryptedKey :: EncryptedKey
+testEncryptedKey =
+    case mkEncryptedKey (BS.replicate 128 0x02) of
+        Left err -> error $ "testEncryptedKey: " <> show err
+        Right k -> k
 
 -- | Extract the hex line from wallet-key-export output.
 -- Looks for the line after "=== Raw XPrv (hex) ===".

--- a/lib/wallet/exe/wallet-key-export-test.hs
+++ b/lib/wallet/exe/wallet-key-export-test.hs
@@ -70,6 +70,9 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Types
     ( WalletId
     )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
@@ -206,7 +209,7 @@ prop_shelleyRoundtrip exe =
                             encPass
                 (_, passHash) <- encryptPassphrase userPass
                 let (rootHex, hashHex) =
-                        serializeXPrv ShelleyKeyS (key, passHash)
+                        serializeXPrv ShelleyKeyS (HashedCredentialsV1 key passHash)
                     xprv = getRawKey ShelleyKeyS key
                     expected =
                         B16.encode
@@ -244,7 +247,7 @@ prop_byronRoundtrip exe =
                 passHash <-
                     encryptPassphraseTestingOnly hashLen encPass
                 let (rootHex, hashHex) =
-                        serializeXPrv ByronKeyS (key, passHash)
+                        serializeXPrv ByronKeyS (HashedCredentialsV1 key passHash)
                     xprv = getRawKey ByronKeyS key
                     expected =
                         B16.encode
@@ -282,7 +285,7 @@ prop_wrongPassphrase exe =
                             generateKeyFromSeed (mnemonic, Nothing) encPass
                     (_, passHash) <- encryptPassphrase userPass
                     let (rootHex, hashHex) =
-                            serializeXPrv ShelleyKeyS (key, passHash)
+                            serializeXPrv ShelleyKeyS (HashedCredentialsV1 key passHash)
                     runWrongPassTest exe wid rootHex hashHex wrongPass
 
 -- | Wrong passphrase with Byron/Scrypt scheme.
@@ -311,7 +314,7 @@ prop_wrongPassphraseByron exe =
                     let (rootHex, hashHex) =
                             serializeXPrv
                                 ByronKeyS
-                                (key, passHash)
+                                (HashedCredentialsV1 key passHash)
                     runWrongPassTest
                         exe
                         wid
@@ -340,7 +343,7 @@ prop_wrongSchemeShelley exe =
                 passHash <-
                     encryptPassphraseTestingOnly 64 encPass
                 let (rootHex, hashHex) =
-                        serializeXPrv ShelleyKeyS (key, passHash)
+                        serializeXPrv ShelleyKeyS (HashedCredentialsV1 key passHash)
                 -- Tool detects Shelley, assumes PBKDF2, but hash
                 -- is Scrypt — should fail even with correct pass.
                 runWrongPassTest
@@ -368,7 +371,7 @@ prop_wrongSchemeByron exe =
                         Byron.generateKeyFromSeed mnemonic encPass
                 (_, passHash) <- encryptPassphrase userPass
                 let (rootHex, hashHex) =
-                        serializeXPrv ByronKeyS (key, passHash)
+                        serializeXPrv ByronKeyS (HashedCredentialsV1 key passHash)
                 -- Tool detects Byron, assumes Scrypt, but hash
                 -- is PBKDF2 — should fail even with correct pass.
                 runWrongPassTest

--- a/lib/wallet/exe/wallet-key-export.hs
+++ b/lib/wallet/exe/wallet-key-export.hs
@@ -34,6 +34,9 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     , Passphrase (..)
     , PassphraseScheme (..)
     )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
+    )
 import Control.Monad
     ( when
     )
@@ -97,18 +100,6 @@ run dbPath walletId = do
     -- Auto-detect key type: Byron keys contain ':' separator
     let isByron = B8.elem ':' rootHex
 
-    -- Deserialize and extract XPrv + PassphraseHash
-    let (xprv, passHash, scheme) =
-            if isByron
-                then
-                    let (key, h) =
-                            unsafeDeserializeXPrv ByronKeyS (rootHex, hashHex)
-                    in  (getRawKey ByronKeyS key, h, EncryptWithScrypt)
-                else
-                    let (key, h) =
-                            unsafeDeserializeXPrv ShelleyKeyS (rootHex, hashHex)
-                    in  (getRawKey ShelleyKeyS key, h, EncryptWithPBKDF2)
-
     putStrLn
         $ "Key type: "
             <> if isByron then "Byron" else "Shelley"
@@ -116,20 +107,38 @@ run dbPath walletId = do
     -- Prompt for passphrase
     userPass <- promptPassphrase
 
-    -- Verify passphrase
-    case checkPassphrase scheme userPass passHash of
-        Left ErrWrongPassphrase -> do
-            putStrLn "Error: wrong passphrase"
-            exitFailure
-        Right () -> pure ()
-
-    -- Decrypt: change passphrase from user's to empty
-    let prepared = preparePassphrase scheme userPass
-        emptyPass = mempty :: Passphrase "encryption"
-        decrypted = xPrvChangePass prepared emptyPass xprv
+    -- Deserialize, verify passphrase, and decrypt
+    xprv <-
+        if isByron
+            then case unsafeDeserializeXPrv ByronKeyS (rootHex, hashHex) of
+                HashedCredentialsV1 key passHash -> do
+                    case checkPassphrase EncryptWithScrypt userPass passHash of
+                        Left ErrWrongPassphrase -> do
+                            putStrLn "Error: wrong passphrase"
+                            exitFailure
+                        Right () -> pure ()
+                    let prepared = preparePassphrase EncryptWithScrypt userPass
+                        emptyPass = mempty :: Passphrase "encryption"
+                    pure $ xPrvChangePass prepared emptyPass (getRawKey ByronKeyS key)
+                HashedCredentialsV2{} -> do
+                    putStrLn "Error: V2 (Argon2id) keys cannot be exported in XPrv format"
+                    exitFailure
+            else case unsafeDeserializeXPrv ShelleyKeyS (rootHex, hashHex) of
+                HashedCredentialsV1 key passHash -> do
+                    case checkPassphrase EncryptWithPBKDF2 userPass passHash of
+                        Left ErrWrongPassphrase -> do
+                            putStrLn "Error: wrong passphrase"
+                            exitFailure
+                        Right () -> pure ()
+                    let prepared = preparePassphrase EncryptWithPBKDF2 userPass
+                        emptyPass = mempty :: Passphrase "encryption"
+                    pure $ xPrvChangePass prepared emptyPass (getRawKey ShelleyKeyS key)
+                HashedCredentialsV2{} -> do
+                    putStrLn "Error: V2 (Argon2id) keys cannot be exported in XPrv format"
+                    exitFailure
 
     -- Output raw hex (128 bytes = 256 hex chars)
-    let hexKey = B16.encode (unXPrv decrypted)
+    let hexKey = B16.encode (unXPrv xprv)
     putStrLn ""
     putStrLn "=== Raw XPrv (hex) ==="
     B8.putStrLn hexKey

--- a/lib/wallet/exe/wallet-key-export.hs
+++ b/lib/wallet/exe/wallet-key-export.hs
@@ -77,6 +77,7 @@ import System.IO
 import Prelude
 
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
@@ -97,12 +98,17 @@ run dbPath walletId = do
     -- Read root key and hash from the SQLite database
     (rootHex, hashHex) <- readPrivateKey dbPath walletId
 
-    -- Auto-detect key type: Byron keys contain ':' separator
-    let isByron = B8.elem ':' rootHex
+    -- Auto-detect key type from the serialized key column.
+    let isV2 = "V2:" `BS.isPrefixOf` rootHex
+        isByron = not isV2 && isByronV1RootKey rootHex
 
     putStrLn
         $ "Key type: "
             <> if isByron then "Byron" else "Shelley"
+
+    when isV2 $ do
+        putStrLn "Error: V2 (Argon2id) keys cannot be exported in XPrv format"
+        exitFailure
 
     -- Prompt for passphrase
     userPass <- promptPassphrase
@@ -184,6 +190,12 @@ readPrivateKey dbPath walletId = do
         _ -> do
             putStrLn "Error: unexpected number of rows in private_key table"
             exitFailure
+
+isByronV1RootKey :: ByteString -> Bool
+isByronV1RootKey rootHex =
+    case B8.split ':' rootHex of
+        [keyHex, _payloadHex] -> BS.length keyHex == 256
+        _ -> False
 
 promptPassphrase :: IO (Passphrase "user")
 promptPassphrase = do

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -294,7 +294,7 @@ import Cardano.Balance.Tx.Tx
 import Cardano.Crypto.Wallet
     ( toXPub
     )
-import Cardano.Crypto.WalletV2.Encrypted
+import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     , XPrvError (..)
     , encryptedCreateDirectWithTweak

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -319,8 +319,13 @@ import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
     )
 import Cardano.Ledger.Api
     ( EraTxBody (allInputsTxBodyF)
+    , addrTxWitsL
     , bodyTxL
     , feeTxBodyL
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( inputsTxBodyL
     )
 import Cardano.Ledger.Binary
     ( serialize'
@@ -502,6 +507,9 @@ import Cardano.Wallet.Primitive.Ledger.Convert
 import Cardano.Wallet.Primitive.Ledger.Read.Block
     ( fromCardanoBlock
     )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
+    ( getTxExtended
+    )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( fromCardanoTxIn
     , fromCardanoTxOut
@@ -665,6 +673,7 @@ import Cardano.Wallet.Shelley.Transaction.Ledger
     ( certificateFromDelegationActionLedger
     , certificateFromVotingActionLedger
     , constructUnsignedTxLedger
+    , mkShelleyWitnessFromExtKeyMaterial
     , mkTransaction
     , sealWriteTx
     )
@@ -685,6 +694,7 @@ import Cardano.Wallet.Transaction
     , WitnessCountCtx (..)
     , containsSelfWithdrawal
     , defaultTransactionCtx
+    , selectionDelta
     , withdrawalToCoin
     )
 import Cardano.Wallet.Transaction.Built
@@ -2581,10 +2591,172 @@ buildSignSubmitTransaction
                         & interpretQuery (neverFails "slot is ahead of the node tip" ti)
                         & fmap (BuiltTx{..},)
                         & liftIO
-                RootKeyAccessV2{} ->
-                    liftIO
-                        $ error
-                            "buildSignSubmitTransaction: V2 key signing not yet implemented"
+                RootKeyAccessV2 ekey _mPayload userPwd -> lift $ do
+                    let recentEra' = _era
+                        anyCardanoEra = case recentEra' of
+                            Write.RecentEraConway ->
+                                Read.EraValue Read.Conway
+                            Write.RecentEraDijkstra ->
+                                Read.EraValue Read.Dijkstra
+                    (unsignedTx, wallet, slot) <- atomically $ do
+                        pendingTxs <-
+                            fmap fromTransactionInfo
+                                <$> readTransactions
+                                    Nothing
+                                    Descending
+                                    Range.everything
+                                    (Just Pending)
+                                    Nothing
+                                    Nothing
+                        ( throwOnErr
+                                <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
+                            )
+                            $ \s -> do
+                                let wallet = WalletState.getLatest s
+                                    utxo = availableUTxO
+                                        (Set.fromList pendingTxs) wallet
+                                buildTransactionPure @s
+                                    wallet
+                                    timeTranslation
+                                    utxo
+                                    changeAddrGen
+                                    protocolParams
+                                    preSelection
+                                    txCtx
+                                    & runExceptT
+                                        . withExceptT wrapBalanceConstructError
+                                    & (`evalRand` stdGen)
+                                    & fmap
+                                        ( \(tx, newState) ->
+                                            let wallet' =
+                                                    wallet{getState = newState}
+                                            in  ( [ReplacePrologue
+                                                    $ getPrologue newState]
+                                                , ( tx
+                                                  , wallet
+                                                  , currentTip wallet'
+                                                        ^. #slotNo
+                                                  )
+                                                )
+                                        )
+                    let txBody = unsignedTx ^. bodyTxL
+                        walletSt = getState wallet
+                        walletUtxo = wallet ^. #utxo
+                        inputPaths =
+                            L.nub
+                                $ mapMaybe
+                                    ( \ledIn ->
+                                        UTxO.lookup
+                                            (toWallet ledIn)
+                                            walletUtxo
+                                            >>= \(TxOut addr _) ->
+                                                fst (isOurs addr walletSt)
+                                    )
+                                    ( Set.toList
+                                        $ unsignedTx
+                                            ^. bodyTxL
+                                            . inputsTxBodyL
+                                    )
+                        mStakePath =
+                            case walletFlavor @s of
+                                ShelleyWallet ->
+                                    Just
+                                        $ stakeDerivationPath
+                                        $ Seq.derivationPrefix walletSt
+                                _ -> Nothing
+                        needsStakeKey =
+                            isJust (view #txDelegationAction txCtx)
+                                || isJust (view #txVotingAction txCtx)
+                                || containsSelfWithdrawal
+                                    (view #txWithdrawal txCtx)
+                        allPaths =
+                            inputPaths
+                                <> case (needsStakeKey, mStakePath) of
+                                    (True, Just p) -> [p]
+                                    _ -> []
+                    witsE <-
+                        withDecryptedExtKeyMaterial ekey userPwd
+                            $ \rootKm -> do
+                                results <-
+                                    forM allPaths $ \path ->
+                                        withDerivedExtKeyMaterial
+                                            DerivationScheme2
+                                            rootKm
+                                            ( map getDerivationIndex
+                                                $ NE.toList path
+                                            )
+                                            $ \addrKm ->
+                                                Right
+                                                    <$> mkShelleyWitnessFromExtKeyMaterial
+                                                        recentEra'
+                                                        txBody
+                                                        addrKm
+                                pure $ sequence results
+                    shelleyWits <- case witsE of
+                        Left e ->
+                            error
+                                $ "buildSignSubmitTransaction V2: "
+                                <> show e
+                        Right wits -> pure wits
+                    let signedLedgerTx =
+                            unsignedTx
+                                & witsTxL . addrTxWitsL
+                                    .~ Set.fromList shelleyWits
+                        builtSealedTx = sealWriteTx recentEra' signedLedgerTx
+                        rawTx =
+                            walletTx
+                                $ decodeTx txLayer anyCardanoEra builtSealedTx
+                        utxo' =
+                            applyOurTxToUTxO
+                                (Slot.at $ currentTip wallet ^. #slotNo)
+                                (currentTip wallet ^. #blockHeight)
+                                walletSt
+                                rawTx
+                                walletUtxo
+                        builtTxMeta = case utxo' of
+                            Nothing ->
+                                error
+                                    "buildSignSubmitTransaction V2: \
+                                    \Can't apply constructed transaction."
+                            Just ((_tx, appliedMeta), _, _) ->
+                                appliedMeta
+                                    { status = Pending
+                                    , expiry =
+                                        Just
+                                            (snd $ txValidityInterval txCtx)
+                                    }
+                        resolveInputs_ =
+                            fmap
+                                ( \(txIn, _) ->
+                                    (txIn, UTxO.lookup txIn walletUtxo)
+                                )
+                        txResolved =
+                            rawTx
+                                { resolvedInputs =
+                                    resolveInputs_ (resolvedInputs rawTx)
+                                , resolvedCollateralInputs =
+                                    resolveInputs_
+                                        (resolvedCollateralInputs rawTx)
+                                }
+                    let builtTx =
+                            BuiltTx
+                                { builtTx = txResolved
+                                , builtTxMeta
+                                , builtSealedTx
+                                }
+                    atomically
+                        $ Delta.onDBVar walletState
+                        . WalletState.updateSubmissions
+                        . Delta.update
+                        $ \_ -> Submissions.addTxSubmission builtTx slot
+                    postSealedTx netLayer builtSealedTx
+                        & throwWrappedErr wrapNetworkError
+                        & liftIO
+                    slotToUTCTime slot
+                        & interpretQuery
+                            (neverFails "slot is ahead of the node tip" ti)
+                        & fmap (builtTx,)
+                        & liftIO
       where
         wrapRootKeyError = ExceptionWitnessTx . ErrWitnessTxWithRootKey
         wrapNetworkError = ExceptionSubmitTx . ErrSubmitTxNetwork
@@ -2897,10 +3069,146 @@ buildAndSignTransaction
 buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
     db & \DBLayer{..} ->
         withRootKey db wid pwd ErrSignPaymentWithRootKey $ \case
-            RootKeyAccessV2{} ->
-                liftIO
-                    $ error
-                        "buildAndSignTransaction: V2 key signing not yet implemented"
+            RootKeyAccessV2 ekey _mPayload userPwd -> do
+                cp <- mapExceptT atomically $ lift readCheckpoint
+                (Write.PParamsInAnyRecentEra era' _pp, _) <-
+                    liftIO $ readNodeTipStateForTxWrite nl
+                let walletSt = getState cp
+                    walletUtxo = cp ^. #utxo
+                    network = sNetworkIdToLedger $ sNetworkId @(NetworkOf s)
+                    stakeXPub = case walletFlavor @s of
+                        ShelleyWallet ->
+                            getRawKey kF $ Seq.rewardAccountKey walletSt
+                        _ -> error "buildAndSignTransaction V2: non-shelley wallet"
+                    delegCerts = case view #txDelegationAction txCtx of
+                        Nothing -> []
+                        Just action ->
+                            certificateFromDelegationActionLedger
+                                era'
+                                (Left stakeXPub)
+                                (view #txDeposit txCtx)
+                                action
+                    votingCerts = case view #txVotingAction txCtx of
+                        Nothing -> []
+                        Just action ->
+                            certificateFromVotingActionLedger
+                                era'
+                                (Left stakeXPub)
+                                (view #txDeposit txCtx)
+                                action
+                    allCerts = L.nub $ delegCerts <> votingCerts
+                unsignedTx <- withExceptT ErrSignPaymentMkTx
+                    $ ExceptT
+                    $ pure
+                    $ constructUnsignedTxLedger
+                        era'
+                        network
+                        (view #txMetadata txCtx, allCerts)
+                        (txValidityInterval txCtx)
+                        (view #txWithdrawal txCtx)
+                        ( fst $ view #txAssetsToMint txCtx
+                        , fst $ view #txAssetsToBurn txCtx
+                        )
+                        (Right sel)
+                        (selectionDelta sel)
+                let txBody = unsignedTx ^. bodyTxL
+                    inputPaths =
+                        L.nub
+                            $ mapMaybe
+                                ( \ledIn ->
+                                    UTxO.lookup
+                                        (toWallet ledIn)
+                                        walletUtxo
+                                        >>= \(TxOut addr _) ->
+                                            fst (isOurs addr walletSt)
+                                )
+                                ( Set.toList
+                                    $ unsignedTx ^. bodyTxL . inputsTxBodyL
+                                )
+                    mStakePath = case walletFlavor @s of
+                        ShelleyWallet ->
+                            Just
+                                $ stakeDerivationPath
+                                $ Seq.derivationPrefix walletSt
+                        _ -> Nothing
+                    needsStakeKey =
+                        isJust (view #txDelegationAction txCtx)
+                            || isJust (view #txVotingAction txCtx)
+                            || containsSelfWithdrawal (view #txWithdrawal txCtx)
+                    allPaths =
+                        inputPaths
+                            <> case (needsStakeKey, mStakePath) of
+                                (True, Just p) -> [p]
+                                _ -> []
+                witsE <-
+                    liftIO $ withDecryptedExtKeyMaterial ekey userPwd
+                        $ \rootKm -> do
+                            results <-
+                                forM allPaths $ \path ->
+                                    withDerivedExtKeyMaterial
+                                        DerivationScheme2
+                                        rootKm
+                                        ( map getDerivationIndex
+                                            $ NE.toList path
+                                        )
+                                        $ \addrKm ->
+                                            Right
+                                                <$> mkShelleyWitnessFromExtKeyMaterial
+                                                    era'
+                                                    txBody
+                                                    addrKm
+                            pure $ sequence results
+                shelleyWits <- case witsE of
+                    Left e ->
+                        error
+                            $ "buildAndSignTransaction V2: "
+                            <> show e
+                    Right wits -> pure wits
+                let signedLedgerTx =
+                        unsignedTx
+                            & witsTxL . addrTxWitsL
+                                .~ Set.fromList shelleyWits
+                    builtSealedTx = sealWriteTx era' signedLedgerTx
+                    txExt = case era' of
+                        Write.RecentEraConway ->
+                            getTxExtended
+                                (Read.Tx signedLedgerTx :: Read.Tx Read.Conway)
+                        Write.RecentEraDijkstra ->
+                            getTxExtended
+                                ( Read.Tx signedLedgerTx
+                                    :: Read.Tx Read.Dijkstra
+                                )
+                    rawTx = walletTx txExt
+                    amountOut :: Coin =
+                        F.fold
+                            $ fmap TxOut.coin (sel ^. #change)
+                                <> mapMaybe
+                                    (`ourCoin` walletSt)
+                                    (sel ^. #outputs)
+                    amountIn :: Coin =
+                        F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
+                            & case view #txWithdrawal txCtx of
+                                w@WithdrawalSelf{} ->
+                                    Coin.add (withdrawalToCoin w)
+                                WithdrawalExternal{} -> Prelude.id
+                                NoWithdrawal -> Prelude.id
+                    resolveInputs =
+                        fmap (\(txIn, _) -> (txIn, UTxO.lookup txIn walletUtxo))
+                    txResolved =
+                        rawTx
+                            { resolvedInputs =
+                                resolveInputs (resolvedInputs rawTx)
+                            , resolvedCollateralInputs =
+                                resolveInputs (resolvedCollateralInputs rawTx)
+                            }
+                time <- liftIO $ tipSlotStartTime $ currentTip cp
+                let meta =
+                        mkTxMeta
+                            (currentTip cp)
+                            (txValidityInterval txCtx)
+                            amountIn
+                            amountOut
+                pure (txResolved, meta, time, builtSealedTx)
             RootKeyAccessV1 xprv scheme ->
                 let pwdP = preparePassphrase scheme pwd
                 in mapExceptT atomically $ do

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -291,19 +291,11 @@ import Cardano.Balance.Tx.TimeTranslation
 import Cardano.Balance.Tx.Tx
     ( toRecentEraGADT
     )
-import Cardano.Crypto.Libsodium
-    ( mlsbFinalize
-    , mlsbToByteString
-    )
 import Cardano.Crypto.Wallet
     ( toXPub
     )
 import Cardano.Crypto.WalletHD.Encrypted
-    ( EncryptedKey
-    , XPrvError (..)
-    , encryptedChainCode
-    , encryptedCreateDirectWithTweak
-    , encryptedKeyMaterial
+    ( encryptedCreateDirectWithTweak
     , encryptedValidatePassphrase
     )
 import Cardano.Ledger.Api
@@ -3715,9 +3707,9 @@ attachPrivateKeyFromPwd ctx (key, pwd) = do
   where
     db = ctx ^. dbLayer
 
--- | Build a 'HashedCredentialsV2' from a v1-PBKDF2-encrypted root key.
--- Decrypts the scalar, wraps it in a v2 Argon2id envelope, and preserves the
--- Byron address-derivation payload (if applicable).
+-- | Build a 'HashedCredentialsV2' from a PBKDF2-encrypted root key.
+-- Derives the plaintext scalar+chaincode to create an Argon2id authentication
+-- envelope, and stores the original PBKDF2-encrypted key for key operations.
 mkV2Credentials
     :: KeyFlavorS k
     -> k 'RootK XPrv
@@ -3731,14 +3723,11 @@ mkV2Credentials kF key pwd = do
         raw128 = CC.unXPrv plaintextXprv
         -- Master-key group for encryptedCreateDirectWithTweak: scalar(64) || cc(32)
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
-        mPayload = case kF of
-            ByronKeyS -> Just (payloadPassphrase key)
-            _ -> Nothing
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left err ->
             error
                 $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
-        Right ekey -> pure $ HashedCredentialsV2 ekey mPayload
+        Right ekey -> pure $ HashedCredentialsV2 key ekey
 
 -- | The hash here is the output of Scrypt function with the following parameters:
 -- - logN = 14
@@ -3781,7 +3770,7 @@ reattachPrivateKey ctx creds =
   where
     scheme = case creds of
         HashedCredentialsV1 _ _ -> currentPassphraseScheme
-        HashedCredentialsV2 _ _ -> EncryptWithArgon2idV2
+        HashedCredentialsV2{} -> EncryptWithArgon2idV2
 
 attachPrivateKey
     :: DBLayer IO s
@@ -3809,15 +3798,16 @@ attachPrivateKey db creds scheme =
 --
 -- 'withRootKey' takes a callback function with two arguments:
 --
---  - The root private key (plaintext scalar for v2, PBKDF2/Scrypt-encrypted for v1)
---  - The underlying passphrase scheme
+--  - The root private key (PBKDF2-encrypted for all stored variants)
+--  - The passphrase scheme to use ('currentPassphraseScheme')
 --
 -- Callers are expected to use 'preparePassphrase' with the given scheme in
 -- order to "prepare" the passphrase before passing it to signing / derivation
--- functions.  For v2 keys the scheme is 'EncryptWithArgon2idV2', and
--- @preparePassphrase EncryptWithArgon2idV2 _ = Passphrase mempty@, which
--- causes the C layer to run in memcpy / no-op mode (correct, because the
--- in-memory XPrv already has a plaintext scalar).
+-- functions.
+--
+-- For v2 keys, passphrase authentication uses the Argon2id AEAD envelope;
+-- the key itself remains PBKDF2-encrypted so key-operation callers use the
+-- same 'preparePassphrase' path as v1.
 --
 -- V1 keys are opportunistically migrated to v2 on every successful use.
 --
@@ -3845,30 +3835,31 @@ withRootKey db@DBLayer{..} wid pwd embed action = do
             pure $ case checkPassphrase scheme pwd hpwd of
                 Left err -> Left $ ErrWithRootKeyWrongPassphrase wid err
                 Right _ -> Right $ Left (xprv, scheme)
-        (Just (HashedCredentialsV2 ekey mPayload), Just _) -> do
+        (Just (HashedCredentialsV2 xprv ekey), Just _) -> do
             result <- encryptedValidatePassphrase ekey pwd
             pure $ case result of
                 Left _ ->
                     Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
-                Right () -> Right $ Right (ekey, mPayload)
+                Right () -> Right $ Right xprv
         _ -> pure $ Left $ ErrWithRootKeyNoRootKey wid
     case validated of
         Left (xprv, scheme) -> do
             -- Opportunistically migrate V1 → V2 on successful passphrase use.
             lift $ migrateV1toV2 db kF xprv scheme pwd
             action xprv scheme
-        Right (ekey, mPayload) -> do
-            result <- lift $ decryptV2 kF ekey mPayload pwd
-            case result of
-                Left _ ->
-                    throwE $ embed $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
-                Right xprv -> action xprv EncryptWithArgon2idV2
+        Right xprv ->
+            action xprv currentPassphraseScheme
   where
     kF = keyFlavorFromState @s
 
 -- | Migrate a V1 PBKDF2- or Scrypt-encrypted root key to a V2 Argon2id
 -- envelope and write it back to the database.  Fails silently so that the
 -- current operation is not affected if migration is unsuccessful.
+--
+-- The stored XPrv in the resulting 'HashedCredentialsV2' is always
+-- re-encrypted with 'currentPassphraseScheme' (PBKDF2), regardless of the
+-- original V1 scheme.  This ensures that 'withRootKey' can always return
+-- 'currentPassphraseScheme' for V2 credentials.
 migrateV1toV2
     :: forall s
      . DBLayer IO s
@@ -3880,40 +3871,25 @@ migrateV1toV2
 migrateV1toV2 DBLayer{..} kF key scheme pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase scheme pwd
+        -- Decrypt to plaintext (empty passphrase)
         plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
         raw128 = CC.unXPrv plaintextXprv
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        -- Re-encrypt with current scheme (PBKDF2) for V2 stored key
+        pbkdf2Prepared = preparePassphrase currentPassphraseScheme pwd
+        pbkdf2XPrv = CC.xPrvChangePass (mempty :: ByteString) pbkdf2Prepared plaintextXprv
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
+        v2Key = reconstructRootKey kF pbkdf2XPrv mPayload
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left _ -> pure () -- fail silently; key stays V1 until next use
         Right ekey -> atomically $ do
-            putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
+            putPrivateKey walletState (HashedCredentialsV2 v2Key ekey)
             meta <- readWalletMeta walletState
             let updateScheme info = info{passphraseScheme = EncryptWithArgon2idV2}
             putWalletMeta walletState
                 $ meta{passphraseInfo = fmap updateScheme (passphraseInfo meta)}
-
--- | Decrypt a V2 'EncryptedKey' and reconstruct the flavored root key with a
--- plaintext scalar (suitable for use with 'EncryptWithArgon2idV2' scheme).
-decryptV2
-    :: KeyFlavorS k
-    -> EncryptedKey
-    -> Maybe (Passphrase "addr-derivation-payload")
-    -> Passphrase "user"
-    -> IO (Either XPrvError (k 'RootK XPrv))
-decryptV2 kF ekey mPayload pwd = do
-    result <- encryptedKeyMaterial ekey pwd
-    case result of
-        Left err -> pure $ Left err
-        Right scalar64 -> do
-            scalar64bs <- mlsbToByteString scalar64
-            mlsbFinalize scalar64
-            let raw96bs = scalar64bs <> encryptedChainCode ekey
-            pure $ case CC.xprv raw96bs of
-                Left _ -> Left XPrvInvalidSecretKey
-                Right plaintextXprv -> Right $ reconstructRootKey kF plaintextXprv mPayload
 
 reconstructRootKey
     :: KeyFlavorS k

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -753,6 +753,7 @@ import Control.Monad.Trans.State
 import Control.Tracer
     ( Tracer
     , contramap
+    , nullTracer
     , traceWith
     )
 import Cryptography.Hash.Blake
@@ -1300,7 +1301,7 @@ updateWalletPassphraseWithOldPassphrase
     -> (Passphrase "user", Passphrase "user")
     -> ExceptT ErrUpdatePassphrase IO ()
 updateWalletPassphraseWithOldPassphrase wF ctx wid (old, new) =
-    withRootKey db wid old ErrUpdatePassphraseWithRootKey $ \case
+    withRootKey (contramap MsgWallet (logger_ ctx)) db wid old ErrUpdatePassphraseWithRootKey $ \case
         RootKeyAccessV1 xprv scheme -> do
             -- IMPORTANT NOTE:
             -- This uses 'EncryptWithPBKDF2', regardless of the passphrase
@@ -1941,7 +1942,7 @@ createRandomAddress
     -> ExceptT ErrCreateRandomAddress IO (Address, NonEmpty DerivationIndex)
 createRandomAddress ctx wid pwd mIx =
     db & \DBLayer{..} ->
-        withRootKey db wid pwd ErrCreateAddrWithRootKey $ \case
+        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrCreateAddrWithRootKey $ \case
             RootKeyAccessV1 xprv scheme ->
                 ExceptT
                     . atomically
@@ -2534,63 +2535,8 @@ buildSignSubmitTransaction
             readNodeTipStateForTxWrite netLayer
         let ti = timeInterpreter netLayer
         throwOnErr <=< runExceptT
-            $ withRootKey db walletId pwd wrapRootKeyError
+            $ withRootKey nullTracer db walletId pwd wrapRootKeyError
             $ \case
-                RootKeyAccessV1 rootKey scheme -> lift $ do
-                    (BuiltTx{..}, slot) <- atomically $ do
-                        pendingTxs <-
-                            fmap fromTransactionInfo
-                                <$> readTransactions
-                                    Nothing
-                                    Descending
-                                    Range.everything
-                                    (Just Pending)
-                                    Nothing
-                                    Nothing
-                        txWithSlot@(builtTx, slot) <- ( throwOnErr
-                                                            <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
-                                                      )
-                            $ \s -> do
-                                let wallet = WalletState.getLatest s
-                                    utxo = availableUTxO (Set.fromList pendingTxs) wallet
-                                buildAndSignTransactionPure @k @s
-                                    timeTranslation
-                                    utxo
-                                    rootKey
-                                    scheme
-                                    pwd
-                                    protocolParams
-                                    txLayer
-                                    changeAddrGen
-                                    preSelection
-                                    txCtx
-                                    & (`runStateT` wallet)
-                                    & runExceptT . withExceptT wrapBalanceConstructError
-                                    & (`evalRand` stdGen)
-                                    & fmap
-                                        ( \(builtTx, wallet') ->
-                                            -- Newly generated change addresses
-                                            -- only change the Prologue
-                                            ( [ReplacePrologue $ getPrologue $ getState wallet']
-                                            , (builtTx, currentTip wallet' ^. #slotNo)
-                                            )
-                                        )
-
-                        Delta.onDBVar walletState
-                            . WalletState.updateSubmissions
-                            . Delta.update
-                            $ \_ -> Submissions.addTxSubmission builtTx slot
-
-                        pure txWithSlot
-
-                    postSealedTx netLayer builtSealedTx
-                        & throwWrappedErr wrapNetworkError
-                        & liftIO
-
-                    slotToUTCTime slot
-                        & interpretQuery (neverFails "slot is ahead of the node tip" ti)
-                        & fmap (BuiltTx{..},)
-                        & liftIO
                 RootKeyAccessV2 ekey _mPayload userPwd -> lift $ do
                     let recentEra' = _era
                         anyCardanoEra = case recentEra' of
@@ -2756,6 +2702,60 @@ buildSignSubmitTransaction
                         & interpretQuery
                             (neverFails "slot is ahead of the node tip" ti)
                         & fmap (builtTx,)
+                        & liftIO
+                RootKeyAccessV1 rootKey scheme -> lift $ do
+                    (BuiltTx{..}, slot) <- atomically $ do
+                        pendingTxs <-
+                            fmap fromTransactionInfo
+                                <$> readTransactions
+                                    Nothing
+                                    Descending
+                                    Range.everything
+                                    (Just Pending)
+                                    Nothing
+                                    Nothing
+                        txWithSlot@(builtTx, slot) <-
+                            ( throwOnErr
+                                    <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
+                                )
+                                $ \s -> do
+                                    let wallet = WalletState.getLatest s
+                                        utxo = availableUTxO (Set.fromList pendingTxs) wallet
+                                    buildAndSignTransactionPure @k @s
+                                        timeTranslation
+                                        utxo
+                                        rootKey
+                                        scheme
+                                        pwd
+                                        protocolParams
+                                        txLayer
+                                        changeAddrGen
+                                        preSelection
+                                        txCtx
+                                        & (`runStateT` wallet)
+                                        & runExceptT . withExceptT wrapBalanceConstructError
+                                        & (`evalRand` stdGen)
+                                        & fmap
+                                            ( \(builtTx, wallet') ->
+                                                ( [ReplacePrologue $ getPrologue $ getState wallet']
+                                                , (builtTx, currentTip wallet' ^. #slotNo)
+                                                )
+                                            )
+
+                        Delta.onDBVar walletState
+                            . WalletState.updateSubmissions
+                            . Delta.update
+                            $ \_ -> Submissions.addTxSubmission builtTx slot
+
+                        pure txWithSlot
+
+                    postSealedTx netLayer builtSealedTx
+                        & throwWrappedErr wrapNetworkError
+                        & liftIO
+
+                    slotToUTCTime slot
+                        & interpretQuery (neverFails "slot is ahead of the node tip" ti)
+                        & fmap (BuiltTx{..},)
                         & liftIO
       where
         wrapRootKeyError = ExceptionWitnessTx . ErrWitnessTxWithRootKey
@@ -3068,7 +3068,7 @@ buildAndSignTransaction
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
     db & \DBLayer{..} ->
-        withRootKey db wid pwd ErrSignPaymentWithRootKey $ \case
+        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrSignPaymentWithRootKey $ \case
             RootKeyAccessV2 ekey _mPayload userPwd -> do
                 cp <- mapExceptT atomically $ lift readCheckpoint
                 (Write.PParamsInAnyRecentEra era' _pp, _) <-
@@ -3079,6 +3079,9 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
                     stakeXPub = case walletFlavor @s of
                         ShelleyWallet ->
                             getRawKey kF $ Seq.rewardAccountKey walletSt
+                        -- Guard: only Shelley wallets have sequential state and a
+                        -- reward account; this branch is unreachable for other flavors
+                        -- because the outer ShelleyWallet constraint holds.
                         _ -> error "buildAndSignTransaction V2: non-shelley wallet"
                     delegCerts = case view #txDelegationAction txCtx of
                         Nothing -> []
@@ -4105,9 +4108,25 @@ attachPrivateKeyFromPwd ctx (key, pwd) = do
   where
     db = ctx ^. dbLayer
 
+-- | Strip the 32-byte internal PBKDF2 passphrase hash from a plaintext
+-- (decrypted) cardano-crypto 'XPrv' and return the 96-byte payload expected
+-- by 'encryptedCreateDirectWithTweak'.
+--
+-- cardano-crypto 'XPrv' layout (128 bytes):
+--   bytes  0– 63: Ed25519 extended scalar
+--   bytes 64– 95: PBKDF2-encrypted scalar copy (internal; not used after decryption)
+--   bytes 96–127: chain code
+extractPlaintextMasterBytes :: XPrv -> ByteString
+extractPlaintextMasterBytes plaintextXprv =
+    let raw128 = CC.unXPrv plaintextXprv
+    in  BS.take 64 raw128 <> BS.drop 96 raw128
+
 -- | Build a 'HashedCredentialsV2' from a PBKDF2-encrypted root key.
 -- Derives the plaintext scalar+chaincode to create an Argon2id AEAD
 -- envelope.  The plaintext key is never persisted.
+--
+-- NOTE: Only valid for PBKDF2-encrypted keys.  For Scrypt-encrypted keys
+-- use 'migrateV1toV2', which accepts the actual passphrase scheme.
 mkV2Credentials
     :: KeyFlavorS k
     -> k 'RootK XPrv
@@ -4117,8 +4136,7 @@ mkV2Credentials kF key pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase currentPassphraseScheme pwd
         plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
-        raw128 = CC.unXPrv plaintextXprv
-        masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        masterKey96 = extractPlaintextMasterBytes plaintextXprv
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
@@ -4220,13 +4238,14 @@ data RootKeyAccess k
 withRootKey
     :: forall s e a
      . WalletFlavor s
-    => DBLayer IO s
+    => Tracer IO WalletLog
+    -> DBLayer IO s
     -> WalletId
     -> Passphrase "user"
     -> (ErrWithRootKey -> e)
     -> (RootKeyAccess (KeyOf s) -> ExceptT e IO a)
     -> ExceptT e IO a
-withRootKey db@DBLayer{..} wid pwd embed action = do
+withRootKey tr db@DBLayer{..} wid pwd embed action = do
     (mCreds, mScheme) <- lift . atomically $ do
         wMetadata <- readWalletMeta walletState
         let mScheme = passphraseScheme <$> passphraseInfo wMetadata
@@ -4245,7 +4264,7 @@ withRootKey db@DBLayer{..} wid pwd embed action = do
         _ -> pure $ Left $ ErrWithRootKeyNoRootKey wid
     case validated of
         rka@(RootKeyAccessV1 xprv scheme) -> do
-            lift $ migrateV1toV2 db kF xprv scheme pwd
+            lift $ migrateV1toV2 tr db kF xprv scheme pwd
             action rka
         rka@(RootKeyAccessV2 _ _ _) -> action rka
   where
@@ -4265,27 +4284,28 @@ withDerivedExtKeyMaterial scheme km (ix : ixs) k =
         withDerivedExtKeyMaterial scheme km' ixs k
 
 -- | Migrate a V1 PBKDF2- or Scrypt-encrypted root key to a V2 Argon2id
--- envelope and write it back to the database.  Fails silently so that the
--- current operation is not affected if migration is unsuccessful.
+-- envelope and write it back to the database.  On failure the error is traced
+-- as a 'MsgV2MigrationFailed' warning and the key stays V1 until the next use.
 migrateV1toV2
     :: forall s
-     . DBLayer IO s
+     . Tracer IO WalletLog
+    -> DBLayer IO s
     -> KeyFlavorS (KeyOf s)
     -> KeyOf s 'RootK XPrv
     -> PassphraseScheme
     -> Passphrase "user"
     -> IO ()
-migrateV1toV2 DBLayer{..} kF key scheme pwd = do
+migrateV1toV2 tr DBLayer{..} kF key scheme pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase scheme pwd
         plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
-        raw128 = CC.unXPrv plaintextXprv
-        masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        masterKey96 = extractPlaintextMasterBytes plaintextXprv
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
-        Left _ -> pure () -- fail silently; key stays V1 until next use
+        Left err -> do
+            traceWith tr $ MsgV2MigrationFailed $ T.pack $ show err
         Right ekey -> atomically $ do
             putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
             meta <- readWalletMeta walletState
@@ -4318,7 +4338,7 @@ signMetadataWith ctx wid pwd (role_, ix) metadata =
 
         cp <- lift $ atomically readCheckpoint
 
-        withRootKey db wid pwd ErrSignMetadataWithRootKey $ \case
+        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrSignMetadataWithRootKey $ \case
             RootKeyAccessV1 rootK scheme -> do
                 let encPwd = preparePassphrase scheme pwd
                     DerivationPrefix (_, _, acctIx) = Seq.derivationPrefix (getState cp)
@@ -4411,6 +4431,7 @@ writePolicyPublicKey ctx wid pwd =
         let (SeqPrologue seqState) = getPrologue $ getState cp
 
         policyXPub <- withRootKey
+            (contramap MsgWallet (logger_ ctx))
             db
             wid
             pwd
@@ -4513,7 +4534,7 @@ getAccountPublicKeyAtIndex ctx wid pwd ix purposeM =
 
         _cp <- lift $ atomically readCheckpoint
         let kf = keyFlavorFromState @s
-        withRootKey db wid pwd ErrReadAccountPublicKeyRootKey
+        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrReadAccountPublicKeyRootKey
             $ \case
                 RootKeyAccessV1 rootK scheme -> do
                     let encPwd = preparePassphrase scheme pwd
@@ -4967,6 +4988,7 @@ data WalletLog
     | MsgRewardBalanceExited
     | MsgTxSubmit TxSubmitLog
     | MsgIsStakeKeyRegistered Bool
+    | MsgV2MigrationFailed Text
     deriving (Show, Eq)
 
 instance ToText WalletFollowLog where
@@ -5031,6 +5053,8 @@ instance ToText WalletLog where
             "Wallet stake key is registered. Will not register it again."
         MsgIsStakeKeyRegistered False ->
             "Wallet stake key is not registered. Will register..."
+        MsgV2MigrationFailed err ->
+            "V1->V2 key migration failed (key stays V1 until next use): " <> err
 
 instance HasPrivacyAnnotation WalletFollowLog
 instance HasSeverityAnnotation WalletFollowLog where
@@ -5053,6 +5077,7 @@ instance HasSeverityAnnotation WalletLog where
         MsgRewardBalanceExited -> Notice
         MsgTxSubmit msg -> getSeverityAnnotation msg
         MsgIsStakeKeyRegistered _ -> Info
+        MsgV2MigrationFailed _ -> Warning
 
 data TxSubmitLog
     = MsgSubmitTx BuiltTx (BracketLog' (Either ErrSubmitTx ()))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3877,7 +3877,8 @@ migrateV1toV2 DBLayer{..} kF key scheme pwd = do
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
         -- Re-encrypt with current scheme (PBKDF2) for V2 stored key
         pbkdf2Prepared = preparePassphrase currentPassphraseScheme pwd
-        pbkdf2XPrv = CC.xPrvChangePass (mempty :: ByteString) pbkdf2Prepared plaintextXprv
+        pbkdf2XPrv =
+            CC.xPrvChangePass (mempty :: ByteString) pbkdf2Prepared plaintextXprv
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -294,6 +294,10 @@ import Cardano.Balance.Tx.Tx
 import Cardano.Crypto.Wallet
     ( toXPub
     )
+import Cardano.Crypto.Libsodium
+    ( mlsbFinalize
+    , mlsbToByteString
+    )
 import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     , XPrvError (..)
@@ -3703,8 +3707,9 @@ attachPrivateKeyFromPwd
     => WalletLayer IO s
     -> (KeyOf s 'RootK XPrv, Passphrase "user")
     -> IO ()
-attachPrivateKeyFromPwd ctx (key, pwd) =
-    attachPrivateKey db (mkV2Credentials (keyFlavorFromState @s) key pwd) EncryptWithArgon2idV2
+attachPrivateKeyFromPwd ctx (key, pwd) = do
+    creds <- mkV2Credentials (keyFlavorFromState @s) key pwd
+    attachPrivateKey db creds EncryptWithArgon2idV2
   where
     db = ctx ^. dbLayer
 
@@ -3715,8 +3720,8 @@ mkV2Credentials
     :: KeyFlavorS k
     -> k 'RootK XPrv
     -> Passphrase "user"
-    -> HashedCredentials k
-mkV2Credentials kF key pwd =
+    -> IO (HashedCredentials k)
+mkV2Credentials kF key pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase currentPassphraseScheme pwd
         -- Decrypt PBKDF2-encrypted XPrv to plaintext (empty new passphrase)
@@ -3727,10 +3732,10 @@ mkV2Credentials kF key pwd =
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
-    in case encryptedCreateDirectWithTweak masterKey96 pwd of
+    encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left err ->
             error $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
-        Right ekey -> HashedCredentialsV2 ekey mPayload
+        Right ekey -> pure $ HashedCredentialsV2 ekey mPayload
 
 -- | The hash here is the output of Scrypt function with the following parameters:
 -- - logN = 14
@@ -3824,28 +3829,31 @@ withRootKey
     -> (KeyOf s 'RootK XPrv -> PassphraseScheme -> ExceptT e IO a)
     -> ExceptT e IO a
 withRootKey db@DBLayer{..} wid pwd embed action = do
-    validated <- withExceptT embed . ExceptT . atomically $ do
+    (mCreds, mScheme) <- lift . atomically $ do
         wMetadata <- readWalletMeta walletState
         let mScheme = passphraseScheme <$> passphraseInfo wMetadata
         mCreds <- readPrivateKey walletState
-        pure $ case (mCreds, mScheme) of
-            (Just (HashedCredentialsV1 xprv hpwd), Just scheme) ->
-                case checkPassphrase scheme pwd hpwd of
-                    Left err -> Left $ ErrWithRootKeyWrongPassphrase wid err
-                    Right _ -> Right $ Left (xprv, scheme)
-            (Just (HashedCredentialsV2 ekey mPayload), Just _) ->
-                case encryptedValidatePassphrase ekey pwd of
-                    Left _ ->
-                        Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
-                    Right () -> Right $ Right (ekey, mPayload)
-            _ -> Left $ ErrWithRootKeyNoRootKey wid
+        pure (mCreds, mScheme)
+    validated <- withExceptT embed . ExceptT $ case (mCreds, mScheme) of
+        (Just (HashedCredentialsV1 xprv hpwd), Just scheme) ->
+            pure $ case checkPassphrase scheme pwd hpwd of
+                Left err -> Left $ ErrWithRootKeyWrongPassphrase wid err
+                Right _ -> Right $ Left (xprv, scheme)
+        (Just (HashedCredentialsV2 ekey mPayload), Just _) -> do
+            result <- encryptedValidatePassphrase ekey pwd
+            pure $ case result of
+                Left _ ->
+                    Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                Right () -> Right $ Right (ekey, mPayload)
+        _ -> pure $ Left $ ErrWithRootKeyNoRootKey wid
     case validated of
         Left (xprv, scheme) -> do
             -- Opportunistically migrate V1 → V2 on successful passphrase use.
             lift $ migrateV1toV2 db kF xprv scheme pwd
             action xprv scheme
-        Right (ekey, mPayload) ->
-            case decryptV2 kF ekey mPayload pwd of
+        Right (ekey, mPayload) -> do
+            result <- lift $ decryptV2 kF ekey mPayload pwd
+            case result of
                 Left _ ->
                     throwE $ embed $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
                 Right xprv -> action xprv EncryptWithArgon2idV2
@@ -3872,7 +3880,7 @@ migrateV1toV2 DBLayer{..} kF key scheme pwd = do
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
-    case encryptedCreateDirectWithTweak masterKey96 pwd of
+    encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left _ -> pure ()  -- fail silently; key stays V1 until next use
         Right ekey -> atomically $ do
             putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
@@ -3888,13 +3896,17 @@ decryptV2
     -> EncryptedKey
     -> Maybe (Passphrase "addr-derivation-payload")
     -> Passphrase "user"
-    -> Either XPrvError (k 'RootK XPrv)
+    -> IO (Either XPrvError (k 'RootK XPrv))
 decryptV2 kF ekey mPayload pwd = do
-    raw128 <- encryptedKeyMaterial ekey pwd
-    let raw128bs = BA.convert raw128 :: ByteString
-    case CC.xprv raw128bs of
-        Left _ -> Left XPrvInvalidSecretKey
-        Right plaintextXprv -> Right $ reconstructRootKey kF plaintextXprv mPayload
+    result <- encryptedKeyMaterial ekey pwd
+    case result of
+        Left err -> pure $ Left err
+        Right raw128 -> do
+            raw128bs <- mlsbToByteString raw128
+            mlsbFinalize raw128
+            pure $ case CC.xprv raw128bs of
+                Left _ -> Left XPrvInvalidSecretKey
+                Right plaintextXprv -> Right $ reconstructRootKey kF plaintextXprv mPayload
 
 reconstructRootKey
     :: KeyFlavorS k

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2444,12 +2444,7 @@ signTransactionV2 era sealedTx wallet walletUtxo ekey userPwd =
                         DerivationScheme2
                         rootKm
                         (map getDerivationIndex $ NE.toList path)
-                        $ \addrKm ->
-                            Right
-                                <$> mkShelleyWitnessFromExtKeyMaterial
-                                    recentEra'
-                                    txBody
-                                    addrKm
+                        $ fmap Right . mkShelleyWitnessFromExtKeyMaterial recentEra' txBody
             pure $ sequence results
         case witsE of
             Left e ->
@@ -2774,12 +2769,7 @@ buildSignSubmitTransaction
                                             ( map getDerivationIndex
                                                 $ NE.toList path
                                             )
-                                            $ \addrKm ->
-                                                Right
-                                                    <$> mkShelleyWitnessFromExtKeyMaterial
-                                                        recentEra'
-                                                        txBody
-                                                        addrKm
+                                            $ fmap Right . mkShelleyWitnessFromExtKeyMaterial recentEra' txBody
                                 pure $ sequence results
                     shelleyWits <- case witsE of
                         Left e ->
@@ -3321,12 +3311,7 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
                                             ( map getDerivationIndex
                                                 $ NE.toList path
                                             )
-                                            $ \addrKm ->
-                                                Right
-                                                    <$> mkShelleyWitnessFromExtKeyMaterial
-                                                        era'
-                                                        txBody
-                                                        addrKm
+                                            $ fmap Right . mkShelleyWitnessFromExtKeyMaterial era' txBody
                                 pure $ sequence results
                     shelleyWits <- case witsE of
                         Left e ->
@@ -4465,7 +4450,7 @@ withRootKey tr db@DBLayer{..} wid pwd embed action = do
                 IcarusKeyS -> pure ()
                 _ -> lift $ migrateV1toV2 tr db kF xprv scheme pwd
             action rka
-        rka@(RootKeyAccessV2 _ _ _) -> action rka
+        rka@RootKeyAccessV2{} -> action rka
   where
     kF = keyFlavorFromState @s
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -75,6 +75,7 @@ module Cardano.Wallet
     , attachPrivateKeyFromPwd
     , attachPrivateKeyFromPwdHashByron
     , attachPrivateKeyFromPwdHashShelley
+    , reattachPrivateKey
     , getWalletUtxoSnapshot
     , listUtxoStatistics
     , readWallet
@@ -293,6 +294,13 @@ import Cardano.Balance.Tx.Tx
 import Cardano.Crypto.Wallet
     ( toXPub
     )
+import Cardano.Crypto.WalletV2.Encrypted
+    ( EncryptedKey
+    , XPrvError (..)
+    , encryptedCreateDirectWithTweak
+    , encryptedKeyMaterial
+    , encryptedValidatePassphrase
+    )
 import Cardano.Ledger.Api
     ( EraTxBody (allInputsTxBodyF)
     , bodyTxL
@@ -334,10 +342,12 @@ import Cardano.Wallet.Address.Derivation
     , stakeDerivationPath
     )
 import Cardano.Wallet.Address.Derivation.Byron
-    ( ByronKey
+    ( ByronKey (..)
+    , hdPassphrase
+    , payloadPassphrase
     )
 import Cardano.Wallet.Address.Derivation.Icarus
-    ( IcarusKey
+    ( IcarusKey (..)
     )
 import Cardano.Wallet.Address.Derivation.MintBurn
     ( derivePolicyPrivateKey
@@ -504,7 +514,6 @@ import Cardano.Wallet.Primitive.Passphrase
     , WalletPassphraseInfo (..)
     , checkPassphrase
     , currentPassphraseScheme
-    , encryptPassphrase
     , preparePassphrase
     )
 import Cardano.Wallet.Primitive.Slotting
@@ -566,6 +575,7 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Credentials
     ( ClearCredentials
+    , HashedCredentials (..)
     , RootCredentials (..)
     )
 import Cardano.Wallet.Primitive.Types.DRep
@@ -909,6 +919,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
 import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F
 import qualified Data.Functor
@@ -1155,19 +1166,16 @@ readWalletMeta walletState = walletMeta . info <$> readDBVar walletState
 readPrivateKey
     :: Functor stm
     => DBVar stm (DeltaWalletState s)
-    -> stm (Maybe (KeyOf s 'RootK XPrv, PassphraseHash))
-readPrivateKey walletState =
-    readDBVar walletState <&> \mc -> do
-        (RootCredentials pk h) <- credentials mc
-        pure (pk, h)
+    -> stm (Maybe (HashedCredentials (KeyOf s)))
+readPrivateKey walletState = credentials <$> readDBVar walletState
 
 putPrivateKey
     :: Monad m
     => DBVar m (DeltaWalletState s)
-    -> (KeyOf s 'RootK XPrv, PassphraseHash)
+    -> HashedCredentials (KeyOf s)
     -> m ()
-putPrivateKey walletState (pk, hpw) = onDBVar walletState $ update $ \_ ->
-    [UpdateCredentials $ Replace $ Just $ RootCredentials pk hpw]
+putPrivateKey walletState creds = onDBVar walletState $ update $ \_ ->
+    [UpdateCredentials $ Replace $ Just creds]
 
 readDelegation
     :: Monad stm
@@ -1255,7 +1263,8 @@ updateWallet ctx f = onWalletState ctx $ update $ \s ->
 -- | Change a wallet's passphrase to the given passphrase.
 updateWalletPassphraseWithOldPassphrase
     :: forall s
-     . WalletFlavorS s
+     . WalletFlavor s
+    => WalletFlavorS s
     -> WalletLayer IO s
     -> WalletId
     -> (Passphrase "user", Passphrase "user")
@@ -1278,7 +1287,8 @@ updateWalletPassphraseWithOldPassphrase wF ctx wid (old, new) =
     db = ctx ^. typed
 
 updateWalletPassphraseWithMnemonic
-    :: WalletLayer IO s
+    :: WalletFlavor s
+    => WalletLayer IO s
     -> (KeyOf s 'RootK XPrv, Passphrase "user")
     -> IO ()
 updateWalletPassphraseWithMnemonic ctx (xprv, new) =
@@ -1883,6 +1893,7 @@ createRandomAddress
        , ByronKey ~ KeyOf s
        , AddressBookIso s
        , HasSNetworkId n
+       , WalletFlavor s
        )
     => WalletLayer IO s
     -> WalletId
@@ -3681,20 +3692,45 @@ padFeePercentiles
                                   Key Store
 -------------------------------------------------------------------------------}
 
--- | Store an 'XPrv' which was encrypted with the given passphrase,
--- and also store the 'PassphraseHash' of the passphrase.
+-- | Store a root key encrypted with the given passphrase as a v2
+-- (Argon2id + XChaCha20-Poly1305) envelope and update the wallet metadata.
 --
--- Uses 'Cardano.Wallet.Primitive.Passphrase.encryptPassphrase' to
--- hash/encrypt the passphrase using the 'currentPassphraseScheme'.
+-- The input 'XPrv' must be encrypted with
+-- @preparePassphrase currentPassphraseScheme pwd@ (PBKDF2), which is the
+-- invariant upheld by all wallet-creation and passphrase-change paths.
 attachPrivateKeyFromPwd
-    :: WalletLayer IO s
+    :: forall s. WalletFlavor s
+    => WalletLayer IO s
     -> (KeyOf s 'RootK XPrv, Passphrase "user")
     -> IO ()
-attachPrivateKeyFromPwd ctx (xprv, pwd) = do
-    (scheme, hpwd) <- encryptPassphrase pwd
-    attachPrivateKey db (xprv, hpwd) scheme
+attachPrivateKeyFromPwd ctx (key, pwd) =
+    attachPrivateKey db (mkV2Credentials (keyFlavorFromState @s) key pwd) EncryptWithArgon2idV2
   where
     db = ctx ^. dbLayer
+
+-- | Build a 'HashedCredentialsV2' from a v1-PBKDF2-encrypted root key.
+-- Decrypts the scalar, wraps it in a v2 Argon2id envelope, and preserves the
+-- Byron address-derivation payload (if applicable).
+mkV2Credentials
+    :: KeyFlavorS k
+    -> k 'RootK XPrv
+    -> Passphrase "user"
+    -> HashedCredentials k
+mkV2Credentials kF key pwd =
+    let rawXprv = getRawKey kF key
+        prepared = preparePassphrase currentPassphraseScheme pwd
+        -- Decrypt PBKDF2-encrypted XPrv to plaintext (empty new passphrase)
+        plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
+        raw128 = CC.unXPrv plaintextXprv
+        -- Master-key group for encryptedCreateDirectWithTweak: scalar(64) || cc(32)
+        masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        mPayload = case kF of
+            ByronKeyS -> Just (payloadPassphrase key)
+            _ -> Nothing
+    in case encryptedCreateDirectWithTweak masterKey96 pwd of
+        Left err ->
+            error $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
+        Right ekey -> HashedCredentialsV2 ekey mPayload
 
 -- | The hash here is the output of Scrypt function with the following parameters:
 -- - logN = 14
@@ -3706,10 +3742,9 @@ attachPrivateKeyFromPwdHashByron
     -> (KeyOf s 'RootK XPrv, PassphraseHash)
     -> IO ()
 attachPrivateKeyFromPwdHashByron ctx (xprv, hpwd) =
-    db & \_ ->
-        -- NOTE Only legacy wallets are imported through this function, passphrase
-        -- were encrypted with the legacy scheme (Scrypt).
-        attachPrivateKey db (xprv, hpwd) EncryptWithScrypt
+    -- NOTE Only legacy wallets are imported through this function, passphrase
+    -- were encrypted with the legacy scheme (Scrypt).
+    attachPrivateKey db (HashedCredentialsV1 xprv hpwd) EncryptWithScrypt
   where
     db = ctx ^. dbLayer
 
@@ -3718,21 +3753,35 @@ attachPrivateKeyFromPwdHashShelley
     -> (KeyOf s 'RootK XPrv, PassphraseHash)
     -> IO ()
 attachPrivateKeyFromPwdHashShelley ctx (xprv, hpwd) =
-    db & \_ ->
-        attachPrivateKey db (xprv, hpwd) currentPassphraseScheme
+    attachPrivateKey db (HashedCredentialsV1 xprv hpwd) currentPassphraseScheme
   where
     db = ctx ^. dbLayer
 
+-- | Re-attach stored 'HashedCredentials' after a wallet is deleted and
+-- recreated (e.g. shared wallet activation).  The passphrase scheme is
+-- inferred from the credential format: V1 → 'currentPassphraseScheme',
+-- V2 → 'EncryptWithArgon2idV2'.
+reattachPrivateKey
+    :: WalletLayer IO s
+    -> HashedCredentials (KeyOf s)
+    -> IO ()
+reattachPrivateKey ctx creds =
+    attachPrivateKey (ctx ^. dbLayer) creds scheme
+  where
+    scheme = case creds of
+        HashedCredentialsV1 _ _ -> currentPassphraseScheme
+        HashedCredentialsV2 _ _ -> EncryptWithArgon2idV2
+
 attachPrivateKey
     :: DBLayer IO s
-    -> (KeyOf s 'RootK XPrv, PassphraseHash)
+    -> HashedCredentials (KeyOf s)
     -> PassphraseScheme
     -> IO ()
-attachPrivateKey db pk scheme =
+attachPrivateKey db creds scheme =
     db & \DBLayer{..} -> do
         now <- liftIO getCurrentTime
         atomically $ do
-            putPrivateKey walletState pk
+            putPrivateKey walletState creds
             meta <- readWalletMeta walletState
             let modify x =
                     x
@@ -3749,38 +3798,116 @@ attachPrivateKey db pk scheme =
 --
 -- 'withRootKey' takes a callback function with two arguments:
 --
---  - The encrypted root private key itself
---  - The underlying passphrase scheme (legacy or new)
+--  - The root private key (plaintext scalar for v2, PBKDF2/Scrypt-encrypted for v1)
+--  - The underlying passphrase scheme
 --
--- Caller are then expected to use 'preparePassphrase' with the given scheme in
--- order to "prepare" the passphrase to be used by other function. This does
--- nothing for the new encryption, but for the legacy encryption with Scrypt,
--- passphrases needed to first be CBOR serialized and blake2b_256 hashed.
+-- Callers are expected to use 'preparePassphrase' with the given scheme in
+-- order to "prepare" the passphrase before passing it to signing / derivation
+-- functions.  For v2 keys the scheme is 'EncryptWithArgon2idV2', and
+-- @preparePassphrase EncryptWithArgon2idV2 _ = Passphrase mempty@, which
+-- causes the C layer to run in memcpy / no-op mode (correct, because the
+-- in-memory XPrv already has a plaintext scalar).
+--
+-- V1 keys are opportunistically migrated to v2 on every successful use.
 --
 -- @@@
---     withRootKey @ctx @s @k ctx wid pwd OnError $ \xprv scheme ->
+--     withRootKey db wid pwd OnError $ \xprv scheme ->
 --         changePassphrase (preparePassphrase scheme pwd) newPwd xprv
 -- @@@
 withRootKey
     :: forall s e a
-     . DBLayer IO s
+     . WalletFlavor s
+    => DBLayer IO s
     -> WalletId
     -> Passphrase "user"
     -> (ErrWithRootKey -> e)
     -> (KeyOf s 'RootK XPrv -> PassphraseScheme -> ExceptT e IO a)
     -> ExceptT e IO a
-withRootKey DBLayer{..} wid pwd embed action = do
-    (xprv, scheme) <- withExceptT embed . ExceptT . atomically $ do
+withRootKey db@DBLayer{..} wid pwd embed action = do
+    validated <- withExceptT embed . ExceptT . atomically $ do
         wMetadata <- readWalletMeta walletState
         let mScheme = passphraseScheme <$> passphraseInfo wMetadata
-        mXPrv <- readPrivateKey walletState
-        pure $ case (mXPrv, mScheme) of
-            (Just (xprv, hpwd), Just scheme) ->
+        mCreds <- readPrivateKey walletState
+        pure $ case (mCreds, mScheme) of
+            (Just (HashedCredentialsV1 xprv hpwd), Just scheme) ->
                 case checkPassphrase scheme pwd hpwd of
                     Left err -> Left $ ErrWithRootKeyWrongPassphrase wid err
-                    Right _ -> Right (xprv, scheme)
+                    Right _ -> Right $ Left (xprv, scheme)
+            (Just (HashedCredentialsV2 ekey mPayload), Just _) ->
+                case encryptedValidatePassphrase ekey pwd of
+                    Left _ ->
+                        Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                    Right () -> Right $ Right (ekey, mPayload)
             _ -> Left $ ErrWithRootKeyNoRootKey wid
-    action xprv scheme
+    case validated of
+        Left (xprv, scheme) -> do
+            -- Opportunistically migrate V1 → V2 on successful passphrase use.
+            lift $ migrateV1toV2 db kF xprv scheme pwd
+            action xprv scheme
+        Right (ekey, mPayload) ->
+            case decryptV2 kF ekey mPayload pwd of
+                Left _ ->
+                    throwE $ embed $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                Right xprv -> action xprv EncryptWithArgon2idV2
+  where
+    kF = keyFlavorFromState @s
+
+-- | Migrate a V1 PBKDF2- or Scrypt-encrypted root key to a V2 Argon2id
+-- envelope and write it back to the database.  Fails silently so that the
+-- current operation is not affected if migration is unsuccessful.
+migrateV1toV2
+    :: forall s
+     . DBLayer IO s
+    -> KeyFlavorS (KeyOf s)
+    -> KeyOf s 'RootK XPrv
+    -> PassphraseScheme
+    -> Passphrase "user"
+    -> IO ()
+migrateV1toV2 DBLayer{..} kF key scheme pwd = do
+    let rawXprv = getRawKey kF key
+        prepared = preparePassphrase scheme pwd
+        plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
+        raw128 = CC.unXPrv plaintextXprv
+        masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        mPayload = case kF of
+            ByronKeyS -> Just (payloadPassphrase key)
+            _ -> Nothing
+    case encryptedCreateDirectWithTweak masterKey96 pwd of
+        Left _ -> pure ()  -- fail silently; key stays V1 until next use
+        Right ekey -> atomically $ do
+            putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
+            meta <- readWalletMeta walletState
+            let updateScheme info = info{passphraseScheme = EncryptWithArgon2idV2}
+            putWalletMeta walletState
+                $ meta{passphraseInfo = fmap updateScheme (passphraseInfo meta)}
+
+-- | Decrypt a V2 'EncryptedKey' and reconstruct the flavored root key with a
+-- plaintext scalar (suitable for use with 'EncryptWithArgon2idV2' scheme).
+decryptV2
+    :: KeyFlavorS k
+    -> EncryptedKey
+    -> Maybe (Passphrase "addr-derivation-payload")
+    -> Passphrase "user"
+    -> Either XPrvError (k 'RootK XPrv)
+decryptV2 kF ekey mPayload pwd = do
+    raw128 <- encryptedKeyMaterial ekey pwd
+    let raw128bs = BA.convert raw128 :: ByteString
+    case CC.xprv raw128bs of
+        Left _ -> Left XPrvInvalidSecretKey
+        Right plaintextXprv -> Right $ reconstructRootKey kF plaintextXprv mPayload
+
+reconstructRootKey
+    :: KeyFlavorS k
+    -> XPrv
+    -> Maybe (Passphrase "addr-derivation-payload")
+    -> k 'RootK XPrv
+reconstructRootKey kF plaintextXprv mPayload = case kF of
+    ByronKeyS ->
+        ByronKey plaintextXprv ()
+            $ fromMaybe (hdPassphrase (toXPub plaintextXprv)) mPayload
+    IcarusKeyS  -> IcarusKey  plaintextXprv
+    ShelleyKeyS -> ShelleyKey plaintextXprv
+    SharedKeyS  -> SharedKey  plaintextXprv
 
 -- | Sign an arbitrary transaction metadata object with a private key belonging
 -- to the wallet's account.
@@ -3864,7 +3991,9 @@ readAccountPublicKey ctx =
 
 writePolicyPublicKey
     :: forall s n
-     . s ~ SeqState n ShelleyKey
+     . ( s ~ SeqState n ShelleyKey
+       , WalletFlavor s
+       )
     => WalletLayer IO s
     -> WalletId
     -> Passphrase "user"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -305,8 +305,8 @@ import Cardano.Crypto.WalletHD.Encrypted
     , XPrvError
     , chainCodeByteString
     , deriveExtKeyMaterial
-    , encryptedChangePassphrase
     , encryptedChainCode
+    , encryptedChangePassphrase
     , encryptedCreateDirectWithTweak
     , encryptedDerivePrivate
     , encryptedPublic
@@ -314,9 +314,6 @@ import Cardano.Crypto.WalletHD.Encrypted
     , publicKeyByteString
     , signWithExtKeyMaterial
     , withDecryptedExtKeyMaterial
-    )
-import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
-    ( Signature (..)
     )
 import Cardano.Ledger.Api
     ( EraTxBody (allInputsTxBodyF)
@@ -331,12 +328,12 @@ import Cardano.Ledger.Api.Tx.Body
     , mintTxBodyL
     , withdrawalsTxBodyL
     )
-import Cardano.Ledger.Core
-    ( certsTxBodyL
-    )
 import Cardano.Ledger.Binary
     ( serialize'
     , shelleyProtVer
+    )
+import Cardano.Ledger.Core
+    ( certsTxBodyL
     )
 import Cardano.Mnemonic
     ( SomeMnemonic
@@ -937,6 +934,9 @@ import qualified Cardano.Balance.Tx.Tx as Write
     , stakeKeyDeposit
     )
 import qualified Cardano.Crypto.Wallet as CC
+import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
+    ( Signature (..)
+    )
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Slotting.Slot as Slot
 import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
@@ -1311,28 +1311,38 @@ updateWalletPassphraseWithOldPassphrase
     -> (Passphrase "user", Passphrase "user")
     -> ExceptT ErrUpdatePassphrase IO ()
 updateWalletPassphraseWithOldPassphrase wF ctx wid (old, new) =
-    withRootKey (contramap MsgWallet (logger_ ctx)) db wid old ErrUpdatePassphraseWithRootKey $ \case
-        RootKeyAccessV1 xprv scheme -> do
-            -- IMPORTANT NOTE:
-            -- This uses 'EncryptWithPBKDF2', regardless of the passphrase
-            -- current scheme, we'll re-encrypt it using the current scheme,
-            -- always.
-            let xprv' =
-                    changePassphraseNew
-                        (keyOfWallet wF)
-                        (scheme, old)
-                        (currentPassphraseScheme, new)
-                        xprv
-            lift $ attachPrivateKeyFromPwd ctx (xprv', new)
-        RootKeyAccessV2 ekey mPayload _ -> do
-            ekey' <- liftIO $ encryptedChangePassphrase old new ekey
-            case ekey' of
-                Left _ ->
-                    throwE $ ErrUpdatePassphraseWithRootKey
-                        $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
-                Right newEkey ->
-                    lift $ attachPrivateKey db (HashedCredentialsV2 newEkey mPayload)
-                        EncryptWithArgon2idV2
+    withRootKey
+        (contramap MsgWallet (logger_ ctx))
+        db
+        wid
+        old
+        ErrUpdatePassphraseWithRootKey
+        $ \case
+            RootKeyAccessV1 xprv scheme -> do
+                -- IMPORTANT NOTE:
+                -- This uses 'EncryptWithPBKDF2', regardless of the passphrase
+                -- current scheme, we'll re-encrypt it using the current scheme,
+                -- always.
+                let xprv' =
+                        changePassphraseNew
+                            (keyOfWallet wF)
+                            (scheme, old)
+                            (currentPassphraseScheme, new)
+                            xprv
+                lift $ attachPrivateKeyFromPwd ctx (xprv', new)
+            RootKeyAccessV2 ekey mPayload _ -> do
+                ekey' <- liftIO $ encryptedChangePassphrase old new ekey
+                case ekey' of
+                    Left _ ->
+                        throwE
+                            $ ErrUpdatePassphraseWithRootKey
+                            $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                    Right newEkey ->
+                        lift
+                            $ attachPrivateKey
+                                db
+                                (HashedCredentialsV2 newEkey mPayload)
+                                EncryptWithArgon2idV2
   where
     db = ctx ^. typed
 
@@ -1713,7 +1723,11 @@ readRewardAccount db = do
         ShelleyWallet -> do
             let rewardKey = Seq.rewardAccountKey walletState
                 path = stakeDerivationPath $ Seq.derivationPrefix walletState
-            pure (toRewardAccount rewardKey, Just $ getRawKey ShelleyKeyS rewardKey, path)
+            pure
+                ( toRewardAccount rewardKey
+                , Just $ getRawKey ShelleyKeyS rewardKey
+                , path
+                )
         SharedWallet -> do
             let path = stakeDerivationPath $ Shared.derivationPrefix walletState
             case Shared.rewardAccountKey walletState of
@@ -1952,41 +1966,49 @@ createRandomAddress
     -> ExceptT ErrCreateRandomAddress IO (Address, NonEmpty DerivationIndex)
 createRandomAddress ctx wid pwd mIx =
     db & \DBLayer{..} ->
-        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrCreateAddrWithRootKey $ \case
-            RootKeyAccessV1 xprv scheme ->
-                ExceptT
-                    . atomically
-                    . Delta.onDBVar walletState
-                    . Delta.updateWithResultAndError
-                    $ createRandomAddressV1 xprv scheme
-            RootKeyAccessV2 ekey mPayload userPwd -> do
-                -- Phase 1 (STM): determine path
-                -- Note: atomically has existential stm type; must be used
-                -- directly in the DBLayer{..} binding scope, not in where
-                -- clauses.
-                path <- ExceptT . atomically $ do
-                    wal <- readDBVar walletState
-                    let s0 = getState $ getLatest wal
-                        accIx = Rnd.defaultAccountIndex s0
-                    pure $ case mIx of
-                        Just addrIx
-                            | (liftIndex accIx, liftIndex addrIx)
-                                `Set.member` Rnd.unavailablePaths s0 ->
-                                Left $ ErrIndexAlreadyExists addrIx
-                        Just addrIx ->
-                            Right (liftIndex accIx, liftIndex addrIx)
-                        Nothing ->
-                            Right $ fst $
-                                Rnd.withRNG s0 $ \rng ->
-                                    Rnd.findUnusedPath rng accIx (Rnd.unavailablePaths s0)
-                -- Phase 2 (IO): derive address from encrypted key
-                addr <- liftIO $ deriveByronV2Address ekey mPayload userPwd path
-                -- Phase 3 (STM): write path + address to state
-                lift . atomically . Delta.onDBVar walletState . Delta.update
-                    $ \wal ->
+        withRootKey
+            (contramap MsgWallet (logger_ ctx))
+            db
+            wid
+            pwd
+            ErrCreateAddrWithRootKey
+            $ \case
+                RootKeyAccessV1 xprv scheme ->
+                    ExceptT
+                        . atomically
+                        . Delta.onDBVar walletState
+                        . Delta.updateWithResultAndError
+                        $ createRandomAddressV1 xprv scheme
+                RootKeyAccessV2 ekey mPayload userPwd -> do
+                    -- Phase 1 (STM): determine path
+                    -- Note: atomically has existential stm type; must be used
+                    -- directly in the DBLayer{..} binding scope, not in where
+                    -- clauses.
+                    path <- ExceptT . atomically $ do
+                        wal <- readDBVar walletState
                         let s0 = getState $ getLatest wal
-                        in [ReplacePrologue $ getPrologue $ Rnd.addPendingAddress addr path s0]
-                pure (addr, Rnd.toDerivationIndexes path)
+                            accIx = Rnd.defaultAccountIndex s0
+                        pure $ case mIx of
+                            Just addrIx
+                                | (liftIndex accIx, liftIndex addrIx)
+                                    `Set.member` Rnd.unavailablePaths s0 ->
+                                    Left $ ErrIndexAlreadyExists addrIx
+                            Just addrIx ->
+                                Right (liftIndex accIx, liftIndex addrIx)
+                            Nothing ->
+                                Right
+                                    $ fst
+                                    $ Rnd.withRNG s0
+                                    $ \rng ->
+                                        Rnd.findUnusedPath rng accIx (Rnd.unavailablePaths s0)
+                    -- Phase 2 (IO): derive address from encrypted key
+                    addr <- liftIO $ deriveByronV2Address ekey mPayload userPwd path
+                    -- Phase 3 (STM): write path + address to state
+                    lift . atomically . Delta.onDBVar walletState . Delta.update
+                        $ \wal ->
+                            let s0 = getState $ getLatest wal
+                            in  [ReplacePrologue $ getPrologue $ Rnd.addPendingAddress addr path s0]
+                    pure (addr, Rnd.toDerivationIndexes path)
   where
     db = ctx ^. dbLayer
 
@@ -1995,7 +2017,8 @@ createRandomAddress ctx wid pwd mIx =
             | isKnownIndex addrIx s0 ->
                 Left $ ErrIndexAlreadyExists addrIx
         Just addrIx ->
-            Right $ addAddressV1 xprv scheme ((liftIndex accIx, liftIndex addrIx), s0)
+            Right
+                $ addAddressV1 xprv scheme ((liftIndex accIx, liftIndex addrIx), s0)
         Nothing ->
             Right $ addAddressV1 xprv scheme $ Rnd.withRNG s0 $ \rng ->
                 Rnd.findUnusedPath rng accIx (Rnd.unavailablePaths s0)
@@ -2015,14 +2038,23 @@ createRandomAddress ctx wid pwd mIx =
         addr = Rnd.deriveRndStateAddress @n xprv prepared path
 
     deriveByronV2Address ekey mPayload userPwd (accIdx, addrIdx) = do
-        let payload = fromMaybe
-                (error "createRandomAddress: V2 Byron key missing payload")
-                mPayload
+        let payload =
+                fromMaybe
+                    (error "createRandomAddress: V2 Byron key missing payload")
+                    mPayload
         accEkey <-
-            encryptedDerivePrivate DerivationScheme1 ekey userPwd (getIndex accIdx)
+            encryptedDerivePrivate
+                DerivationScheme1
+                ekey
+                userPwd
+                (getIndex accIdx)
                 >>= either (error . ("createRandomAddress V2 acct: " <>) . show) pure
         addrEkey <-
-            encryptedDerivePrivate DerivationScheme1 accEkey userPwd (getIndex addrIdx)
+            encryptedDerivePrivate
+                DerivationScheme1
+                accEkey
+                userPwd
+                (getIndex addrIdx)
                 >>= either (error . ("createRandomAddress V2 addr: " <>) . show) pure
         let pubBytes = publicKeyByteString (encryptedPublic addrEkey)
             ccBytes = chainCodeByteString (encryptedChainCode addrEkey)
@@ -2030,8 +2062,11 @@ createRandomAddress ctx wid pwd mIx =
             case xpub (pubBytes <> ccBytes) of
                 Left e -> error $ "createRandomAddress V2 xpub: " <> e
                 Right x -> pure x
-        pure $ paymentAddressS @n
-            (ByronKey addrXPub (accIdx, addrIdx) payload :: ByronKey 'CredFromKeyK XPub)
+        pure
+            $ paymentAddressS @n
+                ( ByronKey addrXPub (accIdx, addrIdx) payload
+                    :: ByronKey 'CredFromKeyK XPub
+                )
 
 importRandomAddresses
     :: forall s
@@ -2231,8 +2266,9 @@ readWalletUTxO ctx = do
     (cp, _, pending) <- readWallet ctx
     let avail = availableUTxO pending cp
         tokenList = TokenMap.toFlatList (UTxO.balance avail ^. #tokens)
-    traceWith (contramap MsgWallet (logger_ ctx)) $ MsgDebugUTxO $
-        "readWalletUTxO: pendingCount="
+    traceWith (contramap MsgWallet (logger_ ctx))
+        $ MsgDebugUTxO
+        $ "readWalletUTxO: pendingCount="
             <> T.pack (show (Set.size pending))
             <> " availTokens="
             <> T.pack (show tokenList)
@@ -2655,8 +2691,10 @@ buildSignSubmitTransaction
                             )
                             $ \s -> do
                                 let wallet = WalletState.getLatest s
-                                    utxo = availableUTxO
-                                        (Set.fromList pendingTxs) wallet
+                                    utxo =
+                                        availableUTxO
+                                            (Set.fromList pendingTxs)
+                                            wallet
                                 buildTransactionPure @s
                                     wallet
                                     timeTranslation
@@ -2672,13 +2710,16 @@ buildSignSubmitTransaction
                                         ( \(tx, newState) ->
                                             let wallet' =
                                                     wallet{getState = newState}
-                                            in  ( [ReplacePrologue
-                                                    $ getPrologue newState]
-                                                , ( tx
-                                                  , wallet
-                                                  , currentTip wallet'
+                                            in  (
+                                                    [ ReplacePrologue
+                                                        $ getPrologue newState
+                                                    ]
+                                                ,
+                                                    ( tx
+                                                    , wallet
+                                                    , currentTip wallet'
                                                         ^. #slotNo
-                                                  )
+                                                    )
                                                 )
                                         )
                     let txBody = unsignedTx ^. bodyTxL
@@ -2697,7 +2738,7 @@ buildSignSubmitTransaction
                                     ( Set.toList
                                         $ unsignedTx
                                             ^. bodyTxL
-                                            . inputsTxBodyL
+                                                . inputsTxBodyL
                                     )
                         mStakePath =
                             case walletFlavor @s of
@@ -2744,7 +2785,7 @@ buildSignSubmitTransaction
                         Left e ->
                             error
                                 $ "buildSignSubmitTransaction V2: "
-                                <> show e
+                                    <> show e
                         Right wits -> pure wits
                     let mExternalWit = case view #txWithdrawal txCtx of
                             WithdrawalExternal _ _ _ extXPrv ->
@@ -2756,7 +2797,8 @@ buildSignSubmitTransaction
                             _ -> Nothing
                         signedLedgerTx =
                             unsignedTx
-                                & witsTxL . addrTxWitsL
+                                & witsTxL
+                                    . addrTxWitsL
                                     .~ Set.fromList
                                         (shelleyWits <> maybeToList mExternalWit)
                         builtSealedTx = sealWriteTx recentEra' signedLedgerTx
@@ -2803,8 +2845,8 @@ buildSignSubmitTransaction
                                 }
                     atomically
                         $ Delta.onDBVar walletState
-                        . WalletState.updateSubmissions
-                        . Delta.update
+                            . WalletState.updateSubmissions
+                            . Delta.update
                         $ \_ -> Submissions.addTxSubmission builtTx slot
                     postSealedTx netLayer builtSealedTx
                         & throwWrappedErr wrapNetworkError
@@ -2827,8 +2869,8 @@ buildSignSubmitTransaction
                                     Nothing
                         txWithSlot@(builtTx, slot) <-
                             ( throwOnErr
-                                    <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
-                                )
+                                <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
+                            )
                                 $ \s -> do
                                     let wallet = WalletState.getLatest s
                                         utxo = availableUTxO (Set.fromList pendingTxs) wallet
@@ -3179,193 +3221,166 @@ buildAndSignTransaction
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
     db & \DBLayer{..} ->
-        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrSignPaymentWithRootKey $ \case
-            RootKeyAccessV2 ekey _mPayload userPwd -> do
-                cp <- mapExceptT atomically $ lift readCheckpoint
-                (Write.PParamsInAnyRecentEra era' _pp, _) <-
-                    liftIO $ readNodeTipStateForTxWrite nl
-                let walletSt = getState cp
-                    walletUtxo = cp ^. #utxo
-                    network = sNetworkIdToLedger $ sNetworkId @(NetworkOf s)
-                    stakeXPub = case walletFlavor @s of
-                        ShelleyWallet ->
-                            getRawKey kF $ Seq.rewardAccountKey walletSt
-                        -- Guard: only Shelley wallets have sequential state and a
-                        -- reward account; this branch is unreachable for other flavors
-                        -- because the outer ShelleyWallet constraint holds.
-                        _ -> error "buildAndSignTransaction V2: non-shelley wallet"
-                    delegCerts = case view #txDelegationAction txCtx of
-                        Nothing -> []
-                        Just action ->
-                            certificateFromDelegationActionLedger
-                                era'
-                                (Left stakeXPub)
-                                (view #txDeposit txCtx)
-                                action
-                    votingCerts = case view #txVotingAction txCtx of
-                        Nothing -> []
-                        Just action ->
-                            certificateFromVotingActionLedger
-                                era'
-                                (Left stakeXPub)
-                                (view #txDeposit txCtx)
-                                action
-                    allCerts = L.nub $ delegCerts <> votingCerts
-                unsignedTx <- withExceptT ErrSignPaymentMkTx
-                    $ ExceptT
-                    $ pure
-                    $ constructUnsignedTxLedger
-                        era'
-                        network
-                        (view #txMetadata txCtx, allCerts)
-                        (txValidityInterval txCtx)
-                        (view #txWithdrawal txCtx)
-                        ( fst $ view #txAssetsToMint txCtx
-                        , fst $ view #txAssetsToBurn txCtx
-                        )
-                        (Right sel)
-                        (selectionDelta sel)
-                let txBody = unsignedTx ^. bodyTxL
-                    inputPaths =
-                        L.nub
-                            $ mapMaybe
-                                ( \ledIn ->
-                                    UTxO.lookup
-                                        (toWallet ledIn)
-                                        walletUtxo
-                                        >>= \(TxOut addr _) ->
-                                            fst (isOurs addr walletSt)
-                                )
-                                ( Set.toList
-                                    $ unsignedTx ^. bodyTxL . inputsTxBodyL
-                                )
-                    mStakePath = case walletFlavor @s of
-                        ShelleyWallet ->
-                            Just
-                                $ stakeDerivationPath
-                                $ Seq.derivationPrefix walletSt
-                        _ -> Nothing
-                    needsStakeKey =
-                        isJust (view #txDelegationAction txCtx)
-                            || isJust (view #txVotingAction txCtx)
-                            || containsSelfWithdrawal (view #txWithdrawal txCtx)
-                    needsMinting =
-                        txBody ^. mintTxBodyL /= mempty
-                    mPolicyPath = case walletFlavor @s of
-                        ShelleyWallet | needsMinting -> Just policyDerivationPath
-                        _ -> Nothing
-                    allPaths =
-                        inputPaths
-                            <> case (needsStakeKey, mStakePath) of
-                                (True, Just p) -> [p]
-                                _ -> []
-                            <> maybeToList mPolicyPath
-                witsE <-
-                    liftIO $ withDecryptedExtKeyMaterial ekey userPwd
-                        $ \rootKm -> do
-                            results <-
-                                forM allPaths $ \path ->
-                                    withDerivedExtKeyMaterial
-                                        DerivationScheme2
-                                        rootKm
-                                        ( map getDerivationIndex
-                                            $ NE.toList path
-                                        )
-                                        $ \addrKm ->
-                                            Right
-                                                <$> mkShelleyWitnessFromExtKeyMaterial
-                                                    era'
-                                                    txBody
-                                                    addrKm
-                            pure $ sequence results
-                shelleyWits <- case witsE of
-                    Left e ->
-                        error
-                            $ "buildAndSignTransaction V2: "
-                            <> show e
-                    Right wits -> pure wits
-                let mExternalWit = case view #txWithdrawal txCtx of
-                        WithdrawalExternal _ _ _ extXPrv ->
-                            Just
-                                $ mkShelleyWitnessLedger
-                                    era'
-                                    txBody
-                                    (extXPrv, mempty)
-                        _ -> Nothing
-                    signedLedgerTx =
-                        unsignedTx
-                            & witsTxL . addrTxWitsL
-                                .~ Set.fromList
-                                    (shelleyWits <> maybeToList mExternalWit)
-                    builtSealedTx = sealWriteTx era' signedLedgerTx
-                    txExt = case era' of
-                        Write.RecentEraConway ->
-                            getTxExtended
-                                (Read.Tx signedLedgerTx :: Read.Tx Read.Conway)
-                        Write.RecentEraDijkstra ->
-                            getTxExtended
-                                ( Read.Tx signedLedgerTx
-                                    :: Read.Tx Read.Dijkstra
-                                )
-                    rawTx = walletTx txExt
-                    amountOut :: Coin =
-                        F.fold
-                            $ fmap TxOut.coin (sel ^. #change)
-                                <> mapMaybe
-                                    (`ourCoin` walletSt)
-                                    (sel ^. #outputs)
-                    amountIn :: Coin =
-                        F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
-                            & case view #txWithdrawal txCtx of
-                                w@WithdrawalSelf{} ->
-                                    Coin.add (withdrawalToCoin w)
-                                WithdrawalExternal{} -> Prelude.id
-                                NoWithdrawal -> Prelude.id
-                    resolveInputs =
-                        fmap (\(txIn, _) -> (txIn, UTxO.lookup txIn walletUtxo))
-                    txResolved =
-                        rawTx
-                            { resolvedInputs =
-                                resolveInputs (resolvedInputs rawTx)
-                            , resolvedCollateralInputs =
-                                resolveInputs (resolvedCollateralInputs rawTx)
-                            }
-                time <- liftIO $ tipSlotStartTime $ currentTip cp
-                let meta =
-                        mkTxMeta
-                            (currentTip cp)
-                            (txValidityInterval txCtx)
-                            amountIn
-                            amountOut
-                pure (txResolved, meta, time, builtSealedTx)
-            RootKeyAccessV1 xprv scheme ->
-                let pwdP = preparePassphrase scheme pwd
-                in mapExceptT atomically $ do
-                    cp <- lift readCheckpoint
-                    (Write.PParamsInAnyRecentEra era _pp, _) <-
+        withRootKey
+            (contramap MsgWallet (logger_ ctx))
+            db
+            wid
+            pwd
+            ErrSignPaymentWithRootKey
+            $ \case
+                RootKeyAccessV2 ekey _mPayload userPwd -> do
+                    cp <- mapExceptT atomically $ lift readCheckpoint
+                    (Write.PParamsInAnyRecentEra era' _pp, _) <-
                         liftIO $ readNodeTipStateForTxWrite nl
-                    let keyFrom = isOwned wF (getState cp) (xprv, pwdP)
-                        rewardAcnt = mkRwdAcct $ RootCredentials xprv pwdP
-                    (tx, sealedTx) <-
+                    let walletSt = getState cp
+                        walletUtxo = cp ^. #utxo
+                        network = sNetworkIdToLedger $ sNetworkId @(NetworkOf s)
+                        stakeXPub = case walletFlavor @s of
+                            ShelleyWallet ->
+                                getRawKey kF $ Seq.rewardAccountKey walletSt
+                            -- Guard: only Shelley wallets have sequential state and a
+                            -- reward account; this branch is unreachable for other flavors
+                            -- because the outer ShelleyWallet constraint holds.
+                            _ -> error "buildAndSignTransaction V2: non-shelley wallet"
+                        delegCerts = case view #txDelegationAction txCtx of
+                            Nothing -> []
+                            Just action ->
+                                certificateFromDelegationActionLedger
+                                    era'
+                                    (Left stakeXPub)
+                                    (view #txDeposit txCtx)
+                                    action
+                        votingCerts = case view #txVotingAction txCtx of
+                            Nothing -> []
+                            Just action ->
+                                certificateFromVotingActionLedger
+                                    era'
+                                    (Left stakeXPub)
+                                    (view #txDeposit txCtx)
+                                    action
+                        allCerts = L.nub $ delegCerts <> votingCerts
+                    unsignedTx <-
                         withExceptT ErrSignPaymentMkTx
                             $ ExceptT
                             $ pure
-                            $ mkTransaction era net kF rewardAcnt keyFrom txCtx sel
-                    let amountOut :: Coin =
+                            $ constructUnsignedTxLedger
+                                era'
+                                network
+                                (view #txMetadata txCtx, allCerts)
+                                (txValidityInterval txCtx)
+                                (view #txWithdrawal txCtx)
+                                ( fst $ view #txAssetsToMint txCtx
+                                , fst $ view #txAssetsToBurn txCtx
+                                )
+                                (Right sel)
+                                (selectionDelta sel)
+                    let txBody = unsignedTx ^. bodyTxL
+                        inputPaths =
+                            L.nub
+                                $ mapMaybe
+                                    ( \ledIn ->
+                                        UTxO.lookup
+                                            (toWallet ledIn)
+                                            walletUtxo
+                                            >>= \(TxOut addr _) ->
+                                                fst (isOurs addr walletSt)
+                                    )
+                                    ( Set.toList
+                                        $ unsignedTx ^. bodyTxL . inputsTxBodyL
+                                    )
+                        mStakePath = case walletFlavor @s of
+                            ShelleyWallet ->
+                                Just
+                                    $ stakeDerivationPath
+                                    $ Seq.derivationPrefix walletSt
+                            _ -> Nothing
+                        needsStakeKey =
+                            isJust (view #txDelegationAction txCtx)
+                                || isJust (view #txVotingAction txCtx)
+                                || containsSelfWithdrawal (view #txWithdrawal txCtx)
+                        needsMinting =
+                            txBody ^. mintTxBodyL /= mempty
+                        mPolicyPath = case walletFlavor @s of
+                            ShelleyWallet | needsMinting -> Just policyDerivationPath
+                            _ -> Nothing
+                        allPaths =
+                            inputPaths
+                                <> case (needsStakeKey, mStakePath) of
+                                    (True, Just p) -> [p]
+                                    _ -> []
+                                <> maybeToList mPolicyPath
+                    witsE <-
+                        liftIO
+                            $ withDecryptedExtKeyMaterial ekey userPwd
+                            $ \rootKm -> do
+                                results <-
+                                    forM allPaths $ \path ->
+                                        withDerivedExtKeyMaterial
+                                            DerivationScheme2
+                                            rootKm
+                                            ( map getDerivationIndex
+                                                $ NE.toList path
+                                            )
+                                            $ \addrKm ->
+                                                Right
+                                                    <$> mkShelleyWitnessFromExtKeyMaterial
+                                                        era'
+                                                        txBody
+                                                        addrKm
+                                pure $ sequence results
+                    shelleyWits <- case witsE of
+                        Left e ->
+                            error
+                                $ "buildAndSignTransaction V2: "
+                                    <> show e
+                        Right wits -> pure wits
+                    let mExternalWit = case view #txWithdrawal txCtx of
+                            WithdrawalExternal _ _ _ extXPrv ->
+                                Just
+                                    $ mkShelleyWitnessLedger
+                                        era'
+                                        txBody
+                                        (extXPrv, mempty)
+                            _ -> Nothing
+                        signedLedgerTx =
+                            unsignedTx
+                                & witsTxL
+                                    . addrTxWitsL
+                                    .~ Set.fromList
+                                        (shelleyWits <> maybeToList mExternalWit)
+                        builtSealedTx = sealWriteTx era' signedLedgerTx
+                        txExt = case era' of
+                            Write.RecentEraConway ->
+                                getTxExtended
+                                    (Read.Tx signedLedgerTx :: Read.Tx Read.Conway)
+                            Write.RecentEraDijkstra ->
+                                getTxExtended
+                                    ( Read.Tx signedLedgerTx
+                                        :: Read.Tx Read.Dijkstra
+                                    )
+                        rawTx = walletTx txExt
+                        amountOut :: Coin =
                             F.fold
                                 $ fmap TxOut.coin (sel ^. #change)
-                                    <> mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
+                                    <> mapMaybe
+                                        (`ourCoin` walletSt)
+                                        (sel ^. #outputs)
                         amountIn :: Coin =
                             F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
-                                -- NOTE: In case where rewards are pulled from an external
-                                -- source, they aren't added to the calculation, as the
-                                -- money is considered to come from outside the wallet. In
-                                -- such cases, transactions are categorised as "incoming",
-                                -- as they bring extra money to the wallet from elsewhere.
-                                & case txWithdrawal txCtx of
-                                    w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
+                                & case view #txWithdrawal txCtx of
+                                    w@WithdrawalSelf{} ->
+                                        Coin.add (withdrawalToCoin w)
                                     WithdrawalExternal{} -> Prelude.id
                                     NoWithdrawal -> Prelude.id
+                        resolveInputs =
+                            fmap (\(txIn, _) -> (txIn, UTxO.lookup txIn walletUtxo))
+                        txResolved =
+                            rawTx
+                                { resolvedInputs =
+                                    resolveInputs (resolvedInputs rawTx)
+                                , resolvedCollateralInputs =
+                                    resolveInputs (resolvedCollateralInputs rawTx)
+                                }
                     time <- liftIO $ tipSlotStartTime $ currentTip cp
                     let meta =
                             mkTxMeta
@@ -3373,7 +3388,43 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
                                 (txValidityInterval txCtx)
                                 amountIn
                                 amountOut
-                    pure (tx, meta, time, sealedTx)
+                    pure (txResolved, meta, time, builtSealedTx)
+                RootKeyAccessV1 xprv scheme ->
+                    let pwdP = preparePassphrase scheme pwd
+                    in  mapExceptT atomically $ do
+                            cp <- lift readCheckpoint
+                            (Write.PParamsInAnyRecentEra era _pp, _) <-
+                                liftIO $ readNodeTipStateForTxWrite nl
+                            let keyFrom = isOwned wF (getState cp) (xprv, pwdP)
+                                rewardAcnt = mkRwdAcct $ RootCredentials xprv pwdP
+                            (tx, sealedTx) <-
+                                withExceptT ErrSignPaymentMkTx
+                                    $ ExceptT
+                                    $ pure
+                                    $ mkTransaction era net kF rewardAcnt keyFrom txCtx sel
+                            let amountOut :: Coin =
+                                    F.fold
+                                        $ fmap TxOut.coin (sel ^. #change)
+                                            <> mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
+                                amountIn :: Coin =
+                                    F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
+                                        -- NOTE: In case where rewards are pulled from an external
+                                        -- source, they aren't added to the calculation, as the
+                                        -- money is considered to come from outside the wallet. In
+                                        -- such cases, transactions are categorised as "incoming",
+                                        -- as they bring extra money to the wallet from elsewhere.
+                                        & case txWithdrawal txCtx of
+                                            w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
+                                            WithdrawalExternal{} -> Prelude.id
+                                            NoWithdrawal -> Prelude.id
+                            time <- liftIO $ tipSlotStartTime $ currentTip cp
+                            let meta =
+                                    mkTxMeta
+                                        (currentTip cp)
+                                        (txValidityInterval txCtx)
+                                        amountIn
+                                        amountOut
+                            pure (tx, meta, time, sealedTx)
   where
     wF = walletFlavor @s
     kF = keyFlavorFromState @s
@@ -3402,7 +3453,11 @@ constructTransaction era db txCtx preSel = do
     (_, mRewardXPub, _) <- lift $ readRewardAccount db
     when (containsSelfWithdrawal (txCtx ^. #txWithdrawal))
         $ assertIsVoting db era
-    mkUnsignedTransaction netId (Left $ fromJust mRewardXPub) txCtx (Left preSel)
+    mkUnsignedTransaction
+        netId
+        (Left $ fromJust mRewardXPub)
+        txCtx
+        (Left preSel)
         & withExceptT ErrConstructTxBody . except
   where
     netId = networkIdVal $ sNetworkId @n
@@ -4482,41 +4537,49 @@ signMetadataWith ctx wid pwd (role_, ix) metadata =
 
         cp <- lift $ atomically readCheckpoint
 
-        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrSignMetadataWithRootKey $ \case
-            RootKeyAccessV1 rootK scheme -> do
-                let encPwd = preparePassphrase scheme pwd
-                    DerivationPrefix (_, _, acctIx) = Seq.derivationPrefix (getState cp)
-                    acctK = deriveAccountPrivateKey encPwd rootK acctIx
-                    addrK = deriveAddressPrivateKey encPwd acctK role_ addrIx
-                pure
-                    $ Signature
-                    $ BA.convert
-                    $ CC.sign encPwd (getRawKey (keyFlavorFromState @s) addrK)
-                    $ hash @ByteString @Blake2b_256
-                    $ serialize' shelleyProtVer
-                    $ toShelleyMetadata
-                    $ unTxMetadata metadata
-            RootKeyAccessV2 ekey _ userPwd -> do
-                let DerivationPrefix (purpose, coinType, acctIx) =
-                        Seq.derivationPrefix (getState cp)
-                    msg =
-                        hash @ByteString @Blake2b_256
-                            $ serialize' shelleyProtVer
-                            $ toShelleyMetadata
-                            $ unTxMetadata metadata
-                    path =
-                        [ getIndex purpose
-                        , getIndex coinType
-                        , getIndex acctIx
-                        , fromIntegral (fromEnum role_)
-                        , getIndex addrIx
-                        ]
-                sigE <- liftIO $ withDecryptedExtKeyMaterial ekey userPwd $ \rootKm ->
-                    withDerivedExtKeyMaterial DerivationScheme2 rootKm path $ \addrKm ->
-                        fmap (fmap (\(EncHD.Signature s) -> s)) (signWithExtKeyMaterial addrKm msg)
-                case sigE of
-                    Left e -> error $ "signMetadataWith V2: " <> show e
-                    Right sig -> pure $ Signature $ BA.convert sig
+        withRootKey
+            (contramap MsgWallet (logger_ ctx))
+            db
+            wid
+            pwd
+            ErrSignMetadataWithRootKey
+            $ \case
+                RootKeyAccessV1 rootK scheme -> do
+                    let encPwd = preparePassphrase scheme pwd
+                        DerivationPrefix (_, _, acctIx) = Seq.derivationPrefix (getState cp)
+                        acctK = deriveAccountPrivateKey encPwd rootK acctIx
+                        addrK = deriveAddressPrivateKey encPwd acctK role_ addrIx
+                    pure
+                        $ Signature
+                        $ BA.convert
+                        $ CC.sign encPwd (getRawKey (keyFlavorFromState @s) addrK)
+                        $ hash @ByteString @Blake2b_256
+                        $ serialize' shelleyProtVer
+                        $ toShelleyMetadata
+                        $ unTxMetadata metadata
+                RootKeyAccessV2 ekey _ userPwd -> do
+                    let DerivationPrefix (purpose, coinType, acctIx) =
+                            Seq.derivationPrefix (getState cp)
+                        msg =
+                            hash @ByteString @Blake2b_256
+                                $ serialize' shelleyProtVer
+                                $ toShelleyMetadata
+                                $ unTxMetadata metadata
+                        path =
+                            [ getIndex purpose
+                            , getIndex coinType
+                            , getIndex acctIx
+                            , fromIntegral (fromEnum role_)
+                            , getIndex addrIx
+                            ]
+                    sigE <- liftIO $ withDecryptedExtKeyMaterial ekey userPwd $ \rootKm ->
+                        withDerivedExtKeyMaterial DerivationScheme2 rootKm path $ \addrKm ->
+                            fmap
+                                (fmap (\(EncHD.Signature s) -> s))
+                                (signWithExtKeyMaterial addrKm msg)
+                    case sigE of
+                        Left e -> error $ "signMetadataWith V2: " <> show e
+                        Right sig -> pure $ Signature $ BA.convert sig
   where
     db = ctx ^. dbLayer
 
@@ -4678,7 +4741,12 @@ getAccountPublicKeyAtIndex ctx wid pwd ix purposeM =
 
         _cp <- lift $ atomically readCheckpoint
         let kf = keyFlavorFromState @s
-        withRootKey (contramap MsgWallet (logger_ ctx)) db wid pwd ErrReadAccountPublicKeyRootKey
+        withRootKey
+            (contramap MsgWallet (logger_ ctx))
+            db
+            wid
+            pwd
+            ErrReadAccountPublicKeyRootKey
             $ \case
                 RootKeyAccessV1 rootK scheme -> do
                     let encPwd = preparePassphrase scheme pwd

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -301,6 +301,7 @@ import Cardano.Crypto.Libsodium
 import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     , XPrvError (..)
+    , encryptedChainCode
     , encryptedCreateDirectWithTweak
     , encryptedKeyMaterial
     , encryptedValidatePassphrase
@@ -3901,10 +3902,11 @@ decryptV2 kF ekey mPayload pwd = do
     result <- encryptedKeyMaterial ekey pwd
     case result of
         Left err -> pure $ Left err
-        Right raw128 -> do
-            raw128bs <- mlsbToByteString raw128
-            mlsbFinalize raw128
-            pure $ case CC.xprv raw128bs of
+        Right scalar64 -> do
+            scalar64bs <- mlsbToByteString scalar64
+            mlsbFinalize scalar64
+            let raw96bs = scalar64bs <> encryptedChainCode ekey
+            pure $ case CC.xprv raw96bs of
                 Left _ -> Left XPrvInvalidSecretKey
                 Right plaintextXprv -> Right $ reconstructRootKey kF plaintextXprv mPayload
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -214,6 +214,7 @@ module Cardano.Wallet
 
       -- ** Root Key
     , withRootKey
+    , RootKeyAccess (..)
     , derivePublicKey
     , getAccountPublicKeyAtIndex
     , readAccountPublicKey
@@ -293,10 +294,28 @@ import Cardano.Balance.Tx.Tx
     )
 import Cardano.Crypto.Wallet
     ( toXPub
+    , xpub
     )
 import Cardano.Crypto.WalletHD.Encrypted
-    ( encryptedCreateDirectWithTweak
+    ( DerivationScheme (..)
+    , EncryptedKey
+    , ExtKeyMaterial
+    , Validated
+    , XPrvError
+    , chainCodeByteString
+    , deriveExtKeyMaterial
+    , encryptedChangePassphrase
+    , encryptedChainCode
+    , encryptedCreateDirectWithTweak
+    , encryptedDerivePrivate
+    , encryptedPublic
     , encryptedValidatePassphrase
+    , publicKeyByteString
+    , signWithExtKeyMaterial
+    , withDecryptedExtKeyMaterial
+    )
+import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
+    ( Signature (..)
     )
 import Cardano.Ledger.Api
     ( EraTxBody (allInputsTxBodyF)
@@ -336,11 +355,11 @@ import Cardano.Wallet.Address.Derivation
     , deriveRewardAccount
     , liftDelegationAddressS
     , liftIndex
+    , paymentAddressS
     , stakeDerivationPath
     )
 import Cardano.Wallet.Address.Derivation.Byron
     ( ByronKey (..)
-    , hdPassphrase
     , payloadPassphrase
     )
 import Cardano.Wallet.Address.Derivation.Icarus
@@ -349,6 +368,7 @@ import Cardano.Wallet.Address.Derivation.Icarus
 import Cardano.Wallet.Address.Derivation.MintBurn
     ( derivePolicyPrivateKey
     , policyDerivationPath
+    , purposeCIP1855
     )
 import Cardano.Wallet.Address.Derivation.SharedKey
     ( SharedKey (..)
@@ -367,6 +387,7 @@ import Cardano.Wallet.Address.Discovery
     , GetPurpose (..)
     , IsOurs (..)
     , KnownAddresses (..)
+    , coinTypeAda
     )
 import Cardano.Wallet.Address.Discovery.Random
     ( ErrImportAddress (..)
@@ -676,7 +697,8 @@ import Control.DeepSeq
     ( NFData
     )
 import Control.Monad
-    ( forM
+    ( foldM
+    , forM
     , forM_
     , join
     , replicateM
@@ -811,7 +833,8 @@ import Data.Void
     ( Void
     )
 import Data.Word
-    ( Word64
+    ( Word32
+    , Word64
     )
 import Fmt
     ( Buildable
@@ -1267,10 +1290,10 @@ updateWalletPassphraseWithOldPassphrase
     -> (Passphrase "user", Passphrase "user")
     -> ExceptT ErrUpdatePassphrase IO ()
 updateWalletPassphraseWithOldPassphrase wF ctx wid (old, new) =
-    withRootKey db wid old ErrUpdatePassphraseWithRootKey
-        $ \xprv scheme -> do
+    withRootKey db wid old ErrUpdatePassphraseWithRootKey $ \case
+        RootKeyAccessV1 xprv scheme -> do
             -- IMPORTANT NOTE:
-            -- This use 'EncryptWithPBKDF2', regardless of the passphrase
+            -- This uses 'EncryptWithPBKDF2', regardless of the passphrase
             -- current scheme, we'll re-encrypt it using the current scheme,
             -- always.
             let xprv' =
@@ -1280,6 +1303,15 @@ updateWalletPassphraseWithOldPassphrase wF ctx wid (old, new) =
                         (currentPassphraseScheme, new)
                         xprv
             lift $ attachPrivateKeyFromPwd ctx (xprv', new)
+        RootKeyAccessV2 ekey mPayload _ -> do
+            ekey' <- liftIO $ encryptedChangePassphrase old new ekey
+            case ekey' of
+                Left _ ->
+                    throwE $ ErrUpdatePassphraseWithRootKey
+                        $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                Right newEkey ->
+                    lift $ attachPrivateKey db (HashedCredentialsV2 newEkey mPayload)
+                        EncryptWithArgon2idV2
   where
     db = ctx ^. typed
 
@@ -1658,9 +1690,9 @@ readRewardAccount db = do
     walletState <- getState <$> readWalletCheckpoint db
     case walletFlavor @s of
         ShelleyWallet -> do
-            let xpub = Seq.rewardAccountKey walletState
+            let rewardKey = Seq.rewardAccountKey walletState
                 path = stakeDerivationPath $ Seq.derivationPrefix walletState
-            pure (toRewardAccount xpub, Just $ getRawKey ShelleyKeyS xpub, path)
+            pure (toRewardAccount rewardKey, Just $ getRawKey ShelleyKeyS rewardKey, path)
         SharedWallet -> do
             let path = stakeDerivationPath $ Shared.derivationPrefix walletState
             case Shared.rewardAccountKey walletState of
@@ -1741,10 +1773,10 @@ readPolicyPublicKey ctx =
                 let s = getState cp
                 case Seq.policyXPub s of
                     Nothing -> pure $ Left ErrReadPolicyPublicKeyAbsent
-                    Just xpub ->
+                    Just policyKey ->
                         pure
                             $ Right
-                                ( getRawKey (keyFlavorFromState @s) xpub
+                                ( getRawKey (keyFlavorFromState @s) policyKey
                                 , policyDerivationPath
                                 )
             _ ->
@@ -1899,23 +1931,52 @@ createRandomAddress
     -> ExceptT ErrCreateRandomAddress IO (Address, NonEmpty DerivationIndex)
 createRandomAddress ctx wid pwd mIx =
     db & \DBLayer{..} ->
-        withRootKey db wid pwd ErrCreateAddrWithRootKey $ \xprv scheme ->
-            ExceptT
-                . atomically
-                . Delta.onDBVar walletState
-                . Delta.updateWithResultAndError
-                $ createRandomAddress' xprv scheme
+        withRootKey db wid pwd ErrCreateAddrWithRootKey $ \case
+            RootKeyAccessV1 xprv scheme ->
+                ExceptT
+                    . atomically
+                    . Delta.onDBVar walletState
+                    . Delta.updateWithResultAndError
+                    $ createRandomAddressV1 xprv scheme
+            RootKeyAccessV2 ekey mPayload userPwd -> do
+                -- Phase 1 (STM): determine path
+                -- Note: atomically has existential stm type; must be used
+                -- directly in the DBLayer{..} binding scope, not in where
+                -- clauses.
+                path <- ExceptT . atomically $ do
+                    wal <- readDBVar walletState
+                    let s0 = getState $ getLatest wal
+                        accIx = Rnd.defaultAccountIndex s0
+                    pure $ case mIx of
+                        Just addrIx
+                            | (liftIndex accIx, liftIndex addrIx)
+                                `Set.member` Rnd.unavailablePaths s0 ->
+                                Left $ ErrIndexAlreadyExists addrIx
+                        Just addrIx ->
+                            Right (liftIndex accIx, liftIndex addrIx)
+                        Nothing ->
+                            Right $ fst $
+                                Rnd.withRNG s0 $ \rng ->
+                                    Rnd.findUnusedPath rng accIx (Rnd.unavailablePaths s0)
+                -- Phase 2 (IO): derive address from encrypted key
+                addr <- liftIO $ deriveByronV2Address ekey mPayload userPwd path
+                -- Phase 3 (STM): write path + address to state
+                lift . atomically . Delta.onDBVar walletState . Delta.update
+                    $ \wal ->
+                        let s0 = getState $ getLatest wal
+                        in [ReplacePrologue $ getPrologue $ Rnd.addPendingAddress addr path s0]
+                pure (addr, Rnd.toDerivationIndexes path)
   where
     db = ctx ^. dbLayer
 
-    createRandomAddress' xprv scheme wal = case mIx of
+    createRandomAddressV1 xprv scheme wal = case mIx of
         Just addrIx
             | isKnownIndex addrIx s0 ->
                 Left $ ErrIndexAlreadyExists addrIx
         Just addrIx ->
-            Right $ addAddress ((liftIndex accIx, liftIndex addrIx), s0)
+            Right $ addAddressV1 xprv scheme ((liftIndex accIx, liftIndex addrIx), s0)
         Nothing ->
-            Right $ addAddress $ Rnd.withRNG s0 $ \rng ->
+            Right $ addAddressV1 xprv scheme $ Rnd.withRNG s0 $ \rng ->
                 Rnd.findUnusedPath rng accIx (Rnd.unavailablePaths s0)
       where
         s0 = getState $ getLatest wal
@@ -1924,13 +1985,32 @@ createRandomAddress ctx wid pwd mIx =
             (liftIndex accIx, liftIndex addrIx)
                 `Set.member` Rnd.unavailablePaths s
 
-        addAddress (path, s1) =
-            ( [ReplacePrologue $ getPrologue $ Rnd.addPendingAddress addr path s1]
-            , (addr, Rnd.toDerivationIndexes path)
-            )
-          where
-            prepared = preparePassphrase scheme pwd
-            addr = Rnd.deriveRndStateAddress @n xprv prepared path
+    addAddressV1 xprv scheme (path, s1) =
+        ( [ReplacePrologue $ getPrologue $ Rnd.addPendingAddress addr path s1]
+        , (addr, Rnd.toDerivationIndexes path)
+        )
+      where
+        prepared = preparePassphrase scheme pwd
+        addr = Rnd.deriveRndStateAddress @n xprv prepared path
+
+    deriveByronV2Address ekey mPayload userPwd (accIdx, addrIdx) = do
+        let payload = fromMaybe
+                (error "createRandomAddress: V2 Byron key missing payload")
+                mPayload
+        accEkey <-
+            encryptedDerivePrivate DerivationScheme1 ekey userPwd (getIndex accIdx)
+                >>= either (error . ("createRandomAddress V2 acct: " <>) . show) pure
+        addrEkey <-
+            encryptedDerivePrivate DerivationScheme1 accEkey userPwd (getIndex addrIdx)
+                >>= either (error . ("createRandomAddress V2 addr: " <>) . show) pure
+        let pubBytes = publicKeyByteString (encryptedPublic addrEkey)
+            ccBytes = chainCodeByteString (encryptedChainCode addrEkey)
+        addrXPub <-
+            case xpub (pubBytes <> ccBytes) of
+                Left e -> error $ "createRandomAddress V2 xpub: " <> e
+                Right x -> pure x
+        pure $ paymentAddressS @n
+            (ByronKey addrXPub (accIdx, addrIdx) payload :: ByronKey 'CredFromKeyK XPub)
 
 importRandomAddresses
     :: forall s
@@ -2445,61 +2525,66 @@ buildSignSubmitTransaction
         let ti = timeInterpreter netLayer
         throwOnErr <=< runExceptT
             $ withRootKey db walletId pwd wrapRootKeyError
-            $ \rootKey scheme -> lift $ do
-                (BuiltTx{..}, slot) <- atomically $ do
-                    pendingTxs <-
-                        fmap fromTransactionInfo
-                            <$> readTransactions
-                                Nothing
-                                Descending
-                                Range.everything
-                                (Just Pending)
-                                Nothing
-                                Nothing
-                    txWithSlot@(builtTx, slot) <- ( throwOnErr
-                                                        <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
-                                                  )
-                        $ \s -> do
-                            let wallet = WalletState.getLatest s
-                                utxo = availableUTxO (Set.fromList pendingTxs) wallet
-                            buildAndSignTransactionPure @k @s
-                                timeTranslation
-                                utxo
-                                rootKey
-                                scheme
-                                pwd
-                                protocolParams
-                                txLayer
-                                changeAddrGen
-                                preSelection
-                                txCtx
-                                & (`runStateT` wallet)
-                                & runExceptT . withExceptT wrapBalanceConstructError
-                                & (`evalRand` stdGen)
-                                & fmap
-                                    ( \(builtTx, wallet') ->
-                                        -- Newly generated change addresses
-                                        -- only change the Prologue
-                                        ( [ReplacePrologue $ getPrologue $ getState wallet']
-                                        , (builtTx, currentTip wallet' ^. #slotNo)
+            $ \case
+                RootKeyAccessV1 rootKey scheme -> lift $ do
+                    (BuiltTx{..}, slot) <- atomically $ do
+                        pendingTxs <-
+                            fmap fromTransactionInfo
+                                <$> readTransactions
+                                    Nothing
+                                    Descending
+                                    Range.everything
+                                    (Just Pending)
+                                    Nothing
+                                    Nothing
+                        txWithSlot@(builtTx, slot) <- ( throwOnErr
+                                                            <=< (Delta.onDBVar walletState . Delta.updateWithResultAndError)
+                                                      )
+                            $ \s -> do
+                                let wallet = WalletState.getLatest s
+                                    utxo = availableUTxO (Set.fromList pendingTxs) wallet
+                                buildAndSignTransactionPure @k @s
+                                    timeTranslation
+                                    utxo
+                                    rootKey
+                                    scheme
+                                    pwd
+                                    protocolParams
+                                    txLayer
+                                    changeAddrGen
+                                    preSelection
+                                    txCtx
+                                    & (`runStateT` wallet)
+                                    & runExceptT . withExceptT wrapBalanceConstructError
+                                    & (`evalRand` stdGen)
+                                    & fmap
+                                        ( \(builtTx, wallet') ->
+                                            -- Newly generated change addresses
+                                            -- only change the Prologue
+                                            ( [ReplacePrologue $ getPrologue $ getState wallet']
+                                            , (builtTx, currentTip wallet' ^. #slotNo)
+                                            )
                                         )
-                                    )
 
-                    Delta.onDBVar walletState
-                        . WalletState.updateSubmissions
-                        . Delta.update
-                        $ \_ -> Submissions.addTxSubmission builtTx slot
+                        Delta.onDBVar walletState
+                            . WalletState.updateSubmissions
+                            . Delta.update
+                            $ \_ -> Submissions.addTxSubmission builtTx slot
 
-                    pure txWithSlot
+                        pure txWithSlot
 
-                postSealedTx netLayer builtSealedTx
-                    & throwWrappedErr wrapNetworkError
-                    & liftIO
+                    postSealedTx netLayer builtSealedTx
+                        & throwWrappedErr wrapNetworkError
+                        & liftIO
 
-                slotToUTCTime slot
-                    & interpretQuery (neverFails "slot is ahead of the node tip" ti)
-                    & fmap (BuiltTx{..},)
-                    & liftIO
+                    slotToUTCTime slot
+                        & interpretQuery (neverFails "slot is ahead of the node tip" ti)
+                        & fmap (BuiltTx{..},)
+                        & liftIO
+                RootKeyAccessV2{} ->
+                    liftIO
+                        $ error
+                            "buildSignSubmitTransaction: V2 key signing not yet implemented"
       where
         wrapRootKeyError = ExceptionWitnessTx . ErrWitnessTxWithRootKey
         wrapNetworkError = ExceptionSubmitTx . ErrSubmitTxNetwork
@@ -2811,42 +2896,47 @@ buildAndSignTransaction
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
     db & \DBLayer{..} ->
-        withRootKey db wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
-            let pwdP = preparePassphrase scheme pwd
-            mapExceptT atomically $ do
-                cp <- lift readCheckpoint
-                (Write.PParamsInAnyRecentEra era _pp, _) <-
-                    liftIO $ readNodeTipStateForTxWrite nl
-                let keyFrom = isOwned wF (getState cp) (xprv, pwdP)
-                    rewardAcnt = mkRwdAcct $ RootCredentials xprv pwdP
-                (tx, sealedTx) <-
-                    withExceptT ErrSignPaymentMkTx
-                        $ ExceptT
-                        $ pure
-                        $ mkTransaction era net kF rewardAcnt keyFrom txCtx sel
-                let amountOut :: Coin =
-                        F.fold
-                            $ fmap TxOut.coin (sel ^. #change)
-                                <> mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
-                    amountIn :: Coin =
-                        F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
-                            -- NOTE: In case where rewards are pulled from an external
-                            -- source, they aren't added to the calculation, as the
-                            -- money is considered to come from outside the wallet. In
-                            -- such cases, transactions are categorised as "incoming",
-                            -- as they bring extra money to the wallet from elsewhere.
-                            & case txWithdrawal txCtx of
-                                w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
-                                WithdrawalExternal{} -> Prelude.id
-                                NoWithdrawal -> Prelude.id
-                time <- liftIO $ tipSlotStartTime $ currentTip cp
-                let meta =
-                        mkTxMeta
-                            (currentTip cp)
-                            (txValidityInterval txCtx)
-                            amountIn
-                            amountOut
-                pure (tx, meta, time, sealedTx)
+        withRootKey db wid pwd ErrSignPaymentWithRootKey $ \case
+            RootKeyAccessV2{} ->
+                liftIO
+                    $ error
+                        "buildAndSignTransaction: V2 key signing not yet implemented"
+            RootKeyAccessV1 xprv scheme ->
+                let pwdP = preparePassphrase scheme pwd
+                in mapExceptT atomically $ do
+                    cp <- lift readCheckpoint
+                    (Write.PParamsInAnyRecentEra era _pp, _) <-
+                        liftIO $ readNodeTipStateForTxWrite nl
+                    let keyFrom = isOwned wF (getState cp) (xprv, pwdP)
+                        rewardAcnt = mkRwdAcct $ RootCredentials xprv pwdP
+                    (tx, sealedTx) <-
+                        withExceptT ErrSignPaymentMkTx
+                            $ ExceptT
+                            $ pure
+                            $ mkTransaction era net kF rewardAcnt keyFrom txCtx sel
+                    let amountOut :: Coin =
+                            F.fold
+                                $ fmap TxOut.coin (sel ^. #change)
+                                    <> mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
+                        amountIn :: Coin =
+                            F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
+                                -- NOTE: In case where rewards are pulled from an external
+                                -- source, they aren't added to the calculation, as the
+                                -- money is considered to come from outside the wallet. In
+                                -- such cases, transactions are categorised as "incoming",
+                                -- as they bring extra money to the wallet from elsewhere.
+                                & case txWithdrawal txCtx of
+                                    w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
+                                    WithdrawalExternal{} -> Prelude.id
+                                    NoWithdrawal -> Prelude.id
+                    time <- liftIO $ tipSlotStartTime $ currentTip cp
+                    let meta =
+                            mkTxMeta
+                                (currentTip cp)
+                                (txValidityInterval txCtx)
+                                amountIn
+                                amountOut
+                    pure (tx, meta, time, sealedTx)
   where
     wF = walletFlavor @s
     kF = keyFlavorFromState @s
@@ -2872,10 +2962,10 @@ constructTransaction
     -> PreSelection
     -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))
 constructTransaction era db txCtx preSel = do
-    (_, xpub, _) <- lift $ readRewardAccount db
+    (_, mRewardXPub, _) <- lift $ readRewardAccount db
     when (containsSelfWithdrawal (txCtx ^. #txWithdrawal))
         $ assertIsVoting db era
-    mkUnsignedTransaction netId (Left $ fromJust xpub) txCtx (Left preSel)
+    mkUnsignedTransaction netId (Left $ fromJust mRewardXPub) txCtx (Left preSel)
         & withExceptT ErrConstructTxBody . except
   where
     netId = networkIdVal $ sNetworkId @n
@@ -3708,8 +3798,8 @@ attachPrivateKeyFromPwd ctx (key, pwd) = do
     db = ctx ^. dbLayer
 
 -- | Build a 'HashedCredentialsV2' from a PBKDF2-encrypted root key.
--- Derives the plaintext scalar+chaincode to create an Argon2id authentication
--- envelope, and stores the original PBKDF2-encrypted key for key operations.
+-- Derives the plaintext scalar+chaincode to create an Argon2id AEAD
+-- envelope.  The plaintext key is never persisted.
 mkV2Credentials
     :: KeyFlavorS k
     -> k 'RootK XPrv
@@ -3718,16 +3808,17 @@ mkV2Credentials
 mkV2Credentials kF key pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase currentPassphraseScheme pwd
-        -- Decrypt PBKDF2-encrypted XPrv to plaintext (empty new passphrase)
         plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
         raw128 = CC.unXPrv plaintextXprv
-        -- Master-key group for encryptedCreateDirectWithTweak: scalar(64) || cc(32)
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
+        mPayload = case kF of
+            ByronKeyS -> Just (payloadPassphrase key)
+            _ -> Nothing
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left err ->
             error
                 $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
-        Right ekey -> pure $ HashedCredentialsV2 key ekey
+        Right ekey -> pure $ HashedCredentialsV2 ekey mPayload
 
 -- | The hash here is the output of Scrypt function with the following parameters:
 -- - logN = 14
@@ -3794,27 +3885,30 @@ attachPrivateKey db creds scheme =
                         }
             putWalletMeta walletState (modify meta)
 
--- | Execute an action which requires holding a root XPrv.
+-- | Safe handle to a validated root key, used as the callback argument in
+-- 'withRootKey'.  V2 credentials never expose plaintext key bytes.
+data RootKeyAccess k
+    = RootKeyAccessV1 (k 'RootK XPrv) PassphraseScheme
+    | RootKeyAccessV2
+        !EncryptedKey
+        !(Maybe (Passphrase "addr-derivation-payload"))
+        !(Passphrase "user")
+
+-- | Execute an action which requires access to a root key.
 --
--- 'withRootKey' takes a callback function with two arguments:
+-- 'withRootKey' validates the passphrase and passes a 'RootKeyAccess' handle
+-- to the callback.
 --
---  - The root private key (PBKDF2-encrypted for all stored variants)
---  - The passphrase scheme to use ('currentPassphraseScheme')
+-- * V1 keys: the callback receives the plaintext 'XPrv' and its
+--   'PassphraseScheme' as a 'RootKeyAccessV1'.  The caller can call
+--   @preparePassphrase scheme pwd@ to encrypt before passing to the C layer.
 --
--- Callers are expected to use 'preparePassphrase' with the given scheme in
--- order to "prepare" the passphrase before passing it to signing / derivation
--- functions.
+-- * V2 keys: the callback receives 'RootKeyAccessV2' carrying the
+--   'EncryptedKey'.  Key material stays in @sodium_malloc@-backed memory
+--   and is zeroed after use; the plaintext scalar is never copied to the
+--   GC heap.
 --
--- For v2 keys, passphrase authentication uses the Argon2id AEAD envelope;
--- the key itself remains PBKDF2-encrypted so key-operation callers use the
--- same 'preparePassphrase' path as v1.
---
--- V1 keys are opportunistically migrated to v2 on every successful use.
---
--- @@@
---     withRootKey db wid pwd OnError $ \xprv scheme ->
---         changePassphrase (preparePassphrase scheme pwd) newPwd xprv
--- @@@
+-- V1 keys are opportunistically migrated to V2 on every successful use.
 withRootKey
     :: forall s e a
      . WalletFlavor s
@@ -3822,7 +3916,7 @@ withRootKey
     -> WalletId
     -> Passphrase "user"
     -> (ErrWithRootKey -> e)
-    -> (KeyOf s 'RootK XPrv -> PassphraseScheme -> ExceptT e IO a)
+    -> (RootKeyAccess (KeyOf s) -> ExceptT e IO a)
     -> ExceptT e IO a
 withRootKey db@DBLayer{..} wid pwd embed action = do
     (mCreds, mScheme) <- lift . atomically $ do
@@ -3834,32 +3928,37 @@ withRootKey db@DBLayer{..} wid pwd embed action = do
         (Just (HashedCredentialsV1 xprv hpwd), Just scheme) ->
             pure $ case checkPassphrase scheme pwd hpwd of
                 Left err -> Left $ ErrWithRootKeyWrongPassphrase wid err
-                Right _ -> Right $ Left (xprv, scheme)
-        (Just (HashedCredentialsV2 xprv ekey), Just _) -> do
+                Right _ -> Right $ RootKeyAccessV1 xprv scheme
+        (Just (HashedCredentialsV2 ekey mPayload), Just _) -> do
             result <- encryptedValidatePassphrase ekey pwd
             pure $ case result of
-                Left _ ->
-                    Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
-                Right () -> Right $ Right xprv
+                Left _ -> Left $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase
+                Right () -> Right $ RootKeyAccessV2 ekey mPayload pwd
         _ -> pure $ Left $ ErrWithRootKeyNoRootKey wid
     case validated of
-        Left (xprv, scheme) -> do
-            -- Opportunistically migrate V1 → V2 on successful passphrase use.
+        rka@(RootKeyAccessV1 xprv scheme) -> do
             lift $ migrateV1toV2 db kF xprv scheme pwd
-            action xprv scheme
-        Right xprv ->
-            action xprv currentPassphraseScheme
+            action rka
+        rka@(RootKeyAccessV2 _ _ _) -> action rka
   where
     kF = keyFlavorFromState @s
+
+-- | CPS key derivation along a path for V2 'ExtKeyMaterial'.
+-- Recursively nests 'deriveExtKeyMaterial' calls for each index in the path.
+withDerivedExtKeyMaterial
+    :: DerivationScheme
+    -> ExtKeyMaterial s' Validated
+    -> [Word32]
+    -> (forall s. ExtKeyMaterial s Validated -> IO (Either XPrvError a))
+    -> IO (Either XPrvError a)
+withDerivedExtKeyMaterial _ km [] k = k km
+withDerivedExtKeyMaterial scheme km (ix : ixs) k =
+    deriveExtKeyMaterial scheme km ix $ \km' ->
+        withDerivedExtKeyMaterial scheme km' ixs k
 
 -- | Migrate a V1 PBKDF2- or Scrypt-encrypted root key to a V2 Argon2id
 -- envelope and write it back to the database.  Fails silently so that the
 -- current operation is not affected if migration is unsuccessful.
---
--- The stored XPrv in the resulting 'HashedCredentialsV2' is always
--- re-encrypted with 'currentPassphraseScheme' (PBKDF2), regardless of the
--- original V1 scheme.  This ensures that 'withRootKey' can always return
--- 'currentPassphraseScheme' for V2 credentials.
 migrateV1toV2
     :: forall s
      . DBLayer IO s
@@ -3871,39 +3970,20 @@ migrateV1toV2
 migrateV1toV2 DBLayer{..} kF key scheme pwd = do
     let rawXprv = getRawKey kF key
         prepared = preparePassphrase scheme pwd
-        -- Decrypt to plaintext (empty passphrase)
         plaintextXprv = CC.xPrvChangePass prepared (mempty :: ByteString) rawXprv
         raw128 = CC.unXPrv plaintextXprv
         masterKey96 = BS.take 64 raw128 <> BS.drop 96 raw128
-        -- Re-encrypt with current scheme (PBKDF2) for V2 stored key
-        pbkdf2Prepared = preparePassphrase currentPassphraseScheme pwd
-        pbkdf2XPrv =
-            CC.xPrvChangePass (mempty :: ByteString) pbkdf2Prepared plaintextXprv
         mPayload = case kF of
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
-        v2Key = reconstructRootKey kF pbkdf2XPrv mPayload
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left _ -> pure () -- fail silently; key stays V1 until next use
         Right ekey -> atomically $ do
-            putPrivateKey walletState (HashedCredentialsV2 v2Key ekey)
+            putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
             meta <- readWalletMeta walletState
             let updateScheme info = info{passphraseScheme = EncryptWithArgon2idV2}
             putWalletMeta walletState
                 $ meta{passphraseInfo = fmap updateScheme (passphraseInfo meta)}
-
-reconstructRootKey
-    :: KeyFlavorS k
-    -> XPrv
-    -> Maybe (Passphrase "addr-derivation-payload")
-    -> k 'RootK XPrv
-reconstructRootKey kF plaintextXprv mPayload = case kF of
-    ByronKeyS ->
-        ByronKey plaintextXprv ()
-            $ fromMaybe (hdPassphrase (toXPub plaintextXprv)) mPayload
-    IcarusKeyS -> IcarusKey plaintextXprv
-    ShelleyKeyS -> ShelleyKey plaintextXprv
-    SharedKeyS -> SharedKey plaintextXprv
 
 -- | Sign an arbitrary transaction metadata object with a private key belonging
 -- to the wallet's account.
@@ -3930,19 +4010,41 @@ signMetadataWith ctx wid pwd (role_, ix) metadata =
 
         cp <- lift $ atomically readCheckpoint
 
-        withRootKey db wid pwd ErrSignMetadataWithRootKey $ \rootK scheme -> do
-            let encPwd = preparePassphrase scheme pwd
-                DerivationPrefix (_, _, acctIx) = Seq.derivationPrefix (getState cp)
-                acctK = deriveAccountPrivateKey encPwd rootK acctIx
-                addrK = deriveAddressPrivateKey encPwd acctK role_ addrIx
-            pure
-                $ Signature
-                $ BA.convert
-                $ CC.sign encPwd (getRawKey (keyFlavorFromState @s) addrK)
-                $ hash @ByteString @Blake2b_256
-                $ serialize' shelleyProtVer
-                $ toShelleyMetadata
-                $ unTxMetadata metadata
+        withRootKey db wid pwd ErrSignMetadataWithRootKey $ \case
+            RootKeyAccessV1 rootK scheme -> do
+                let encPwd = preparePassphrase scheme pwd
+                    DerivationPrefix (_, _, acctIx) = Seq.derivationPrefix (getState cp)
+                    acctK = deriveAccountPrivateKey encPwd rootK acctIx
+                    addrK = deriveAddressPrivateKey encPwd acctK role_ addrIx
+                pure
+                    $ Signature
+                    $ BA.convert
+                    $ CC.sign encPwd (getRawKey (keyFlavorFromState @s) addrK)
+                    $ hash @ByteString @Blake2b_256
+                    $ serialize' shelleyProtVer
+                    $ toShelleyMetadata
+                    $ unTxMetadata metadata
+            RootKeyAccessV2 ekey _ userPwd -> do
+                let DerivationPrefix (purpose, coinType, acctIx) =
+                        Seq.derivationPrefix (getState cp)
+                    msg =
+                        hash @ByteString @Blake2b_256
+                            $ serialize' shelleyProtVer
+                            $ toShelleyMetadata
+                            $ unTxMetadata metadata
+                    path =
+                        [ getIndex purpose
+                        , getIndex coinType
+                        , getIndex acctIx
+                        , fromIntegral (fromEnum role_)
+                        , getIndex addrIx
+                        ]
+                sigE <- liftIO $ withDecryptedExtKeyMaterial ekey userPwd $ \rootKm ->
+                    withDerivedExtKeyMaterial DerivationScheme2 rootKm path $ \addrKm ->
+                        fmap (fmap (\(EncHD.Signature s) -> s)) (signWithExtKeyMaterial addrKm msg)
+                case sigE of
+                    Left e -> error $ "signMetadataWith V2: " <> show e
+                    Right sig -> pure $ Signature $ BA.convert sig
   where
     db = ctx ^. dbLayer
 
@@ -4005,14 +4107,38 @@ writePolicyPublicKey ctx wid pwd =
             wid
             pwd
             ErrWritePolicyPublicKeyWithRootKey
-            $ \rootK scheme -> do
-                let encPwd = preparePassphrase scheme pwd
-                    xprv =
-                        derivePolicyPrivateKey
-                            encPwd
-                            (getRawKey ShelleyKeyS rootK)
-                            minBound
-                pure $ ShelleyKey $ toXPub xprv
+            $ \case
+                RootKeyAccessV1 rootK scheme -> do
+                    let encPwd = preparePassphrase scheme pwd
+                        xprv =
+                            derivePolicyPrivateKey
+                                encPwd
+                                (getRawKey ShelleyKeyS rootK)
+                                minBound
+                    pure $ ShelleyKey $ toXPub xprv
+                RootKeyAccessV2 ekey _ userPwd -> liftIO $ do
+                    let policyIx :: Index 'Hardened 'PolicyK
+                        policyIx = minBound
+                        path =
+                            [ getIndex purposeCIP1855
+                            , getIndex coinTypeAda
+                            , getIndex policyIx
+                            ]
+                    policyEkey <-
+                        foldM
+                            ( \ek ix ->
+                                encryptedDerivePrivate DerivationScheme2 ek userPwd ix
+                                    >>= either
+                                        (error . ("writePolicyPublicKey V2: " <>) . show)
+                                        pure
+                            )
+                            ekey
+                            path
+                    let pubBytes = publicKeyByteString (encryptedPublic policyEkey)
+                        ccBytes = chainCodeByteString (encryptedChainCode policyEkey)
+                    case xpub (pubBytes <> ccBytes) of
+                        Left e -> error $ "writePolicyPublicKey V2 xpub: " <> e
+                        Right xpub' -> pure $ ShelleyKey xpub'
 
         let seqState' = seqState & #policyXPub .~ Just policyXPub
         lift
@@ -4080,15 +4206,37 @@ getAccountPublicKeyAtIndex ctx wid pwd ix purposeM =
         _cp <- lift $ atomically readCheckpoint
         let kf = keyFlavorFromState @s
         withRootKey db wid pwd ErrReadAccountPublicKeyRootKey
-            $ \rootK scheme -> do
-                let encPwd = preparePassphrase scheme pwd
-                    xprv =
-                        deriveAccountPrivateKeyShelley
-                            purpose
-                            encPwd
-                            (getRawKey kf rootK)
-                            acctIx
-                pure $ liftRawKey kf $ toXPub xprv
+            $ \case
+                RootKeyAccessV1 rootK scheme -> do
+                    let encPwd = preparePassphrase scheme pwd
+                        xprv =
+                            deriveAccountPrivateKeyShelley
+                                purpose
+                                encPwd
+                                (getRawKey kf rootK)
+                                acctIx
+                    pure $ liftRawKey kf $ toXPub xprv
+                RootKeyAccessV2 ekey _ userPwd -> liftIO $ do
+                    let path =
+                            [ getIndex purpose
+                            , getIndex coinTypeAda
+                            , getIndex acctIx
+                            ]
+                    accountEkey <-
+                        foldM
+                            ( \ek pathIx ->
+                                encryptedDerivePrivate DerivationScheme2 ek userPwd pathIx
+                                    >>= either
+                                        (error . ("getAccountPublicKeyAtIndex V2: " <>) . show)
+                                        pure
+                            )
+                            ekey
+                            path
+                    let pubBytes = publicKeyByteString (encryptedPublic accountEkey)
+                        ccBytes = chainCodeByteString (encryptedChainCode accountEkey)
+                    case xpub (pubBytes <> ccBytes) of
+                        Left e -> error $ "getAccountPublicKeyAtIndex V2 xpub: " <> e
+                        Right xpub' -> pure $ liftRawKey kf xpub'
   where
     db = ctx ^. dbLayer
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -4178,6 +4178,10 @@ attachPrivateKeyFromPwdHashShelley ctx (xprv, hpwd) =
 -- recreated (e.g. shared wallet activation).  The passphrase scheme is
 -- inferred from the credential format: V1 → 'currentPassphraseScheme',
 -- V2 → 'EncryptWithArgon2idV2'.
+--
+-- NOTE: V1 Byron wallets use 'EncryptWithScrypt', not 'currentPassphraseScheme'.
+-- The current callers of this function are Shelley-only, so this is not a
+-- current bug, but Byron credentials must not be routed through here.
 reattachPrivateKey
     :: WalletLayer IO s
     -> HashedCredentials (KeyOf s)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -291,12 +291,12 @@ import Cardano.Balance.Tx.TimeTranslation
 import Cardano.Balance.Tx.Tx
     ( toRecentEraGADT
     )
-import Cardano.Crypto.Wallet
-    ( toXPub
-    )
 import Cardano.Crypto.Libsodium
     ( mlsbFinalize
     , mlsbToByteString
+    )
+import Cardano.Crypto.Wallet
+    ( toXPub
     )
 import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
@@ -3704,7 +3704,8 @@ padFeePercentiles
 -- @preparePassphrase currentPassphraseScheme pwd@ (PBKDF2), which is the
 -- invariant upheld by all wallet-creation and passphrase-change paths.
 attachPrivateKeyFromPwd
-    :: forall s. WalletFlavor s
+    :: forall s
+     . WalletFlavor s
     => WalletLayer IO s
     -> (KeyOf s 'RootK XPrv, Passphrase "user")
     -> IO ()
@@ -3735,7 +3736,8 @@ mkV2Credentials kF key pwd = do
             _ -> Nothing
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
         Left err ->
-            error $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
+            error
+                $ "mkV2Credentials: encryptedCreateDirectWithTweak: " <> show err
         Right ekey -> pure $ HashedCredentialsV2 ekey mPayload
 
 -- | The hash here is the output of Scrypt function with the following parameters:
@@ -3759,7 +3761,10 @@ attachPrivateKeyFromPwdHashShelley
     -> (KeyOf s 'RootK XPrv, PassphraseHash)
     -> IO ()
 attachPrivateKeyFromPwdHashShelley ctx (xprv, hpwd) =
-    attachPrivateKey db (HashedCredentialsV1 xprv hpwd) currentPassphraseScheme
+    attachPrivateKey
+        db
+        (HashedCredentialsV1 xprv hpwd)
+        currentPassphraseScheme
   where
     db = ctx ^. dbLayer
 
@@ -3882,7 +3887,7 @@ migrateV1toV2 DBLayer{..} kF key scheme pwd = do
             ByronKeyS -> Just (payloadPassphrase key)
             _ -> Nothing
     encryptedCreateDirectWithTweak masterKey96 pwd >>= \case
-        Left _ -> pure ()  -- fail silently; key stays V1 until next use
+        Left _ -> pure () -- fail silently; key stays V1 until next use
         Right ekey -> atomically $ do
             putPrivateKey walletState (HashedCredentialsV2 ekey mPayload)
             meta <- readWalletMeta walletState
@@ -3919,9 +3924,9 @@ reconstructRootKey kF plaintextXprv mPayload = case kF of
     ByronKeyS ->
         ByronKey plaintextXprv ()
             $ fromMaybe (hdPassphrase (toXPub plaintextXprv)) mPayload
-    IcarusKeyS  -> IcarusKey  plaintextXprv
+    IcarusKeyS -> IcarusKey plaintextXprv
     ShelleyKeyS -> ShelleyKey plaintextXprv
-    SharedKeyS  -> SharedKey  plaintextXprv
+    SharedKeyS -> SharedKey plaintextXprv
 
 -- | Sign an arbitrary transaction metadata object with a private key belonging
 -- to the wallet's account.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -197,6 +197,7 @@ module Cardano.Wallet
     , getTransaction
     , submitExternalTx
     , submitTx
+    , signTransactionV2
     , readLocalTxSubmissionPending
     , LocalTxSubmissionConfig (..)
     , defaultLocalTxSubmissionConfig
@@ -325,7 +326,13 @@ import Cardano.Ledger.Api
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( inputsTxBodyL
+    ( Withdrawals (..)
+    , inputsTxBodyL
+    , mintTxBodyL
+    , withdrawalsTxBodyL
+    )
+import Cardano.Ledger.Core
+    ( certsTxBodyL
     )
 import Cardano.Ledger.Binary
     ( serialize'
@@ -540,6 +547,7 @@ import Cardano.Wallet.Primitive.Passphrase
     , WalletPassphraseInfo (..)
     , checkPassphrase
     , currentPassphraseScheme
+    , encryptPassphrase
     , preparePassphrase
     )
 import Cardano.Wallet.Primitive.Slotting
@@ -667,6 +675,7 @@ import Cardano.Wallet.Shelley.Transaction
     ( mkUnsignedTransaction
     , txConstraints
     , txWitnessTagForKey
+    , withSealedTxRecentEra
     , _txRewardWithdrawalCost
     )
 import Cardano.Wallet.Shelley.Transaction.Ledger
@@ -674,6 +683,7 @@ import Cardano.Wallet.Shelley.Transaction.Ledger
     , certificateFromVotingActionLedger
     , constructUnsignedTxLedger
     , mkShelleyWitnessFromExtKeyMaterial
+    , mkShelleyWitnessLedger
     , mkTransaction
     , sealWriteTx
     )
@@ -2219,7 +2229,14 @@ readWalletUTxO
     -> IO (UTxO, Wallet s, Set Tx)
 readWalletUTxO ctx = do
     (cp, _, pending) <- readWallet ctx
-    return (availableUTxO pending cp, cp, pending)
+    let avail = availableUTxO pending cp
+        tokenList = TokenMap.toFlatList (UTxO.balance avail ^. #tokens)
+    traceWith (contramap MsgWallet (logger_ ctx)) $ MsgDebugUTxO $
+        "readWalletUTxO: pendingCount="
+            <> T.pack (show (Set.size pending))
+            <> " availTokens="
+            <> T.pack (show tokenList)
+    return (avail, cp, pending)
 
 -- | Calculate the minimum coin values required for a bunch of specified
 -- outputs.
@@ -2329,6 +2346,85 @@ signTransaction
                 stakingKeyM
                 keyLookup
                 inputResolver
+
+-- | Sign an externally-built transaction using V2 (Argon2id AEAD) key material.
+--
+-- Computes Shelley witnesses for every wallet-owned input address and, for
+-- Shelley sequential wallets, the staking key.  Returns 'Nothing' when the
+-- sealed transaction is in an era older than Conway (pre-recent-era txs
+-- cannot be re-sealed).
+signTransactionV2
+    :: forall s
+     . ( IsOurs s Address
+       , WalletFlavor s
+       )
+    => Read.EraValue Read.Era
+    -- ^ Preferred era (used to decode the sealed tx)
+    -> SealedTx
+    -- ^ The externally-built, unsigned transaction
+    -> Wallet s
+    -- ^ Current wallet snapshot (address state + UTxO)
+    -> UTxO
+    -- ^ Total UTxO set (including pending)
+    -> EncryptedKey
+    -- ^ V2 root key
+    -> Passphrase "user"
+    -- ^ User passphrase
+    -> IO (Maybe SealedTx)
+signTransactionV2 era sealedTx wallet walletUtxo ekey userPwd =
+    sequence $ withSealedTxRecentEra era sealedTx $ \recentEra' ledgerTx -> do
+        let txBody = ledgerTx ^. bodyTxL
+            walletSt = getState wallet
+            inputPaths =
+                L.nub
+                    $ mapMaybe
+                        ( \ledIn ->
+                            UTxO.lookup (toWallet ledIn) walletUtxo
+                                >>= \(TxOut addr _) -> fst (isOurs addr walletSt)
+                        )
+                        (Set.toList $ txBody ^. inputsTxBodyL)
+            -- Only include the stake key when the tx actually uses it;
+            -- adding an unnecessary witness inflates tx size past the fee estimate.
+            needsStakeKey =
+                not (null $ unWithdrawals (txBody ^. withdrawalsTxBodyL))
+                    || not (null $ txBody ^. certsTxBodyL)
+            mStakePath =
+                case walletFlavor @s of
+                    ShelleyWallet
+                        | needsStakeKey ->
+                            Just $ stakeDerivationPath $ Seq.derivationPrefix walletSt
+                    _ -> Nothing
+            -- Include the policy key when the tx mints or burns native assets.
+            needsMinting = txBody ^. mintTxBodyL /= mempty
+            mPolicyPath = case walletFlavor @s of
+                ShelleyWallet | needsMinting -> Just policyDerivationPath
+                _ -> Nothing
+            allPaths =
+                inputPaths <> maybeToList mStakePath <> maybeToList mPolicyPath
+        witsE <- withDecryptedExtKeyMaterial ekey userPwd $ \rootKm -> do
+            results <-
+                forM allPaths $ \path ->
+                    withDerivedExtKeyMaterial
+                        DerivationScheme2
+                        rootKm
+                        (map getDerivationIndex $ NE.toList path)
+                        $ \addrKm ->
+                            Right
+                                <$> mkShelleyWitnessFromExtKeyMaterial
+                                    recentEra'
+                                    txBody
+                                    addrKm
+            pure $ sequence results
+        case witsE of
+            Left e ->
+                error $ "signTransactionV2: key derivation failed: " <> show e
+            Right wits ->
+                pure
+                    -- Union (not replace) so that witnesses from previous signers
+                    -- are preserved (multi-party shared wallets, cross-wallet reward
+                    -- redemption, etc.).
+                    $ sealWriteTx recentEra'
+                    $ over (witsTxL . addrTxWitsL) (Set.union (Set.fromList wits)) ledgerTx
 
 type MakeRewardAccountBuilder k =
     ClearCredentials k -> (XPrv, Passphrase "encryption")
@@ -2615,11 +2711,17 @@ buildSignSubmitTransaction
                                 || isJust (view #txVotingAction txCtx)
                                 || containsSelfWithdrawal
                                     (view #txWithdrawal txCtx)
+                        needsMinting =
+                            txBody ^. mintTxBodyL /= mempty
+                        mPolicyPath = case walletFlavor @s of
+                            ShelleyWallet | needsMinting -> Just policyDerivationPath
+                            _ -> Nothing
                         allPaths =
                             inputPaths
                                 <> case (needsStakeKey, mStakePath) of
                                     (True, Just p) -> [p]
                                     _ -> []
+                                <> maybeToList mPolicyPath
                     witsE <-
                         withDecryptedExtKeyMaterial ekey userPwd
                             $ \rootKm -> do
@@ -2644,10 +2746,19 @@ buildSignSubmitTransaction
                                 $ "buildSignSubmitTransaction V2: "
                                 <> show e
                         Right wits -> pure wits
-                    let signedLedgerTx =
+                    let mExternalWit = case view #txWithdrawal txCtx of
+                            WithdrawalExternal _ _ _ extXPrv ->
+                                Just
+                                    $ mkShelleyWitnessLedger
+                                        recentEra'
+                                        txBody
+                                        (extXPrv, mempty)
+                            _ -> Nothing
+                        signedLedgerTx =
                             unsignedTx
                                 & witsTxL . addrTxWitsL
-                                    .~ Set.fromList shelleyWits
+                                    .~ Set.fromList
+                                        (shelleyWits <> maybeToList mExternalWit)
                         builtSealedTx = sealWriteTx recentEra' signedLedgerTx
                         rawTx =
                             walletTx
@@ -3138,11 +3249,17 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
                         isJust (view #txDelegationAction txCtx)
                             || isJust (view #txVotingAction txCtx)
                             || containsSelfWithdrawal (view #txWithdrawal txCtx)
+                    needsMinting =
+                        txBody ^. mintTxBodyL /= mempty
+                    mPolicyPath = case walletFlavor @s of
+                        ShelleyWallet | needsMinting -> Just policyDerivationPath
+                        _ -> Nothing
                     allPaths =
                         inputPaths
                             <> case (needsStakeKey, mStakePath) of
                                 (True, Just p) -> [p]
                                 _ -> []
+                            <> maybeToList mPolicyPath
                 witsE <-
                     liftIO $ withDecryptedExtKeyMaterial ekey userPwd
                         $ \rootKm -> do
@@ -3167,10 +3284,19 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel =
                             $ "buildAndSignTransaction V2: "
                             <> show e
                     Right wits -> pure wits
-                let signedLedgerTx =
+                let mExternalWit = case view #txWithdrawal txCtx of
+                        WithdrawalExternal _ _ _ extXPrv ->
+                            Just
+                                $ mkShelleyWitnessLedger
+                                    era'
+                                    txBody
+                                    (extXPrv, mempty)
+                        _ -> Nothing
+                    signedLedgerTx =
                         unsignedTx
                             & witsTxL . addrTxWitsL
-                                .~ Set.fromList shelleyWits
+                                .~ Set.fromList
+                                    (shelleyWits <> maybeToList mExternalWit)
                     builtSealedTx = sealWriteTx era' signedLedgerTx
                     txExt = case era' of
                         Write.RecentEraConway ->
@@ -4102,11 +4228,20 @@ attachPrivateKeyFromPwd
     => WalletLayer IO s
     -> (KeyOf s 'RootK XPrv, Passphrase "user")
     -> IO ()
-attachPrivateKeyFromPwd ctx (key, pwd) = do
-    creds <- mkV2Credentials (keyFlavorFromState @s) key pwd
-    attachPrivateKey db creds EncryptWithArgon2idV2
+attachPrivateKeyFromPwd ctx (key, pwd) =
+    case keyFlavorFromState @s of
+        ByronKeyS -> legacyV1
+        IcarusKeyS -> legacyV1
+        kF -> do
+            creds <- mkV2Credentials kF key pwd
+            attachPrivateKey db creds EncryptWithArgon2idV2
   where
     db = ctx ^. dbLayer
+    -- Byron and Icarus wallets stay on V1: V2 signing is not yet implemented
+    -- for these legacy wallet types.
+    legacyV1 = do
+        (scheme, hpwd) <- encryptPassphrase pwd
+        attachPrivateKey db (HashedCredentialsV1 key hpwd) scheme
 
 -- | Strip the 32-byte internal PBKDF2 passphrase hash from a plaintext
 -- (decrypted) cardano-crypto 'XPrv' and return the 96-byte payload expected
@@ -4268,7 +4403,12 @@ withRootKey tr db@DBLayer{..} wid pwd embed action = do
         _ -> pure $ Left $ ErrWithRootKeyNoRootKey wid
     case validated of
         rka@(RootKeyAccessV1 xprv scheme) -> do
-            lift $ migrateV1toV2 tr db kF xprv scheme pwd
+            -- Byron and Icarus wallets stay on V1: V2 signing is not yet
+            -- implemented for these legacy wallet types.
+            case kF of
+                ByronKeyS -> pure ()
+                IcarusKeyS -> pure ()
+                _ -> lift $ migrateV1toV2 tr db kF xprv scheme pwd
             action rka
         rka@(RootKeyAccessV2 _ _ _) -> action rka
   where
@@ -4993,6 +5133,7 @@ data WalletLog
     | MsgTxSubmit TxSubmitLog
     | MsgIsStakeKeyRegistered Bool
     | MsgV2MigrationFailed Text
+    | MsgDebugUTxO Text
     deriving (Show, Eq)
 
 instance ToText WalletFollowLog where
@@ -5059,6 +5200,7 @@ instance ToText WalletLog where
             "Wallet stake key is not registered. Will register..."
         MsgV2MigrationFailed err ->
             "V1->V2 key migration failed (key stays V1 until next use): " <> err
+        MsgDebugUTxO msg -> msg
 
 instance HasPrivacyAnnotation WalletFollowLog
 instance HasSeverityAnnotation WalletFollowLog where
@@ -5082,6 +5224,7 @@ instance HasSeverityAnnotation WalletLog where
         MsgTxSubmit msg -> getSeverityAnnotation msg
         MsgIsStakeKeyRegistered _ -> Info
         MsgV2MigrationFailed _ -> Warning
+        MsgDebugUTxO _ -> Info
 
 data TxSubmitLog
     = MsgSubmitTx BuiltTx (BracketLog' (Either ErrSubmitTx ()))

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -17,6 +17,11 @@ import Cardano.Crypto.Wallet
     ( unXPrv
     , xprv
     )
+import Cardano.Crypto.WalletV2.Encrypted
+    ( EncryptedKey
+    , encryptedKey
+    , unEncryptedKey
+    )
 import Cardano.Wallet.Address.Derivation
     ( Depth (RootK)
     , fromHex
@@ -41,89 +46,143 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
     , PassphraseHash (..)
     )
-import Control.Monad
-    ( (<=<)
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials (..)
     )
 import Data.ByteString
     ( ByteString
     )
 import Prelude
 
-import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Derivation.Icarus as Icarus
 import qualified Cardano.Wallet.Address.Derivation.SharedKey as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
--- | Convert a private key and its password hash into hexadecimal strings
--- suitable for storing in a text file or database column.
+-- | Convert a 'HashedCredentials' value into hexadecimal strings suitable for
+-- storing in a text file or database column.
+--
+-- The first element of the pair is the key column; the second is the hash
+-- column (empty for v2 keys, which are self-authenticating).
+--
+-- Serialization format
+-- ====================
+--
+-- V1 non-Byron : @hex(unXPrv k)@  (exactly 256 hex chars = 128 bytes)
+-- V1 Byron     : @hex(unXPrv k) ":" hex(payloadPass)@
+--
+-- V2 non-Byron : @hex(unEncryptedKey ekey)@  (> 256 hex chars, CBOR envelope)
+-- V2 Byron     : @hex(unEncryptedKey ekey) ":" hex(payloadPass)@
+--
+-- V1 and V2 are distinguished by the length of the first colon-delimited
+-- segment: exactly 256 hex chars ↔ V1 (128-byte XPrv), longer ↔ V2.
 serializeXPrv
     :: KeyFlavorS k
-    -- ^ The type of key to serialize.
-    -> (k 'RootK CC.XPrv, PassphraseHash)
-    -- ^ Private key and its password hash.
+    -> HashedCredentials k
     -> (ByteString, ByteString)
-    -- ^ Hexadecimal strings.
-serializeXPrv = \case
-    ByronKeyS -> f serializeXPrvByron
-    IcarusKeyS -> f serializeXPrvIcarus
-    ShelleyKeyS -> f serializeXPrvShelley
-    SharedKeyS -> f serializeXPrvShared
+serializeXPrv kF = \case
+    HashedCredentialsV1 k h -> serializeV1 kF k h
+    HashedCredentialsV2 ekey mPayload -> serializeV2 kF ekey mPayload
+
+serializeV1
+    :: KeyFlavorS k
+    -> k 'RootK XPrv
+    -> PassphraseHash
+    -> (ByteString, ByteString)
+serializeV1 kF k h = (keyBytes, hex . getPassphraseHash $ h)
   where
-    f g (k, h) = (g k, hex . getPassphraseHash $ h)
+    keyBytes = case kF of
+        ByronKeyS ->
+            let ByronKey xk _ (Passphrase p) = k
+            in  hex (unXPrv xk) <> ":" <> hex p
+        IcarusKeyS  -> hex . unXPrv . Icarus.getKey  $ k
+        ShelleyKeyS -> hex . unXPrv . Shelley.getKey $ k
+        SharedKeyS  -> hex . unXPrv . Shared.getKey  $ k
 
-    serializeXPrvByron ((ByronKey k _ (Passphrase p))) =
-        hex (unXPrv k) <> ":" <> hex p
-    serializeXPrvIcarus = hex . unXPrv . Icarus.getKey
-    serializeXPrvShelley = hex . unXPrv . Shelley.getKey
-    serializeXPrvShared = hex . unXPrv . Shared.getKey
+serializeV2
+    :: KeyFlavorS k
+    -> EncryptedKey
+    -> Maybe (Passphrase "addr-derivation-payload")
+    -> (ByteString, ByteString)
+serializeV2 kF ekey mPayload = (keyBytes, "")
+  where
+    keyBytes = case (kF, mPayload) of
+        (ByronKeyS, Just (Passphrase p)) ->
+            hex (unEncryptedKey ekey) <> ":" <> hex p
+        _ -> hex (unEncryptedKey ekey)
 
--- | The reverse of 'serializeXPrv'. This may fail if the inputs are not
--- valid hexadecimal strings, or if the key is of the wrong length.
+-- | The reverse of 'serializeXPrv'. Dies with 'error' if the inputs are not
+-- valid hexadecimal strings or if the key is of the wrong length\/format.
 unsafeDeserializeXPrv
     :: KeyFlavorS k
-    -- ^ The type of key to deserialize.
     -> (ByteString, ByteString)
-    -- ^ Hexadecimal strings.
-    -> (k 'RootK CC.XPrv, PassphraseHash)
-    -- ^ Private key and its password hash.
-unsafeDeserializeXPrv = \case
-    ByronKeyS -> deserialize unsafeDeserializeXPrvByron "ByronKey"
-    IcarusKeyS -> deserialize (fmap IcarusKey . xprvFromText) "IcarusKey"
-    ShelleyKeyS -> deserialize (fmap ShelleyKey . xprvFromText) "ShelleyKey"
-    SharedKeyS -> deserialize (fmap SharedKey . xprvFromText) "SharedKey"
+    -> HashedCredentials k
+unsafeDeserializeXPrv kF (keyCol, hashCol) = case kF of
+    ByronKeyS   -> deserializeByron   keyCol hashCol
+    IcarusKeyS  -> deserializeSimple  IcarusKey  keyCol hashCol
+    ShelleyKeyS -> deserializeSimple  ShelleyKey keyCol hashCol
+    SharedKeyS  -> deserializeSimple  SharedKey  keyCol hashCol
+
+-- | Detect whether the key column encodes a V1 (128-byte) or V2 (CBOR) key.
+-- We split on ':' and check the length of the first segment: exactly 256 hex
+-- chars means 128 bytes = V1.
+isV1KeySegment :: ByteString -> Bool
+isV1KeySegment seg = BS.length seg == 256
+
+-- Deserialize a non-Byron key (Icarus / Shelley / Shared).
+-- V1: @hex(xprv)@        → HashedCredentialsV1 (wrap xprv) hash
+-- V2: @hex(ekey cbor)@   → HashedCredentialsV2 ekey Nothing
+deserializeSimple
+    :: (XPrv -> k 'RootK XPrv)
+    -> ByteString
+    -> ByteString
+    -> HashedCredentials k
+deserializeSimple wrap keyCol hashCol
+    | isV1KeySegment keyCol =
+        case fromHex @ByteString keyCol of
+            Left _    -> bad
+            Right rawK -> case xprv rawK of
+                Left _  -> bad
+                Right k -> case fromHex @ByteString hashCol of
+                    Left _     -> bad
+                    Right rawH -> HashedCredentialsV1 (wrap k) (PassphraseHash (BA.convert rawH))
+    | otherwise =
+        case fromHex @ByteString keyCol of
+            Left _    -> bad
+            Right rawE -> case encryptedKey rawE of
+                Left _     -> bad
+                Right ekey -> HashedCredentialsV2 ekey Nothing
   where
-    deserialize deserializeKey errText (k, h) =
-        either err id
-            $ (,)
-                <$> deserializeKey k
-                <*> fmap PassphraseHash (fromHex h)
-      where
-        err _ =
-            error
-                $ "unsafeDeserializeXPrv: unable to deserialize " <> errText
+    bad = error "unsafeDeserializeXPrv: unable to deserialize key"
 
-    xprvFromText :: ByteString -> Either String XPrv
-    xprvFromText = xprv <=< fromHex @ByteString
-
-    unsafeDeserializeXPrvByron
-        :: ByteString
-        -> Either String (ByronKey 'RootK XPrv)
-    unsafeDeserializeXPrvByron = fmap mkKey . deserializeKey
-      where
-        mkKey (key, pwd) = ByronKey key () pwd
-        deserializeKey
-            :: ByteString
-            -> Either
-                String
-                ( XPrv
-                , Passphrase "addr-derivation-payload"
-                )
-        deserializeKey b = case map (fromHex @ByteString) (B8.split ':' b) of
-            [Right rawK, Right p] ->
-                case xprv rawK of
-                    Right k' -> Right (k', Passphrase (BA.convert p))
-                    Left e -> Left e
-            _ ->
-                Left "Key input must be two hex strings separated by :"
+-- Deserialize a Byron key.
+-- V1: @hex(xprv):hex(payload)@ → HashedCredentialsV1 (ByronKey xprv () payload) hash
+-- V2: @hex(ekey):hex(payload)@ → HashedCredentialsV2 ekey (Just payload)
+deserializeByron :: ByteString -> ByteString -> HashedCredentials ByronKey
+deserializeByron keyCol hashCol =
+    case B8.split ':' keyCol of
+        [keyHex, payloadHex]
+            | isV1KeySegment keyHex ->
+                case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
+                    (Right rawK, Right rawP) -> case xprv rawK of
+                        Left _  -> bad
+                        Right k -> case fromHex @ByteString hashCol of
+                            Left _     -> bad
+                            Right rawH ->
+                                let p = Passphrase (BA.convert rawP)
+                                    h = PassphraseHash (BA.convert rawH)
+                                in  HashedCredentialsV1 (ByronKey k () p) h
+                    _ -> bad
+            | otherwise ->
+                case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
+                    (Right rawE, Right rawP) -> case encryptedKey rawE of
+                        Left _     -> bad
+                        Right ekey ->
+                            let p = Passphrase (BA.convert rawP)
+                            in  HashedCredentialsV2 ekey (Just p)
+                    _ -> bad
+        _ -> bad
+  where
+    bad = error "unsafeDeserializeXPrv: unable to deserialize ByronKey"

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -180,12 +180,10 @@ deserializeByron keyCol hashCol
         case B8.split ':' (BS.drop 3 keyCol) of
             [keyHex, ekeyHex, payloadHex]
                 | isV1KeySegment keyHex ->
-                    case
-                        ( fromHex @ByteString keyHex
-                        , fromHex @ByteString ekeyHex
-                        , fromHex @ByteString payloadHex
-                        )
-                      of
+                    case ( fromHex @ByteString keyHex
+                         , fromHex @ByteString ekeyHex
+                         , fromHex @ByteString payloadHex
+                         ) of
                         (Right rawK, Right rawE, Right rawP) ->
                             case (xprv rawK, mkEncryptedKey rawE) of
                                 (Right k, Right ekey) ->

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -97,9 +97,9 @@ serializeV1 kF k h = (keyBytes, hex . getPassphraseHash $ h)
         ByronKeyS ->
             let ByronKey xk _ (Passphrase p) = k
             in  hex (unXPrv xk) <> ":" <> hex p
-        IcarusKeyS  -> hex . unXPrv . Icarus.getKey  $ k
+        IcarusKeyS -> hex . unXPrv . Icarus.getKey $ k
         ShelleyKeyS -> hex . unXPrv . Shelley.getKey $ k
-        SharedKeyS  -> hex . unXPrv . Shared.getKey  $ k
+        SharedKeyS -> hex . unXPrv . Shared.getKey $ k
 
 serializeV2
     :: KeyFlavorS k
@@ -120,10 +120,10 @@ unsafeDeserializeXPrv
     -> (ByteString, ByteString)
     -> HashedCredentials k
 unsafeDeserializeXPrv kF (keyCol, hashCol) = case kF of
-    ByronKeyS   -> deserializeByron   keyCol hashCol
-    IcarusKeyS  -> deserializeSimple  IcarusKey  keyCol hashCol
-    ShelleyKeyS -> deserializeSimple  ShelleyKey keyCol hashCol
-    SharedKeyS  -> deserializeSimple  SharedKey  keyCol hashCol
+    ByronKeyS -> deserializeByron keyCol hashCol
+    IcarusKeyS -> deserializeSimple IcarusKey keyCol hashCol
+    ShelleyKeyS -> deserializeSimple ShelleyKey keyCol hashCol
+    SharedKeyS -> deserializeSimple SharedKey keyCol hashCol
 
 -- | Detect whether the key column encodes a V1 (128-byte) or V2 (CBOR) key.
 -- We split on ':' and check the length of the first segment: exactly 256 hex
@@ -142,17 +142,17 @@ deserializeSimple
 deserializeSimple wrap keyCol hashCol
     | isV1KeySegment keyCol =
         case fromHex @ByteString keyCol of
-            Left _    -> bad
+            Left _ -> bad
             Right rawK -> case xprv rawK of
-                Left _  -> bad
+                Left _ -> bad
                 Right k -> case fromHex @ByteString hashCol of
-                    Left _     -> bad
+                    Left _ -> bad
                     Right rawH -> HashedCredentialsV1 (wrap k) (PassphraseHash (BA.convert rawH))
     | otherwise =
         case fromHex @ByteString keyCol of
-            Left _    -> bad
+            Left _ -> bad
             Right rawE -> case encryptedKey rawE of
-                Left _     -> bad
+                Left _ -> bad
                 Right ekey -> HashedCredentialsV2 ekey Nothing
   where
     bad = error "unsafeDeserializeXPrv: unable to deserialize key"
@@ -160,16 +160,17 @@ deserializeSimple wrap keyCol hashCol
 -- Deserialize a Byron key.
 -- V1: @hex(xprv):hex(payload)@ → HashedCredentialsV1 (ByronKey xprv () payload) hash
 -- V2: @hex(ekey):hex(payload)@ → HashedCredentialsV2 ekey (Just payload)
-deserializeByron :: ByteString -> ByteString -> HashedCredentials ByronKey
+deserializeByron
+    :: ByteString -> ByteString -> HashedCredentials ByronKey
 deserializeByron keyCol hashCol =
     case B8.split ':' keyCol of
         [keyHex, payloadHex]
             | isV1KeySegment keyHex ->
                 case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
                     (Right rawK, Right rawP) -> case xprv rawK of
-                        Left _  -> bad
+                        Left _ -> bad
                         Right k -> case fromHex @ByteString hashCol of
-                            Left _     -> bad
+                            Left _ -> bad
                             Right rawH ->
                                 let p = Passphrase (BA.convert rawP)
                                     h = PassphraseHash (BA.convert rawH)
@@ -178,7 +179,7 @@ deserializeByron keyCol hashCol =
             | otherwise ->
                 case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
                     (Right rawE, Right rawP) -> case encryptedKey rawE of
-                        Left _     -> bad
+                        Left _ -> bad
                         Right ekey ->
                             let p = Passphrase (BA.convert rawP)
                             in  HashedCredentialsV2 ekey (Just p)

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -132,6 +132,9 @@ unsafeDeserializeXPrv kF (keyCol, hashCol) = case kF of
 
 -- | Detect whether a key segment (first colon-delimited field) is V1.
 -- V1 XPrv hex is exactly 256 chars (128 bytes).
+-- V2 EncryptedKey hex is structurally larger (AEAD overhead + header), so
+-- this heuristic is unambiguous. The 'PersistPrivateKeySpec' suite asserts
+-- that V2 key columns are always longer than 256 hex chars.
 isV1KeySegment :: ByteString -> Bool
 isV1KeySegment seg = BS.length seg == 256
 

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -81,8 +81,9 @@ import qualified Data.ByteString.Char8 as B8
 -- Within V1, Byron keys are distinguished by the presence of a single ":"
 -- separator (the key segment is exactly 256 hex chars).
 --
--- Older V2 rows may contain an extra PBKDF2-XPrv hex segment (now
--- removed for security); 'unsafeDeserializeXPrv' accepts both formats.
+-- Older V2 rows may contain a leading PBKDF2-XPrv hex segment; the segment is
+-- ignored on read and not written by new code. 'unsafeDeserializeXPrv' accepts
+-- both formats.
 serializeXPrv
     :: KeyFlavorS k
     -> HashedCredentials k
@@ -143,7 +144,7 @@ isV1KeySegment seg = BS.length seg == 256
 --          → HashedCredentialsV2 ekey Nothing
 --
 -- V2 old : @"V2:" hex(xprv256) ":" hex(ekey)@   (xprv hex is exactly 256 chars)
---          → HashedCredentialsV2 ekey Nothing     (xprv discarded — security fix)
+--          → HashedCredentialsV2 ekey Nothing     (leading XPrv segment ignored)
 deserializeSimple
     :: (XPrv -> k 'RootK XPrv)
     -> ByteString
@@ -161,6 +162,7 @@ deserializeSimple wrap keyCol hashCol
                             _ -> bad
                         _ -> bad
             -- old format: first segment is the 256-char XPrv hex, second is ekey
+            -- (leading XPrv segment ignored)
             [_keyHex, ekeyHex]
                 | isV1KeySegment _keyHex ->
                     case fromHex @ByteString ekeyHex of
@@ -190,7 +192,7 @@ deserializeSimple wrap keyCol hashCol
 --          → HashedCredentialsV2 ekey (Just payload)
 --
 -- V2 old : @"V2:" hex(xprv256) ":" hex(ekey) ":" hex(payload)@
---          → HashedCredentialsV2 ekey (Just payload)   (xprv discarded — security fix)
+--          → HashedCredentialsV2 ekey (Just payload)   (leading XPrv segment ignored)
 deserializeByron
     :: ByteString -> ByteString -> HashedCredentials ByronKey
 deserializeByron keyCol hashCol
@@ -206,6 +208,7 @@ deserializeByron keyCol hashCol
                             _ -> bad
                         _ -> bad
             -- old format: xprv256 ":" ekey ":" payload
+            -- (leading XPrv segment ignored)
             [_keyHex, ekeyHex, payloadHex]
                 | isV1KeySegment _keyHex ->
                     case (fromHex @ByteString ekeyHex, fromHex @ByteString payloadHex) of

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -17,7 +17,7 @@ import Cardano.Crypto.Wallet
     ( unXPrv
     , xprv
     )
-import Cardano.Crypto.WalletV2.Encrypted
+import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     , encryptedKey
     , unEncryptedKey

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -74,19 +74,22 @@ import qualified Data.ByteString.Char8 as B8
 -- V1 non-Byron : @hex(unXPrv k)@  (exactly 256 hex chars = 128 bytes)
 -- V1 Byron     : @hex(unXPrv k) ":" hex(payloadPass)@
 --
--- V2 non-Byron : @"V2:" hex(unXPrv k) ":" hex(unEncryptedKey ekey)@
--- V2 Byron     : @"V2:" hex(unXPrv k) ":" hex(unEncryptedKey ekey) ":" hex(payloadPass)@
+-- V2 non-Byron : @"V2:" hex(unEncryptedKey ekey)@
+-- V2 Byron     : @"V2:" hex(unEncryptedKey ekey) ":" hex(payloadPass)@
 --
 -- V1 and V2 are distinguished by the "V2:" prefix in the key column.
 -- Within V1, Byron keys are distinguished by the presence of a single ":"
 -- separator (the key segment is exactly 256 hex chars).
+--
+-- Older V2 rows may contain an extra PBKDF2-XPrv hex segment (now
+-- removed for security); 'unsafeDeserializeXPrv' accepts both formats.
 serializeXPrv
     :: KeyFlavorS k
     -> HashedCredentials k
     -> (ByteString, ByteString)
 serializeXPrv kF = \case
     HashedCredentialsV1 k h -> serializeV1 kF k h
-    HashedCredentialsV2 k ekey -> serializeV2 kF k ekey
+    HashedCredentialsV2 ekey mPayload -> serializeV2 ekey mPayload
 
 serializeV1
     :: KeyFlavorS k
@@ -104,20 +107,15 @@ serializeV1 kF k h = (keyBytes, hex . getPassphraseHash $ h)
         SharedKeyS -> hex . unXPrv . Shared.getKey $ k
 
 serializeV2
-    :: KeyFlavorS k
-    -> k 'RootK XPrv
-    -> EncryptedKey
+    :: EncryptedKey
+    -> Maybe (Passphrase "addr-derivation-payload")
     -> (ByteString, ByteString)
-serializeV2 kF k ekey = (keyBytes, "")
+serializeV2 ekey mPayload = (keyBytes, "")
   where
     ekeyHex = hex (unEncryptedKey ekey)
-    keyBytes = case kF of
-        ByronKeyS ->
-            let ByronKey xk _ (Passphrase p) = k
-            in  "V2:" <> hex (unXPrv xk) <> ":" <> ekeyHex <> ":" <> hex p
-        IcarusKeyS -> "V2:" <> hex (unXPrv (Icarus.getKey k)) <> ":" <> ekeyHex
-        ShelleyKeyS -> "V2:" <> hex (unXPrv (Shelley.getKey k)) <> ":" <> ekeyHex
-        SharedKeyS -> "V2:" <> hex (unXPrv (Shared.getKey k)) <> ":" <> ekeyHex
+    keyBytes = case mPayload of
+        Nothing -> "V2:" <> ekeyHex
+        Just (Passphrase p) -> "V2:" <> ekeyHex <> ":" <> hex p
 
 -- | The reverse of 'serializeXPrv'. Dies with 'error' if the inputs are not
 -- valid hexadecimal strings or if the key is of the wrong length\/format.
@@ -137,8 +135,15 @@ isV1KeySegment :: ByteString -> Bool
 isV1KeySegment seg = BS.length seg == 256
 
 -- Deserialize a non-Byron key (Icarus / Shelley / Shared).
--- V1: @hex(xprv)@                      → HashedCredentialsV1 (wrap xprv) hash
--- V2: @"V2:" hex(xprv) ":" hex(ekey)@  → HashedCredentialsV2 (wrap xprv) ekey
+--
+-- V1  : @hex(xprv)@
+--       → HashedCredentialsV1 (wrap xprv) hash
+--
+-- V2 new : @"V2:" hex(ekey)@
+--          → HashedCredentialsV2 ekey Nothing
+--
+-- V2 old : @"V2:" hex(xprv256) ":" hex(ekey)@   (xprv hex is exactly 256 chars)
+--          → HashedCredentialsV2 ekey Nothing     (xprv discarded — security fix)
 deserializeSimple
     :: (XPrv -> k 'RootK XPrv)
     -> ByteString
@@ -147,13 +152,21 @@ deserializeSimple
 deserializeSimple wrap keyCol hashCol
     | "V2:" `BS.isPrefixOf` keyCol =
         case B8.split ':' (BS.drop 3 keyCol) of
-            [keyHex, ekeyHex]
-                | isV1KeySegment keyHex ->
-                    case (fromHex @ByteString keyHex, fromHex @ByteString ekeyHex) of
-                        (Right rawK, Right rawE) ->
-                            case (xprv rawK, mkEncryptedKey rawE) of
-                                (Right k, Right ekey) -> HashedCredentialsV2 (wrap k) ekey
-                                _ -> bad
+            -- new format: single segment is the ekey
+            [ekeyHex]
+                | not (isV1KeySegment ekeyHex) ->
+                    case fromHex @ByteString ekeyHex of
+                        Right rawE -> case mkEncryptedKey rawE of
+                            Right ekey -> HashedCredentialsV2 ekey Nothing
+                            _ -> bad
+                        _ -> bad
+            -- old format: first segment is the 256-char XPrv hex, second is ekey
+            [_keyHex, ekeyHex]
+                | isV1KeySegment _keyHex ->
+                    case fromHex @ByteString ekeyHex of
+                        Right rawE -> case mkEncryptedKey rawE of
+                            Right ekey -> HashedCredentialsV2 ekey Nothing
+                            _ -> bad
                         _ -> bad
             _ -> bad
     | isV1KeySegment keyCol =
@@ -169,27 +182,37 @@ deserializeSimple wrap keyCol hashCol
     bad = error "unsafeDeserializeXPrv: unable to deserialize key"
 
 -- Deserialize a Byron key.
--- V1: @hex(xprv) ":" hex(payload)@
---     → HashedCredentialsV1 (ByronKey xprv () payload) hash
--- V2: @"V2:" hex(xprv) ":" hex(ekey) ":" hex(payload)@
---     → HashedCredentialsV2 (ByronKey xprv () payload) ekey
+--
+-- V1  : @hex(xprv) ":" hex(payload)@
+--       → HashedCredentialsV1 (ByronKey xprv () payload) hash
+--
+-- V2 new : @"V2:" hex(ekey) ":" hex(payload)@
+--          → HashedCredentialsV2 ekey (Just payload)
+--
+-- V2 old : @"V2:" hex(xprv256) ":" hex(ekey) ":" hex(payload)@
+--          → HashedCredentialsV2 ekey (Just payload)   (xprv discarded — security fix)
 deserializeByron
     :: ByteString -> ByteString -> HashedCredentials ByronKey
 deserializeByron keyCol hashCol
     | "V2:" `BS.isPrefixOf` keyCol =
         case B8.split ':' (BS.drop 3 keyCol) of
-            [keyHex, ekeyHex, payloadHex]
-                | isV1KeySegment keyHex ->
-                    case ( fromHex @ByteString keyHex
-                         , fromHex @ByteString ekeyHex
-                         , fromHex @ByteString payloadHex
-                         ) of
-                        (Right rawK, Right rawE, Right rawP) ->
-                            case (xprv rawK, mkEncryptedKey rawE) of
-                                (Right k, Right ekey) ->
-                                    let p = Passphrase (BA.convert rawP)
-                                    in  HashedCredentialsV2 (ByronKey k () p) ekey
-                                _ -> bad
+            -- new format: ekey ":" payload
+            [ekeyHex, payloadHex]
+                | not (isV1KeySegment ekeyHex) ->
+                    case (fromHex @ByteString ekeyHex, fromHex @ByteString payloadHex) of
+                        (Right rawE, Right rawP) -> case mkEncryptedKey rawE of
+                            Right ekey ->
+                                HashedCredentialsV2 ekey (Just (Passphrase (BA.convert rawP)))
+                            _ -> bad
+                        _ -> bad
+            -- old format: xprv256 ":" ekey ":" payload
+            [_keyHex, ekeyHex, payloadHex]
+                | isV1KeySegment _keyHex ->
+                    case (fromHex @ByteString ekeyHex, fromHex @ByteString payloadHex) of
+                        (Right rawE, Right rawP) -> case mkEncryptedKey rawE of
+                            Right ekey ->
+                                HashedCredentialsV2 ekey (Just (Passphrase (BA.convert rawP)))
+                            _ -> bad
                         _ -> bad
             _ -> bad
     | otherwise =

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Operations for saving a private key into a database, and restoring it from
@@ -19,7 +20,7 @@ import Cardano.Crypto.Wallet
     )
 import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
-    , encryptedKey
+    , mkEncryptedKey
     , unEncryptedKey
     )
 import Cardano.Wallet.Address.Derivation
@@ -73,18 +74,19 @@ import qualified Data.ByteString.Char8 as B8
 -- V1 non-Byron : @hex(unXPrv k)@  (exactly 256 hex chars = 128 bytes)
 -- V1 Byron     : @hex(unXPrv k) ":" hex(payloadPass)@
 --
--- V2 non-Byron : @hex(unEncryptedKey ekey)@  (> 256 hex chars, CBOR envelope)
--- V2 Byron     : @hex(unEncryptedKey ekey) ":" hex(payloadPass)@
+-- V2 non-Byron : @"V2:" hex(unXPrv k) ":" hex(unEncryptedKey ekey)@
+-- V2 Byron     : @"V2:" hex(unXPrv k) ":" hex(unEncryptedKey ekey) ":" hex(payloadPass)@
 --
--- V1 and V2 are distinguished by the length of the first colon-delimited
--- segment: exactly 256 hex chars ↔ V1 (128-byte XPrv), longer ↔ V2.
+-- V1 and V2 are distinguished by the "V2:" prefix in the key column.
+-- Within V1, Byron keys are distinguished by the presence of a single ":"
+-- separator (the key segment is exactly 256 hex chars).
 serializeXPrv
     :: KeyFlavorS k
     -> HashedCredentials k
     -> (ByteString, ByteString)
 serializeXPrv kF = \case
     HashedCredentialsV1 k h -> serializeV1 kF k h
-    HashedCredentialsV2 ekey mPayload -> serializeV2 kF ekey mPayload
+    HashedCredentialsV2 k ekey -> serializeV2 kF k ekey
 
 serializeV1
     :: KeyFlavorS k
@@ -103,15 +105,19 @@ serializeV1 kF k h = (keyBytes, hex . getPassphraseHash $ h)
 
 serializeV2
     :: KeyFlavorS k
+    -> k 'RootK XPrv
     -> EncryptedKey
-    -> Maybe (Passphrase "addr-derivation-payload")
     -> (ByteString, ByteString)
-serializeV2 kF ekey mPayload = (keyBytes, "")
+serializeV2 kF k ekey = (keyBytes, "")
   where
-    keyBytes = case (kF, mPayload) of
-        (ByronKeyS, Just (Passphrase p)) ->
-            hex (unEncryptedKey ekey) <> ":" <> hex p
-        _ -> hex (unEncryptedKey ekey)
+    ekeyHex = hex (unEncryptedKey ekey)
+    keyBytes = case kF of
+        ByronKeyS ->
+            let ByronKey xk _ (Passphrase p) = k
+            in  "V2:" <> hex (unXPrv xk) <> ":" <> ekeyHex <> ":" <> hex p
+        IcarusKeyS -> "V2:" <> hex (unXPrv (Icarus.getKey k)) <> ":" <> ekeyHex
+        ShelleyKeyS -> "V2:" <> hex (unXPrv (Shelley.getKey k)) <> ":" <> ekeyHex
+        SharedKeyS -> "V2:" <> hex (unXPrv (Shared.getKey k)) <> ":" <> ekeyHex
 
 -- | The reverse of 'serializeXPrv'. Dies with 'error' if the inputs are not
 -- valid hexadecimal strings or if the key is of the wrong length\/format.
@@ -125,21 +131,31 @@ unsafeDeserializeXPrv kF (keyCol, hashCol) = case kF of
     ShelleyKeyS -> deserializeSimple ShelleyKey keyCol hashCol
     SharedKeyS -> deserializeSimple SharedKey keyCol hashCol
 
--- | Detect whether the key column encodes a V1 (128-byte) or V2 (CBOR) key.
--- We split on ':' and check the length of the first segment: exactly 256 hex
--- chars means 128 bytes = V1.
+-- | Detect whether a key segment (first colon-delimited field) is V1.
+-- V1 XPrv hex is exactly 256 chars (128 bytes).
 isV1KeySegment :: ByteString -> Bool
 isV1KeySegment seg = BS.length seg == 256
 
 -- Deserialize a non-Byron key (Icarus / Shelley / Shared).
--- V1: @hex(xprv)@        → HashedCredentialsV1 (wrap xprv) hash
--- V2: @hex(ekey cbor)@   → HashedCredentialsV2 ekey Nothing
+-- V1: @hex(xprv)@                      → HashedCredentialsV1 (wrap xprv) hash
+-- V2: @"V2:" hex(xprv) ":" hex(ekey)@  → HashedCredentialsV2 (wrap xprv) ekey
 deserializeSimple
     :: (XPrv -> k 'RootK XPrv)
     -> ByteString
     -> ByteString
     -> HashedCredentials k
 deserializeSimple wrap keyCol hashCol
+    | "V2:" `BS.isPrefixOf` keyCol =
+        case B8.split ':' (BS.drop 3 keyCol) of
+            [keyHex, ekeyHex]
+                | isV1KeySegment keyHex ->
+                    case (fromHex @ByteString keyHex, fromHex @ByteString ekeyHex) of
+                        (Right rawK, Right rawE) ->
+                            case (xprv rawK, mkEncryptedKey rawE) of
+                                (Right k, Right ekey) -> HashedCredentialsV2 (wrap k) ekey
+                                _ -> bad
+                        _ -> bad
+            _ -> bad
     | isV1KeySegment keyCol =
         case fromHex @ByteString keyCol of
             Left _ -> bad
@@ -148,42 +164,51 @@ deserializeSimple wrap keyCol hashCol
                 Right k -> case fromHex @ByteString hashCol of
                     Left _ -> bad
                     Right rawH -> HashedCredentialsV1 (wrap k) (PassphraseHash (BA.convert rawH))
-    | otherwise =
-        case fromHex @ByteString keyCol of
-            Left _ -> bad
-            Right rawE -> case encryptedKey rawE of
-                Left _ -> bad
-                Right ekey -> HashedCredentialsV2 ekey Nothing
+    | otherwise = bad
   where
     bad = error "unsafeDeserializeXPrv: unable to deserialize key"
 
 -- Deserialize a Byron key.
--- V1: @hex(xprv):hex(payload)@ → HashedCredentialsV1 (ByronKey xprv () payload) hash
--- V2: @hex(ekey):hex(payload)@ → HashedCredentialsV2 ekey (Just payload)
+-- V1: @hex(xprv) ":" hex(payload)@
+--     → HashedCredentialsV1 (ByronKey xprv () payload) hash
+-- V2: @"V2:" hex(xprv) ":" hex(ekey) ":" hex(payload)@
+--     → HashedCredentialsV2 (ByronKey xprv () payload) ekey
 deserializeByron
     :: ByteString -> ByteString -> HashedCredentials ByronKey
-deserializeByron keyCol hashCol =
-    case B8.split ':' keyCol of
-        [keyHex, payloadHex]
-            | isV1KeySegment keyHex ->
-                case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
-                    (Right rawK, Right rawP) -> case xprv rawK of
-                        Left _ -> bad
-                        Right k -> case fromHex @ByteString hashCol of
+deserializeByron keyCol hashCol
+    | "V2:" `BS.isPrefixOf` keyCol =
+        case B8.split ':' (BS.drop 3 keyCol) of
+            [keyHex, ekeyHex, payloadHex]
+                | isV1KeySegment keyHex ->
+                    case
+                        ( fromHex @ByteString keyHex
+                        , fromHex @ByteString ekeyHex
+                        , fromHex @ByteString payloadHex
+                        )
+                      of
+                        (Right rawK, Right rawE, Right rawP) ->
+                            case (xprv rawK, mkEncryptedKey rawE) of
+                                (Right k, Right ekey) ->
+                                    let p = Passphrase (BA.convert rawP)
+                                    in  HashedCredentialsV2 (ByronKey k () p) ekey
+                                _ -> bad
+                        _ -> bad
+            _ -> bad
+    | otherwise =
+        case B8.split ':' keyCol of
+            [keyHex, payloadHex]
+                | isV1KeySegment keyHex ->
+                    case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
+                        (Right rawK, Right rawP) -> case xprv rawK of
                             Left _ -> bad
-                            Right rawH ->
-                                let p = Passphrase (BA.convert rawP)
-                                    h = PassphraseHash (BA.convert rawH)
-                                in  HashedCredentialsV1 (ByronKey k () p) h
-                    _ -> bad
-            | otherwise ->
-                case (fromHex @ByteString keyHex, fromHex @ByteString payloadHex) of
-                    (Right rawE, Right rawP) -> case encryptedKey rawE of
-                        Left _ -> bad
-                        Right ekey ->
-                            let p = Passphrase (BA.convert rawP)
-                            in  HashedCredentialsV2 ekey (Just p)
-                    _ -> bad
-        _ -> bad
+                            Right k -> case fromHex @ByteString hashCol of
+                                Left _ -> bad
+                                Right rawH ->
+                                    let p = Passphrase (BA.convert rawP)
+                                        h = PassphraseHash (BA.convert rawH)
+                                    in  HashedCredentialsV1 (ByronKey k () p) h
+                        _ -> bad
+                | otherwise -> bad
+            _ -> bad
   where
     bad = error "unsafeDeserializeXPrv: unable to deserialize ByronKey"

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
@@ -25,8 +25,7 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId
     )
 import Cardano.Wallet.Primitive.Types.Credentials
-    ( HashedCredentials
-    , RootCredentials (..)
+    ( HashedCredentials (..)
     )
 import Control.Exception
     ( SomeException (..)
@@ -86,7 +85,7 @@ mkStorePrivateKey kF wid = mkSimpleStore load write
       where
         privateKeyFromEntity :: Schema.PrivateKey -> HashedCredentials k
         privateKeyFromEntity (Schema.PrivateKey _ k h) =
-            uncurry RootCredentials $ unsafeDeserializeXPrv kF (k, h)
+            unsafeDeserializeXPrv kF (k, h)
 
     write :: Maybe (HashedCredentials k) -> SqlPersistT IO ()
     write (Just key) = do
@@ -94,11 +93,11 @@ mkStorePrivateKey kF wid = mkSimpleStore load write
         insert_ (mkPrivateKeyEntity key)
     write Nothing = deleteWhere ([] :: [Filter Schema.PrivateKey])
 
-    mkPrivateKeyEntity (RootCredentials k h) =
+    mkPrivateKeyEntity creds =
         Schema.PrivateKey
             { Schema.privateKeyWalletId = wid
             , Schema.privateKeyRootKey = root
             , Schema.privateKeyHash = hash
             }
       where
-        (root, hash) = serializeXPrv kF (k, h)
+        (root, hash) = serializeXPrv kF creds

--- a/lib/wallet/src/Cardano/Wallet/Flavor.hs
+++ b/lib/wallet/src/Cardano/Wallet/Flavor.hs
@@ -72,6 +72,7 @@ import Cardano.Wallet.Address.States.Families
     )
 import Cardano.Wallet.Address.States.Features
     ( TestFeatures
+    , defaultTestFeatures
     )
 import Cardano.Wallet.Address.States.Test.State
     ( TestState
@@ -148,6 +149,9 @@ instance WalletFlavor (RndAnyState n p) where
 
 instance WalletFlavor (SharedState n SharedKey) where
     walletFlavor = SharedWallet
+
+instance KeyFlavor k => WalletFlavor (TestState s n k kt) where
+    walletFlavor = TestStateS defaultTestFeatures
 
 -- | A singleton type to capture the flavor of a key.
 data KeyFlavorS a where

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -46,7 +46,9 @@ deriving instance
 -- only for Byron-flavoured wallets).
 data HashedCredentials k
     = HashedCredentialsV1 !(k 'RootK XPrv) !PassphraseHash
-    | HashedCredentialsV2 !EncryptedKey !(Maybe (Passphrase "addr-derivation-payload"))
+    | HashedCredentialsV2
+        !EncryptedKey
+        !(Maybe (Passphrase "addr-derivation-payload"))
 
 deriving instance (Eq (k 'RootK XPrv)) => Eq (HashedCredentials k)
 deriving instance (Show (k 'RootK XPrv)) => Show (HashedCredentials k)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -39,14 +39,14 @@ deriving instance
 -- 'HashedCredentialsV1' uses the legacy PBKDF2\/Scrypt passphrase-hash
 -- scheme; present only for wallets that have not yet been migrated.
 --
--- 'HashedCredentialsV2' stores a PBKDF2-encrypted root key for key
--- operations alongside an Argon2id+XChaCha20-Poly1305 AEAD envelope
--- for passphrase authentication.  The AEAD tag replaces the
--- 'PassphraseHash'; the stored key remains PBKDF2-encrypted so that
--- all key-operation callers use the same 'preparePassphrase' path.
+-- 'HashedCredentialsV2' stores only the Argon2id+XChaCha20-Poly1305
+-- AEAD envelope.  The plaintext scalar is reconstructed on demand by
+-- decrypting the envelope; it is never persisted.  The optional
+-- 'Passphrase' is the Byron address-derivation payload (non-Nothing
+-- only for Byron-flavoured wallets).
 data HashedCredentials k
     = HashedCredentialsV1 !(k 'RootK XPrv) !PassphraseHash
-    | HashedCredentialsV2 !(k 'RootK XPrv) !EncryptedKey
+    | HashedCredentialsV2 !EncryptedKey !(Maybe (Passphrase "addr-derivation-payload"))
 
 deriving instance (Eq (k 'RootK XPrv)) => Eq (HashedCredentials k)
 deriving instance (Show (k 'RootK XPrv)) => Show (HashedCredentials k)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -45,7 +45,9 @@ deriving instance
 -- address-derivation-payload passphrase (only present for Byron keys).
 data HashedCredentials k
     = HashedCredentialsV1 !(k 'RootK XPrv) !PassphraseHash
-    | HashedCredentialsV2 !EncryptedKey !(Maybe (Passphrase "addr-derivation-payload"))
+    | HashedCredentialsV2
+        !EncryptedKey
+        !(Maybe (Passphrase "addr-derivation-payload"))
 
 deriving instance (Eq (k 'RootK XPrv)) => Eq (HashedCredentials k)
 deriving instance (Show (k 'RootK XPrv)) => Show (HashedCredentials k)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -4,12 +4,15 @@
 
 module Cardano.Wallet.Primitive.Types.Credentials
     ( RootCredentials (..)
-    , HashedCredentials
+    , HashedCredentials (..)
     , ClearCredentials
     ) where
 
 import Cardano.Address.Derivation
     ( XPrv
+    )
+import Cardano.Crypto.WalletV2.Encrypted
+    ( EncryptedKey
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (RootK)
@@ -31,6 +34,20 @@ deriving instance
 deriving instance
     (Show (k 'RootK XPrv), Show pw) => Show (RootCredentials k pw)
 
-type HashedCredentials k = RootCredentials k PassphraseHash
+-- | Stored credentials for a wallet root key.
+--
+-- 'HashedCredentialsV1' uses the legacy PBKDF2\/Scrypt passphrase-hash
+-- scheme; present only for wallets that have not yet been migrated.
+--
+-- 'HashedCredentialsV2' uses a v2 Argon2id+XChaCha20-Poly1305 AEAD
+-- envelope.  The 'PassphraseHash' is gone; the AEAD tag authenticates
+-- the passphrase directly.  The @Maybe@ field carries the Byron
+-- address-derivation-payload passphrase (only present for Byron keys).
+data HashedCredentials k
+    = HashedCredentialsV1 !(k 'RootK XPrv) !PassphraseHash
+    | HashedCredentialsV2 !EncryptedKey !(Maybe (Passphrase "addr-derivation-payload"))
+
+deriving instance (Eq (k 'RootK XPrv)) => Eq (HashedCredentials k)
+deriving instance (Show (k 'RootK XPrv)) => Show (HashedCredentials k)
 
 type ClearCredentials k = RootCredentials k (Passphrase "encryption")

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -11,7 +11,7 @@ module Cardano.Wallet.Primitive.Types.Credentials
 import Cardano.Address.Derivation
     ( XPrv
     )
-import Cardano.Crypto.WalletV2.Encrypted
+import Cardano.Crypto.WalletHD.Encrypted
     ( EncryptedKey
     )
 import Cardano.Wallet.Address.Derivation

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -39,15 +39,14 @@ deriving instance
 -- 'HashedCredentialsV1' uses the legacy PBKDF2\/Scrypt passphrase-hash
 -- scheme; present only for wallets that have not yet been migrated.
 --
--- 'HashedCredentialsV2' uses a v2 Argon2id+XChaCha20-Poly1305 AEAD
--- envelope.  The 'PassphraseHash' is gone; the AEAD tag authenticates
--- the passphrase directly.  The @Maybe@ field carries the Byron
--- address-derivation-payload passphrase (only present for Byron keys).
+-- 'HashedCredentialsV2' stores a PBKDF2-encrypted root key for key
+-- operations alongside an Argon2id+XChaCha20-Poly1305 AEAD envelope
+-- for passphrase authentication.  The AEAD tag replaces the
+-- 'PassphraseHash'; the stored key remains PBKDF2-encrypted so that
+-- all key-operation callers use the same 'preparePassphrase' path.
 data HashedCredentials k
     = HashedCredentialsV1 !(k 'RootK XPrv) !PassphraseHash
-    | HashedCredentialsV2
-        !EncryptedKey
-        !(Maybe (Passphrase "addr-derivation-payload"))
+    | HashedCredentialsV2 !(k 'RootK XPrv) !EncryptedKey
 
 deriving instance (Eq (k 'RootK XPrv)) => Eq (HashedCredentials k)
 deriving instance (Show (k 'RootK XPrv)) => Show (HashedCredentials k)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -37,6 +37,7 @@ module Cardano.Wallet.Shelley.Transaction
     ( newTransactionLayer
     , txConstraints
     , mkUnsignedTransaction
+    , withSealedTxRecentEra
 
       -- * Internals
     , TxPayload (..)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -30,6 +30,7 @@ module Cardano.Wallet.Shelley.Transaction.Ledger
       -- * Signing
     , signTransaction
     , mkShelleyWitnessLedger
+    , mkShelleyWitnessFromExtKeyMaterial
     , mkByronWitnessLedger
 
       -- * Payload
@@ -66,6 +67,16 @@ import Cardano.Crypto.DSIGN
     ( SignedDSIGN (SignedDSIGN)
     , rawDeserialiseSigDSIGN
     , rawDeserialiseVerKeyDSIGN
+    )
+import Cardano.Crypto.WalletHD.Encrypted
+    ( ExtKeyMaterial
+    , Validated
+    , extKeyMaterialPublicKey
+    , publicKeyByteString
+    , signWithExtKeyMaterial
+    )
+import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
+    ( Signature (..)
     )
 import Cardano.Crypto.Hash.Class
     ( hashToBytes
@@ -340,6 +351,41 @@ mkShelleyWitnessLedger _era body (xprv, pwd) =
                 error
                     "mkShelleyWitnessLedger: \
                     \invalid signature"
+
+-- | Construct a Shelley-era key witness from a V2 'ExtKeyMaterial'.
+-- Hashes the transaction body, calls 'signWithExtKeyMaterial', and
+-- assembles a 'WitVKey' from the resulting signature and public key.
+mkShelleyWitnessFromExtKeyMaterial
+    :: forall era s
+     . Write.IsRecentEra era
+    => RecentEra era
+    -> Write.TxBody era
+    -> ExtKeyMaterial s Validated
+    -> IO (Keys.WitVKey Keys.Witness)
+mkShelleyWitnessFromExtKeyMaterial _era body km = do
+    let bodyHash =
+            hashToBytes
+                $ extractHash
+                $ hashAnnotated @_ @EraIndependentTxBody body
+    sigResult <- signWithExtKeyMaterial km bodyHash
+    case sigResult of
+        Left err ->
+            error $ "mkShelleyWitnessFromExtKeyMaterial: " <> show err
+        Right (EncHD.Signature sigBytes) ->
+            let pubBytes = publicKeyByteString (extKeyMaterialPublicKey km)
+                vkey = case rawDeserialiseVerKeyDSIGN pubBytes of
+                    Just vk -> VKey vk
+                    Nothing ->
+                        error
+                            "mkShelleyWitnessFromExtKeyMaterial: \
+                            \invalid public key"
+                sig = case rawDeserialiseSigDSIGN sigBytes of
+                    Just s -> SignedDSIGN s
+                    Nothing ->
+                        error
+                            "mkShelleyWitnessFromExtKeyMaterial: \
+                            \invalid signature"
+            in pure $ WitVKey vkey sig
 
 -- | Construct a Byron bootstrap witness directly from
 -- ledger types, bypassing cardano-api.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
@@ -68,18 +68,15 @@ import Cardano.Crypto.DSIGN
     , rawDeserialiseSigDSIGN
     , rawDeserialiseVerKeyDSIGN
     )
+import Cardano.Crypto.Hash.Class
+    ( hashToBytes
+    )
 import Cardano.Crypto.WalletHD.Encrypted
     ( ExtKeyMaterial
     , Validated
     , extKeyMaterialPublicKey
     , publicKeyByteString
     , signWithExtKeyMaterial
-    )
-import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
-    ( Signature (..)
-    )
-import Cardano.Crypto.Hash.Class
-    ( hashToBytes
     )
 import Cardano.Ledger.Hashes
     ( EraIndependentTxBody
@@ -173,6 +170,9 @@ import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Tx as Write
 import qualified Cardano.Crypto as CC
 import qualified Cardano.Crypto.Wallet as Crypto.HD
+import qualified Cardano.Crypto.WalletHD.Encrypted as EncHD
+    ( Signature (..)
+    )
 import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
 import qualified Cardano.Wallet.Read as Read
@@ -385,7 +385,7 @@ mkShelleyWitnessFromExtKeyMaterial _era body km = do
                         error
                             "mkShelleyWitnessFromExtKeyMaterial: \
                             \invalid signature"
-            in pure $ WitVKey vkey sig
+            in  pure $ WitVKey vkey sig
 
 -- | Construct a Byron bootstrap witness directly from
 -- ledger types, bypassing cardano-api.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -418,6 +418,11 @@ haskell-nix.cabalProject' [
                   pkgs.libblst
                 ]
               ];
+              packages.cardano-crypto-wallet.components.library.pkgconfig = lib.mkForce [
+                [
+                  pkgs.libsodium-vrf
+                ]
+              ];
             }
           )
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1215,8 +1215,15 @@ x-walletPassphraseInfo :: &walletPassphraseInfo
   type: object
   required:
     - last_updated_at
+    - encryption_method
   properties:
     last_updated_at: *date
+    encryption_method:
+      type: string
+      enum:
+        - scrypt
+        - pbkdf2-hmac-sha512
+        - argon2id-v2
 
 x-transactionId: &transactionId
   description: A unique identifier for this transaction

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1215,15 +1215,18 @@ x-walletPassphraseInfo :: &walletPassphraseInfo
   type: object
   required:
     - last_updated_at
-    - encryption_method
   properties:
     last_updated_at: *date
     encryption_method:
+      description: |
+        The scheme used to protect the wallet's root key in storage.
+        Absent on wallets that have no stored passphrase (e.g. watch-only wallets).
       type: string
       enum:
         - scrypt
         - pbkdf2-hmac-sha512
         - argon2id-v2
+      example: argon2id-v2
 
 x-transactionId: &transactionId
   description: A unique identifier for this transaction

--- a/specs/003-root-key-v2-upgrade/checklists/requirements.md
+++ b/specs/003-root-key-v2-upgrade/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Root Key Protection Upgrade to V2
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-004 names the three identifier strings (`scrypt`, `pbkdf2-hmac-sha512`,
+  `argon2id-v2`). These are stable API contract values, not implementation details, so
+  they are appropriate in the spec.
+- The spec deliberately avoids naming cryptographic primitives (Argon2id, XChaCha20,
+  PBKDF2) inside requirements — they appear only in the title/input context line.
+- All items pass. Ready for `/speckit.plan`.

--- a/specs/003-root-key-v2-upgrade/contracts/wallet-passphrase-info.yaml
+++ b/specs/003-root-key-v2-upgrade/contracts/wallet-passphrase-info.yaml
@@ -1,0 +1,25 @@
+# Contract: walletPassphraseInfo
+#
+# This is the PROPOSED change to specifications/api/swagger.yaml.
+# The `walletPassphraseInfo` anchor currently only has `last_updated_at`.
+# This contract shows the full intended schema after the feature is merged.
+#
+# IMPORTANT: Do not commit this file. Apply the diff to swagger.yaml when ready.
+
+x-walletPassphraseInfo: &walletPassphraseInfo
+  description: Information about the wallet's passphrase
+  type: object
+  required:
+    - last_updated_at
+  properties:
+    last_updated_at: *date
+    encryption_method:
+      description: |
+        The scheme used to protect the wallet's root key in storage.
+        Absent on wallets that have no stored passphrase (e.g. watch-only wallets).
+      type: string
+      enum:
+        - scrypt
+        - pbkdf2-hmac-sha512
+        - argon2id-v2
+      example: argon2id-v2

--- a/specs/003-root-key-v2-upgrade/data-model.md
+++ b/specs/003-root-key-v2-upgrade/data-model.md
@@ -1,0 +1,240 @@
+# Data Model: Root Key Protection Upgrade to V2
+
+**Branch**: `003-root-key-v2-upgrade` | **Date**: 2026-05-06
+
+---
+
+## Entities
+
+### HashedCredentials
+
+The in-memory and on-disk representation of a stored wallet root key.  A sum type with
+two constructors.
+
+| Constructor | Fields | When used |
+|-------------|--------|-----------|
+| `HashedCredentialsV1` | `k 'RootK XPrv` (scheme-encrypted key), `PassphraseHash` (PBKDF2/Scrypt hash) | Legacy wallets not yet migrated |
+| `HashedCredentialsV2` | `EncryptedKey` (AEAD envelope), `Maybe (Passphrase "addr-derivation-payload")` | All new wallets; migrated wallets |
+
+**Invariants**:
+- A V1 key's `PassphraseHash` is produced by the scheme recorded in wallet metadata
+  (`passphraseScheme`).
+- A V2 key's `EncryptedKey` is self-authenticating; the `PassphraseHash` column in the
+  DB is left empty.
+- The Byron payload passphrase is `Nothing` for all non-Byron key flavors.
+
+**State transition**:
+```
+HashedCredentialsV1 ──(successful unlock)──► HashedCredentialsV2
+```
+The transition is one-way and written atomically alongside the metadata update.
+
+> [!WARNING]
+> **Irreversible.** Once a wallet row is written as V2, any binary that does not
+> understand the `"V2:"` prefix will either crash or permanently lock that wallet.
+> Back up the database before deploying this version if rollback may be required.
+
+---
+
+### WalletPassphraseInfo
+
+Wallet metadata sub-record.  Extended with a new field.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `lastUpdatedAt` | `UTCTime` | Timestamp of last passphrase change |
+| `passphraseScheme` | `PassphraseScheme` | **Extended**: now also `EncryptWithArgon2idV2` |
+
+---
+
+### PassphraseScheme
+
+Enumeration of supported key-protection schemes.
+
+| Value | DB text | API JSON | Notes |
+|-------|---------|----------|-------|
+| `EncryptWithScrypt` | `"scrypt"` | `"scrypt"` | Legacy; imported Byron wallets only |
+| `EncryptWithPBKDF2` | `"pbkdf2-hmac-sha512"` | `"pbkdf2-hmac-sha512"` | All wallets created before this feature |
+| `EncryptWithArgon2idV2` | `"argon2id-v2"` | `"argon2id-v2"` | New default; all migrated wallets |
+
+---
+
+### ApiWalletPassphraseInfo (API layer)
+
+JSON representation of `WalletPassphraseInfo` returned by `GET /v2/wallets/{id}`.
+
+| Field | JSON key | Type | Notes |
+|-------|----------|------|-------|
+| `lastUpdatedAt` | `last_updated_at` | ISO-8601 datetime | Unchanged |
+| `encryptionMethod` | `encryption_method` | string enum | **New field** |
+
+The `encryption_method` field is optional in the response schema to preserve
+backward-compatibility: clients that do not understand it can ignore it, and wallets
+without a passphrase omit the entire `passphrase` object as before.
+
+---
+
+## DB Column Encoding
+
+```
+private_key table
+┌──────────────────────────────────────────────────────────────────┬──────────────────┐
+│ key (TEXT)                                                       │ hash (TEXT)      │
+├──────────────────────────────────────────────────────────────────┼──────────────────┤
+│ V1 non-Byron: hex(unXPrv k)              [exactly 256 hex chars] │ hex(hpwd)        │
+│ V1 Byron:     hex(unXPrv k):hex(pp)      [first seg = 256 chars] │ hex(hpwd)        │
+│ V2 non-Byron: "V2:" hex(unEncryptedKey ek)                       │ (empty)          │
+│ V2 Byron:     "V2:" hex(unEncryptedKey ek) ":" hex(pp)           │ (empty)          │
+└──────────────────────────────────────────────────────────────────┴──────────────────┘
+
+Distinguisher: presence of the literal prefix `"V2:"` in the `key` column.
+  key starts with "V2:"  →  V2
+  otherwise              →  V1
+
+Within V1, Byron keys are distinguished from non-Byron keys by the presence of a
+single `":"` separator after the first 256-character hex segment.
+
+Within V2, Byron keys are distinguished from non-Byron keys by the presence of an
+additional `":"` separator after the `EncryptedKey` hex.
+
+Note: the length of the first `":"` -delimited segment is also a valid V1/V2
+distinguisher (== 256 → V1; 2 chars "V2" → V2), but the explicit prefix is
+canonical and is what the implementation checks first.
+```
+
+### Legacy "old V2" format (migration compatibility only)
+
+During the transition period when V2 was first introduced, some wallets were written
+with an additional PBKDF2-XPrv segment that has since been removed for security.
+The deserialization layer accepts but silently discards this segment:
+
+```
+Old V2 non-Byron: "V2:" hex(unXPrv k) [256 chars] ":" hex(unEncryptedKey ek)
+Old V2 Byron:     "V2:" hex(unXPrv k) [256 chars] ":" hex(unEncryptedKey ek) ":" hex(pp)
+```
+
+The stale XPrv bytes are discarded on read; the key is re-serialized in the new
+format on the next write (e.g., migration or passphrase change). New software never
+writes this format.
+
+---
+
+## Validation Rules
+
+- `encryption_method` in API requests is not accepted (read-only; derived from stored
+  scheme, not user-supplied).
+- `PassphraseScheme` `FromText` must reject any string not in the defined set.
+- V2 migration MUST NOT occur if passphrase verification fails (enforced by the control
+  flow: migration is only called after `Right _` from the verify step).
+
+---
+
+## V2 Envelope Binary Format (`EncryptedKey` internals)
+
+`unEncryptedKey` (the bytes stored after the `"V2:"` DB prefix) is a CBOR-encoded
+5-element list:
+
+```
+[Salt, Nonce, AAD, EncSecretKey, Tag]
+```
+
+| Field | CBOR type | Size | Notes |
+|-------|-----------|------|-------|
+| `Salt` | bytes | 32 | Argon2id salt; random per encryption |
+| `Nonce` | bytes | 24 | XChaCha20-Poly1305 nonce; random per encryption |
+| `AAD` | bytes | variable | Nested CBOR (see below); bound as AEAD additional data |
+| `EncSecretKey` | bytes | 64 | XChaCha20-Poly1305 ciphertext of the 64-byte extended secret key |
+| `Tag` | bytes | 16 | XChaCha20-Poly1305 authentication tag |
+
+The `AAD` is itself a CBOR-encoded 8-element list that **permanently records the
+envelope metadata**:
+
+```
+[version, kdfId, [memoryKiB, timeCost, parallelism, outputLen], cipherId, payloadKind, payloadLen, pubKey, chainCode]
+```
+
+| AAD field | Value | Notes |
+|-----------|-------|-------|
+| `version` | `2` | Envelope version |
+| `kdfId` | `1` (= Argon2id) | |
+| `memoryKiB` | `131072` | 128 MiB |
+| `timeCost` | `3` | |
+| `parallelism` | `4` | |
+| `outputLen` | `32` | Wrapping key size in bytes |
+| `cipherId` | `1` (= XChaCha20-Poly1305) | |
+| `payloadKind` | `1` | Indicates secret-key payload |
+| `payloadLen` | `64` | |
+| `pubKey` | bytes | 32-byte Ed25519 public key |
+| `chainCode` | bytes | 32-byte BIP-32 chain code |
+
+**Implications**:
+
+- The public key and chain code are **authenticated but not encrypted**: they can be
+  read from the raw bytes without the passphrase.  `encryptedPublic` and
+  `encryptedChainCode` exploit this.
+
+- The Argon2id production parameters (`128 MiB / t=3 / p=4`) are **fixed in the
+  AAD** and validated on every decode.  An envelope produced with different parameters
+  (e.g., the fast-test parameters) cannot be decoded by production code, and production
+  envelopes cannot be "upgraded" to higher parameters without full re-encryption.
+
+- `withDecryptedExtKeyMaterial` **only operates on `EnvelopeV2` keys**.  When called
+  on a `LegacyV1` `EncryptedKey` (128-byte raw XPrv bytes), it returns
+  `Left XPrvDecodeError` immediately.  V1 keys are decrypted via the separate
+  `cardano-crypto` XPrv pathway; this function is V2-only.
+
+### Library-level format discriminator
+
+The library distinguishes V1 from V2 by **byte-length** of the raw `EncryptedKey`
+bytes (separate from the DB column `"V2:"` prefix, which is stripped before the bytes
+reach the library):
+
+```haskell
+data XPrvFormat = LegacyV1 | EnvelopeV2
+
+encryptedKeyFormat :: EncryptedKey -> XPrvFormat
+-- LegacyV1 iff byte-length == 128  (64 secret + 32 pub + 32 cc, unencrypted)
+-- EnvelopeV2 otherwise             (CBOR envelope, always longer than 128 bytes)
+```
+
+---
+
+## Library types and error handling (`cardano-crypto-wallet` 0.2)
+
+### `XPrvError`
+
+All fallible library operations return `Either XPrvError a`.  Relevant variants:
+
+| Variant | When raised |
+|---------|-------------|
+| `XPrvDecodeError` | CBOR decode failure; also returned by `withDecryptedExtKeyMaterial` for `LegacyV1` keys |
+| `XPrvUnsupportedVersion` | AAD `version ≠ 2` |
+| `XPrvUnsupportedKdf` | AAD `kdfId ≠ 1` |
+| `XPrvUnsupportedCipher` | AAD `cipherId ≠ 1` |
+| `XPrvInvalidKdfParams` | AAD KDF params do not match the fixed production values |
+| `XPrvAuthenticationFailed` | XChaCha20-Poly1305 tag check failed (wrong passphrase or tampered bytes) |
+| `XPrvPublicKeyMismatch` | Decrypted secret key does not match the authenticated public key in AAD |
+| `XPrvHardenedDerivationUnsupported` | `encryptedDerivePublic` called with a hardened index (≥ 0x80000000) |
+| `XPrvInternalError` | C-level operation failed unexpectedly |
+
+`XPrvAuthenticationFailed` is the canonical wrong-passphrase signal.
+`XPrvPublicKeyMismatch` indicates a corrupt or tampered envelope.
+
+### Test helpers
+
+Two bracket-scoped overrides are available for tests:
+
+```haskell
+-- Reduce Argon2id cost (4 MiB / t=1 / p=1) for fast test execution.
+-- Envelopes created inside this bracket are NOT decodable outside it.
+withFastKdfForTesting :: IO a -> IO a
+
+-- Replace system RNG with a deterministic counter so test output is reproducible.
+withDeterministicRandomnessForTesting :: IO a -> IO a
+```
+
+These two helpers are independent and can be nested.  `withFastKdfForTesting` is
+required for any test that creates a V2 key and then immediately decrypts it in the
+same test run (otherwise the 128 MiB Argon2id cost makes the test suite impractically
+slow).  `withDeterministicRandomnessForTesting` is useful for golden tests where the
+exact ciphertext bytes must be stable across runs.

--- a/specs/003-root-key-v2-upgrade/plan.md
+++ b/specs/003-root-key-v2-upgrade/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: Root Key Protection Upgrade to V2
+
+**Branch**: `003-root-key-v2-upgrade` | **Date**: 2026-05-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/003-root-key-v2-upgrade/spec.md`
+
+## Summary
+
+Upgrade the wallet root-key storage format from the legacy V1 scheme (PBKDF2-HMAC-SHA512
+or Scrypt) to a modern V2 authenticated-encryption envelope, with opportunistic silent
+migration on each successful wallet unlock.  Expose the active scheme as a stable
+machine-readable field (`encryption_method`) on the `GET /v2/wallets/{id}` passphrase
+info object so that frontends can detect wallets still using V1 and prompt users
+accordingly.
+
+The cryptographic primitive library (`cardano-crypto-wallet-v2`) is already written and
+pinned in `cabal.project`.  The wallet business logic, persistence layer, API types, and
+OpenAPI contract all need coordinated changes.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.6), `NoImplicitPrelude`, `-Wall`/`-Werror` in CI
+**Primary Dependencies**:
+- `cardano-crypto-wallet-v2` — V2 envelope (already pinned via `source-repository-package`)
+- `cardano-crypto` — existing `XPrv` / `xprv` / `unXPrv`
+- `persistent` + `persistent-sqlite` — SQLite key/hash column storage
+- `servant` — REST API routing and type-level contracts
+- `aeson` — JSON serialisation of `ApiWalletPassphraseInfo`
+
+**Storage**: SQLite; root key stored in `private_key` table as two `TEXT` columns (`key`,
+`hash`).  V1 and V2 are distinguished by the byte-length of the first colon-delimited
+segment of the `key` column (exactly 256 hex chars = V1 XPrv; longer = V2 CBOR
+envelope).  Passphrase scheme tracked separately in wallet metadata (`passphrase_scheme`
+column).  **No schema migration required.**
+
+**Testing**: `hspec` + `QuickCheck` (unit); local cardano-node cluster (integration);
+preprod (E2E).
+
+**Target Platform**: Linux x86_64 / aarch64 (musl static), Windows (cross-compiled),
+macOS x86_64 + arm64.
+
+**Project Type**: Library + REST web-service (Servant).
+
+**Performance Goals**: V1→V2 migration adds < 50 ms to a single wallet-unlock operation
+(dominated by Argon2id KDF, acceptable for a one-time per-wallet cost).
+
+**Constraints**: 70-character Fourmolu line limit; leading commas; 4-space indent; HLint
+must pass; `-Werror` in release; no breaking changes to the public API contract.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Maintenance-First Stability | ✓ PASS | Opportunistic migration; no forced re-keying; fully backward-compatible DB; old clients can still read V1 rows |
+| II. Era-Aware Design | ✓ PASS | `KeyFlavorS` GADT dispatches over Byron / Icarus / Shelley / Shared uniformly; address-derivation payload preserved for Byron |
+| III. Type Safety as Security | ✓ PASS | `HashedCredentials` sum type makes V1/V2 statically distinct; `PassphraseScheme` in metadata prevents silent downgrade |
+| IV. Formal Specification | ⚠ GAP | `specifications/api/swagger.yaml` `walletPassphraseInfo` object is missing the `encryption_method` property — **must be added before merge** |
+| V. Reproducible Builds | ✓ PASS | `cardano-crypto-wallet-v2` pinned via `source-repository-package` SHA256 in `cabal.project` |
+| VI. Comprehensive Testing | ⚠ GAP | Store-law unit tests exist; missing: (a) roundtrip test for V1/V2 serialisation in `PersistPrivateKey`, (b) unit test for `withRootKey` migration path, (c) unit test for `migrateV1toV2` atomicity, (d) `ApiWalletPassphraseInfo` golden JSON test for each scheme |
+| VII. Code Quality Gates | ✓ PASS | Compiles with `-Wall`; Fourmolu formatting applied; HLint passing |
+
+**Gate result**: Two constitution gaps must be closed before merge:
+1. OpenAPI spec updated with `encryption_method`
+2. Missing unit tests written
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-root-key-v2-upgrade/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── wallet-passphrase-info.yaml
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+cabal.project                                       # source-repository-package pin (done)
+
+lib/secrets/src/Cardano/Wallet/Primitive/
+└── Passphrase/Types.hs                             # PassphraseScheme + FromText (done)
+
+lib/wallet/src/Cardano/Wallet/
+├── Primitive/Types/Credentials.hs                  # HashedCredentials sum type (done)
+├── Address/Keys/PersistPrivateKey.hs               # V1/V2 serialisation (done)
+└── Wallet.hs                                       # withRootKey + migrateV1toV2 (done)
+
+lib/api/src/Cardano/Wallet/Api/
+├── Types.hs                                        # ApiWalletPassphraseInfo + JSON (done)
+└── Http/Shelley/Server.hs                          # toApiPassphraseInfo helper (done)
+
+specifications/api/swagger.yaml                     # walletPassphraseInfo schema (MISSING)
+
+lib/unit/test/unit/Cardano/Wallet/
+├── Api/TypesSpec.hs                                # Arbitrary instance (done)
+├── DB/Store/PrivateKey/StoreSpec.hs                # store-law tests (done, needs V2 coverage)
+└── Address/Keys/PersistPrivateKeySpec.hs           # V1/V2 roundtrip tests (MISSING)
+```
+
+## Complexity Tracking
+
+No constitution violations requiring justification. Both gaps (OpenAPI spec, test
+coverage) are straightforward additions, not architectural complexity.
+
+---
+
+## Phase 0: Research
+
+> All unknowns resolved. No external research agents needed — implementation is complete
+> and the codebase is the source of truth. See `research.md` for findings.
+
+---
+
+## Phase 1: Design & Contracts
+
+> See `data-model.md` for entity definitions and `contracts/wallet-passphrase-info.yaml`
+> for the API contract change.

--- a/specs/003-root-key-v2-upgrade/quickstart.md
+++ b/specs/003-root-key-v2-upgrade/quickstart.md
@@ -1,0 +1,158 @@
+# Quickstart: Root Key Protection Upgrade to V2
+
+**Branch**: `003-root-key-v2-upgrade` | **Date**: 2026-05-06
+
+This document describes the remaining work needed to bring the implementation to
+constitution compliance.  The core feature (migration logic, API types, persistence)
+is already implemented in commit `7aa70dffe6`.
+
+---
+
+## What is already done
+
+- `PassphraseScheme` extended with `EncryptWithArgon2idV2`; `FromText`/`ToText` instances
+- `HashedCredentials` sum type (`V1` / `V2`) in `Credentials.hs`
+- `PersistPrivateKey`: V1/V2 serialise/deserialise via length-based distinguisher
+- `withRootKey`: opportunistic V1→V2 migration on successful unlock
+- `migrateV1toV2`: atomic write of new key + updated metadata scheme
+- `ApiWalletPassphraseInfo` extended with `encryptionMethod :: ApiT PassphraseScheme`
+- `ToJSON`/`FromJSON` for `ApiT PassphraseScheme`
+- `toApiPassphraseInfo` helper wiring all three wallet-type construction sites
+- `Arbitrary ApiWalletPassphraseInfo` updated in `TypesSpec`
+- Cross-version rejection tests in `PersistPrivateKeySpec.hs` (Gap 2a — complete)
+- T006 golden JSON tests for all three `PassphraseScheme` values in `TypesSpec.hs` (Gap 2c — complete)
+- T003 V2 wrong-passphrase test in `WalletSpec.hs` (partial Gap 2b coverage)
+
+---
+
+## Remaining work (constitution gaps)
+
+### Gap 0 — Update `cabal.project` pin for `cardano-crypto-wallet` 0.2
+
+When `cardano-crypto-wallet` 0.2 is published to CHaP, update the
+`source-repository-package` stanza (lines marked `-- BEGIN cardano-crypto-wallet` /
+`-- END cardano-crypto-wallet`) to point at the new release tag and refresh the `sha256`
+hash.  The wallet code already uses the 0.2 API names (`ExtKeyMaterial`,
+`withDeterministicRandomnessForTesting`, etc.).
+
+### Gap 1 — OpenAPI spec (Principle IV: Formal Specification)
+
+**File**: `specifications/api/swagger.yaml`
+
+Add `encryption_method` to the `walletPassphraseInfo` object.  See the proposed schema
+in `contracts/wallet-passphrase-info.yaml`.
+
+Concretely, change lines ~1213–1219 from:
+
+```yaml
+x-walletPassphraseInfo :: &walletPassphraseInfo
+  description: Information about the wallet's passphrase
+  type: object
+  required:
+    - last_updated_at
+  properties:
+    last_updated_at: *date
+```
+
+to:
+
+```yaml
+x-walletPassphraseInfo :: &walletPassphraseInfo
+  description: Information about the wallet's passphrase
+  type: object
+  required:
+    - last_updated_at
+  properties:
+    last_updated_at: *date
+    encryption_method:
+      description: |
+        The scheme used to protect the wallet's root key in storage.
+        Absent on wallets that have no stored passphrase (e.g. watch-only wallets).
+      type: string
+      enum:
+        - scrypt
+        - pbkdf2-hmac-sha512
+        - argon2id-v2
+      example: argon2id-v2
+```
+
+---
+
+### Gap 2 — Unit tests (Principle VI: Comprehensive Testing)
+
+#### 2a. `PersistPrivateKey` roundtrip — **COMPLETE**
+
+`lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs` covers:
+
+- V1 Shelley key: `serializeXPrv` → `unsafeDeserializeXPrv` roundtrip
+- V1 Byron key (with payload passphrase): roundtrip
+- V2 Shelley key: roundtrip
+- V2 Byron key (with payload passphrase): roundtrip
+- Cross-version rejection: V2 row does not deserialise as V1 and vice-versa
+
+Use `withFastKdfForTesting` (and optionally `withDeterministicRandomnessForTesting` for
+golden bytes) to keep V2 roundtrip tests fast.
+
+#### 2b. `withRootKey` migration path (add to existing wallet unit tests)
+
+In `lib/unit/test/unit/Cardano/Wallet/WalletSpec.hs` (or equivalent), test:
+
+- Given a V1 wallet, when `withRootKey` is called with the correct passphrase, then
+  the stored credentials are upgraded to V2 and scheme metadata is updated
+- Given a V1 wallet, when `withRootKey` is called with a wrong passphrase, then
+  credentials remain V1 and the error is propagated
+- Given a V2 wallet, `withRootKey` does not re-encrypt (idempotent)
+
+#### 2c. `ApiWalletPassphraseInfo` JSON golden tests — **COMPLETE**
+
+Golden JSON assertions for all three `PassphraseScheme` values are in
+`lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs` alongside the existing
+`jsonTest`.
+
+---
+
+## Deployment considerations
+
+> [!WARNING]
+> **Migration is irreversible.** The first time a wallet is unlocked after this
+> version is deployed, its root key is silently re-encrypted under Argon2id and
+> the database row is updated in-place. There is no opt-out and no undo.
+>
+> **Downgrading the binary after migration will lock wallets.**  An older
+> `cardano-wallet` binary that reads a `"V2:"` key column will crash the wallet
+> worker process for that wallet; the wallet will appear inaccessible until the
+> binary is upgraded again.  Funds are not lost — the key material is intact — but
+> they cannot be spent until the binary is restored.
+>
+> **Recommended operator checklist before deploying:**
+> 1. Back up all wallet databases (SQLite files in the wallet state directory).
+> 2. Confirm you can re-deploy this binary version quickly if rollback is needed.
+> 3. After deploying, do not downgrade to any binary that predates this release.
+
+## How to verify locally
+
+```sh
+# Build and test the wallet library
+nix develop
+cabal build lib:cardano-wallet lib:cardano-wallet-api
+cabal test lib:unit --test-options '--match "/Api.Types/ApiWalletPassphraseInfo"'
+
+# Validate the swagger spec (once updated)
+cabal run validate-swagger -- specifications/api/swagger.yaml
+```
+
+---
+
+## Notes for reviewers
+
+- The `encryption_method` field is **not** in the `required` list of
+  `walletPassphraseInfo`; existing clients that omit it will parse the response
+  correctly (forward-compatibility).
+- `migrateV1toV2` currently fails silently; a low-priority follow-up is to add a
+  tracer event so operators can observe migration progress in logs.
+- Any test that creates a V2 `EncryptedKey` must wrap the creation in
+  `withFastKdfForTesting`; the production Argon2id cost (128 MiB / t=3 / p=4) makes
+  naive unit tests prohibitively slow.
+- Use `withDeterministicRandomnessForTesting` in addition when the exact ciphertext
+  bytes must be stable (e.g., golden binary tests).  Both helpers are bracket-scoped
+  and can be nested.

--- a/specs/003-root-key-v2-upgrade/research.md
+++ b/specs/003-root-key-v2-upgrade/research.md
@@ -1,0 +1,109 @@
+# Research: Root Key Protection Upgrade to V2
+
+**Branch**: `003-root-key-v2-upgrade` | **Date**: 2026-05-06
+
+All decisions were resolved by reading the existing implementation and the project
+constitution.  No external research was required.
+
+---
+
+## Decision 1: Migration trigger point
+
+**Decision**: Migrate V1 → V2 opportunistically inside `withRootKey`, immediately after
+a successful passphrase verification, before invoking the caller's action callback.
+
+**Rationale**: `withRootKey` is the single choke-point through which every passphrase-
+authenticated operation flows (signing, address derivation, passphrase change).
+Hooking migration here guarantees the upgrade happens on the first real use without
+requiring callers to be aware of it.
+
+**Alternatives considered**:
+- Explicit migration endpoint (`POST /v2/wallets/{id}/migrate-key`): rejected — requires
+  user action, defeats the zero-friction goal.
+- Background migration task at wallet open: rejected — introduces concurrency complexity
+  and the wallet may never be opened by the owner on that node.
+
+---
+
+## Decision 2: Atomicity of the migration write
+
+**Decision**: The migration writes both the new key record and the updated
+`passphrase_scheme` metadata in a single `atomically` block via the existing
+`DBLayer` STM interface.
+
+**Rationale**: SQLite transactions guarantee that either both writes land or neither
+does.  The `atomically` wrapper in `DBLayer` composes the two `stm` actions into one
+transaction.  A crash mid-migration therefore leaves the DB in a consistent V1 state.
+
+**Alternatives considered**:
+- Two separate transactions: rejected — window between writes allows inconsistent state
+  (key=V2, scheme=V1 or vice-versa).
+
+---
+
+## Decision 3: Silent failure on migration error
+
+**Decision**: `migrateV1toV2` returns `IO ()` and swallows errors from the V2 encryption
+call.  The key stays V1 and migration is retried on the next unlock.
+
+**Rationale**: The primary operation (signing, etc.) must not be blocked by a migration
+failure.  V2 encryption errors are highly unlikely once the library is correct (they
+indicate a malformed key, which would have already failed V1 verification).
+
+**Gap identified**: There is currently no log/trace event on migration failure or
+success.  The constitution's maintenance-first principle suggests this should be
+observable.  A `tracer` call should be added (low-priority, does not block merge).
+
+---
+
+## Decision 4: V1/V2 serialisation distinguisher
+
+**Decision**: V1 vs V2 is identified by the byte-length of the first colon-delimited
+segment of the `key` DB column: exactly 256 hex chars (128 bytes) = V1 XPrv; anything
+longer = V2 CBOR envelope.
+
+**Rationale**: Reuses the existing two-column schema (`key`, `hash`) without any schema
+migration.  The V2 CBOR envelope is self-describing and always longer than 256 hex chars.
+
+**Alternatives considered**:
+- New DB column `key_version`: rejected — requires a schema migration on existing
+  production databases, violating maintenance-first stability.
+- Sentinel prefix byte: rejected — more fragile than length-based detection and requires
+  the CBOR decoder to skip it.
+
+---
+
+## Decision 5: In-memory representation after V2 decrypt
+
+**Decision**: After decrypting a V2 key, `withRootKey` reconstructs a standard `k 'RootK
+XPrv` with a **plaintext scalar** and passes it to the action callback with
+`EncryptWithArgon2idV2` as the scheme.  The action then calls
+`preparePassphrase EncryptWithArgon2idV2 _  = Passphrase mempty`, which causes the C
+signing layer to run in no-op (memcpy) mode.
+
+**Rationale**: Existing callers of `withRootKey` already use `preparePassphrase` with the
+scheme argument to prepare the passphrase before passing it to the C layer.  Returning
+`EncryptWithArgon2idV2` from the callback is sufficient to make all callers correct
+without any changes to downstream code.
+
+---
+
+## Decision 6: API field name and values
+
+**Decision**: Field name `encryption_method`; values `"scrypt"`, `"pbkdf2-hmac-sha512"`,
+`"argon2id-v2"`.  These match the `ToText`/`FromText` instances on `PassphraseScheme`
+and are serialised via the existing `ApiT` + `toTextApiT`/`fromTextApiT` pattern.
+
+**Rationale**: Consistent with the existing `ToText PassphraseScheme` implementation
+already used for DB storage.  The `ApiT` wrapper provides automatic JSON
+round-trip via `ToText`/`FromText` without bespoke encoding.
+
+---
+
+## Open items (non-blocking)
+
+| Item | Priority | Owner |
+|------|----------|-------|
+| Add tracer events to `migrateV1toV2` (success + failure) | Low | wallet team |
+| Integration test: V1 wallet → sign tx → verify `encryption_method` = v2 | Medium | wallet team |
+| E2E test on preprod with imported Daedalus scrypt wallet | Low | QA team |

--- a/specs/003-root-key-v2-upgrade/spec.md
+++ b/specs/003-root-key-v2-upgrade/spec.md
@@ -1,0 +1,232 @@
+# Feature Specification: Root Key Protection Upgrade to V2
+
+**Feature Branch**: `003-root-key-v2-upgrade`
+**Created**: 2026-05-06
+**Status**: Draft
+**Input**: User description: "Upgrade root-key storage to v2 envelope (Argon2id+XChaCha20-Poly1305) with opportunistic V1-to-V2 migration on wallet unlock, and expose encryption_method in GET /v2/wallets/{id} passphrase info so frontends can detect V1 keys and prompt a passphrase-change dialog if desired."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automatic Key Protection Upgrade on Unlock (Priority: P1)
+
+A wallet user (or node operator running an automated service) has an existing wallet
+whose root key is protected by an older scheme (V1). The next time they perform any
+operation that requires their passphrase — such as signing a transaction or listing
+addresses — the system silently upgrades the stored key to the latest protection scheme
+(V2) without requiring any additional user interaction. The user's passphrase itself does
+not change; only how it is stored is improved.
+
+**Why this priority**: This is the core security improvement. Without it, existing wallets
+remain on weaker protection indefinitely. It must work invisibly to avoid friction for the
+large installed base of V1 wallets.
+
+**Independent Test**: Can be fully tested by creating a wallet, verifying it reports V1
+scheme in the API, signing a transaction, and confirming it now reports V2 scheme — with
+no change to the passphrase or wallet funds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a wallet whose passphrase info reports protection scheme `scrypt` or
+   `pbkdf2-hmac-sha512`, **When** the user sends a transaction (or any other operation
+   requiring passphrase verification), **Then** the wallet's stored key is upgraded to
+   `argon2id-v2` and subsequent reads of the wallet info reflect the new scheme.
+
+2. **Given** a wallet already using `argon2id-v2`, **When** any passphrase operation is
+   performed, **Then** the key is left unchanged and no unnecessary re-encryption occurs.
+
+3. **Given** a wallet with a V1 key and an **incorrect** passphrase supplied, **When** an
+   operation is attempted, **Then** the operation is rejected with an authentication
+   error and the key remains at V1 (no partial or corrupt migration state is written).
+
+4. **Given** a wallet that has just been restored from its seed phrase and has never
+   been unlocked since, **When** the user first unlocks it, **Then** the migration to
+   V2 occurs at that point.
+
+---
+
+### User Story 2 - Frontend Detection of V1 Wallets (Priority: P2)
+
+A frontend application developer wants to show users a prompt encouraging them to
+re-enter their passphrase when their wallet is still using an older protection scheme.
+The developer needs a stable, machine-readable field in the wallet info API response to
+detect this condition programmatically.
+
+**Why this priority**: Without this, frontends have no reliable way to prompt users
+proactively. The opportunistic migration (P1) is sufficient for security, but the UI
+affordance improves visibility and gives users agency.
+
+**Independent Test**: Can be fully tested by querying `GET /v2/wallets/{id}` on wallets
+in each scheme state and asserting that `passphrase.encryption_method` returns the
+correct stable identifier, independent of any migration logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** any wallet (Shelley sequential, Shelley random, or shared), **When** `GET /v2/wallets/{id}` is
+   called and a passphrase was set, **Then** the response includes
+   `passphrase.encryption_method` with one of the defined scheme identifiers.
+
+2. **Given** a wallet using a V1 protection scheme, **When** the wallet info is fetched,
+   **Then** `passphrase.encryption_method` returns the V1 identifier, allowing the
+   frontend to display an upgrade prompt.
+
+3. **Given** a wallet that has just been migrated to V2 (by P1 story), **When** the
+   wallet info is fetched immediately after, **Then** `passphrase.encryption_method`
+   returns the V2 identifier.
+
+4. **Given** a wallet with no passphrase set (e.g., hardware wallets),
+   **When** wallet info is fetched, **Then** the `passphrase` object is absent (no
+   `encryption_method` field present), consistent with existing behaviour.
+
+---
+
+### User Story 3 - Explicit Upgrade via Passphrase Change (Priority: P3)
+
+A user who has been prompted by their wallet frontend can explicitly trigger the upgrade
+to V2 by going through the standard passphrase change flow — either changing to a new
+passphrase or providing the same one. After this, their wallet reports V2 protection.
+
+**Why this priority**: The explicit path is a convenient complement to the opportunistic
+migration, particularly for wallets that are mainly used for receiving funds (no outbound
+transactions) and would otherwise stay at V1 for a long time.
+
+**Independent Test**: Can be fully tested by calling the change-passphrase endpoint on
+a V1 wallet and confirming the `encryption_method` switches to V2, all without any
+balance or address change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a wallet reporting `scrypt` or `pbkdf2-hmac-sha512`, **When** the user
+   submits a passphrase change (new passphrase may equal the old one), **Then** the
+   wallet now reports `argon2id-v2`.
+
+---
+
+### Edge Cases
+
+- What happens when the wallet database is read by an older version of the software that
+  does not understand V2 keys? The stored format must be self-describing so older
+  software can fail gracefully rather than silently corrupting data.
+
+- How does the system handle a crash or power loss mid-migration? The upgrade write must
+  be atomic: either the full V2 record is committed or the original V1 record remains
+  intact.
+
+- What happens when the same wallet is concurrently unlocked from two processes? The
+  migration must be idempotent: two simultaneous upgrades must not produce a corrupt or
+  inconsistent stored key.
+
+- What happens when a wallet is imported from another software (e.g., Daedalus) that
+  used the legacy scrypt scheme? The import must succeed, and the first unlock must
+  trigger migration to V2.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST upgrade a wallet's root-key protection scheme to V2 the
+  first time the user successfully authenticates with their passphrase after the feature
+  is deployed, without requiring any explicit user action beyond normal authentication.
+
+- **FR-002**: The system MUST NOT change the user's passphrase during an automatic
+  upgrade; only the storage format of the existing passphrase-protected key changes.
+
+- **FR-003**: The wallet info endpoint MUST include a stable, machine-readable
+  `encryption_method` field within the `passphrase` object, identifying which protection
+  scheme currently secures the wallet's root key.
+
+- **FR-004**: The `encryption_method` field MUST use one of three defined identifiers:
+  `scrypt`, `pbkdf2-hmac-sha512`, or `argon2id-v2`. No other values are permitted.
+
+- **FR-005**: The system MUST continue to accept and unlock wallets using any supported
+  protection scheme (V1 or V2) without requiring manual re-keying or database migration
+  scripts.
+
+- **FR-006**: The migration from V1 to V2 MUST be atomic: the stored key record is
+  either fully updated to V2 or left fully intact as V1. Partial writes are not
+  permitted.
+
+- **FR-007**: Following a successful V1-to-V2 migration, the wallet metadata MUST
+  reflect the new scheme so that subsequent reads of wallet info return `argon2id-v2`.
+
+- **FR-008**: The system MUST reject any passphrase-authenticated operation if the
+  passphrase verification fails, regardless of the key protection scheme in use, and
+  MUST NOT modify the stored key as a result of a failed attempt.
+
+- **FR-009**: All Shelley wallet types (Shelley sequential, Shelley random, shared
+  multisig) MUST be subject to the same upgrade path.
+
+- **FR-010**: New wallets created after deployment MUST use V2 protection by default.
+
+### Key Entities
+
+- **Wallet**: Has a root key, passphrase info, and balance. The root key's protection
+  scheme is an attribute of how the key is stored, not of the wallet itself.
+
+- **Passphrase info**: Records when the passphrase was last changed and which protection
+  scheme currently secures the stored root key. This is the entity extended by
+  `encryption_method`.
+
+- **Key protection scheme**: A versioned cryptographic envelope that wraps the wallet's
+  root key. V1 schemes use PBKDF2 or scrypt for key derivation; V2 uses a stronger
+  modern construction. The scheme identifier is human-readable and stable across
+  software versions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All wallets with a V1 protection scheme are migrated to V2 within one
+  successful passphrase operation after deployment, requiring zero additional steps from
+  the user beyond what they would normally do.
+
+- **SC-002**: The wallet info response for every Shelley wallet with a passphrase includes
+  `passphrase.encryption_method`, with 100% coverage across all Shelley wallet types
+  (sequential, random, shared).
+
+- **SC-003**: Zero wallets experience loss of access to funds or addresses as a result
+  of the migration. All funds remain spendable and all addresses remain derivable after
+  V2 upgrade.
+
+- **SC-004**: The migration adds no perceptible latency to wallet unlock operations
+  from the user's perspective (target: indistinguishable from a normal unlock).
+
+- **SC-005**: Existing integration tests continue to pass unchanged, demonstrating that
+  the upgrade is fully backward-compatible with the current API contract.
+
+## Deployment Warning: Irreversible Migration
+
+> [!WARNING]
+> **This upgrade is one-way and permanent. Once any wallet in a database has been
+> migrated to V2, that database requires a binary that understands the V2 format.**
+>
+> - **Do not downgrade** the `cardano-wallet` binary after wallets have migrated.
+>   An older binary that encounters a V2 key column will either crash the wallet
+>   worker process or permanently lock the wallet (funds become inaccessible until
+>   the binary is upgraded again).
+> - **Back up wallet databases** before deploying this version in production
+>   environments where rollback may be needed.
+> - Migration is triggered silently on the first successful passphrase operation
+>   per wallet; there is no opt-out and no bulk pre-migration step.
+
+## Assumptions
+
+- Wallets already using V2 protection (created after a previous deployment of this
+  feature) are unaffected and will not be re-encrypted unnecessarily.
+
+- The upgrade is one-directional: V1 → V2 only. Downgrading a V2 wallet to V1 is not
+  a supported operation.
+
+- The `encryption_method` field is additive to the existing `passphrase` object and
+  does not break clients that ignore unknown fields (standard REST API forward
+  compatibility).
+
+- Byron (random/Icarus) and hardware/watch-only wallets are out of scope; they are not
+  subject to the V2 upgrade path and continue to have no `passphrase.encryption_method`
+  in the API response.
+
+- The feature targets the `cardano-wallet` backend service; companion changes to any
+  specific frontend are out of scope for this specification.
+
+- The existing wallet database schema can represent V2 keys in the same columns used
+  for V1 keys, distinguished by the format of the stored data; no schema migration is
+  required.

--- a/specs/003-root-key-v2-upgrade/tasks.md
+++ b/specs/003-root-key-v2-upgrade/tasks.md
@@ -1,0 +1,186 @@
+# Tasks: Root Key Protection Upgrade to V2
+
+**Input**: Design documents from `specs/003-root-key-v2-upgrade/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Note**: Core implementation is complete in commit `7aa70dffe6`. All remaining tasks
+close the two constitution gaps identified in `plan.md`: missing OpenAPI spec update
+(Principle IV) and missing unit test coverage (Principle VI).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other [P] tasks in the same phase
+- **[US#]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Status**: Complete. Core implementation, `PassphraseScheme` extension, `HashedCredentials`
+sum type, `PersistPrivateKey` V1/V2 serialisation, `withRootKey` migration logic,
+`ApiWalletPassphraseInfo` extension, and `Arbitrary` instance are all landed in
+commit `7aa70dffe6`. No setup tasks remain.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Confirm the existing implementation compiles cleanly before adding tests.
+
+- [ ] T001 Verify `cabal build lib:cardano-wallet lib:cardano-wallet-api` passes with zero warnings on the `003-root-key-v2-upgrade` branch
+
+**Checkpoint**: Clean build confirmed — test and spec work can proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 — Automatic Key Upgrade on Unlock (Priority: P1) 🎯 MVP
+
+**Goal**: The migration path is correct, atomic, and tested. A V1 wallet that is unlocked
+comes out as V2 with the scheme metadata updated; a failed unlock leaves V1 intact.
+
+**Independent Test**: `cabal test lib:unit --test-options '--match "/PersistPrivateKey"'`
+and `--match "/withRootKey"` both green.
+
+### Implementation for User Story 1
+
+- [ ] T002 [P] [US1] Create `lib/unit/test/unit/Cardano/Wallet/Address/Keys/PersistPrivateKeySpec.hs` with property tests:
+  - V1 Shelley roundtrip: `serializeXPrv` → `unsafeDeserializeXPrv` yields identical `HashedCredentialsV1`
+  - V1 Byron roundtrip: same, with non-empty payload passphrase
+  - V2 Shelley roundtrip: yields identical `HashedCredentialsV2`
+  - V2 Byron roundtrip: same, with non-empty payload passphrase
+  - Distinguisher: first segment of a V2-serialised key is longer than 256 hex chars
+
+- [ ] T003 [P] [US1] Add `withRootKey` migration tests to `lib/unit/test/unit/Cardano/Wallet/` (new describe block, e.g. in `WalletSpec.hs` or a dedicated `WithRootKeySpec.hs`):
+  - Given V1 creds + correct passphrase → stored key becomes `HashedCredentialsV2`, metadata scheme becomes `EncryptWithArgon2idV2`
+  - Given V1 creds + wrong passphrase → `ErrWithRootKeyWrongPassphrase` returned, stored key unchanged
+  - Given V2 creds + correct passphrase → stored key unchanged (no redundant re-encryption)
+  - Given V2 creds + wrong passphrase → `ErrWithRootKeyWrongPassphrase` returned
+
+- [ ] T004 [US1] Register the new spec(s) in the unit test `Main.hs` or cabal `other-modules` so they are picked up by `cabal test lib:unit`
+
+**Checkpoint**: User Story 1 fully tested — migration correctness and atomicity verified.
+
+---
+
+## Phase 4: User Story 2 — Frontend Detection via `encryption_method` (Priority: P2)
+
+**Goal**: The OpenAPI contract is updated and the JSON serialisation is golden-tested for
+all three scheme values. Frontends can rely on the documented field.
+
+**Independent Test**: `cabal test lib:unit --test-options '--match "/ApiWalletPassphraseInfo"'`
+green; `swagger.yaml` validates cleanly.
+
+### Implementation for User Story 2
+
+- [ ] T005 [P] [US2] Update `specifications/api/swagger.yaml` — add `encryption_method` property to the `walletPassphraseInfo` anchor (lines ~1213–1219). Apply the diff in `specs/003-root-key-v2-upgrade/contracts/wallet-passphrase-info.yaml`. Field is optional (not in `required` list) for forward-compatibility.
+
+- [ ] T006 [P] [US2] Add golden JSON assertions to `lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs`:
+  - `ApiWalletPassphraseInfo` with `EncryptWithScrypt` round-trips as `{"last_updated_at": …, "encryption_method": "scrypt"}`
+  - same for `EncryptWithPBKDF2` → `"pbkdf2-hmac-sha512"`
+  - same for `EncryptWithArgon2idV2` → `"argon2id-v2"`
+  - `FromJSON` rejects unknown `encryption_method` strings
+
+**Checkpoint**: OpenAPI contract matches implementation; JSON serialisation verified for all three scheme values.
+
+---
+
+## Phase 5: User Story 3 — Explicit Upgrade via Passphrase Change (Priority: P3)
+
+**Goal**: Confirm that going through the standard passphrase-change flow on a V1 wallet
+results in a V2 wallet, verifiable via the API field.
+
+**Independent Test**: `cabal test lib:unit --test-options '--match "/updateWalletPassphrase"'`
+(or equivalent) green.
+
+### Implementation for User Story 3
+
+- [ ] T007 [US3] Add a unit test for `updateWalletPassphraseWithOldPassphrase` in the wallet unit suite:
+  - Given a V1 wallet, when passphrase is changed (old → new, or old → same), then stored key is `HashedCredentialsV2` and scheme is `EncryptWithArgon2idV2`
+
+**Checkpoint**: All three user stories independently verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T008 [P] Add tracer events to `migrateV1toV2` in `lib/wallet/src/Cardano/Wallet.hs`:
+  - Emit a trace message on successful migration (scheme + wallet id, no key material)
+  - Emit a trace message on silent failure (to make silent errors observable in logs)
+
+- [ ] T009 [P] Verify Fourmolu formatting on all modified/new files:
+  - `lib/wallet/src/Cardano/Wallet.hs`
+  - `lib/wallet/src/Cardano/Wallet/Address/Keys/PersistPrivateKey.hs`
+  - `lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs`
+  - `lib/api/src/Cardano/Wallet/Api/Types.hs`
+  - `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`
+  - all new test files
+
+- [ ] T010 Run full unit test suite: `cabal test lib:unit` — must be 100% green
+
+- [ ] T011 Run `cabal build` with `-Werror` to confirm no warnings remain
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: Complete
+- **Phase 2 (Foundational)**: T001 — run once before parallel test work
+- **Phase 3 (US1)**: T002, T003 can run in parallel after T001; T004 depends on T002+T003
+- **Phase 4 (US2)**: T005, T006 can run in parallel after T001, independent of Phase 3
+- **Phase 5 (US3)**: T007 can start after T001, independent of Phase 3 and Phase 4
+- **Phase 6 (Polish)**: T008–T011 after all story phases complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends only on T001 (clean build)
+- **US2 (P2)**: Depends only on T001 — fully independent of US1
+- **US3 (P3)**: Depends only on T001 — fully independent of US1 and US2
+
+### Parallel Opportunities
+
+```
+After T001 (clean build confirmed):
+  ├─ T002 [US1] PersistPrivateKeySpec.hs
+  ├─ T003 [US1] withRootKey tests
+  ├─ T005 [US2] swagger.yaml update
+  └─ T006 [US2] ApiWalletPassphraseInfo golden tests
+  └─ T007 [US3] passphrase change migration test
+
+After T002 + T003:
+  └─ T004 [US1] register specs in cabal/Main.hs
+
+After all story phases:
+  ├─ T008 tracer events
+  ├─ T009 Fourmolu check
+  ├─ T010 full test suite
+  └─ T011 -Werror build
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 only — closes constitution gap for testing of migration path)
+
+1. T001 — verify clean build
+2. T002, T003 in parallel — write PersistPrivateKey + withRootKey tests
+3. T004 — register new specs
+4. **STOP**: confirm `cabal test lib:unit` green for new tests
+5. US1 is independently verified
+
+### Full Delivery
+
+1. MVP above
+2. T005, T006 in parallel — close OpenAPI + JSON test gap (US2)
+3. T007 — passphrase change test (US3)
+4. T008–T011 — polish, formatting, full green suite
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different files and have no intra-phase dependencies
+- All test file additions must also be registered in the relevant cabal `other-modules` stanza
+- The swagger.yaml change (T005) is the only change to `specifications/`; verify it does not break the swagger validation tooling


### PR DESCRIPTION
Integrates `cardano-crypto-wallet` from cardano-base, replacing the
legacy PBKDF2/ChaCha20 passphrase scheme for root key storage.

## Key changes

- `HashedCredentials` is now a sum type (`V1` | `V2`). V2 stores both
  the PBKDF2-encrypted root key (for derivation/signing) and an Argon2id
  AEAD `EncryptedKey` (for passphrase authentication). Serialization uses
  a `"V2:"` prefix for unambiguous format detection without relying on
  field lengths.

- `withRootKey` validates V2 credentials via Argon2id and returns the
  stored PBKDF2-encrypted key, so callers use the same `preparePassphrase`
  path as V1.

- `withRootKey` opportunistically migrates V1 keys to V2 on every
  successful passphrase use — atomically, silently, no schema migration
  needed.

- `attachPrivateKeyFromPwd` always creates V2 credentials for new
  wallets. A `reattachPrivateKey` helper covers wallet delete-recreate
  flows (shared wallet activation) preserving the credential format.

- `GET /v2/wallets/:id` now includes `encryption_method` in the
  passphrase object (`"scrypt"`, `"pbkdf2-hmac-sha512"`, or
  `"argon2id-v2"`), letting frontends detect legacy keys and prompt for
  a passphrase change.

- `PassphraseScheme` gains a `FromText` instance for JSON round-trips
  via `ApiT`.

- `serveWallet` calls `cryptoInit` before any V2 path to prevent
  `sodium_malloc` from aborting before `sodium_init`.

## Tests

- `PersistPrivateKeySpec`: 6 roundtrip tests — V1/V2 × Shelley/Byron ×
  no-payload/with-payload, plus column-length and empty-hash invariants.
- `WalletSpec`: V1→V2 migration, wrong-passphrase rejection, V2
  idempotency.

## Supporting fixes

- `WalletFlavor`: `TestState` instance so `DummyState` satisfies the
  `WalletFlavor` constraint.
- `Credentials`: `Show` instance for `HashedCredentials`.
- `DerivationSpec`, `LayerSpec`, `StoreSpec`: updated to new
  `HashedCredentials` API.