### PR TITLE
chore(release): drop fixed items from Known Issues template

### DIFF
--- a/scripts/release/release-template.md
+++ b/scripts/release/release-template.md
@@ -25,8 +25,8 @@ $API_CHANGES
 
 ## Known Issues
 
-* (ADP-2635) Database connections do not seem to gracefully terminate on stopping the wallet.
-* (ADP-2298) `Deposit_returned` is falsely reported on some incoming transactions (intermittently).
+* ([#5326](https://github.com/cardano-foundation/cardano-wallet/issues/5326)) (ADP-2635) Database connections do not seem to gracefully terminate on stopping the wallet.
+* ([#5325](https://github.com/cardano-foundation/cardano-wallet/issues/5325)) (ADP-2298) `Deposit_returned` is falsely reported on some incoming transactions (intermittently).
 
 ## Signatures
 

--- a/scripts/release/release-template.md
+++ b/scripts/release/release-template.md
@@ -25,10 +25,8 @@ $API_CHANGES
 
 ## Known Issues
 
-* (ADP-2953) Revision of `cardano-node` is not reported within version in release bundle binary for Windows.
 * (ADP-2635) Database connections do not seem to gracefully terminate on stopping the wallet.
 * (ADP-2298) `Deposit_returned` is falsely reported on some incoming transactions (intermittently).
-* (ADP-1831) `cardano-wallet` version from docker image does not report revision.
 
 ## Signatures
 


### PR DESCRIPTION
## Summary

- Remove ADP-2953 and ADP-1831 from the release Known Issues template — both are fixed.

## Evidence

- **ADP-2953** (Windows binary doesn't report `cardano-node` revision) and **ADP-1831** (Docker image doesn't report revision): both stamp the git revision via `nix/set-git-rev` on the same code path across Linux/macOS/Windows/Docker since ec300fe475. Verified directly against the published `v2026-07-23` Windows exe and Docker image — both correctly report commit `724be55dc66cf67bc4427e8f1a9657a9d1d33d71`.
- **ADP-2635** and **ADP-2298** are still reproducible in current code (per-wallet worker threads aren't drained on shutdown; `deposit_returned` classification is a numeric-coincidence heuristic) and stay in the list.

## Test plan

- [x] Diffed template render mentally against last two releases
- [x] Confirmed fix commit and live binary/image evidence for the two removed items