### PR TITLE
Update Mithril client image to the IntersectMBO container registry

### DIFF
--- a/run/common/docker/docker-compose.yml
+++ b/run/common/docker/docker-compose.yml
@@ -52,7 +52,7 @@ services:
   mithril:
     env_file:
       - .env
-    image: ghcr.io/input-output-hk/mithril-client:main-16c4ecf
+    image: ghcr.io/intersectmbo/mithril-client:2617.0-2478748
     user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ${NODE_DB}:/app/db

--- a/run/mainnet/docker/docker-compose.yml
+++ b/run/mainnet/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   mithril:
     env_file:
       - .env
-    image: ghcr.io/input-output-hk/mithril-client:main-16c4ecf
+    image: ghcr.io/intersectmbo/mithril-client:2617.0-2478748
     user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ${NODE_DB}:/app/db


### PR DESCRIPTION
This PR adapts the Mithril image to the container registry move to `IntersectMBO`:
- Repoints the `mithril` service image in `run/common/docker/docker-compose.yml` and `run/mainnet/docker/docker-compose.yml` from the frozen pin `ghcr.io/input-output-hk/mithril-client:main-16c4ecf` to `ghcr.io/intersectmbo/mithril-client:2617.0-2478748` (the latest stable release; the old `main-16c4ecf` build is not published under the new namespace). Use `:unstable` to track the tip of `main`, or `:latest` for the latest stable release, if you prefer a moving tag.