### PR TITLE
fix: persist macOS Nix eval caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,8 @@ jobs:
   build-gate-mac:
     name: "Build Gate (macOS)"
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -597,6 +599,8 @@ jobs:
     name: "Check Nix (macOS)"
     needs: build-gate-mac
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -611,6 +615,8 @@ jobs:
     name: "Local Cluster Tests (macOS)"
     needs: build-gate-mac
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -638,6 +644,8 @@ jobs:
     name: "Build Package (macOS, x86_64)"
     needs: build-gate-mac
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -655,6 +663,8 @@ jobs:
     name: "Build Package (macOS, arm64)"
     needs: build-gate-mac
     runs-on: [self-hosted, macOS, ARM64, cardano-wallet]
+    env:
+      XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/macos-boot-sync.yml
+++ b/.github/workflows/macos-boot-sync.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  XDG_CACHE_HOME: /tmp/nix-eval-cache/${{ github.job }}
+  XDG_CACHE_HOME: /Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}
 
 jobs:
   boot-syncs:

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+
+nix run --accept-flake-config nixpkgs#actionlint -- \
+  -ignore 'label ".+" is unknown' \
+  .github/workflows/ci.yml \
+  .github/workflows/macos-boot-sync.yml
+
+nix develop --quiet --command scripts/ci/check-code-format.sh
+nix develop --quiet --command bash -c 'hlint lib'
+
+nix build --quiet \
+  .#cardano-wallet .#cardano-node .#cardano-cli \
+  .#local-cluster .#integration-exe .#test-local-cluster-exe \
+  .#unit-cardano-wallet-unit .#unit-cardano-numeric \
+  .#unit-cardano-wallet-primitive \
+  .#unit-cardano-wallet-secrets .#unit-cardano-wallet-test-utils \
+  .#unit-cardano-wallet-launcher .#unit-cardano-wallet-network-layer \
+  .#unit-cardano-wallet-application-tls .#unit-cardano-wallet-blackbox-benchmarks \
+  .#unit-delta-chain .#unit-delta-store .#unit-delta-table \
+  .#unit-delta-types .#unit-std-gen-seed .#unit-wai-middleware-logging \
+  .#unit-benchmark-history \
+  .#wallet-key-export .#wallet-key-export-test

--- a/specs/5242-macos-nix-eval-cache/plan.md
+++ b/specs/5242-macos-nix-eval-cache/plan.md
@@ -1,0 +1,26 @@
+# Plan
+
+## Scope
+
+This is one vertical, bisect-safe implementation slice. It changes only:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/macos-boot-sync.yml`
+
+## Slice 1: persist macOS evaluation caches
+
+Add a job-level `env` override to each of the five macOS jobs in `ci.yml`.
+Change the boot-sync workflow's macOS-only workflow-level value. Use the runner
+account's persistent cache directory and keep `${{ github.job }}` isolation to
+avoid reintroducing cross-job SQLite lock contention.
+
+Proof consists of:
+
+1. a focused checker observed failing on the base files;
+2. the same checker passing on the edited files;
+3. Actionlint, formatting, HLint, and the Nix build gate passing locally;
+4. three consecutive successful live macOS build-gate runs without the
+   reported repository error.
+
+No runner provisioning, cache migration, cleanup command, Nix expression, or
+non-macOS workflow behavior is in scope.

--- a/specs/5242-macos-nix-eval-cache/spec.md
+++ b/specs/5242-macos-nix-eval-cache/spec.md
@@ -1,0 +1,28 @@
+# Issue #5242: persistent macOS Nix evaluation caches
+
+## User story
+
+As a maintainer, I want macOS CI to retain its Nix evaluation cache outside
+`/tmp` so periodic operating-system cleanup cannot corrupt the cache's bare Git
+repository and make otherwise-correct builds fail.
+
+## Requirements
+
+- FR1: Every macOS job in `.github/workflows/ci.yml` overrides
+  `XDG_CACHE_HOME` with
+  `/Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}`.
+- FR2: `.github/workflows/macos-boot-sync.yml` uses the same persistent,
+  per-job cache root.
+- FR3: The workflow-level Linux cache root in `.github/workflows/ci.yml`
+  remains `/tmp/nix-eval-cache/${{ github.job }}`.
+- FR4: Workflow syntax remains valid.
+
+## Acceptance
+
+- A focused checker must fail against the original workflow state and pass
+  after the change.
+- Actionlint must pass for both affected workflow files, allowing the
+  repository's custom runner labels.
+- The full local gate must pass before push.
+- `Build Gate (macOS)` must complete successfully for three consecutive
+  branch runs with no `could not find repository` error for `tarball-cache`.

--- a/specs/5242-macos-nix-eval-cache/tasks.md
+++ b/specs/5242-macos-nix-eval-cache/tasks.md
@@ -2,6 +2,6 @@
 
 ## Slice 1: persist macOS evaluation caches
 
-- [ ] T5242 Update the two macOS workflow cache configurations, demonstrate
+- [X] T5242 Update the two macOS workflow cache configurations, demonstrate
   RED then GREEN with the focused checker, pass the full local gate, and commit
   as `fix(ci): persist macOS Nix eval caches`.

--- a/specs/5242-macos-nix-eval-cache/tasks.md
+++ b/specs/5242-macos-nix-eval-cache/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+## Slice 1: persist macOS evaluation caches
+
+- [ ] T5242 Update the two macOS workflow cache configurations, demonstrate
+  RED then GREEN with the focused checker, pass the full local gate, and commit
+  as `fix(ci): persist macOS Nix eval caches`.


### PR DESCRIPTION
Moves the macOS Nix evaluation cache away from `/tmp`, where periodic cleanup
can corrupt the cache's bare Git repository.

The change keeps Linux cache behavior unchanged, gives every macOS CI job a
persistent per-job cache directory, and covers the separate macOS boot-sync
workflow.

Closes #5242

## Verification

The implementation landed as one reviewed slice. A focused structural checker
was demonstrated failing on the old workflows and passing after the change.
Its negative controls cover missing jobs, misplaced workflow-level overrides,
changes to the Linux cache root, additional macOS jobs, boot-sync regression,
and loss of per-job isolation.

The final local gate passed Actionlint, Fourmolu, cabal-fmt, Nixfmt, HLint,
and the Linux CI build-gate derivations. The current CI run is
https://github.com/cardano-foundation/cardano-wallet/actions/runs/30432340981.

The live acceptance criterion—three consecutive successful macOS build-gate
runs with cache reuse and no `tarball-cache` repository error—is now being
collected (0 of 3 confirmed).

## Technical contract / evidence

- Base: `master`
- Workflow files in scope: `.github/workflows/ci.yml` and
  `.github/workflows/macos-boot-sync.yml`
- Linux workflow-level cache setting remains unchanged.
- macOS jobs receive a persistent
  `/Users/gha-runner/.cache/nix-eval-cache/${{ github.job }}` override.
- Current implementation commit: `0877ddb08936251a981141b8fb44247ac071d23c`
- Local focused check: old state exits 1 with seven failures; new state exits
  0 with all 27 assertions passing.
