### PR TITLE
fix(ci): run Linux E2E on push to master

### DIFF
--- a/.github/workflows/linux-e2e.yml
+++ b/.github/workflows/linux-e2e.yml
@@ -1,6 +1,8 @@
 name: Linux E2E Tests
 
 on:
+  push:
+    branches: [master]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Closes #5337.

`linux-e2e.yml` was `workflow_dispatch`-only, so the README's "Linux E2E" badge (which reads the latest run on `branch=master`) was frozen on a failure from 2026-02-17 — the suite itself passes, dispatches just weren't targeted at `master`. Adds `push: branches: [master]`, matching the existing convention on `macos-unit-tests.yml`, `windows.yml`, `linux-benchmarks.yml`, and `linux-mithril-sync.yml`.