### PR TITLE
ci: update all remaining linux workflow jobs to nix-enabled-runners

### DIFF
--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: "Build wallet and node"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -24,7 +24,7 @@ jobs:
   mithril-sync:
     name: "Mainnet Boot Sync with Mithril"
     needs: build
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 250
     env:
       SUCCESS_STATUS: ready

--- a/.github/workflows/local-cluster-stress.yml
+++ b/.github/workflows/local-cluster-stress.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   local-cluster:
     name: "Local Cluster Run ${{ matrix.run }}"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
     # Skip for prereleases (nightly/test are published as prereleases and
     # already had their docker image pushed by release.yml).
     if: ${{ !github.event.release.prerelease }}
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: ${{ github.event.release.tag_name }}
@@ -52,7 +52,7 @@ jobs:
   update-docs:
     name: "Update Documentation Links"
     if: ${{ !github.event.release.prerelease }}
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   verify-linux:
     name: "Verify Linux"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Download and verify
         shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
@@ -156,7 +156,7 @@ jobs:
 
   verify-docker:
     name: "Verify Docker Image"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Download and verify
         shell: nix shell --quiet nixpkgs#gh -c bash -e {0}

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build-e2e:
     name: "Build E2E Bundle (Windows)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-release:
     name: "Build Release Package (Windows)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs:
 
   build-gate-win-tests:
     name: "Build Gate (Windows Tests)"
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,7 +60,7 @@ jobs:
   upload-win-test:
     name: "Upload ${{ matrix.name }}"
     needs: build-gate-win-tests
-    runs-on: [self-hosted, linux, x86_64, cardano-wallet]
+    runs-on: nix-enabled-runners
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

Several workflow jobs across the repository still targeted the stale runner label `[self-hosted, linux, x86_64, cardano-wallet]` (which has no matching online runners), causing them to stay stuck in `queued` indefinitely:

- `verify-release.yml` (`verify-linux`, `verify-docker`) — caused downstream asset verification in release pipelines to queue forever.
- `publish-release.yml` (`push-docker`, `update-docs`)
- `windows.yml` (`build-release`, `build-gate-win-tests`, `upload-win-test`)
- `windows-e2e.yml` (`build-e2e`)
- `linux-mithril-sync.yml` (`build`, `mithril-sync`)
- `local-cluster-stress.yml` (`local-cluster`)

## Fix

Point all remaining linux jobs in these workflows to `nix-enabled-runners`, matching `ci.yml` and `release.yml`.