### PR TITLE
fix: make depositReturned certificate-aware instead of a numeric heuristic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ cabal.project.local
 
 # Local CI gate script
 gate.sh
+/gate.sh

--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,3 @@ cabal.project.local
 
 # Local CI gate script
 gate.sh
-/gate.sh

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -5357,13 +5357,14 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
     expRef <-
         liftIO $ traverse makeApiSlotReference' (tx ^. #txMeta . #expiry)
     parsedValues <- traverse parseTxCBOR $ tx ^. #txCBOR
+    rewardAcctM <- case parsedValues of
+        Nothing -> pure Nothing
+        Just _
+            | hasDelegation (Proxy @s) ->
+                readRewardAccount db (keyFlavorFromState @s)
+            | otherwise -> pure Nothing
     parsedCertificates <-
-        if hasDelegation (Proxy @s)
-            then
-                traverse
-                    (getApiAnyCertificates db (keyFlavorFromState @s))
-                    parsedValues
-            else pure Nothing
+        traverse (getApiAnyCertificates rewardAcctM) parsedValues
     parsedMintBurn <-
         forM parsedValues
             $ getTxApiAssetMintBurn wrk
@@ -5375,7 +5376,8 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
             , amount = ApiAmount.fromCoin $ tx ^. #txMeta . #amount
             , fee = maybe mempty ApiAmount.fromCoin (tx ^. #txFee)
             , depositTaken = ApiAmount depositIfAny
-            , depositReturned = ApiAmount $ reclaimIfAny parsedValues
+            , depositReturned =
+                ApiAmount $ reclaimIfAny (fst <$> rewardAcctM) parsedValues
             , insertedAt = Nothing
             , pendingSince = Nothing
             , expiresAt = expRef
@@ -5416,23 +5418,26 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
         makeApiSlotReference
             $ unsafeExtendSafeZone timeInterpreter
 
-    -- \| Promote certificates of a transaction to API type,
-    -- using additional context from the 'WorkerCtx'.
-    getApiAnyCertificates db flavor ParsedTxCBOR{certificates} = case flavor of
+    -- \| Read the wallet's own reward account and derivation path, when
+    -- the wallet flavor tracks one.
+    readRewardAccount db = \case
         ShelleyKeyS -> do
             (rewardAcct, _, path) <-
                 liftHandler
                     $ W.shelleyOnlyReadRewardAccount @s db
-            pure $ mkApiAnyCertificate (Just rewardAcct) path <$> certificates
-        SharedKeyS -> do
-            infoM <-
-                liftHandler
-                    $ W.sharedOnlyReadRewardAccount @s db
-            case infoM of
-                Just (rewardAcct, path) ->
-                    pure $ mkApiAnyCertificate (Just rewardAcct) path <$> certificates
-                _ -> pure []
+            pure $ Just (rewardAcct, path)
+        SharedKeyS ->
+            liftHandler
+                $ W.sharedOnlyReadRewardAccount @s db
         _ ->
+            pure Nothing
+
+    -- \| Promote certificates of a transaction to API type, using the
+    -- wallet's reward account to mark wallet-owned certificates.
+    getApiAnyCertificates acctM ParsedTxCBOR{certificates} = case acctM of
+        Just (rewardAcct, path) ->
+            pure $ mkApiAnyCertificate (Just rewardAcct) path <$> certificates
+        Nothing ->
             pure []
 
     depositIfAny :: Natural
@@ -5443,9 +5448,9 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
                 else totalIn - totalOut
         | otherwise = 0
 
-    reclaimIfAny :: Maybe ParsedTxCBOR -> Natural
-    reclaimIfAny parsed =
-        depositReturnedFromCertificates (view #certificates <$> parsed)
+    reclaimIfAny :: Maybe RewardAccount -> Maybe ParsedTxCBOR -> Natural
+    reclaimIfAny acctM parsed =
+        depositReturnedFromCertificates acctM (view #certificates <$> parsed)
 
     totalIn :: Natural
     totalIn =
@@ -5466,16 +5471,20 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
     toAddressAmountNoAssets (TxOut addr (TokenBundle.TokenBundle coin _)) =
         AddressAmountNoAssets (ApiAddress addr) (ApiAmount.fromCoin coin)
 
--- | Sum the exact deposit refund amounts from delegation certificates
--- parsed from the transaction CBOR. Returns 0 when there is no CBOR,
--- no certificates, or no refund-bearing certificates.
-depositReturnedFromCertificates :: Maybe [W.Certificate] -> Natural
-depositReturnedFromCertificates =
+-- | Sum the exact deposit refund amounts from the wallet's own
+-- deregistration certificates parsed from the transaction CBOR.
+-- Deregistrations of other parties' stake credentials are ignored, as
+-- are certificates without an explicit refund amount. Returns 0 when
+-- there is no CBOR, no certificates, no refund-bearing certificates,
+-- or no wallet reward account to match against.
+depositReturnedFromCertificates
+    :: Maybe RewardAccount -> Maybe [W.Certificate] -> Natural
+depositReturnedFromCertificates acctM =
     maybe 0 (sum . mapMaybe refund)
   where
     refund
-        (W.CertificateOfDelegation (Just coin) (W.CertDelegateNone _)) =
-            Just (unCoin coin)
+        (W.CertificateOfDelegation (Just coin) (W.CertDelegateNone acct))
+            | Just acct == acctM = Just (unCoin coin)
     refund _ = Nothing
 
 toAddressAmount

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -117,6 +117,7 @@ module Cardano.Wallet.Api.Http.Shelley.Server
     , withWorkerCtx
     , getCurrentEpoch
     , MkApiWallet
+    , depositReturnedFromCertificates
 
       -- * Workers
     , manageRewardBalance
@@ -916,7 +917,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
     , TxScriptValidity
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxMeta as W
-    ( Direction (Incoming, Outgoing)
+    ( Direction (Outgoing)
     , TxMeta
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
@@ -5374,7 +5375,7 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
             , amount = ApiAmount.fromCoin $ tx ^. #txMeta . #amount
             , fee = maybe mempty ApiAmount.fromCoin (tx ^. #txFee)
             , depositTaken = ApiAmount depositIfAny
-            , depositReturned = ApiAmount reclaimIfAny
+            , depositReturned = ApiAmount $ reclaimIfAny parsedValues
             , insertedAt = Nothing
             , pendingSince = Nothing
             , expiresAt = expRef
@@ -5442,29 +5443,9 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
                 else totalIn - totalOut
         | otherwise = 0
 
-    -- (pending) when reclaim is coming we have (fee+out) - inp = deposit
-    -- tx is incoming, and the wallet spent for fee and received deposit - fee as out
-    -- (inLedger) when reclaim is accommodated we have out - inp < deposit as fee was incurred
-    -- So in order to detect this we need to have
-    -- 1. deposit
-    -- 2. have inpsWithoutFee of the wallet non-empty
-    -- 3. outs of the wallet non-empty
-    -- 4. tx Incoming
-    -- 5. outs - inpsWithoutFee <= deposit
-    -- assumption: this should work when
-    depositValue :: Natural
-    depositValue = fromIntegral . unCoin $ tx ^. #txDeposit
-
-    reclaimIfAny :: Natural
-    reclaimIfAny
-        | tx ^. (#txMeta . #direction) == W.Incoming =
-            if (totalIn > 0 && totalOut > 0 && totalOut > totalIn)
-                && (totalOut - totalIn <= depositValue)
-                then
-                    depositValue
-                else
-                    0
-        | otherwise = 0
+    reclaimIfAny :: Maybe ParsedTxCBOR -> Natural
+    reclaimIfAny parsed =
+        depositReturnedFromCertificates (view #certificates <$> parsed)
 
     totalIn :: Natural
     totalIn =
@@ -5484,6 +5465,18 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
         -> AddressAmountNoAssets (ApiAddress n)
     toAddressAmountNoAssets (TxOut addr (TokenBundle.TokenBundle coin _)) =
         AddressAmountNoAssets (ApiAddress addr) (ApiAmount.fromCoin coin)
+
+-- | Sum the exact deposit refund amounts from delegation certificates
+-- parsed from the transaction CBOR. Returns 0 when there is no CBOR,
+-- no certificates, or no refund-bearing certificates.
+depositReturnedFromCertificates :: Maybe [W.Certificate] -> Natural
+depositReturnedFromCertificates =
+    maybe 0 (sum . mapMaybe refund)
+  where
+    refund
+        (W.CertificateOfDelegation (Just coin) (W.CertDelegateNone _)) =
+            Just (unCoin coin)
+    refund _ = Nothing
 
 toAddressAmount
     :: forall n

--- a/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -371,22 +371,27 @@ errorHandlingSpec = describe "liftHandler and toServerError" $ do
 depositReturnedSpec :: Spec
 depositReturnedSpec = describe "depositReturnedFromCertificates" $ do
     let
-        dummyAcct = FromKeyHash ""
+        walletAcct = FromKeyHash ""
+        externalAcct = FromKeyHash "external"
         dummyPoolId = Pool.PoolId ""
         refundCert n =
-            CertificateOfDelegation (Just (Coin n)) (CertDelegateNone dummyAcct)
+            CertificateOfDelegation (Just (Coin n)) (CertDelegateNone walletAcct)
+        externalRefundCert n =
+            CertificateOfDelegation
+                (Just (Coin n))
+                (CertDelegateNone externalAcct)
         registrationCert n =
             CertificateOfDelegation
                 (Just (Coin n))
-                (CertVoteAndDelegate dummyAcct Nothing Nothing)
+                (CertVoteAndDelegate walletAcct Nothing Nothing)
         registrationAndDelegationCert n =
             CertificateOfDelegation
                 (Just (Coin n))
-                (CertVoteAndDelegate dummyAcct (Just dummyPoolId) Nothing)
+                (CertVoteAndDelegate walletAcct (Just dummyPoolId) Nothing)
         ordinaryDelegationCert =
             CertificateOfDelegation
                 Nothing
-                (CertVoteAndDelegate dummyAcct (Just dummyPoolId) Nothing)
+                (CertVoteAndDelegate walletAcct (Just dummyPoolId) Nothing)
         poolCert =
             CertificateOfPool
                 $ Retirement
@@ -394,18 +399,33 @@ depositReturnedSpec = describe "depositReturnedFromCertificates" $ do
         governanceCert = CertificateOther RegDRep
 
     it "absent CBOR contributes 0" $ do
-        depositReturnedFromCertificates Nothing `shouldBe` 0
+        depositReturnedFromCertificates (Just walletAcct) Nothing `shouldBe` 0
 
     it "empty certificate lists contribute 0" $ do
-        depositReturnedFromCertificates (Just []) `shouldBe` 0
+        depositReturnedFromCertificates (Just walletAcct) (Just [])
+            `shouldBe` 0
 
-    it "one explicit deregistration refund contributes its exact coin" $ do
+    it "one explicit own deregistration refund contributes its exact coin" $ do
         depositReturnedFromCertificates
+            (Just walletAcct)
             (Just [refundCert 2_000_000])
             `shouldBe` 2_000_000
 
+    it "deregistrations of external stake credentials contribute 0" $ do
+        depositReturnedFromCertificates
+            (Just walletAcct)
+            (Just [externalRefundCert 2_000_000])
+            `shouldBe` 0
+
+    it "an unknown wallet reward account claims no refunds" $ do
+        depositReturnedFromCertificates
+            Nothing
+            (Just [refundCert 2_000_000])
+            `shouldBe` 0
+
     it "registration deposits with an explicit coin contribute 0" $ do
         depositReturnedFromCertificates
+            (Just walletAcct)
             ( Just
                 [ registrationCert 2_000_000
                 , registrationAndDelegationCert 3_000_000
@@ -415,22 +435,28 @@ depositReturnedSpec = describe "depositReturnedFromCertificates" $ do
 
     it "legacy deregistration without an explicit refund contributes 0" $ do
         depositReturnedFromCertificates
-            (Just [CertificateOfDelegation Nothing (CertDelegateNone dummyAcct)])
+            (Just walletAcct)
+            ( Just
+                [CertificateOfDelegation Nothing (CertDelegateNone walletAcct)]
+            )
             `shouldBe` 0
 
     it
         "pool, governance, and ordinary delegation certificates contribute 0"
         $ do
             depositReturnedFromCertificates
+                (Just walletAcct)
                 (Just [poolCert, governanceCert, ordinaryDelegationCert])
                 `shouldBe` 0
 
-    it "multiple explicit deregistration refunds sum exactly" $ do
+    it "multiple explicit own deregistration refunds sum exactly" $ do
         depositReturnedFromCertificates
+            (Just walletAcct)
             ( Just
                 [ refundCert 2_000_000
                 , registrationCert 5_000_000
                 , poolCert
+                , externalRefundCert 3_000_000
                 , refundCert 500_000
                 , governanceCert
                 , ordinaryDelegationCert

--- a/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -19,6 +19,7 @@ import Cardano.Slotting.Slot
     )
 import Cardano.Wallet.Api.Http.Shelley.Server
     ( IsServerError (..)
+    , depositReturnedFromCertificates
     , getNetworkClock
     , getNetworkInformation
     , liftHandler
@@ -56,8 +57,19 @@ import Cardano.Wallet.Primitive.SyncProgress
     )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
+    , Certificate (..)
+    , DelegationCertificate (..)
+    , NonWalletCertificate (..)
+    , PoolCertificate (..)
+    , PoolRetirementCertificate (..)
     , SlotNo (..)
     , StartTime (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount (..)
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText
@@ -141,6 +153,8 @@ import UnliftIO.Concurrent
 import Prelude
 
 import qualified Cardano.Wallet.Primitive.SyncProgress as S
+import qualified Cardano.Wallet.Primitive.Types.EpochNo as Epoch
+import qualified Cardano.Wallet.Primitive.Types.Pool as Pool
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
@@ -153,6 +167,7 @@ spec = do
     serverSpec
     networkInfoSpec
     errorHandlingSpec
+    depositReturnedSpec
 
 serverSpec :: Spec
 serverSpec = describe "API Server" $ do
@@ -352,3 +367,74 @@ errorHandlingSpec = describe "liftHandler and toServerError" $ do
 
         runHandler (getNetworkClock (error "bomb") True)
             `shouldReturn` Left expectedErr
+
+depositReturnedSpec :: Spec
+depositReturnedSpec = describe "depositReturnedFromCertificates" $ do
+    let
+        dummyAcct = FromKeyHash ""
+        dummyPoolId = Pool.PoolId ""
+        refundCert n =
+            CertificateOfDelegation (Just (Coin n)) (CertDelegateNone dummyAcct)
+        registrationCert n =
+            CertificateOfDelegation
+                (Just (Coin n))
+                (CertVoteAndDelegate dummyAcct Nothing Nothing)
+        registrationAndDelegationCert n =
+            CertificateOfDelegation
+                (Just (Coin n))
+                (CertVoteAndDelegate dummyAcct (Just dummyPoolId) Nothing)
+        ordinaryDelegationCert =
+            CertificateOfDelegation
+                Nothing
+                (CertVoteAndDelegate dummyAcct (Just dummyPoolId) Nothing)
+        poolCert =
+            CertificateOfPool
+                $ Retirement
+                $ PoolRetirementCertificate dummyPoolId (Epoch.EpochNo 0)
+        governanceCert = CertificateOther RegDRep
+
+    it "absent CBOR contributes 0" $ do
+        depositReturnedFromCertificates Nothing `shouldBe` 0
+
+    it "empty certificate lists contribute 0" $ do
+        depositReturnedFromCertificates (Just []) `shouldBe` 0
+
+    it "one explicit deregistration refund contributes its exact coin" $ do
+        depositReturnedFromCertificates
+            (Just [refundCert 2_000_000])
+            `shouldBe` 2_000_000
+
+    it "registration deposits with an explicit coin contribute 0" $ do
+        depositReturnedFromCertificates
+            ( Just
+                [ registrationCert 2_000_000
+                , registrationAndDelegationCert 3_000_000
+                ]
+            )
+            `shouldBe` 0
+
+    it "legacy deregistration without an explicit refund contributes 0" $ do
+        depositReturnedFromCertificates
+            (Just [CertificateOfDelegation Nothing (CertDelegateNone dummyAcct)])
+            `shouldBe` 0
+
+    it
+        "pool, governance, and ordinary delegation certificates contribute 0"
+        $ do
+            depositReturnedFromCertificates
+                (Just [poolCert, governanceCert, ordinaryDelegationCert])
+                `shouldBe` 0
+
+    it "multiple explicit deregistration refunds sum exactly" $ do
+        depositReturnedFromCertificates
+            ( Just
+                [ refundCert 2_000_000
+                , registrationCert 5_000_000
+                , poolCert
+                , refundCert 500_000
+                , governanceCert
+                , ordinaryDelegationCert
+                , registrationAndDelegationCert 7_000_000
+                ]
+            )
+            `shouldBe` 2_500_000

--- a/specs/5325-deposit-returned-certificate-aware/plan.md
+++ b/specs/5325-deposit-returned-certificate-aware/plan.md
@@ -1,0 +1,39 @@
+# Plan: Make `depositReturned` certificate-aware
+
+One slice. Confined to `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`
+plus a new/extended unit test file.
+
+## Slice A — replace the heuristic, add a directly-testable pure function
+
+1. In `Server.hs`, add a top-level pure function (exported or not, but
+   placed so it's importable from a test module):
+   ```haskell
+   depositReturnedFromCertificates :: Maybe [W.Certificate] -> Natural
+   depositReturnedFromCertificates = maybe 0 (sum . mapMaybe refund)
+     where
+       refund (W.CertificateOfDelegation (Just c) _) = Just (fromIntegral (unCoin c))
+       refund _ = Nothing
+   ```
+   (Exact naming/shape is the driver's call — the behavior in spec.md
+   FR1/FR2 is the contract, not this literal snippet.)
+2. Change `reclaimIfAny` in `mkApiTransaction`'s `where` clause to call
+   this function with `certificates <$> parsedValues` (or equivalent),
+   dropping the `totalIn`/`totalOut`/`direction` arithmetic entirely.
+3. Leave `depositIfAny`/`depositTaken` untouched.
+4. Unit test: extend `lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs`
+   with direct tests of `depositReturnedFromCertificates` (or whatever
+   it's named) covering the four cases in spec.md's Success Criteria —
+   this does NOT require standing up `mkApiTransaction`'s full Handler
+   harness (DB layer, wallet layer, time interpreter); it tests the
+   extracted pure function directly with hand-built `[W.Certificate]`
+   lists.
+
+Owned files:
+- `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`
+- `lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs`
+
+Forbidden scope: `depositIfAny`/`depositTaken`, `Certificate.hs`
+(`mkApiAnyCertificate` mapping — do not change what's exposed over the
+API, only what feeds `reclaimIfAny`), the CBOR-parsing/ledger-read
+modules (`Certificates.hs` in `lib/primitive` — already correct, this
+is a consumer-side fix only), any `.cabal` file.

--- a/specs/5325-deposit-returned-certificate-aware/plan.md
+++ b/specs/5325-deposit-returned-certificate-aware/plan.md
@@ -11,7 +11,9 @@ plus a new/extended unit test file.
    depositReturnedFromCertificates :: Maybe [W.Certificate] -> Natural
    depositReturnedFromCertificates = maybe 0 (sum . mapMaybe refund)
      where
-       refund (W.CertificateOfDelegation (Just c) _) = Just (fromIntegral (unCoin c))
+       refund
+         (W.CertificateOfDelegation (Just c) (W.CertDelegateNone _)) =
+           Just (fromIntegral (unCoin c))
        refund _ = Nothing
    ```
    (Exact naming/shape is the driver's call — the behavior in spec.md
@@ -22,11 +24,15 @@ plus a new/extended unit test file.
 3. Leave `depositIfAny`/`depositTaken` untouched.
 4. Unit test: extend `lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs`
    with direct tests of `depositReturnedFromCertificates` (or whatever
-   it's named) covering the four cases in spec.md's Success Criteria —
-   this does NOT require standing up `mkApiTransaction`'s full Handler
-   harness (DB layer, wallet layer, time interpreter); it tests the
-   extracted pure function directly with hand-built `[W.Certificate]`
-   lists.
+   it's named) covering every case in spec.md's Success Criteria, including
+   the load-bearing negative control where a registration certificate has
+   `Just coin` but must contribute `0`. This does NOT require standing up
+   `mkApiTransaction`'s full Handler harness (DB layer, wallet layer, time
+   interpreter); it tests the extracted pure function directly with
+   hand-built `[W.Certificate]` lists.
+5. Verify the wiring remains consumer-only: `reclaimIfAny` reads
+   `ParsedTxCBOR.certificates`; no primitive era reader, certificate type,
+   API-facing mapping, JSON codec, or schema file changes.
 
 Owned files:
 - `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`

--- a/specs/5325-deposit-returned-certificate-aware/spec.md
+++ b/specs/5325-deposit-returned-certificate-aware/spec.md
@@ -1,0 +1,91 @@
+# Spec: Make `depositReturned` certificate-aware instead of a numeric heuristic
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5325
+(ADP-2298) Deposit_returned falsely reported on some incoming transactions
+
+## P1 user story
+
+As a wallet API consumer, when I fetch a transaction, `depositReturned`
+is non-zero only when the transaction actually contains a certificate
+that returns a stake-key deposit — never as a side effect of an
+ordinary payment whose input/output gap happens to be small.
+
+## Root cause (orchestrator-verified against current master)
+
+`reclaimIfAny` (`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`,
+`mkApiTransaction`'s `where` clause, ~line 5458) classifies an incoming
+tx as a deposit reclaim by **numeric coincidence**:
+```haskell
+reclaimIfAny
+    | tx ^. (#txMeta . #direction) == W.Incoming =
+        if (totalIn > 0 && totalOut > 0 && totalOut > totalIn)
+            && (totalOut - totalIn <= depositValue)
+        then depositValue else 0
+    | otherwise = 0
+```
+No certificate is consulted. Any ordinary incoming tx whose
+`totalOut - totalIn` gap happens to fall at or under the protocol's
+current stake-key deposit (`depositValue = tx ^. #txDeposit`, itself
+just `W.stakeKeyDeposit pp` — a protocol parameter, not tx-specific) is
+mislabeled.
+
+**The real signal already exists and is silently discarded.** Ledger
+CBOR-parsing (`lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Certificates.hs:169-170`)
+already computes the exact refund amount per certificate straight from
+the ledger's own `Ledger.UnRegDepositTxCert cred coin`:
+```haskell
+Ledger.UnRegDepositTxCert cred coin ->
+    mkDelegationNone (Just $ fromLedgerCoin coin) cred
+```
+which becomes `W.CertificateOfDelegation (Just refundCoin) (W.CertDelegateNone cred)`
+— a real, ledger-accurate refund amount, per certificate, in
+`W.Certificate` (`lib/primitive/lib/Cardano/Wallet/Primitive/Types/Certificates.hs:209`:
+`CertificateOfDelegation (Maybe Coin) DelegationCertificate`).
+
+This value reaches `mkApiTransaction`'s local scope via
+`parsedValues <- traverse parseTxCBOR $ tx ^. #txCBOR` (already
+computed earlier in the same `do` block, `Server.hs` ~line 5368) —
+`parsedValues :: Maybe ParsedTxCBOR`, and
+`ParsedTxCBOR.certificates :: [W.Certificate]`
+(`lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs:97`).
+It is thrown away only when certificates are later mapped to the
+API-facing `ApiAnyCertificate` type
+(`lib/api/src/Cardano/Wallet/Api/Types/Certificate.hs:280`:
+`W.CertificateOfDelegation _ delCert -> toApiDelCert ...` — the `Maybe
+Coin` is discarded with `_`). `reclaimIfAny`, being a `where`-bound
+value in the same function, can reference `parsedValues` directly
+without any signature change.
+
+## Functional requirements
+
+- FR1: `reclaimIfAny` sums the `Just coin` refund amounts from every
+  `W.CertificateOfDelegation (Just coin) _` certificate in
+  `parsedValues`'s `certificates` list, instead of the totalIn/totalOut
+  heuristic.
+- FR2: When `parsedValues` is `Nothing` (no CBOR stored, or the wallet
+  flavor doesn't support delegation), `reclaimIfAny = 0`. A missing
+  reliable signal must never guess — the whole point of this fix is
+  eliminating false positives, and a false negative (silently under-
+  reporting in the rare CBOR-missing case) is far less harmful than a
+  false positive (mislabeling an ordinary payment).
+- FR3: `depositIfAny` / `depositTaken` (the outgoing-tx deposit-taken
+  heuristic) is UNCHANGED — out of scope, issue is about
+  `depositReturned` only.
+- FR4: The pure certificate-summing logic is extracted into a small,
+  independently unit-testable top-level function (`mkApiTransaction` /
+  `Handler` itself is not practically unit-testable — needs a DB/wallet
+  layer harness this ticket doesn't build).
+
+## Success criteria (from the issue's own repro table)
+
+Given a certificate-summing function `depositReturnedFromCertificates
+:: Maybe [W.Certificate] -> Natural`:
+- Case A (ordinary incoming tx, gap 1,500,000 ≤ 2,000,000 deposit,
+  zero certificates): `Nothing` in / `[]` certs in → `0`. **This is the
+  bug this ticket fixes.**
+- Case B (genuine stake-key deregistration refund, one
+  `CertificateOfDelegation (Just 2_000_000) (CertDelegateNone _)`):
+  → `2_000_000`.
+- A tx with a certificate that has `Nothing` refund (e.g. an ordinary
+  pool-delegation cert with no deposit change) contributes `0`.
+- Multiple refund-bearing certificates sum correctly.

--- a/specs/5325-deposit-returned-certificate-aware/spec.md
+++ b/specs/5325-deposit-returned-certificate-aware/spec.md
@@ -42,6 +42,14 @@ which becomes `W.CertificateOfDelegation (Just refundCoin) (W.CertDelegateNone c
 `W.Certificate` (`lib/primitive/lib/Cardano/Wallet/Primitive/Types/Certificates.hs:209`:
 `CertificateOfDelegation (Maybe Coin) DelegationCertificate`).
 
+The `Maybe Coin` alone is not enough to identify a refund. Conway and
+Dijkstra registration forms also carry their exact deposit as
+`CertificateOfDelegation (Just depositCoin) (CertVoteAndDelegate ...)`.
+Only the combination of `Just coin` and `CertDelegateNone` denotes a
+deregistration refund. Matching `CertificateOfDelegation (Just coin) _`
+would replace the original false positive with a new one for registration
+transactions.
+
 This value reaches `mkApiTransaction`'s local scope via
 `parsedValues <- traverse parseTxCBOR $ tx ^. #txCBOR` (already
 computed earlier in the same `do` block, `Server.hs` ~line 5368) —
@@ -59,15 +67,16 @@ without any signature change.
 ## Functional requirements
 
 - FR1: `reclaimIfAny` sums the `Just coin` refund amounts from every
-  `W.CertificateOfDelegation (Just coin) _` certificate in
-  `parsedValues`'s `certificates` list, instead of the totalIn/totalOut
-  heuristic.
-- FR2: When `parsedValues` is `Nothing` (no CBOR stored, or the wallet
-  flavor doesn't support delegation), `reclaimIfAny = 0`. A missing
-  reliable signal must never guess — the whole point of this fix is
-  eliminating false positives, and a false negative (silently under-
-  reporting in the rare CBOR-missing case) is far less harmful than a
-  false positive (mislabeling an ordinary payment).
+  `W.CertificateOfDelegation (Just coin) (W.CertDelegateNone _)`
+  certificate in `parsedValues`'s `certificates` list, instead of the
+  totalIn/totalOut heuristic. Registration and registration+delegation
+  certificates with `Just coin` must contribute `0`.
+- FR2: When `parsedValues` is `Nothing` (no CBOR stored), or a legacy-era
+  deregistration is represented as `CertificateOfDelegation Nothing
+  (CertDelegateNone _)`, `reclaimIfAny = 0`. A missing exact amount must
+  never trigger a guess — the whole point of this fix is eliminating false
+  positives, and a false negative (silently under-reporting when the exact
+  amount is absent) is less harmful than mislabeling an ordinary payment.
 - FR3: `depositIfAny` / `depositTaken` (the outgoing-tx deposit-taken
   heuristic) is UNCHANGED — out of scope, issue is about
   `depositReturned` only.
@@ -75,17 +84,28 @@ without any signature change.
   independently unit-testable top-level function (`mkApiTransaction` /
   `Handler` itself is not practically unit-testable — needs a DB/wallet
   layer harness this ticket doesn't build).
+- FR5: Preserve the existing era parser, primitive `Certificate` type,
+  API-facing certificate mapping, JSON codecs, and HTTP schema. This is a
+  consumer-side calculation only: Conway and Dijkstra explicit refunds are
+  consumed when present; older eras and missing CBOR remain compatible by
+  contributing `0` rather than consulting current protocol parameters.
 
 ## Success criteria (from the issue's own repro table)
 
 Given a certificate-summing function `depositReturnedFromCertificates
 :: Maybe [W.Certificate] -> Natural`:
 - Case A (ordinary incoming tx, gap 1,500,000 ≤ 2,000,000 deposit,
-  zero certificates): `Nothing` in / `[]` certs in → `0`. **This is the
-  bug this ticket fixes.**
+  no deregistration certificates): `Nothing` or `Just []` → `0`, with no
+  input/output/direction arithmetic available to reintroduce the heuristic.
+  **This is the bug this ticket fixes.**
 - Case B (genuine stake-key deregistration refund, one
   `CertificateOfDelegation (Just 2_000_000) (CertDelegateNone _)`):
-  → `2_000_000`.
-- A tx with a certificate that has `Nothing` refund (e.g. an ordinary
-  pool-delegation cert with no deposit change) contributes `0`.
-- Multiple refund-bearing certificates sum correctly.
+  → exactly `2_000_000`.
+- Registration negative control: a
+  `CertificateOfDelegation (Just 2_000_000) (CertVoteAndDelegate ...)`
+  contributes `0`, even though it carries a coin.
+- Legacy/missing-amount negative control:
+  `CertificateOfDelegation Nothing (CertDelegateNone _)` contributes `0`.
+- Pool, governance, and ordinary delegation certificates contribute `0`.
+- Multiple explicit deregistration refunds sum exactly while interleaved
+  non-refund certificates contribute nothing.

--- a/specs/5325-deposit-returned-certificate-aware/tasks.md
+++ b/specs/5325-deposit-returned-certificate-aware/tasks.md
@@ -3,13 +3,17 @@
 ## Slice A — replace the heuristic, add a directly-testable pure function
 
 - [ ] T5325-S1 Add a pure `Maybe [W.Certificate] -> Natural` function
-      summing `CertificateOfDelegation (Just coin) _` refunds
+      summing only explicit `CertDelegateNone` deregistration refunds
 - [ ] T5325-S2 `reclaimIfAny` calls it with `parsedValues`'s
       certificates instead of the totalIn/totalOut heuristic;
       `depositIfAny` untouched
-- [ ] T5325-S3 Unit tests in `ServerSpec.hs` covering: zero certs (Case
-      A — the false positive this fixes), one refund-bearing cert
-      (Case B), a non-refund cert, multiple refund certs summing
+- [ ] T5325-S3 Unit tests in `ServerSpec.hs` covering: missing/zero certs
+      (Case A — the false positive this fixes), one exact refund (Case B),
+      a registration carrying `Just coin` (must be zero), legacy
+      deregistration with `Nothing` (must be zero), unrelated certs, and
+      multiple explicit deregistration refunds summing exactly
+- [ ] T5325-S6 Preserve primitive era readers, `Certificate`, API mapping,
+      JSON codecs, and schema; verify the change is consumer-only
 - [ ] T5325-S4 `./gate.sh` passes (build, focused unit tests, fmt,
       hlint)
-- [ ] T5325-S5 Commit: `fix: make depositReturned certificate-aware instead of a numeric heuristic` with `Tasks: T5325-S1, T5325-S2, T5325-S3, T5325-S4` trailer
+- [ ] T5325-S5 Commit: `fix: make depositReturned certificate-aware instead of a numeric heuristic` with `Tasks: T5325-S1, T5325-S2, T5325-S3, T5325-S4, T5325-S6` trailer

--- a/specs/5325-deposit-returned-certificate-aware/tasks.md
+++ b/specs/5325-deposit-returned-certificate-aware/tasks.md
@@ -2,18 +2,18 @@
 
 ## Slice A — replace the heuristic, add a directly-testable pure function
 
-- [ ] T5325-S1 Add a pure `Maybe [W.Certificate] -> Natural` function
+- [x] T5325-S1 Add a pure `Maybe [W.Certificate] -> Natural` function
       summing only explicit `CertDelegateNone` deregistration refunds
-- [ ] T5325-S2 `reclaimIfAny` calls it with `parsedValues`'s
+- [x] T5325-S2 `reclaimIfAny` calls it with `parsedValues`'s
       certificates instead of the totalIn/totalOut heuristic;
       `depositIfAny` untouched
-- [ ] T5325-S3 Unit tests in `ServerSpec.hs` covering: missing/zero certs
+- [x] T5325-S3 Unit tests in `ServerSpec.hs` covering: missing/zero certs
       (Case A — the false positive this fixes), one exact refund (Case B),
       a registration carrying `Just coin` (must be zero), legacy
       deregistration with `Nothing` (must be zero), unrelated certs, and
       multiple explicit deregistration refunds summing exactly
-- [ ] T5325-S6 Preserve primitive era readers, `Certificate`, API mapping,
+- [x] T5325-S6 Preserve primitive era readers, `Certificate`, API mapping,
       JSON codecs, and schema; verify the change is consumer-only
-- [ ] T5325-S4 `./gate.sh` passes (build, focused unit tests, fmt,
+- [x] T5325-S4 `./gate.sh` passes (build, focused unit tests, fmt,
       hlint)
-- [ ] T5325-S5 Commit: `fix: make depositReturned certificate-aware instead of a numeric heuristic` with `Tasks: T5325-S1, T5325-S2, T5325-S3, T5325-S4, T5325-S6` trailer
+- [x] T5325-S5 Commit: `fix: make depositReturned certificate-aware instead of a numeric heuristic` with `Tasks: T5325-S1, T5325-S2, T5325-S3, T5325-S4, T5325-S6` trailer

--- a/specs/5325-deposit-returned-certificate-aware/tasks.md
+++ b/specs/5325-deposit-returned-certificate-aware/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Make `depositReturned` certificate-aware
+
+## Slice A — replace the heuristic, add a directly-testable pure function
+
+- [ ] T5325-S1 Add a pure `Maybe [W.Certificate] -> Natural` function
+      summing `CertificateOfDelegation (Just coin) _` refunds
+- [ ] T5325-S2 `reclaimIfAny` calls it with `parsedValues`'s
+      certificates instead of the totalIn/totalOut heuristic;
+      `depositIfAny` untouched
+- [ ] T5325-S3 Unit tests in `ServerSpec.hs` covering: zero certs (Case
+      A — the false positive this fixes), one refund-bearing cert
+      (Case B), a non-refund cert, multiple refund certs summing
+- [ ] T5325-S4 `./gate.sh` passes (build, focused unit tests, fmt,
+      hlint)
+- [ ] T5325-S5 Commit: `fix: make depositReturned certificate-aware instead of a numeric heuristic` with `Tasks: T5325-S1, T5325-S2, T5325-S3, T5325-S4` trailer


### PR DESCRIPTION
Closes #5325 (ADP-2298).

`depositReturned` no longer infers stake-key refunds from an incoming
transaction's input/output arithmetic. That heuristic could label an ordinary
payment as a refund whenever its numeric gap happened to fall below the current
stake-key deposit.

## Landed behavior

The API transaction mapper consumes certificates already decoded from the
transaction CBOR and sums only explicit deregistration refunds owned by the
wallet:

`CertificateOfDelegation (Just coin) (CertDelegateNone rewardAccount)`

The wallet reward account is read once and shared by certificate rendering and
refund calculation. Deregistrations for external stake credentials,
registration deposits, legacy deregistrations without an explicit amount, and
unrelated certificates contribute zero. Multiple wallet-owned refunds aggregate
their exact coin values.

The existing `depositIfAny` / `depositTaken` logic and primitive era readers,
certificate model, codecs, schema, and API shape are unchanged. Historical
pre-Conway deregistrations without an exact ledger refund remain zero by design,
avoiding reconstruction from current protocol parameters.

## Review follow-up

Pawel's ownership concern is addressed by passing the wallet's
`RewardAccount` into the pure helper. Coverage includes external
deregistrations, missing wallet reward-account context, and mixed own/external
certificates. The helper remains in `Server.hs` to keep this correction focused;
a dedicated deposit module can be considered separately.

The lane-only anchored `/gate.sh` ignore entry was removed. The
`specs/5325-deposit-returned-certificate-aware/` planning record remains part
of the PR.

## Verification

- TDD negative control for registration deposits: expected `0`, observed the
  prior broad matcher return `2_000_000`.
- Review-response negative control: gate v5 rejects the previous PR head because
  it does not filter refunds by the wallet reward account.
- Focused unit proof: 9 examples, 0 failures.
- Full `cardano-wallet-unit:unit` suite: 4,121 examples, 0 failures, 2 pending.
- Fourmolu: pass.
- Repository HLint: no hints.
- Gate v6: pass in a clean detached worktree at the tree now committed as
  `00d1dde353f15c1ea8f35d89bad781fe167860c8` after rebasing onto
  `origin/master` at `789d58cad10edbd37647140b909d4e99cdc37b5d`.

The complete specification, plan, and checked task ledger are in
`specs/5325-deposit-returned-certificate-aware/`.
