### PR TITLE
Harden Byron RndState: seed from the system CSPRNG and redact the generator

### DIFF
--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
@@ -184,17 +184,17 @@ instance NFData (RndState network) where
 
 -- | There's no instance of 'Show' for 'XPrv'
 instance Show (RndState network) where
-    show (RndState _key ix addrs pending g) =
+    show (RndState _key ix addrs pending _gen) =
         unwords
-            ["RndState <xprv>", p ix, p addrs, p pending, p g]
+            ["RndState <xprv>", p ix, p addrs, p pending, "<gen>"]
       where
         p x = "(" ++ show x ++ ")"
 
 instance Buildable (RndState network) where
-    build (RndState _ ix addrs pending g) =
+    build (RndState _ ix addrs pending _) =
         "RndState:\n"
             <> indentF 4 ("Account ix:       " <> build ix)
-            <> indentF 4 ("Random Generator: " <> build (show g))
+            <> indentF 4 "Random Generator: <gen>"
             <> indentF 4 ("Known addresses:  " <> blockMapF' tupleF tupleF addrs)
             <> indentF 4 ("Change addresses: " <> blockMapF' tupleF build pending)
 

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -74,7 +74,6 @@ library
     , network-uri
     , OddWord
     , quiet
-    , random
     , safe
     , servant
     , servant-client

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -820,6 +820,7 @@ import Data.Traversable
     )
 import Data.Word
     ( Word32
+    , Word64
     )
 import Fmt
     ( pretty
@@ -847,10 +848,6 @@ import Servant
 import Servant.Server
     ( Handler (..)
     , runHandler
-    )
-import System.Random
-    ( getStdRandom
-    , random
     )
 import UnliftIO.Async
     ( race_
@@ -1708,6 +1705,15 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
             $ runExceptT
             $ W.withRootKey @s db wid mempty Prelude.id (\_ _ -> pure ())
 
+-- | A 64-bit seed for the Byron HD-random address generator, drawn from the
+-- system CSPRNG rather than the process-global 'StdGen'.
+secureSeed :: IO Int
+secureSeed = do
+    bytes <- genSalt 8
+    pure
+        $ fromIntegral
+        $ BS.foldl' (\acc w -> acc * 256 + fromIntegral w) (0 :: Word64) bytes
+
 postRandomWallet
     :: forall ctx s n
      . ( ctx ~ ApiLayer s
@@ -1717,7 +1723,7 @@ postRandomWallet
     -> ByronWalletPostData '[12, 15, 18, 21, 24]
     -> Handler ApiByronWallet
 postRandomWallet ctx body = do
-    s <- liftIO $ mkRndState rootXPrv <$> getStdRandom random
+    s <- liftIO $ mkRndState rootXPrv <$> secureSeed
     let initialState = InitialState s genesisBlock RestorationPointAtGenesis
     postLegacyWallet ctx (rootXPrv, pwd) $ \wid ->
         W.createWallet @s networkParams wid wName initialState
@@ -1739,7 +1745,7 @@ postRandomWalletFromXPrv
     -> ByronWalletFromXPrvPostData
     -> Handler ApiByronWallet
 postRandomWalletFromXPrv ctx body = do
-    s <- liftIO $ mkRndState byronKey <$> getStdRandom random
+    s <- liftIO $ mkRndState byronKey <$> secureSeed
     let initialState = InitialState s genesisBlock RestorationPointAtGenesis
     void
         $ liftHandler


### PR DESCRIPTION
## Summary

The Byron HD-random address-discovery state `RndState` carries a `gen :: StdGen` that was (a) seeded from the non-cryptographic, process-global `StdGen` at wallet creation, and (b) rendered in the clear by `Show` / `Buildable` — while the root key beside it is redacted to `<xprv>`. This is defense-in-depth hardening for both.

### Seed from the system CSPRNG

`postRandomWallet` / `postRandomWalletFromXPrv` seeded the generator with `mkRndState key <$> getStdRandom random`, drawing from the predictable global splitmix `StdGen`. They now draw the seed from the system CSPRNG:

```haskell
secureSeed :: IO Int
secureSeed = do
    bytes <- genSalt 8
    pure $ fromIntegral
        $ BS.foldl' (\acc w -> acc * 256 + fromIntegral w) (0 :: Word64) bytes
```

`genSalt` is the `crypto-primitives` wrapper over the system RNG — the same source already used for passphrase salts (`lib/secrets`). The seed accumulates in `Word64` (reduced to `Int` at the end) so the 64-bit intent is portable and doesn't lean on `Int` overflow. `mkRndState`'s `Int`-seed signature is unchanged, so the test/benchmark call sites that use fixed seeds for determinism are untouched.

### Redact the generator in `Show` / `Buildable`

`gen` is now rendered as `<gen>`, matching the existing `<xprv>` redaction, so generator state cannot reach a debug log or the pretty-printed state.

## Scope / safety

Purely defense-in-depth, touching **no persistence path**: the `rnd_state` schema, the `PersistField StdGen` codec, and the checkpoint load/save logic are untouched, so **no existing wallet database is affected and no migration is involved**. The diff is confined to `Random.hs` (rendering) and `Server.hs` (creation seed). The now-unused `random` dependency is dropped from `cardano-wallet-api`.

## Verification

`nix develop` → `fourmolu` (clean), `hlint` (No hints), `cabal build cardano-wallet-api` ✅ (exit 0, no new warnings on the changed modules).

Resolves #5300. Part of the randomness-hardening epic #5304 (sibling of the merged #5298 and #5306).
