### PR TITLE
ci(mithril): run nightly instead of on every master push

### DIFF
--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -1,8 +1,8 @@
 name: Linux Mithril Sync
 
 on:
-  push:
-    branches: [master]
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Mithril Sync (`linux-mithril-sync.yml`) triggered on every push to master. The mainnet sync takes up to ~4h, but master pushes land more often than that, and `cancel-in-progress: true` kills the in-flight run every time — so the workflow almost never completes and gives no real green/red signal.

Switched the trigger from `push: master` to a nightly schedule (02:00 UTC) plus `workflow_dispatch` for manual runs. Concurrency group/cancel-in-progress left as-is (still useful if a manual dispatch overlaps the nightly run).