### PR TITLE
ci: probe ARC nix-enabled-runners (throwaway)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,24 @@ jobs:
         run: nix build --quiet .#devShells.x86_64-linux.default.inputDerivation
 
   # ---------------------------------------------------------------------------
+  # ARC runner probe (throwaway) — does CW's nix work on nix-enabled-runners?
+  # Self-contained, no shared store, --max-jobs 0 bounds it to a cache fetch.
+  # ---------------------------------------------------------------------------
+
+  arc-runner-probe:
+    name: "ARC runner probe (nix-enabled-runners)"
+    runs-on: nix-enabled-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Nix is present
+        run: nix --version
+      - name: Fetch CW dev shell from cache (no source build)
+        run: nix build --quiet --max-jobs 0 .#devShells.x86_64-linux.default.inputDerivation
+
+  # ---------------------------------------------------------------------------
   # Nix check
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds one isolated, throwaway job (`ARC runner probe`) on the new ARC `nix-enabled-runners` to check whether CW's nix toolchain works there — mirrors the moog runner probe (cardano-foundation/moog#212).

The job is self-contained (no shared nix store, no `needs`) and bounded with `--max-jobs 0`, so it only *fetches* CW's dev-shell closure from cache and fails fast if the ARC runner's nix.conf lacks CW's IOG substituters (rather than building GHC from source for hours).

Not for merge — delete the branch when done. All other CI jobs are untouched and run on the usual `cardano-wallet` fleet as baseline.