### PR TITLE
ci: run linux CI on nix-enabled-runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ env:
   # All runners share the same OS user, so one evaluating job blocks every other
   # nix command. Per-job XDG_CACHE_HOME eliminates the contention.
   XDG_CACHE_HOME: /tmp/nix-eval-cache/${{ github.job }}
+  # ARC nix-enabled-runners ship no UTF-8 locale, so GHC programs crash printing
+  # non-ASCII (e.g. an em-dash): "commitBuffer: invalid argument (cannot encode
+  # character)". Force a UTF-8 locale (builder-new had one).
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ env:
   # All runners share the same OS user, so one evaluating job blocks every other
   # nix command. Per-job XDG_CACHE_HOME eliminates the contention.
   XDG_CACHE_HOME: /tmp/nix-eval-cache/${{ github.job }}
-  # ARC nix-enabled-runners ship no UTF-8 locale, so GHC programs crash printing
-  # non-ASCII (e.g. an em-dash): "commitBuffer: invalid argument (cannot encode
-  # character)". Force a UTF-8 locale (builder-new had one).
-  LANG: C.UTF-8
-  LC_ALL: C.UTF-8
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Per-pod docker daemons on the ARC fleet don't share the image the
+      # `docker` job built; load it from its artifact (builder-new shared one daemon).
+      - name: Download image
+        uses: actions/download-artifact@v7
+        with:
+          name: docker-image
+          path: artifacts
+
+      - name: Load image
+        run: docker load < artifacts/docker-image.tgz
+
       - name: Run boot sync
         working-directory: ${{ matrix.dir }}
         env:
@@ -674,7 +685,9 @@ jobs:
             command: nix develop --quiet --command scripts/todo-list.sh
 
           - name: "Check HLS Works"
-            command: nix develop --quiet --command bash -c "rm -f cabal.project.local; haskell-language-server lib/wallet/src/Cardano/Wallet.hs"
+            # cabal update so HLS's cabal v2-repl cradle has the hackage/CHaP index
+            # (ephemeral pods lack the cabal home builder-new persisted).
+            command: nix develop --quiet --command bash -c "rm -f cabal.project.local; cabal update; haskell-language-server lib/wallet/src/Cardano/Wallet.hs"
 
           - name: "Check git revision"
             command: scripts/ci/git-revision.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
   build-gate:
     name: "Build Gate (Linux)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,7 +46,7 @@ jobs:
 
   build-gate-artifacts:
     name: "Build Gate (Linux Artifacts)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -61,7 +61,7 @@ jobs:
 
   build-gate-windows:
     name: "Build Gate (Windows)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
 
   build-gate-quality:
     name: "Build Gate (Dev Shell)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,7 +104,7 @@ jobs:
   nix-check:
     name: "Check Nix"
     needs: build-gate
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -120,7 +120,7 @@ jobs:
   unit-tests:
     name: ${{ matrix.name }}
     needs: build-gate
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     strategy:
       fail-fast: false
       matrix:
@@ -275,7 +275,7 @@ jobs:
   integration:
     name: "Conway Integration Tests"
     needs: build-gate
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 120
     env:
       LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
@@ -317,7 +317,7 @@ jobs:
   local-cluster:
     name: "Local Cluster Tests"
     needs: build-gate
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -349,7 +349,7 @@ jobs:
   boot-syncs:
     name: "${{ matrix.name }}"
     needs: build-gate
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -400,7 +400,7 @@ jobs:
   artifacts-package:
     name: "Build Linux Package"
     needs: build-gate-artifacts
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -419,7 +419,7 @@ jobs:
   artifacts-wallet-key-export:
     name: "Build wallet-key-export (static)"
     needs: build-gate-artifacts
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -438,7 +438,7 @@ jobs:
   artifacts-shell:
     name: "Evaluate Linux Shell"
     needs: build-gate-artifacts
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -454,7 +454,7 @@ jobs:
   docker:
     name: "Docker Image"
     needs: build-gate-artifacts
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     outputs:
       image-tag: ${{ steps.build.outputs.tag }}
     steps:
@@ -482,7 +482,7 @@ jobs:
   docker-boot-sync:
     name: "${{ matrix.name }}"
     needs: docker
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     strategy:
       fail-fast: false
       matrix:
@@ -644,7 +644,7 @@ jobs:
   quality-checks:
     name: ${{ matrix.name }}
     needs: build-gate-quality
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     strategy:
       fail-fast: false
       matrix:
@@ -691,7 +691,7 @@ jobs:
   attic-cache:
     name: "Attic Cache"
     needs: [build-gate-quality, build-gate-artifacts, build-gate-windows]
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 180
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:


### PR DESCRIPTION
Flip cardano-wallet's 16 linux `[self-hosted, …, cardano-wallet]` jobs in ci.yml to the ARC `nix-enabled-runners` fleet (macOS jobs untouched). The fleet now provides nix-in-OS + IOG substituters + a persistent shared /nix store (verified), so build-gate's output is reused by the downstream `needs: build-gate` jobs. The hard test for the runner migration.