### PR TITLE
ci: migrate docs and auto-approve workflows to nix-enabled-runners

### DIFF
--- a/.github/workflows/approve-docs.yml
+++ b/.github/workflows/approve-docs.yml
@@ -4,7 +4,7 @@ on: pull_request_target
 jobs:
   review:
     if: '${{ github.ref_protected }}'
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - uses: actions/checkout@v3.2.0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     env:
       PUBLISH_DIR: _build
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

The `Publish Docs` workflow's `docs` job is a **required check** and is currently stuck `queued` on every PR (and on master), blocking all merges.\n\n## Root cause\n\n#5305 migrated `ci.yml`'s linux jobs to the ARC `nix-enabled-runners` fleet but left two workflows on the old label set `[self-hosted, linux, x86_64, cardano-wallet]`:\n\n- `.github/workflows/publish.yml` (the required `docs` check)\n- `.github/workflows/approve-docs.yml` (Auto-Approve Docs)\n\nAll 24 `builder-new-*` runners carrying the `cardano-wallet` label are now **offline**; the only online linux/x86_64 runners carry `cardano-wallet-bench`, and the online `cardano-wallet`-labelled machines are macOS. So no runner satisfies `[self-hosted, linux, x86_64, cardano-wallet]` and the jobs queue indefinitely. The docs job last succeeded on 2026-07-02, before those builders were decommissioned.\n\n## Fix\n\nPoint both jobs at `nix-enabled-runners`, matching `ci.yml`. macOS workflows are intentionally left untouched (their runners are still online), consistent with #5305.