### PR TITLE
chore(release): merge back v2026-05-11 version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ WALLET_DB=./my-databases/wallet-db
 NODE_DB=./my-databases/node-db
 NODE_SOCKET_DIR=/tmp/cardano-node-socket
 NODE_CONFIGS=./my-configs-i-just-copied-from-a-malicious-site
-WALLET_TAG=2026.4.17
+WALLET_TAG=2026.5.11
 
 ```
 

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name:          address-derivation-discovery
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Address derivation and discovery.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-api
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Cardano wallet http api.
 description:   Please see README.md
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            cardano-wallet-application-extras
-version:         0.2026.4.17
+version:         0.2026.5.11
 synopsis:        modules to support applications for the cardano wallet
 license:         Apache-2.0
 license-file:    LICENSE

--- a/lib/application-tls/cardano-wallet-application-tls.cabal
+++ b/lib/application-tls/cardano-wallet-application-tls.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            cardano-wallet-application-tls
-version:         0.2026.4.17
+version:         0.2026.5.11
 synopsis:        cardano-wallet application tls support
 license:         Apache-2.0
 license-file:    LICENSE

--- a/lib/application/cardano-wallet-application.cabal
+++ b/lib/application/cardano-wallet-application.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            cardano-wallet-application
-version:         2026.4.17
+version:         2026.5.11
 synopsis:        cardano-wallet executable
 
 -- description:

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-wallet-benchmarks
-version:       2026.4.17
+version:       2026.5.11
 synopsis:      Benchmarks of the cardano-wallet.
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          cardano-api-extra
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Useful extensions to the Cardano API.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/crypto-primitives/crypto-primitives.cabal
+++ b/lib/crypto-primitives/crypto-primitives.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          crypto-primitives
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Cryptographic primitives
 license:       Apache-2.0
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/delta-chain/delta-chain.cabal
+++ b/lib/delta-chain/delta-chain.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.6
 build-type:         Simple
 name:               delta-chain
-version:            0.2026.4.17
+version:            0.2026.5.11
 synopsis:
   Example for storing a chain in a database, using delta types.
 

--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -1,5 +1,5 @@
 name:          delta-store
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Facility for storing a Haskell value, using delta types.
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.6
 build-type:         Simple
 name:               delta-table
-version:            0.2026.4.17
+version:            0.2026.5.11
 synopsis:           Work with database tables using delta types.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/faucet/faucet.cabal
+++ b/lib/faucet/faucet.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          faucet
-version:       2026.4.17
+version:       2026.5.11
 synopsis:      Faucet for the local Cardano cluster.
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/flaky-tests/flaky-tests.cabal
+++ b/lib/flaky-tests/flaky-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          flaky-tests
-version:       0.2026.4.17
+version:       0.2026.5.11
 description:   Mine GH Actions history for flaky test detection
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-integration
-version:       2026.4.17
+version:       2026.5.11
 synopsis:      Cardano wallet integration tests and DSL
 description:   Please see README.md
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          iohk-monitoring-extra
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Extra functionality extending the iohk monitoring package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:          cardano-wallet-launcher
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Utilities for a building commands launcher
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          local-cluster
-version:       2026.4.17
+version:       2026.5.11
 synopsis:      Local cluster of cardano nodes
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-network-layer
-version:         0.2026.4.17
+version:         0.2026.5.11
 synopsis:        Node communication layer functionality.
 
 -- description:

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-primitive
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Selected primitive types for Cardano Wallet.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-wallet-secrets
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Utilities for storing private keys and passphrases
 license:       Apache-2.0
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/std-gen-seed/std-gen-seed.cabal
+++ b/lib/std-gen-seed/std-gen-seed.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          std-gen-seed
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Support for standard random number generator seeds
 license:       Apache-2.0
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          temporary-extra
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Extra functionality extending the temporary package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:          cardano-wallet-test-utils
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Shared utilities for writing unit and property tests.
 description:   Shared utilities for writing unit and property tests.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:          text-class
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      Extra helpers to convert data-types to and from Text
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-ui
-version:         0.2026.4.17
+version:         0.2026.5.11
 synopsis:        web ui for the cardano-wallet
 license:         Apache-2.0
 license-file:    LICENSE

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.6
 name:               cardano-wallet-unit
-version:            2026.4.17
+version:            2026.5.11
 synopsis:           Cardano wallet unit tests
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          wai-middleware-logging
-version:       0.2026.4.17
+version:       0.2026.5.11
 synopsis:      WAI Middleware for Logging
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-blackbox-benchmarks
-version:       2026.4.17
+version:       2026.5.11
 synopsis:      Benchmarks for the `cardano-wallet` exectuable.
 description:
   This package is a collection of benchmarks

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.6
 name:               cardano-wallet
-version:            0.2026.4.17
+version:            0.2026.5.11
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/prototypes/light-mode-test/light-mode-test.cabal
+++ b/prototypes/light-mode-test/light-mode-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               light-mode-test
-version:            0.2026.4.17
+version:            0.2026.5.11
 synopsis:           Explore feasability of light mode
 description:
     This prototype explores whether we can implement a "light mode"

--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -24,7 +24,7 @@ fi
 source .env
 
 # Define and export wallet and node version tags
-RELEASE_WALLET_TAG=2026.4.17
+RELEASE_WALLET_TAG=2026.5.11
 
 WALLET_TAG=${WALLET_TAG:=$RELEASE_WALLET_TAG}
 export WALLET_TAG

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cardano Wallet Backend API
-  version: v2026-04-17
+  version: v2026-05-11
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/cardano-foundation/cardano-wallet/master/LICENSE


### PR DESCRIPTION
The `release-candidate/v2026-05-11` branch bumped the package version to `2026.5.11` for the v2026-05-11 release but was never merged back to master, so master is still at `2026.4.17`. This trips the cabal-version drift guard in `scripts/release/release-candidate.sh`, failing the nightly Release workflow every night since 2026-05-11 (it aborts in `prepare` before any build).

This merges the bump back. The delta vs the merge-base is 33 one-line version-string changes (`*.cabal`, `README.md`, `run/common/docker/run.sh`, `specifications/api/swagger.yaml`); `git merge-tree` reports no conflicts.