### PR TITLE
ci: run macOS integration tests on master pushes

### DIFF
--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -1,6 +1,9 @@
 name: macOS Integration Tests
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:

--- a/specs/5126-macos-integration-trigger/plan.md
+++ b/specs/5126-macos-integration-trigger/plan.md
@@ -1,0 +1,33 @@
+# Plan
+
+## Scope
+
+This is one vertical, bisect-safe implementation slice. It changes only:
+
+- `.github/workflows/macos-integration.yml`
+
+## Slice 1: add the master-push trigger
+
+First dispatch the existing workflow manually on the branch and require it to
+reach the real macOS runner and complete successfully. If that run exposes a
+workflow defect, freeze the observed failure, amend this plan and the task
+fence, and correct only what blocks execution before proceeding.
+
+Once runnability is proven, add a `push` event filtered to the `master` branch
+alongside the existing manual-dispatch event. Keep the workflow's jobs and
+their configuration unchanged unless the live run proved a specific correction
+necessary.
+
+Proof consists of:
+
+1. a successful manual branch dispatch on the real macOS runner;
+2. a focused checker observed failing on the base workflow;
+3. the same checker passing on the edited workflow;
+4. Actionlint passing;
+5. the first post-merge push-triggered run scheduling and succeeding;
+6. five consecutive successful `master` runs without retries.
+
+Items 5 and 6 are live-boundary observations made after merge. No pull-request
+trigger, schedule, runner provisioning, or unrelated test-content change is
+in scope. A job change enters scope only when the pre-merge live run proves it
+is required for execution.

--- a/specs/5126-macos-integration-trigger/spec.md
+++ b/specs/5126-macos-integration-trigger/spec.md
@@ -1,0 +1,32 @@
+# Issue #5126: run macOS integration tests on master pushes
+
+## User story
+
+As a maintainer, I want the dedicated macOS integration workflow to run after
+every push to `master` so regressions at the live macOS integration boundary
+are detected without a manual dispatch.
+
+## Requirements
+
+- FR1: `.github/workflows/macos-integration.yml` triggers on pushes to the
+  `master` branch.
+- FR2: The existing `workflow_dispatch` trigger remains available.
+- FR3: Before the trigger change is accepted, a manual dispatch must reach the
+  real macOS runner and execute successfully. Any workflow defect that blocks
+  that outcome is in scope; unrelated job changes are not.
+- FR4: If the manual run is already successful, no job, step, permission,
+  runner label, or schedule in the workflow changes.
+- FR5: Workflow syntax remains valid.
+
+## Acceptance
+
+- A focused checker must fail against the original workflow state and pass
+  after the change.
+- Actionlint must pass for the changed workflow, allowing the repository's
+  custom runner labels.
+- Before the trigger commit is accepted, a `workflow_dispatch` run must
+  execute successfully on the macOS runner and its run URL must be recorded.
+- After merge, the first push-to-`master` run must be observed scheduling this
+  workflow, and its run URL must be recorded in the ticket STATUS.
+- Five consecutive `master` runs must complete without retries as the issue's
+  longer-running stability evidence.

--- a/specs/5126-macos-integration-trigger/tasks.md
+++ b/specs/5126-macos-integration-trigger/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## Slice 1: add the master-push trigger
+
+- [ ] T5126 Prove a manual dispatch executes successfully on the real macOS
+  runner; add the `master`-filtered `push` trigger while retaining
+  `workflow_dispatch`; demonstrate RED then GREEN with a focused checker; pass
+  Actionlint; and commit as
+  `ci: run macOS integration tests on master pushes`.
+
+## Post-merge acceptance
+
+After merge, record the first push-to-`master` workflow run URL in this lane's
+STATUS and issue #5126, then confirm five consecutive `master` runs complete
+without retries. This external observation is not part of the pre-merge
+implementation commit.

--- a/specs/5126-macos-integration-trigger/tasks.md
+++ b/specs/5126-macos-integration-trigger/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1: add the master-push trigger
 
-- [ ] T5126 Prove a manual dispatch executes successfully on the real macOS
+- [X] T5126 Prove a manual dispatch executes successfully on the real macOS
   runner; add the `master`-filtered `push` trigger while retaining
   `workflow_dispatch`; demonstrate RED then GREEN with a focused checker; pass
   Actionlint; and commit as


### PR DESCRIPTION
Closes #5126

## Summary

The dedicated macOS integration workflow now runs after every push to
`master`. Manual `workflow_dispatch` remains available.

Before changing the trigger, this PR also proved the existing workflow is
runnable on the real self-hosted macOS ARM64 runner. The dependency build,
Conway integration suite, and log upload all completed successfully:
https://github.com/cardano-foundation/cardano-wallet/actions/runs/30448757047

The trigger is the only workflow change. Jobs, steps, environment, runner
labels, timeout, and concurrency configuration remain unchanged.

## Verification

- A YAML-aware focused checker was observed failing on the dispatch-only
  workflow, then passing on the edited workflow.
- Mutation controls prove the checker rejects an unfiltered push, the wrong
  branch, extra branches, extra events, and removal of manual dispatch.
- Actionlint accepts the final workflow with only the repository's custom
  runner-label allowance.
- A live manual run completed both macOS jobs successfully.
- Both ticket commits are GPG-signed and the implementation task is stamped in
  the same commit as the workflow change.
- After PR #5327 merged, this branch was rebased onto `master`; the PR now
  contains only its two #5126 commits.

## Post-merge acceptance

After merge, the first push to `master` must schedule this workflow. Its run
URL will be recorded in the ticket lane before #5126 is considered complete.
The issue's longer-running evidence also asks for five consecutive successful
master runs without retries.
