### PR TITLE
fix(ci): correct unit-test shard match patterns (were running 0 examples)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,79 +183,89 @@ jobs:
             command: >-
               nix shell --quiet ../../.#cardano-cli -c
               nix run --quiet ../../.#unit-cardano-wallet-unit --
-              --match "/Cardano.Byron./"
-              --match "/Cardano.CLI/"
+              --fail-on=empty
+              --match "/Cardano.Byron"
+              --match "/Cardano.CLI"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB.Sqlite + Pool"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.DB./"
-              --match "/Cardano.Pool./"
+              --fail-on=empty
+              --match "/Cardano.DB"
+              --match "/Cardano.Pool"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Address"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Address./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Address"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Api"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Api./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Api"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Balance"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Balance./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Balance"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.DB./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.DB"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Primitive"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Primitive./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Primitive"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Shelley"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Shelley"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Other Wallet"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet./"
-              --skip "/Cardano.Wallet.Address./"
-              --skip "/Cardano.Wallet.Api./"
-              --skip "/Cardano.Wallet.Balance./"
-              --skip "/Cardano.Wallet.DB./"
-              --skip "/Cardano.Wallet.Primitive./"
-              --skip "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet"
+              --skip "/Cardano.Wallet.Address"
+              --skip "/Cardano.Wallet.Api"
+              --skip "/Cardano.Wallet.Balance"
+              --skip "/Cardano.Wallet.DB"
+              --skip "/Cardano.Wallet.Primitive"
+              --skip "/Cardano.Wallet.Shelley"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Control + Data"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Control./"
-              --match "/Data./"
+              --fail-on=empty
+              --match "/Control"
+              --match "/Data"
               -j1 +RTS -M2G -s -RTS
 
     steps:

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -101,79 +101,89 @@ jobs:
             command: >-
               nix shell --quiet ../../.#cardano-cli -c
               nix run --quiet ../../.#unit-cardano-wallet-unit --
-              --match "/Cardano.Byron./"
-              --match "/Cardano.CLI/"
+              --fail-on=empty
+              --match "/Cardano.Byron"
+              --match "/Cardano.CLI"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB.Sqlite + Pool"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.DB./"
-              --match "/Cardano.Pool./"
+              --fail-on=empty
+              --match "/Cardano.DB"
+              --match "/Cardano.Pool"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Address"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Address./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Address"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Api"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Api./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Api"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Balance"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Balance./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Balance"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / DB"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.DB./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.DB"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Primitive"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Primitive./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Primitive"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Shelley"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Shelley"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Other Wallet"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Cardano.Wallet./"
-              --skip "/Cardano.Wallet.Address./"
-              --skip "/Cardano.Wallet.Api./"
-              --skip "/Cardano.Wallet.Balance./"
-              --skip "/Cardano.Wallet.DB./"
-              --skip "/Cardano.Wallet.Primitive./"
-              --skip "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet"
+              --skip "/Cardano.Wallet.Address"
+              --skip "/Cardano.Wallet.Api"
+              --skip "/Cardano.Wallet.Balance"
+              --skip "/Cardano.Wallet.DB"
+              --skip "/Cardano.Wallet.Primitive"
+              --skip "/Cardano.Wallet.Shelley"
               -j1 +RTS -M2G -s -RTS
 
           - name: "wallet-unit / Control + Data"
             command: >-
               nix shell --quiet .#cardano-cli -c
               nix run --quiet .#unit-cardano-wallet-unit --
-              --match "/Control./"
-              --match "/Data./"
+              --fail-on=empty
+              --match "/Control"
+              --match "/Data"
               -j1 +RTS -M2G -s -RTS
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -110,79 +110,89 @@ jobs:
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Byron./"
-              --match "/Cardano.CLI/"
+              --fail-on=empty
+              --match "/Cardano.Byron"
+              --match "/Cardano.CLI"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / DB.Sqlite + Pool"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.DB./"
-              --match "/Cardano.Pool./"
+              --fail-on=empty
+              --match "/Cardano.DB"
+              --match "/Cardano.Pool"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Address"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.Address./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Address"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Api"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.Api./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Api"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Balance"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.Balance./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Balance"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / DB"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.DB./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.DB"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Primitive"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.Primitive./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Primitive"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Shelley"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet.Shelley"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Other Wallet"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Cardano.Wallet./"
-              --skip "/Cardano.Wallet.Address./"
-              --skip "/Cardano.Wallet.Api./"
-              --skip "/Cardano.Wallet.Balance./"
-              --skip "/Cardano.Wallet.DB./"
-              --skip "/Cardano.Wallet.Primitive./"
-              --skip "/Cardano.Wallet.Shelley./"
+              --fail-on=empty
+              --match "/Cardano.Wallet"
+              --skip "/Cardano.Wallet.Address"
+              --skip "/Cardano.Wallet.Api"
+              --skip "/Cardano.Wallet.Balance"
+              --skip "/Cardano.Wallet.DB"
+              --skip "/Cardano.Wallet.Primitive"
+              --skip "/Cardano.Wallet.Shelley"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           - name: "wallet-unit / Control + Data"
             artifact: win-test-wallet-unit
             command: >-
               .\unit.exe
-              --match "/Control./"
-              --match "/Data./"
+              --fail-on=empty
+              --match "/Control"
+              --match "/Data"
               --color -j1 +RTS -M2G -s -N2 -RTS
 
           # --- standalone suites (test.exe) ---


### PR DESCRIPTION
## Problem

The `wallet-unit` CI matrix shards the unit suite with hspec `--match` filters
like `--match "/Cardano.Wallet.Api./"`. hspec matches a substring of the
`/`-joined example path, whose top-level nodes are the full dotted module names
(e.g. `Cardano.Wallet.Api`, `Cardano.Wallet.Api.Server`). The trailing `./`
never occurs in a path, so these filters select **0 examples** — and hspec
exits 0 on an empty match, so the shard goes **green having run nothing**.

Measured on the built unit binary, 9 of the 10 unit shards ran zero tests:

| Shard | old pattern | examples |
|---|---|---|
| Api | `/Cardano.Wallet.Api./` | 0 |
| Balance | `/Cardano.Wallet.Balance./` | 0 |
| Shelley | `/Cardano.Wallet.Shelley./` | 0 |
| Address | `/Cardano.Wallet.Address./` | 0 |
| Primitive | `/Cardano.Wallet.Primitive./` | 0 |
| DB | `/Cardano.Wallet.DB./` | 0 |
| DB.Sqlite + Pool | `/Cardano.DB./`, `/Cardano.Pool./` | 0 |
| Other Wallet | `/Cardano.Wallet./` + skips | 0 |
| Control + Data | `/Control./`, `/Data./` | 0 |
| Byron + CLI | `/Cardano.Byron./`, `/Cardano.CLI/` | 75 (only the `/Cardano.CLI/` node matched) |

The patterns were introduced on 2026-02-09; the unit suite has therefore been
effectively unrun in CI since, across four releases (v2026-03-31, v2026-04-03,
v2026-04-17, v2026-05-11).

## Fix

- Rewrite every shard pattern to prefix form: `/Cardano.Wallet.Api./` →
  `/Cardano.Wallet.Api`. A leading-slash prefix matches the module node and its
  submodules (`Cardano.Wallet.Api`, `Cardano.Wallet.Api.Server`, …).
- Add `--fail-on=empty` to every shard, so a filter that matches nothing fails
  the shard loudly instead of passing vacuously. This prevents a silent
  recurrence.

Applied consistently to `ci.yml`, `macos-unit-tests.yml`, and `windows.yml`.

## Verification

Ran each corrected pattern against the built unit binary. The shards now
**partition** the 4079-example suite — per-shard counts sum to 4080 (one
trivial overlap, no gaps):

| Shard | examples |
|---|---|
| Api | 3003 |
| Control + Data | 261 |
| Primitive | 259 |
| DB | 139 |
| Address | 99 |
| Byron + CLI | 82 |
| DB.Sqlite + Pool | 81 |
| Shelley | 79 |
| Other Wallet | 63 |
| Balance | 14 |

`--fail-on=empty` was confirmed to exit non-zero on an empty match.

## Note

Turning the unit suite back on will surface pre-existing unit failures that
accumulated while CI was blind (era-naming and metadata-rendering fixture drift,
etc.). Those are tracked separately; this PR is only the CI-visibility fix.
