### PR TITLE
chore(ci): bump deprecated actions to current majors

### DIFF
--- a/.github/workflows/approve-docs.yml
+++ b/.github/workflows/approve-docs.yml
@@ -6,7 +6,7 @@ jobs:
     if: '${{ github.ref_protected }}'
     runs-on: nix-enabled-runners
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v6
 
       - name: 'Check scope of PR'
         run: './scripts/gh/check-scope.sh scope'

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: '📥 Checkout repository'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: ✏️ Set up Lean
       run: |

--- a/.github/workflows/linux-benchmarks.yml
+++ b/.github/workflows/linux-benchmarks.yml
@@ -124,7 +124,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download current run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: current-run-artifacts
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v6
 
       - name: "❄ Install Nix"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -299,7 +299,7 @@ jobs:
 
     steps:
       - name: Download test artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.artifact }}
           path: test-bundle


### PR DESCRIPTION
## Summary

Bump the last Node-20-targeted action pins in the repo, which emit deprecation warnings on every CI run:

| File | Change |
|---|---|
| `windows.yml` | `actions/download-artifact@v4` → `@v8` |
| `linux-benchmarks.yml` | `actions/download-artifact@v4` → `@v8` |
| `lean.yml` | `actions/checkout@v3` → `@v6` |
| `approve-docs.yml` | `actions/checkout@v3.2.0` → `@v6` |
| `publish.yml` | `actions/checkout@v3.2.0` → `@v6` |

All other workflows already use `checkout@v6`, `upload-artifact@v7`, and `download-artifact@v7`/`v8`.

The transitive Node runtime deprecation noise (`Buffer()`, `punycode`) should also disappear with these bumps.

Closes #5333

Golden-sample warning investigation split out to #5334.