### PR TITLE
Generate session keys with the system CSPRNG

### DIFF
--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -75,15 +75,16 @@ library common
     , containers
     , contra-tracer
     , cookie
+    , crypto-primitives
     , exceptions
     , file-embed
     , generic-lens
     , http-media
     , lens
     , lucid
+    , memory
     , mtl
     , operational
-    , random
     , servant
     , servant-server
     , string-interpolate

--- a/lib/ui/src/common/Cardano/Wallet/UI/Cookies.hs
+++ b/lib/ui/src/common/Cardano/Wallet/UI/Cookies.hs
@@ -14,11 +14,15 @@ module Cardano.Wallet.UI.Cookies
     )
 where
 
-import Control.Monad
-    ( replicateM
-    )
 import Control.Monad.IO.Class
     ( liftIO
+    )
+import Cryptography.Core
+    ( MonadRandom (getRandomBytes)
+    )
+import Data.ByteArray.Encoding
+    ( Base (Base16)
+    , convertToBase
     )
 import Data.ByteString
     ( ByteString
@@ -31,9 +35,6 @@ import Servant
     , addHeader
     , type (:>)
     )
-import System.Random
-    ( randomRIO
-    )
 import Web.Cookie
     ( Cookies
     , SetCookie (..)
@@ -42,7 +43,6 @@ import Web.Cookie
     )
 import Prelude
 
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text.Encoding as T
 
 -- | A type representing a request that may contain cookies.
@@ -104,10 +104,9 @@ withSessionRead action mc = do
             maybe createCookie (pure . SessionKey) (lookup cookieName cs)
     action c
 
--- | Create a new session key.
+-- | Create a new session key, drawing 16 bytes from the system
+-- cryptographically-secure RNG and hex-encoding them.
 createCookie :: Handler SessionKey
-createCookie =
-    liftIO
-        $ fmap (SessionKey . B8.pack)
-        $ replicateM 16
-        $ randomRIO ('a', 'z')
+createCookie = liftIO $ do
+    bytes <- getRandomBytes 16 :: IO ByteString
+    pure $ SessionKey $ convertToBase Base16 bytes


### PR DESCRIPTION
## Summary

`createCookie` built the wallet-UI session key with `replicateM 16 $ randomRIO ('a', 'z')`, drawing from the non-cryptographic, process-global `StdGen` (splitmix). splitmix is reconstructable from a short run of observed outputs, so session keys were predictable — and because the same global generator also feeds other call sites, a client-visible draw leaks the shared stream.

This draws 16 bytes from the system CSPRNG and hex-encodes them:

```haskell
createCookie :: Handler SessionKey
createCookie = liftIO $ do
    bytes <- getRandomBytes 16 :: IO ByteString
    pure $ SessionKey $ convertToBase Base16 bytes
```

128 bits of entropy from the system RNG, up from ~75 bits of predictable splitmix.

## Notes

- Uses the codebase's existing crypto idiom: `getRandomBytes` via `Cryptography.Core` (the `crypto-primitives` wrapper already used for passphrase salts in `lib/secrets`), and hex via `memory`'s `Data.ByteArray.Encoding`.
- `library common`: added `crypto-primitives` + `memory`, dropped the now-unused `random`; removed the dead `replicateM` / `randomRIO` / `Data.ByteString.Char8` imports (`-Wunused-packages` / `-Wunused-imports`).

## Verification

`nix develop` → `fourmolu` (clean), `hlint` (No hints), `cabal build cardano-wallet-ui` ✅ (exit 0, no new warnings on the UI library).

Resolves #5301. Part of the randomness-hardening epic #5304 (sibling of the merged #5298).
