### PR TITLE
fix(ci): clean docker boot sync after cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
     env:
       WALLET_TAG: ${{ needs.docker.outputs.image-tag }}
       USE_LOCAL_IMAGE: "true"
+      DOCKER_RESTART_POLICY: "no"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -512,9 +513,25 @@ jobs:
         env:
           SUCCESS_STATUS: ${{ matrix.status }}
           COMPOSE_PROJECT_NAME: gha-${{ github.run_id }}-${{ strategy.job-index }}
+          BOOT_SYNC_DIR: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}
+          NODE_DB: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/node-db
+          WALLET_DB: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/wallet-db
+          NODE_SOCKET_DIR: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/ipc
         run: |
-          rm -rf databases
+          rm -rf "$BOOT_SYNC_DIR"
+          mkdir -p "$NODE_DB" "$WALLET_DB" "$NODE_SOCKET_DIR"
           ./run.sh sync ${{ matrix.timeout }}
+
+      - name: Cleanup boot sync
+        if: always()
+        working-directory: ${{ matrix.dir }}
+        env:
+          COMPOSE_PROJECT_NAME: gha-${{ github.run_id }}-${{ strategy.job-index }}
+          BOOT_SYNC_DIR: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}
+        run: |
+          docker compose -p "$COMPOSE_PROJECT_NAME" down --remove-orphans --timeout 10 || true
+          docker compose -p "$COMPOSE_PROJECT_NAME" rm -sf || true
+          rm -rf "$BOOT_SYNC_DIR"
 
   # ---------------------------------------------------------------------------
   # macOS (build gate + artifacts)
@@ -643,6 +660,9 @@ jobs:
 
           - name: "Lint Bash Scripts"
             command: ./scripts/shellcheck.sh
+
+          - name: "Check Docker Boot Sync Cleanup"
+            command: scripts/ci/check-docker-boot-sync-cleanup.sh
 
           - name: "Check EOL"
             command: nix develop --quiet --command scripts/enforce-eol.sh

--- a/run/common/docker/docker-compose.yml
+++ b/run/common/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ${NODE_DB}:/data
       - ${NODE_SOCKET_DIR}:/ipc
-    restart: on-failure
+    restart: "${DOCKER_RESTART_POLICY:-on-failure}"
     user: ${USER_ID}:${GROUP_ID}
     logging:
       driver: "json-file"
@@ -41,7 +41,7 @@ services:
         --testnet /configs/cardano/${NETWORK}/byron-genesis.json
 
     user: ${USER_ID}:${GROUP_ID}
-    restart: on-failure
+    restart: "${DOCKER_RESTART_POLICY:-on-failure}"
     logging:
       driver: "json-file"
       options:

--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -91,9 +91,8 @@ startup() {
 # Function to clean up the service
 cleanup() {
     echo "Cleaning up..."
-    docker compose -p "$COMPOSE_PROJECT_NAME" down 2>/dev/null
-    sleep  3
-    docker compose -p "$COMPOSE_PROJECT_NAME" kill 2>/dev/null
+    docker compose -p "$COMPOSE_PROJECT_NAME" down --remove-orphans --timeout 10 2>/dev/null || true
+    docker compose -p "$COMPOSE_PROJECT_NAME" rm -sf 2>/dev/null || true
 }
 
 node-db-with-mithril() {
@@ -107,6 +106,10 @@ node-db-with-mithril() {
 # Case statement to handle different command-line arguments
 case "$1" in
     sync)
+        trap cleanup EXIT
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
+
         if [[ -n "${USE_MITHRIL-}" ]]; then
             node-db-with-mithril
         fi
@@ -124,9 +127,6 @@ case "$1" in
         query_status="$command  .sync_progress.status"
         query_time="$command .node_tip.time"
         query_progress="$command .sync_progress.progress.quantity"
-
-        # Execute and display the full query result
-        trap cleanup ERR INT
 
         # Define the wanted status and result, can be "syncing" or "ready"
         SUCCESS_STATUS=${SUCCESS_STATUS:="ready"}
@@ -158,6 +158,7 @@ case "$1" in
         fi
 
         cleanup
+        trap - EXIT INT TERM
 
         # Stop the service after syncing
         echo "Result: $result"

--- a/scripts/ci/check-docker-boot-sync-cleanup.sh
+++ b/scripts/ci/check-docker-boot-sync-cleanup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+compose_file="run/common/docker/docker-compose.yml"
+run_script="run/common/docker/run.sh"
+workflow_file=".github/workflows/ci.yml"
+
+failed=0
+
+require_literal() {
+    local file=$1
+    local literal=$2
+    local description=$3
+
+    if ! grep -Fq -- "$literal" "$file"; then
+        echo "Missing ${description}: ${literal}"
+        failed=1
+    fi
+}
+
+reject_literal() {
+    local file=$1
+    local literal=$2
+    local description=$3
+
+    if grep -Fq -- "$literal" "$file"; then
+        echo "Forbidden ${description}: ${literal}"
+        failed=1
+    fi
+}
+
+restart_count=$(
+    grep -F -c 'restart: "${DOCKER_RESTART_POLICY:-on-failure}"' \
+        "$compose_file" || true
+)
+
+if [[ "$restart_count" -ne 2 ]]; then
+    echo "Expected two configurable restart policies in ${compose_file}; found ${restart_count}."
+    failed=1
+fi
+
+require_literal "$run_script" \
+    'docker compose -p "$COMPOSE_PROJECT_NAME" down --remove-orphans --timeout 10' \
+    "compose orphan cleanup"
+require_literal "$run_script" 'trap cleanup EXIT' "EXIT cleanup trap"
+require_literal "$run_script" "trap 'exit 130' INT" "INT cleanup trap"
+require_literal "$run_script" "trap 'exit 143' TERM" "TERM cleanup trap"
+
+require_literal "$workflow_file" 'DOCKER_RESTART_POLICY: "no"' \
+    "CI restart-policy disable"
+require_literal "$workflow_file" 'BOOT_SYNC_DIR: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}' \
+    "runner-temp boot-sync directory"
+require_literal "$workflow_file" 'NODE_DB: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/node-db' \
+    "runner-temp node database"
+require_literal "$workflow_file" 'WALLET_DB: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/wallet-db' \
+    "runner-temp wallet database"
+require_literal "$workflow_file" 'NODE_SOCKET_DIR: ${{ runner.temp }}/cardano-wallet/${{ github.run_id }}-${{ strategy.job-index }}/ipc' \
+    "runner-temp IPC directory"
+require_literal "$workflow_file" 'if: always()' "always-run cleanup step"
+require_literal "$workflow_file" \
+    'docker compose -p "$COMPOSE_PROJECT_NAME" down --remove-orphans --timeout 10 || true' \
+    "workflow compose cleanup"
+reject_literal "$workflow_file" 'rm -rf databases' \
+    "checkout-local boot-sync database cleanup"
+
+if [[ "$failed" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "Docker boot-sync cleanup contract passed."


### PR DESCRIPTION
Closes #5295

## Summary

- Disable Docker compose restart policies for boot-sync CI jobs while preserving the local default.
- Move Docker boot-sync bind mounts out of the repository checkout and into a job-scoped `$RUNNER_TEMP` directory.
- Clean compose projects with `down --remove-orphans` on script exit and an `if: always()` workflow step.
- Add a static CI guard for the boot-sync cleanup contract.

## Verification

- `scripts/ci/check-docker-boot-sync-cleanup.sh`
- `bash -n run/common/docker/run.sh scripts/ci/check-docker-boot-sync-cleanup.sh`
- `git diff --check HEAD~1..HEAD`
- `./scripts/shellcheck.sh`