### PR TITLE
ci(windows): local-cluster smoke instead of preprod e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           .#ci.artifacts.win64.tests.delta-types
           .#ci.artifacts.win64.tests.std-gen-seed
           .#ci.artifacts.win64.tests.wai-middleware-logging
+          .#ci.artifacts.win64.integration
 
   build-gate-quality:
     name: "Build Gate (Dev Shell)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,9 @@ jobs:
           fetch-depth: 0
 
       - name: Cross-compile Windows E2E bundle
-        run: nix build --quiet .#ci.artifacts.win64.e2e -o result
+        # Local-cluster integration smoke (not preprod): short gate for
+        # Windows wallet/node/cli binaries. Preprod E2E stays on Linux.
+        run: nix build --quiet .#ci.artifacts.win64.integration -o result
 
       - name: Upload E2E bundle
         uses: actions/upload-artifact@v7
@@ -303,7 +305,8 @@ jobs:
     if: inputs.release_type == 'release'
     needs: [prepare, build-e2e-windows]
     runs-on: windows-2025-vs2026
-    timeout-minutes: 240
+    # Local-cluster boot + one API scenario (not preprod cold sync).
+    timeout-minutes: 45
     steps:
       - name: Download E2E bundle
         uses: actions/download-artifact@v8
@@ -311,11 +314,18 @@ jobs:
           name: win-e2e
           path: e2e-bundle/
 
-      - name: Run E2E tests
+      - name: Run Windows smoke (create wallet + single tx)
         working-directory: e2e-bundle
         env:
-          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
-        run: .\e2e.exe
+          LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
+          CARDANO_WALLET_TEST_DATA: test\data
+        shell: pwsh
+        run: |
+          $env:PATH = "$(Get-Location);$env:PATH"
+          .\integration.exe `
+            --fail-on=empty `
+            --match "TRANS_CREATE_01x - Single Output Transaction" `
+            -j1
 
   create-release:
     name: "Create ${{ inputs.release_type || 'nightly' }} Release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Download E2E bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: win-e2e
           path: e2e-bundle/

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -18,7 +18,8 @@ jobs:
           fetch-depth: 0
 
       - name: Cross-compile Windows E2E bundle
-        run: nix build --quiet .#ci.artifacts.win64.e2e -o result
+        # Local-cluster integration smoke (not preprod).
+        run: nix build --quiet .#ci.artifacts.win64.integration -o result
 
       - name: Upload E2E bundle
         uses: actions/upload-artifact@v7
@@ -30,21 +31,23 @@ jobs:
     name: "Windows E2E Tests"
     needs: build-e2e
     runs-on: windows-2025-vs2026
-    timeout-minutes: 120
+    timeout-minutes: 45
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Download E2E bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: win-e2e
           path: e2e-bundle
 
-      - name: Run E2E tests
+      - name: Run Windows smoke (create wallet + single tx)
         working-directory: e2e-bundle
         env:
-          HAL_E2E_PREPROD_MNEMONICS: ${{ secrets.HAL_E2E_PREPROD_MNEMONICS }}
-        run: .\e2e.exe
+          LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
+          CARDANO_WALLET_TEST_DATA: test\data
+        shell: pwsh
+        run: |
+          $env:PATH = "$(Get-Location);$env:PATH"
+          .\integration.exe `
+            --fail-on=empty `
+            --match "TRANS_CREATE_01x - Single Output Transaction" `
+            -j1

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Download E2E bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: win-e2e
           path: e2e-bundle

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,52 @@ jobs:
           .#ci.artifacts.win64.tests.delta-types
           .#ci.artifacts.win64.tests.std-gen-seed
           .#ci.artifacts.win64.tests.wai-middleware-logging
+          .#ci.artifacts.win64.integration
+
+  # Local-cluster smoke: one API scenario (create + single tx) against the
+  # cross-compiled Windows wallet/node/cli. Preprod E2E remains Linux-only.
+  build-integration-smoke:
+    name: "Build Integration Smoke (Windows)"
+    runs-on: nix-enabled-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cross-compile Windows integration smoke bundle
+        run: nix build --quiet .#ci.artifacts.win64.integration -o result
+
+      - name: Upload smoke bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: win-integration-smoke
+          path: result/
+
+  integration-smoke:
+    name: "Integration Smoke"
+    needs: build-integration-smoke
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 45
+    steps:
+      - name: Download smoke bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: win-integration-smoke
+          path: smoke-bundle
+
+      - name: Run TRANS_CREATE_01x on local cluster
+        working-directory: smoke-bundle
+        env:
+          LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
+          CARDANO_WALLET_TEST_DATA: test\data
+        shell: pwsh
+        run: |
+          $env:PATH = "$(Get-Location);$env:PATH"
+          .\integration.exe `
+            --fail-on=empty `
+            --match "TRANS_CREATE_01x - Single Output Transaction" `
+            -j1
 
   upload-win-test:
     name: "Upload ${{ matrix.name }}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Download smoke bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: win-integration-smoke
           path: smoke-bundle

--- a/flake.nix
+++ b/flake.nix
@@ -523,7 +523,10 @@
                     inherit pkgs;
                     name = "integration";
                     test = windowsPackages.unit-cardano-wallet-integration;
+                    # integration harness spawns local-cluster, which in turn
+                    # launches wallet/node/cli from PATH.
                     extraPkgs = [
+                      windowsPackages.local-cluster
                       windowsPackages.cardano-wallet
                       windowsPackages.cardano-node
                       windowsPackages.cardano-cli

--- a/flake.nix
+++ b/flake.nix
@@ -314,6 +314,8 @@
 
                 # Unit test executables (for running with custom RTS flags)
                 unit-cardano-wallet-unit = project.hsPkgs.cardano-wallet-unit.components.tests.unit;
+                unit-cardano-wallet-integration =
+                  project.hsPkgs.cardano-wallet-integration.components.tests.integration;
                 unit-cardano-wallet-primitive = project.hsPkgs.cardano-wallet-primitive.components.tests.test;
                 unit-cardano-wallet-secrets = project.hsPkgs.cardano-wallet-secrets.components.tests.test;
                 unit-cardano-wallet-network-layer =
@@ -515,6 +517,22 @@
                       std-gen-seed = mkTest "std-gen-seed" windowsPackages.unit-std-gen-seed;
                       wai-middleware-logging = mkTest "wai-middleware-logging" windowsPackages.unit-wai-middleware-logging;
                     };
+                  # Local-cluster integration bundle for a short Windows smoke
+                  # (single-test match in windows.yml, release, windows-e2e).
+                  integration = import ./nix/windows-test-exe.nix {
+                    inherit pkgs;
+                    name = "integration";
+                    test = windowsPackages.unit-cardano-wallet-integration;
+                    extraPkgs = [
+                      windowsPackages.cardano-wallet
+                      windowsPackages.cardano-node
+                      windowsPackages.cardano-cli
+                    ];
+                    testDataDirs = [
+                      ./lib/local-cluster/test/data
+                      ./lib/integration/test/data
+                    ];
+                  };
                   e2e = import ./nix/windows-test-exe.nix {
                     inherit pkgs;
                     name = "e2e";

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -7,7 +7,9 @@ import Cardano.BM.ToTextTracer
     , withToTextTracer
     )
 import Cardano.Launcher.Node
-    ( nodeSocketFile
+    ( isWindows
+    , mkWindowsPipeName
+    , nodeSocketFile
     )
 import Cardano.Startup
     ( installSignalHandlers
@@ -79,6 +81,9 @@ import System.Directory
     )
 import System.Environment.Extended
     ( isEnvSet
+    )
+import System.FilePath
+    ( takeFileName
     )
 import System.IO
     ( BufferMode (NoBuffering)
@@ -274,11 +279,25 @@ main = withUtf8 $ do
 
         debug "Creating cluster configuration"
         clusterCfg <- do
-            -- ATM, only unix is supported
-            socketPath <- fmap UnixPipe $ case nodeToClientSocket of
-                Just path -> pure path
-                Nothing ->
-                    FileOf . absFile <$> ContT withTempFile
+            -- Windows needs a named pipe (\\.\pipe\...); Unix uses a socket file.
+            socketPath <- case nodeToClientSocket of
+                Just path
+                    | isWindows ->
+                        pure
+                            $ WindowsPipe
+                            $ mkWindowsPipeName
+                            $ takeFileName
+                            $ toFilePath
+                            $ absFileOf path
+                    | otherwise -> pure $ UnixPipe path
+                Nothing
+                    | isWindows -> do
+                        -- Unique basename only; cardano-node CreateNamedPipe
+                        -- rejects filesystem paths.
+                        tmp <- ContT withTempFile
+                        pure $ WindowsPipe $ mkWindowsPipeName $ takeFileName tmp
+                    | otherwise ->
+                        UnixPipe . FileOf . absFile <$> ContT withTempFile
             clusterEra <- liftIO Cluster.clusterEraFromEnv
             cfgNodeLogging <-
                 liftIO

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -211,6 +211,7 @@ executable local-cluster
     , contra-tracer
     , directory
     , extra
+    , filepath
     , iohk-monitoring-extra
     , lens
     , local-cluster


### PR DESCRIPTION
## Summary

Windows preprod E2E was blocking releases: Mithril + full wallet sync timed out after ~2h at ~57% (`setupPreprodWallets: all wallets are synced`, 5400s).

Replace it with a **local-cluster smoke**: one API test (`TRANS_CREATE_01x - Single Output Transaction`) against the cross-compiled Windows wallet/node/cli.

### Where it runs

| Path | Behavior |
|------|----------|
| **Windows CI** (`windows.yml`, master push) | new **Integration Smoke** job (primary) |
| **CI Build Gate (Windows)** | builds `.#ci.artifacts.win64.integration` on PRs |
| **Release** `e2e-windows` | same smoke, 45m timeout (was preprod 240m) |
| **workflow_dispatch** `windows-e2e.yml` | same smoke |

Linux preprod `e2e` is unchanged (real-network release gate).

### Bundle

`ci.artifacts.win64.integration`: `integration.exe` + wallet/node/cli + local-cluster configs + integration test data.

## Test plan

- [ ] PR CI: Build Gate (Windows) includes integration artifact
- [ ] After merge to master: Windows workflow **Integration Smoke** green
- [ ] Optional: `workflow_dispatch` Windows E2E Tests
- [ ] Next release: e2e-windows finishes in tens of minutes, not hours