### PR TITLE
build(local-cluster): drop cardano-cli library dependency

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
@@ -22,19 +22,15 @@ import Cardano.Api
     ( File (..)
     , HasTextEnvelope
     , Key (..)
-    , SerialiseAsBech32
     , SerialiseAsCBOR (..)
     , StakeKey
     , StakePoolKey
     , VerificationKey
     , VrfKey
+    , readFileTextEnvelope
     )
 import Cardano.Binary
     ( FromCBOR (..)
-    )
-import Cardano.CLI.Type.Key
-    ( VerificationKeyOrFile (..)
-    , readVerificationKeyOrFile
     )
 import Cardano.Launcher.Node
     ( CardanoNodeConfig (..)
@@ -183,7 +179,6 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.ListMap as ListMap
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import qualified RIO
 
 -- | Represents the notion of a fully configured pool. All keys are known, but
 -- not necessarily exposed using this interface.
@@ -324,16 +319,13 @@ genStakeAddrKeyPair (FileOf stakePrv, FileOf stakePub) = do
 
 readFailVerificationKeyOrFile
     :: forall keyrole (s :: Symbol)
-     . ( HasTextEnvelope (VerificationKey keyrole)
-       , SerialiseAsBech32 (VerificationKey keyrole)
-       )
+     . HasTextEnvelope (VerificationKey keyrole)
     => FileOf s
     -> ClusterM (VerificationKey keyrole)
 readFailVerificationKeyOrFile (FileOf op) =
     liftIO
-        $ RIO.runRIO ()
-        $ readVerificationKeyOrFile
-            (VerificationKeyFilePath $ File $ toFilePath op)
+        $ readFileTextEnvelope (File $ toFilePath op)
+            >>= either (error . show) pure
 
 stakePoolIdFromOperatorVerKey
     :: HasCallStack

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -106,7 +106,6 @@ library
     , cardano-addresses
     , cardano-api
     , cardano-binary
-    , cardano-cli
     , cardano-data
     , cardano-diffusion:api
     , cardano-ledger-api

--- a/specs/5088-drop-cardano-cli/plan.md
+++ b/specs/5088-drop-cardano-cli/plan.md
@@ -1,0 +1,34 @@
+# Plan: Stop building the cardano-cli library for local-cluster
+
+One ordered, bisect-safe implementation slice changes exactly two files.
+
+## Slice A — replace the CLI key reader and drop the dependency
+
+Owned files:
+
+- `lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs`
+- `lib/local-cluster/local-cluster.cabal`
+
+RED first: remove `cardano-cli` from the library dependencies without changing
+the import, then run `nix build --quiet --no-link .#local-cluster`. The build
+must fail because `Cardano.CLI.Type.Key` is no longer available. Freeze that
+diff and evidence for navigator review.
+
+GREEN: use `Cardano.Api.readFileTextEnvelope` with the existing typed `File`
+path to read each verification key. Preserve the existing failure behavior by
+turning the returned `FileError` into the same fatal cluster setup failure.
+Remove only imports and constraints made redundant by this replacement.
+
+Proof:
+
+1. The focused Nix build passes.
+2. The local-cluster closure no longer contains a `cardano-cli` library
+   derivation.
+3. The full formatting and HLint checks pass.
+4. The 39-example local-cluster suite, including live local-node cases, passes.
+
+Commit subject:
+`build(local-cluster): drop cardano-cli library dependency`
+
+Commit trailer:
+`Tasks: T508801, T508802, T508803, T508804`

--- a/specs/5088-drop-cardano-cli/spec.md
+++ b/specs/5088-drop-cardano-cli/spec.md
@@ -1,0 +1,48 @@
+# Spec: Stop building the cardano-cli library for local-cluster
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5088
+
+## P1 user story
+
+As a cardano-wallet contributor, I can build `local-cluster` without compiling
+the `cardano-cli` Haskell library, while local clusters continue to use the
+separately supplied `cardano-cli` executable at runtime.
+
+## Problem
+
+`ConfiguredPool.hs` imports `Cardano.CLI.Type.Key` only to read verification
+key text-envelope files. That import requires `local-cluster` to declare a
+Haskell dependency on `cardano-cli`, so the `.#local-cluster` Nix closure
+builds `cardano-cli-lib-cardano-cli-11.0.0.0` from CHaP even though the runtime
+CLI executable is already supplied separately.
+
+The old git `source-repository-package` workaround is already absent on
+`master`; this ticket removes the remaining library dependency.
+
+## Functional requirements
+
+- FR1: `local-cluster` reads the generated stake-pool, VRF, and stake
+  verification-key files through the existing `cardano-api` dependency.
+- FR2: `lib/local-cluster/` contains no Haskell import from `Cardano.CLI`.
+- FR3: the `local-cluster` library stanza has no `cardano-cli` dependency.
+- FR4: the `.#local-cluster` derivation closure contains no
+  `cardano-cli` Haskell library derivation.
+- FR5: the runtime `cardano-cli` executable remains available to cluster
+  processes and tests; runtime command execution is not refactored.
+
+## Success criteria
+
+- Removing only the Cabal dependency makes the unchanged CLI import fail to
+  build, proving the dependency check can go red.
+- `nix build --quiet --no-link .#local-cluster` exits 0 after the reader
+  replacement.
+- `nix path-info --derivation --recursive .#local-cluster` contains no path
+  matching `-lib-cardano-cli-`.
+- `just test-local-cluster` reports 39 examples and 0 failures.
+- Fourmolu, cabal-fmt, nixfmt, HLint, and `git diff --check` are clean.
+
+## Out of scope
+
+- Removing the `cardano-cli` executable from runtime shells or workflows.
+- Changing project-wide `cardano-cli` constraints in `cabal.project`.
+- Refactoring other cluster key or command helpers.

--- a/specs/5088-drop-cardano-cli/tasks.md
+++ b/specs/5088-drop-cardano-cli/tasks.md
@@ -2,12 +2,12 @@
 
 ## Slice A — replace the CLI key reader and drop the dependency
 
-- [ ] T508801 Record RED evidence that removing the Cabal dependency exposes
+- [x] T508801 Record RED evidence that removing the Cabal dependency exposes
   the remaining `Cardano.CLI.Type.Key` import.
-- [ ] T508802 Replace the CLI-only verification-key reader with
+- [x] T508802 Replace the CLI-only verification-key reader with
   `Cardano.Api.readFileTextEnvelope` and remove redundant imports and
   constraints.
-- [ ] T508803 Remove `cardano-cli` from the `local-cluster` library
+- [x] T508803 Remove `cardano-cli` from the `local-cluster` library
   dependencies and prove the Nix closure no longer builds its Haskell library.
-- [ ] T508804 Run `./gate.sh` and commit the slice as
+- [x] T508804 Run `./gate.sh` and commit the slice as
   `build(local-cluster): drop cardano-cli library dependency`.

--- a/specs/5088-drop-cardano-cli/tasks.md
+++ b/specs/5088-drop-cardano-cli/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Stop building the cardano-cli library for local-cluster
+
+## Slice A — replace the CLI key reader and drop the dependency
+
+- [ ] T508801 Record RED evidence that removing the Cabal dependency exposes
+  the remaining `Cardano.CLI.Type.Key` import.
+- [ ] T508802 Replace the CLI-only verification-key reader with
+  `Cardano.Api.readFileTextEnvelope` and remove redundant imports and
+  constraints.
+- [ ] T508803 Remove `cardano-cli` from the `local-cluster` library
+  dependencies and prove the Nix closure no longer builds its Haskell library.
+- [ ] T508804 Run `./gate.sh` and commit the slice as
+  `build(local-cluster): drop cardano-cli library dependency`.


### PR DESCRIPTION
## Summary

`local-cluster` no longer compiles or links the `cardano-cli` Haskell library. Runtime use of the `cardano-cli` executable remains unchanged.

## What changed

- replace the `Cardano.CLI.Type.Key` verification-key reader with `Cardano.Api.readFileTextEnvelope`
- remove the `cardano-cli` library dependency from `local-cluster`
- document the issue scope, acceptance criteria, implementation plan, and completed tasks

## Verification

- RED proof: removing only the Cabal dependency made the build fail on the remaining `Cardano.CLI.Type.Key` import
- positive control: the pre-change `local-cluster` Nix closure contained the `cardano-cli` library derivation
- post-change `nix build .#local-cluster` succeeds and its recursive derivation closure contains no `-lib-cardano-cli-`
- full tracked-tree Fourmolu, cabal-fmt, nixfmt, and HLint checks pass
- `just test-local-cluster`: 39 examples, 0 failures, including live node and runtime CLI cases

The temporary pre-push gate invokes the same formatting tools in check mode. The repository CI wrapper finishes with a clean-worktree assertion, which cannot validate an intentionally uncommitted slice during pre-commit gating.

Closes #5088
