### PR TITLE
test: retry pool-list check after epoch-3 retirement in STAKE_POOLS_JOIN_03

### DIFF
--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -862,9 +862,10 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_JOIN_03 - Cannot join a pool that has retired" $ \ctx -> runResourceT $ do
         waitForEpoch 3 ctx -- One pool retires at epoch 3
-        response <- listPools ctx arbitraryStake
-        verify response [expectListSize 3]
-        let nonRetiredPoolIds = Set.fromList (view #id <$> getResponse response)
+        nonRetiredPoolIds <- eventually "One of the pools should retire." $ do
+            response <- listPools ctx arbitraryStake
+            verify response [expectListSize 3]
+            pure $ Set.fromList (view #id <$> getResponse response)
         let reportError =
                 error
                     $ unlines


### PR DESCRIPTION
## Problem

`STAKE_POOLS_JOIN_03` was the only test in its dependent group that asserted on `listPools` *immediately* after `waitForEpoch 3`, with no retry margin:

```haskell
waitForEpoch 3 ctx -- One pool retires at epoch 3
response <- listPools ctx arbitraryStake
verify response [expectListSize 3]
```

`waitForEpoch` sleeps for exactly the computed slot-time delta to the epoch boundary and only checks the node's tip epoch — it does not account for the wallet backend's own lag in recomputing the stake-pool list after the epoch turns over. Every sibling test that depends on the same retiring pool (`STAKE_POOLS_JOIN_UNSIGNED_01/02/03`, `STAKE_POOLS_LIST_01`) instead polls with `eventually "..." $ ...` (90s timeout) — the pattern this test should have used but didn't.

This is the root cause behind the same 8 `SHELLEY_STAKE_POOLS` tests intermittently failing together in CI (see #5317) — they all depend on the one test-cluster pool configured to retire at epoch 3, and this test's zero-margin check is the weakest link.

## Fix

Wrap the check in `eventually`, matching the sibling tests already in this file:

```haskell
waitForEpoch 3 ctx -- One pool retires at epoch 3
nonRetiredPoolIds <- eventually "One of the pools should retire." $ do
    response <- listPools ctx arbitraryStake
    verify response [expectListSize 3]
    pure $ Set.fromList (view #id <$> getResponse response)
```

4 lines changed, one file.

Fixes #5317

## Verification

Local `cabal build integration` in this worktree currently fails on an unrelated, pre-existing issue: `cardano-wallet-read`'s `Shelley.hs:177` hits a `PaymentCredential` deprecation-as-error. This reproduces even after a full clean rebuild (`dist-newstyle` wiped) and is **not** caused by this change — the identical source builds fine on the existing pristine `master` checkout, so something in how this worktree's nix shell resolved the CHaP/`cardano-ledger-core` snapshot differs from the cached one, despite an identical `flake.lock`. That's a separate environment issue worth its own investigation; CI's packaged nix build is the real verification gate here.
