### PR TITLE
test(sqlite): add progress and timeout diagnostics

### DIFF
--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -14,6 +14,7 @@ module Test.Hspec.Extra
     , it
     , xit
     , itWithCustomTimeout
+    , itWithDiagnosticTimeout
     , parallel
     , counterexample
     , appendFailureReason
@@ -39,8 +40,18 @@ import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO
     )
+import Data.IORef
+    ( newIORef
+    , readIORef
+    , writeIORef
+    )
 import Data.List
     ( elemIndex
+    , intercalate
+    , isInfixOf
+    )
+import Data.Maybe
+    ( fromMaybe
     )
 -- See ADP-1910
 
@@ -50,6 +61,10 @@ import Say
 import System.Environment
     ( lookupEnv
     , withArgs
+    )
+import System.IO
+    ( hFlush
+    , stdout
     )
 import Test.HUnit.Lang
     ( FailureReason (..)
@@ -66,6 +81,16 @@ import Test.Hspec
     , beforeAll
     , beforeWith
     , specify
+    )
+import Test.Hspec.Core.Format
+    ( Event (..)
+    , Format
+    , FormatConfig
+    , Path
+    )
+import Test.Hspec.Core.Formatters.V2
+    ( checks
+    , formatterToFormat
     )
 import Test.Hspec.Core.Runner
     ( Config (..)
@@ -214,6 +239,43 @@ itWithCustomTimeout sec title action = specify title $ \ctx -> do
 
     report = mapM_ (sayString . ("retry: " ++)) . lines
 
+-- | Define an example with a timeout that reports its latest diagnostic
+-- state.
+--
+-- The example action can publish state as it progresses. If it times out, the
+-- failure names the example and reports the last state that was published.
+itWithDiagnosticTimeout
+    :: (HasCallStack, Show state)
+    => Int
+    -- ^ Timeout in seconds.
+    -> String
+    -- ^ Example title.
+    -> ((state -> IO ()) -> ActionWith ctx)
+    -> SpecWith ctx
+itWithDiagnosticTimeout sec title action = specify title $ \ctx -> do
+    latest <- newIORef Nothing
+    let publish state = do
+            let rendered = show state
+            length rendered `seq` writeIORef latest (Just rendered)
+    let timer = do
+            threadDelay (sec * 1000 * 1000)
+            state <- readIORef latest
+            let message =
+                    "timed out in "
+                        <> show sec
+                        <> " seconds while running "
+                        <> show title
+                        <> "; latest diagnostic state: "
+                        <> fromMaybe "no diagnostic state published" state
+            sayString message
+            hFlush stdout
+            pure message
+    race timer (action publish ctx) >>= \case
+        Left message ->
+            assertFailure message
+        Right () ->
+            pure ()
+
 -- | Like Hspec's parallel, except on Windows.
 parallel :: SpecWith a -> SpecWith a
 parallel
@@ -276,8 +338,33 @@ getDefaultConfig = do
     (env, args) <- execParser setEnvParser
     pure
         ( evaluateSummary <=< withArgs args . withAddedEnv env
-        , configWithExecutionTimes defaultConfig
+        , (configWithExecutionTimes defaultConfig)
+            { configFormat = Just sqliteProgressFormat
+            }
         )
+
+sqliteProgressFormat :: FormatConfig -> IO Format
+sqliteProgressFormat config = do
+    format <- formatterToFormat checks config
+    pure $ \event -> do
+        case event of
+            ItemStarted path ->
+                reportSqliteProgress "START" path
+            ItemDone path _ ->
+                reportSqliteProgress "FINISH" path
+            _ ->
+                pure ()
+        format event
+
+reportSqliteProgress :: String -> Path -> IO ()
+reportSqliteProgress event path
+    | "Sqlite" `isInfixOf` fullPath = do
+        putStrLn $ "SQLITE TEST " <> event <> " " <> fullPath
+        hFlush stdout
+    | otherwise =
+        pure ()
+  where
+    fullPath = intercalate "/" $ fst path <> [snd path]
 
 -- | A CLI arguments parser which handles setting environment variables.
 setEnvParser :: ParserInfo ([(String, String)], [String])

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -5,6 +5,7 @@ module Test.Hspec.ExtraSpec (spec) where
 
 import Control.Monad
     ( forM_
+    , replicateM
     , unless
     )
 import Control.Monad.IO.Unlift
@@ -12,6 +13,9 @@ import Control.Monad.IO.Unlift
     )
 import Data.Bifunctor
     ( first
+    )
+import Data.Foldable
+    ( traverse_
     )
 import Data.Function
     ( on
@@ -23,11 +27,16 @@ import Data.IORef
     , writeIORef
     )
 import Data.List
-    ( isPrefixOf
+    ( find
+    , findIndex
+    , isInfixOf
+    , isPrefixOf
     , nubBy
+    , tails
     )
 import Data.Maybe
     ( fromMaybe
+    , isNothing
     , listToMaybe
     )
 import Fmt
@@ -36,15 +45,32 @@ import Fmt
     , (|+)
     , (||+)
     )
+import GHC.Clock
+    ( getMonotonicTimeNSec
+    )
+import GHC.IO.Handle
+    ( hDuplicate
+    , hDuplicateTo
+    )
 import System.Exit
     ( ExitCode (..)
     )
 import System.IO
-    ( stderr
+    ( BufferMode (LineBuffering)
+    , Handle
+    , SeekMode (AbsoluteSeek)
+    , hClose
+    , hFileSize
+    , hFlush
+    , hGetChar
+    , hSeek
+    , hSetBuffering
+    , stderr
     , stdout
     )
 import System.IO.Silently
-    ( capture_
+    ( capture
+    , capture_
     , hCapture
     , silence
     )
@@ -60,6 +86,8 @@ import Test.Hspec
     , it
     , shouldBe
     , shouldContain
+    , shouldNotContain
+    , shouldSatisfy
     )
 import Test.Hspec.Core.Runner
     ( Summary (..)
@@ -99,6 +127,11 @@ import Test.QuickCheck.Monadic
 import Test.Utils.Env
     ( withEnv
     )
+import UnliftIO.Async
+    ( poll
+    , wait
+    , withAsync
+    )
 import UnliftIO.Concurrent
     ( threadDelay
     )
@@ -112,6 +145,7 @@ import UnliftIO.Exception
     , throwString
     , tryAny
     , tryDeep
+    , uninterruptibleMask_
     )
 import UnliftIO.MVar
     ( MVar
@@ -120,6 +154,9 @@ import UnliftIO.MVar
     , putMVar
     , tryReadMVar
     , tryTakeMVar
+    )
+import UnliftIO.Temporary
+    ( withSystemTempFile
     )
 import Prelude
 
@@ -130,6 +167,7 @@ spec = do
     itSpec
     aroundAllSpec
     mainSpec
+    sqliteProgressSpec
 
 itSpec :: Spec
 itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
@@ -165,6 +203,71 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
                 expectationFailure "should have timed out"
         res <- runIt (Extra.itWithCustomTimeout 2) timeout
         res `shouldContain` "timed out in 2 seconds"
+
+    describe "diagnostic timeout" $ sequential $ do
+        it "reports the title and latest published state" $ do
+            let timeout (publish :: String -> IO ()) = do
+                    traverse_ publish ["resource=first", "resource=latest"]
+                    threadDelay (2 * 1000 * 1000)
+            res <-
+                runDiagnosticIt
+                    (Extra.itWithDiagnosticTimeout 1)
+                    timeout
+            let failure = lineContaining "timed out" res
+            failure `shouldContain` "<test spec>"
+            failure `shouldContain` "resource=latest"
+            failure `shouldNotContain` "resource=first"
+
+        it "reports when no diagnostic state was published" $ do
+            let timeout (_publish :: String -> IO ()) =
+                    threadDelay (2 * 1000 * 1000)
+            res <-
+                runDiagnosticIt
+                    (Extra.itWithDiagnosticTimeout 1)
+                    timeout
+            let failure = lineContaining "timed out" res
+            failure `shouldContain` "<test spec>"
+            failure `shouldContain` "no diagnostic state published"
+
+        it "emits state before an uninterruptible worker unwinds"
+            $ withCapturedStdoutFile
+            $ \captureHandle -> do
+                let title = "<uninterruptible test spec>"
+                let latestState = "worker-state=inside-safe-call"
+                let nestedSpec =
+                        Extra.itWithDiagnosticTimeout 1 title
+                            $ \publish (_ctx :: ()) -> do
+                                publish latestState
+                                uninterruptibleMask_
+                                    $ threadDelay (5 * 1000 * 1000)
+                withAsync (runSpec nestedSpec defaultConfig) $ \worker -> do
+                    output <- waitForTimeoutLine 30 captureHandle
+                    (isNothing <$> poll worker) `shouldReturn` True
+                    let failure = lineContaining "timed out" output
+                    failure `shouldContain` title
+                    failure `shouldContain` latestState
+                    summary <- wait worker
+                    summaryFailures summary `shouldBe` 1
+
+        it "preserves an action failure" $ do
+            let failure (_publish :: String -> IO ()) =
+                    expectationFailure "original action failure"
+            res <-
+                runDiagnosticIt
+                    (Extra.itWithDiagnosticTimeout 10)
+                    failure
+            res `shouldContain` "original action failure"
+            res `shouldNotContain` "timed out"
+
+        it "returns promptly when the action succeeds" $ do
+            started <- getMonotonicTimeNSec
+            res <-
+                runDiagnosticIt
+                    (Extra.itWithDiagnosticTimeout 10)
+                    (\(_publish :: String -> IO ()) -> pure ())
+            elapsed <- subtract started <$> getMonotonicTimeNSec
+            res `shouldNotContain` "timed out"
+            elapsed `shouldSatisfy` (< 5 * 1000 * 1000 * 1000)
   where
     -- \| lhs `shouldMatchHSpecIt` rhs asserts that the output of running
     -- (Extra.it "" lhs) and (Hspec.it "" rhs) are equal. Modulo random seed-
@@ -188,17 +291,28 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
             $ flip runSpec defaultConfig
             $ beforeAll (return ())
             $ anyIt "<test spec>" (const body)
-      where
-        -- \| Remove time and seed such that we can compare the captured stdout
-        -- of two different hspec runs.
-        stripTime :: String -> String
-        stripTime =
-            unlines
-                . filter (not . ("Finished in" `isPrefixOf`))
-                . filter (not . ("Randomized" `isPrefixOf`))
-                . filter (not . ("retry:" `isPrefixOf`))
-                . filter (not . ("  To rerun use:" `isPrefixOf`))
-                . lines
+
+    runDiagnosticIt
+        :: (String -> ((state -> IO ()) -> ActionWith ()) -> SpecWith ())
+        -> ((state -> IO ()) -> IO ())
+        -> IO String
+    runDiagnosticIt anyIt body =
+        fmap stripTime
+            $ capture_
+            $ flip runSpec defaultConfig
+            $ beforeAll (return ())
+            $ anyIt "<test spec>" (\publish _ -> body publish)
+
+    -- \| Remove time and seed such that we can compare the captured stdout
+    -- of two different hspec runs.
+    stripTime :: String -> String
+    stripTime =
+        unlines
+            . filter (not . ("Finished in" `isPrefixOf`))
+            . filter (not . ("Randomized" `isPrefixOf`))
+            . filter (not . ("retry:" `isPrefixOf`))
+            . filter (not . ("  To rerun use:" `isPrefixOf`))
+            . lines
 
     -- \| Returns an IO action that is different every time you run it!,
     -- according to the supplied IORef of outcomes.
@@ -286,6 +400,107 @@ aroundAllSpec = sequential $ do
 mainSpec :: Spec
 mainSpec = sequential $ describe "hspecMain" $ do
     prop "correctly sets environment variables" prop_hspecMain
+
+sqliteProgressSpec :: Spec
+sqliteProgressSpec =
+    sequential $ describe "hspecMain SQLite progress" $ do
+        it "surrounds a nested SQLite example and ignores other examples" $ do
+            out <-
+                capture_
+                    $ withArgs []
+                    $ hspecMain
+                    $ do
+                        describe "Cardano.DB.Sqlite.Fake" $ do
+                            describe "inner" $ do
+                                it "leaf" $ putStrLn bodyMarker
+                        describe "Cardano.DB.Memory.Fake" $ do
+                            it "other leaf" $ pure @IO ()
+
+            countOccurrences "SQLITE TEST START" out `shouldBe` 1
+            countOccurrences "SQLITE TEST FINISH" out `shouldBe` 1
+            lineContaining "SQLITE TEST START" out
+                `shouldContain` sqlitePath
+            lineContaining "SQLITE TEST FINISH" out
+                `shouldContain` sqlitePath
+            ordered
+                [ "SQLITE TEST START"
+                , bodyMarker
+                , "SQLITE TEST FINISH"
+                ]
+                out
+                `shouldBe` True
+
+        it "finishes a failing SQLite example without hiding the failure" $ do
+            (out, result) <-
+                capture
+                    $ tryDeep
+                    $ withArgs []
+                    $ hspecMain
+                    $ describe "Cardano.DB.Sqlite.Fake"
+                    $ describe "inner"
+                    $ it "failing leaf"
+                    $ expectationFailure failureMarker
+
+            result `shouldBe` Left (ExitFailure 1)
+            lineContaining "SQLITE TEST START" out
+                `shouldContain` failurePath
+            lineContaining "SQLITE TEST FINISH" out
+                `shouldContain` failurePath
+            out `shouldContain` failureMarker
+  where
+    bodyMarker = "SQLITE BODY MARKER"
+    failureMarker = "SQLITE FAILURE MARKER"
+    sqlitePath = "Cardano.DB.Sqlite.Fake/inner/leaf"
+    failurePath = "Cardano.DB.Sqlite.Fake/inner/failing leaf"
+
+countOccurrences :: String -> String -> Int
+countOccurrences needle =
+    length . filter (isPrefixOf needle) . tails
+
+lineContaining :: String -> String -> String
+lineContaining needle =
+    fromMaybe "" . find (needle `isInfixOf`) . lines
+
+ordered :: [String] -> String -> Bool
+ordered [] _ = True
+ordered (needle : needles) haystack =
+    case findIndex (isPrefixOf needle) $ tails haystack of
+        Nothing -> False
+        Just index ->
+            ordered needles
+                $ drop (index + length needle) haystack
+
+withCapturedStdoutFile :: (Handle -> IO a) -> IO a
+withCapturedStdoutFile action =
+    withSystemTempFile "cardano-wallet-timeout-output"
+        $ \_path captureHandle ->
+            bracket
+                (acquire captureHandle)
+                release
+                (const $ action captureHandle)
+  where
+    acquire captureHandle = do
+        hSetBuffering captureHandle LineBuffering
+        originalStdout <- hDuplicate stdout
+        hDuplicateTo captureHandle stdout
+        pure originalStdout
+
+    release originalStdout = do
+        hFlush stdout
+        hDuplicateTo originalStdout stdout
+        hClose originalStdout
+
+waitForTimeoutLine :: Int -> Handle -> IO String
+waitForTimeoutLine attempts captureHandle = do
+    hFlush stdout
+    size <- hFileSize captureHandle
+    hSeek captureHandle AbsoluteSeek 0
+    output <- replicateM (fromIntegral size) $ hGetChar captureHandle
+    if "timed out" `isInfixOf` output || attempts <= 0
+        then pure output
+        else do
+            threadDelay (100 * 1000)
+            waitForTimeoutLine (attempts - 1) captureHandle
 
 prop_hspecMain
     :: [((NiceString, NiceString), ArgStyle)]

--- a/lib/unit/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/unit/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 
 -- |
@@ -16,14 +17,16 @@ import Control.Retry
     , limitRetries
     )
 import Control.Tracer
-    ( nullTracer
+    ( Tracer (..)
     )
 import Test.Hspec
     ( Spec
     , describe
-    , it
     , shouldBe
     , shouldReturn
+    )
+import Test.Hspec.Extra
+    ( itWithDiagnosticTimeout
     )
 import UnliftIO.Async
     ( concurrently
@@ -43,36 +46,150 @@ spec = describe "RefCount" $ do
     let testId = 1 :: Int
         otherId = 2 :: Int
 
-    it "resource can be allocated multiple times" $ do
-        ref <- newRefCount
-        withRef ref testId $ withRef ref testId $ pure ()
-        waitForFree' nullTracer testPol ref testId $ flip shouldBe 0
+    itWithDiagnosticTimeout 60 "resource can be allocated multiple times"
+        $ \publish _ -> do
+            publish $ diagnostic testId RefCountNotObserved PreparingRefCount
+            ref <- newRefCount
+            publish $ diagnostic testId RefCountNotObserved AcquiringReferences
+            withRef ref testId $ withRef ref testId $ pure ()
+            publish $ diagnostic testId RefCountNotObserved WaitingForFree
+            waitForFree'
+                (refCountTracer publish testId)
+                testPol
+                ref
+                testId
+                $ withObservedCount publish testId CheckingCount
+                $ flip shouldBe 0
 
-    it "waitForFree waits for withRef to finish" $ do
-        ref <- newRefCount
-        closed <- newEmptyMVar
+    itWithDiagnosticTimeout 60 "waitForFree waits for withRef to finish"
+        $ \publish _ -> do
+            publish $ diagnostic testId RefCountNotObserved PreparingRefCount
+            ref <- newRefCount
+            closed <- newEmptyMVar
 
-        let conn = withRef ref testId $ do
-                threadDelay 500_000
-                putMVar closed ()
-        let rm = waitForFree' nullTracer testPol ref testId $ \n -> do
-                n `shouldBe` 0
-                isEmptyMVar closed
+            let conn = withRef ref testId $ do
+                    publish
+                        $ diagnostic
+                            testId
+                            (RefCountObserved $ Just 1)
+                            HoldingReference
+                    threadDelay 500_000
+                    putMVar closed ()
+                    publish
+                        $ diagnostic
+                            testId
+                            (RefCountObserved $ Just 1)
+                            ReleasingReference
+            let rm = do
+                    publish $ diagnostic testId RefCountNotObserved WaitingForFree
+                    waitForFree'
+                        (refCountTracer publish testId)
+                        testPol
+                        ref
+                        testId
+                        $ \n -> do
+                            publish
+                                $ diagnostic
+                                    testId
+                                    (RefCountObserved $ Just n)
+                                    CheckingCloseSignal
+                            n `shouldBe` 0
+                            isEmptyMVar closed
 
-        concurrently conn (threadDelay 50_000 >> rm)
-            `shouldReturn` ((), False)
+            concurrently conn (threadDelay 50_000 >> rm)
+                `shouldReturn` ((), False)
 
-    it "waitForFree uses correct id" $ do
-        ref <- newRefCount
-        withRef ref testId
-            $ waitForFree' nullTracer testPol ref otherId
-            $ flip shouldBe 0
+    itWithDiagnosticTimeout 60 "waitForFree uses correct id"
+        $ \publish _ -> do
+            publish $ diagnostic otherId RefCountNotObserved PreparingRefCount
+            ref <- newRefCount
+            publish
+                $ diagnostic
+                    otherId
+                    RefCountNotObserved
+                    HoldingDifferentResource
+            withRef ref testId
+                $ waitForFree'
+                    (refCountTracer publish otherId)
+                    testPol
+                    ref
+                    otherId
+                $ withObservedCount publish otherId CheckingCount
+                $ flip shouldBe 0
 
-    it "waitForFree times out" $ do
-        ref <- newRefCount
-        withRef ref testId
-            $ waitForFree' nullTracer quickPol ref testId
-            $ flip shouldBe 1
+    itWithDiagnosticTimeout 60 "waitForFree times out"
+        $ \publish _ -> do
+            publish $ diagnostic testId RefCountNotObserved PreparingRefCount
+            ref <- newRefCount
+            publish
+                $ diagnostic
+                    testId
+                    (RefCountObserved $ Just 1)
+                    HoldingReference
+            withRef ref testId
+                $ waitForFree'
+                    (refCountTracer publish testId)
+                    quickPol
+                    ref
+                    testId
+                $ withObservedCount publish testId CheckingRetryResult
+                $ flip shouldBe 1
+
+data DeleteDiagnostic = DeleteDiagnostic
+    { resourceId :: Int
+    , observedReferenceCount :: ReferenceCountObservation
+    , waitStage :: WaitStage
+    }
+    deriving (Show)
+
+data ReferenceCountObservation
+    = RefCountNotObserved
+    | RefCountObserved (Maybe Int)
+    deriving (Show)
+
+data WaitStage
+    = PreparingRefCount
+    | AcquiringReferences
+    | HoldingReference
+    | HoldingDifferentResource
+    | ReleasingReference
+    | WaitingForFree
+    | PollingReferenceCount
+    | CheckingCount
+    | CheckingCloseSignal
+    | CheckingRetryResult
+    deriving (Show)
+
+diagnostic
+    :: Int
+    -> ReferenceCountObservation
+    -> WaitStage
+    -> DeleteDiagnostic
+diagnostic resourceId observedReferenceCount waitStage =
+    DeleteDiagnostic{resourceId, observedReferenceCount, waitStage}
+
+refCountTracer
+    :: (DeleteDiagnostic -> IO ())
+    -> Int
+    -> Tracer IO (Maybe Int)
+refCountTracer publish resourceId = Tracer $ \count ->
+    publish
+        $ diagnostic
+            resourceId
+            (RefCountObserved count)
+            PollingReferenceCount
+
+withObservedCount
+    :: (DeleteDiagnostic -> IO ())
+    -> Int
+    -> WaitStage
+    -> (Int -> IO a)
+    -> Int
+    -> IO a
+withObservedCount publish resourceId waitStage action count = do
+    publish
+        $ diagnostic resourceId (RefCountObserved $ Just count) waitStage
+    action count
 
 testPol :: RetryPolicy
 testPol = constantDelay 50_000 <> limitRetries 20

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Sqlite/Migration/NewSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Sqlite/Migration/NewSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Copyright: © 2023 IOHK License: Apache-2.0
@@ -37,8 +38,10 @@ import System.IO.Temp
 import Test.Hspec
     ( Spec
     , describe
-    , it
     , shouldReturn
+    )
+import Test.Hspec.Extra
+    ( itWithDiagnosticTimeout
     )
 import UnliftIO
     ( MonadUnliftIO
@@ -55,28 +58,77 @@ import qualified Database.Persist.Sqlite as Sqlite
 spec :: Spec
 spec = do
     describe "new migrations" $ do
-        it "handles backupDatabaseFile and withDatabaseFile" $ do
-            withSystemTempDirectory "test" $ \dir -> do
-                let interface = newMigrationInterface nullTracer
-                let dbf = dir <> "/db"
-                execute interface dbf createTable
-                backupDatabaseFile interface dbf $ Version 1
-                execute interface dbf populateTable
-                backupDatabaseFile interface dbf $ Version 2
-                sort <$> listDirectory dir
-                    `shouldReturn` sort ["db", "db.v1.bak", "db.v2.bak"]
+        itWithDiagnosticTimeout
+            60
+            "handles backupDatabaseFile and withDatabaseFile"
+            $ \publish _ ->
+                withSystemTempDirectory "test" $ \dir -> do
+                    let interface = newMigrationInterface nullTracer
+                    let dbf = dir <> "/db"
+                    execute publish interface dbf CreateTable createTable
+                    publish $ diagnostic dbf (BackupTo $ Version 1) LockExpected
+                    backupDatabaseFile interface dbf $ Version 1
+                    publish
+                        $ diagnostic dbf (BackupTo $ Version 1) NoConnectionExpected
+                    execute publish interface dbf PopulateTable populateTable
+                    publish $ diagnostic dbf (BackupTo $ Version 2) LockExpected
+                    backupDatabaseFile interface dbf $ Version 2
+                    publish
+                        $ diagnostic dbf (BackupTo $ Version 2) NoConnectionExpected
+                    publish $ diagnostic dbf InspectFiles NoConnectionExpected
+                    sort <$> listDirectory dir
+                        `shouldReturn` sort ["db", "db.v1.bak", "db.v2.bak"]
 
 execute
     :: MonadUnliftIO m
-    => MigrationInterface m DBHandle
+    => (MigrationDiagnostic -> m ())
+    -> MigrationInterface m DBHandle
     -> FilePath
+    -> MigrationOperation
     -> Text
     -> m ()
-execute interface dbf t =
+execute publish interface dbf operation t = do
+    publish $ diagnostic dbf operation ConnectionOpening
     withDatabaseFile interface dbf $ \handle ->
-        Sqlite.runSqlConn
-            (Sqlite.rawExecute t [])
-            (dbBackend handle)
+        do
+            publish $ diagnostic dbf operation ConnectionOpen
+            Sqlite.runSqlConn
+                (Sqlite.rawExecute t [])
+                (dbBackend handle)
+    publish $ diagnostic dbf operation NoConnectionExpected
+
+data MigrationDiagnostic = MigrationDiagnostic
+    { databaseFile :: FilePath
+    , currentOperation :: MigrationOperation
+    , connectionOrLockExpectation :: ConnectionOrLockExpectation
+    }
+    deriving (Show)
+
+data MigrationOperation
+    = CreateTable
+    | BackupTo Version
+    | PopulateTable
+    | InspectFiles
+    deriving (Show)
+
+data ConnectionOrLockExpectation
+    = NoConnectionExpected
+    | ConnectionOpening
+    | ConnectionOpen
+    | LockExpected
+    deriving (Show)
+
+diagnostic
+    :: FilePath
+    -> MigrationOperation
+    -> ConnectionOrLockExpectation
+    -> MigrationDiagnostic
+diagnostic databaseFile currentOperation connectionOrLockExpectation =
+    MigrationDiagnostic
+        { databaseFile
+        , currentOperation
+        , connectionOrLockExpectation
+        }
 
 createTable :: Text
 createTable =

--- a/specs/5103-sqlite-unit-logging-timeouts/plan.md
+++ b/specs/5103-sqlite-unit-logging-timeouts/plan.md
@@ -1,0 +1,58 @@
+# Plan — #5103 SQLite unit-test diagnostics
+
+## Technical approach
+
+Extend `Test.Hspec.Extra`, the unit-suite runner already used by
+`cardano-wallet-unit`, with two test-only capabilities:
+
+1. A Hspec V2 formatter derived from `specdoc` that emits line-buffered
+   `SQLITE TEST START` and `SQLITE TEST FINISH` events for paths containing
+   `Sqlite`.
+2. A diagnostic timeout example helper. The action receives a callback for
+   publishing its latest state; on timeout, the helper fails with the test
+   title and the last published state.
+
+Use the diagnostic helper in the two SQLite specs that can block:
+`Cardano.DB.Sqlite.DeleteSpec` and
+`Cardano.Wallet.DB.Sqlite.Migration.NewSpec`. The pure persistence tests in
+`Cardano.Wallet.DB.Sqlite.TypesSpec` receive progress logging from the
+formatter and need no fabricated DB state.
+
+## Slice 1 — observable SQLite test execution
+
+One bisect-safe commit owns:
+
+- `lib/test-utils/src/Test/Hspec/Extra.hs`
+- `lib/test-utils/test/Test/Hspec/ExtraSpec.hs`
+- `lib/unit/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs`
+- `lib/unit/test/unit/Cardano/Wallet/DB/Sqlite/Migration/NewSpec.hs`
+
+### RED
+
+Add negative-control tests that demand:
+
+- a deliberately timed-out example reports its title and injected state;
+- a nested SQLite example produces both progress events.
+
+Run the focused `cardano-wallet-test-utils` proof and observe failure before
+implementing the helper and formatter.
+
+### GREEN
+
+Implement the formatter and timeout helper, then apply 60-second diagnostic
+timeouts to the blocking Delete and Migration examples. Re-run the negative
+controls and the three target SQLite modules.
+
+### Verification
+
+- Focused helper tests with `nix run .#unit-cardano-wallet-test-utils`.
+- Target module runs with `nix run .#unit-cardano-wallet-unit` and one
+  `--match` per module.
+- `./gate.sh`, which also performs formatting, HLint, actionlint, and the
+  repository Nix build matrix.
+
+## Commit
+
+Subject: `test(sqlite): add progress and timeout diagnostics`
+
+Trailer: `Tasks: T510301, T510302, T510303, T510304, T510305`

--- a/specs/5103-sqlite-unit-logging-timeouts/plan.md
+++ b/specs/5103-sqlite-unit-logging-timeouts/plan.md
@@ -5,7 +5,8 @@
 Extend `Test.Hspec.Extra`, the unit-suite runner already used by
 `cardano-wallet-unit`, with two test-only capabilities:
 
-1. A Hspec V2 formatter derived from `specdoc` that emits line-buffered
+1. A Hspec V2 formatter derived from the existing `checks` formatter that
+   preserves the current suite output while emitting line-buffered
    `SQLITE TEST START` and `SQLITE TEST FINISH` events for paths containing
    `Sqlite`.
 2. A diagnostic timeout example helper. The action receives a callback for

--- a/specs/5103-sqlite-unit-logging-timeouts/spec.md
+++ b/specs/5103-sqlite-unit-logging-timeouts/spec.md
@@ -1,0 +1,41 @@
+# Specification — #5103 SQLite unit-test diagnostics
+
+## User story
+
+As a CI maintainer, I need a hanging SQLite unit-test job to identify the
+exact example and its last known database or reference-count state, so that
+the failure can be diagnosed from the first Buildkite log.
+
+## Functional requirements
+
+- FR-001: Every unit-test example whose fully-qualified Hspec path contains
+  `Sqlite` emits a line when it starts and a line when it finishes.
+- FR-002: Both progress lines include the fully-qualified example path and
+  are flushed while the process is running.
+- FR-003: SQLite examples that can block on a reference, connection, backup,
+  or query use a 60-second timeout.
+- FR-004: A timeout failure names the example and includes its latest
+  diagnostic state.
+- FR-005: Reference-count diagnostics identify the resource id, observed
+  reference count, and wait/lock stage.
+- FR-006: migration diagnostics identify the database file, current
+  operation, and whether a connection or lock is expected to be open.
+- FR-007: pure `PersistField` SQLite type tests are identified by progress
+  logs but do not invent a database/lock state that they do not have.
+
+## Success criteria
+
+- SC-001: A focused SQLite run visibly prints paired `START` and `FINISH`
+  lines for the Delete, Migration.New, and Types specs.
+- SC-002: A seeded timeout test fails with the example name and injected
+  diagnostic state in its error text.
+- SC-003: A seeded formatter test observes both progress lines before and
+  after an example.
+- SC-004: The existing focused SQLite suite and the full repository gate
+  pass after the change.
+
+## Non-goals
+
+- Changing production SQLite locking, retry, migration, or connection code.
+- Adding retries that hide a hang.
+- Logging SQL parameters or other potentially sensitive values.

--- a/specs/5103-sqlite-unit-logging-timeouts/tasks.md
+++ b/specs/5103-sqlite-unit-logging-timeouts/tasks.md
@@ -2,13 +2,13 @@
 
 ## Slice 1 — observable SQLite test execution
 
-- [ ] T510301 Add negative controls for timeout diagnostics and SQLite
+- [x] T510301 Add negative controls for timeout diagnostics and SQLite
   progress events.
-- [ ] T510302 Implement the Hspec SQLite progress formatter and diagnostic
+- [x] T510302 Implement the Hspec SQLite progress formatter and diagnostic
   timeout helper.
-- [ ] T510303 Apply 60-second state-reporting timeouts to blocking Delete and
+- [x] T510303 Apply 60-second state-reporting timeouts to blocking Delete and
   Migration SQLite examples.
-- [ ] T510304 Prove the helper tests, target SQLite modules, and full gate are
+- [x] T510304 Prove the helper tests, target SQLite modules, and full gate are
   green.
-- [ ] T510305 Land one signed bisect-safe commit with the required task
+- [x] T510305 Land one signed bisect-safe commit with the required task
   trailer.

--- a/specs/5103-sqlite-unit-logging-timeouts/tasks.md
+++ b/specs/5103-sqlite-unit-logging-timeouts/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — #5103 SQLite unit-test diagnostics
+
+## Slice 1 — observable SQLite test execution
+
+- [ ] T510301 Add negative controls for timeout diagnostics and SQLite
+  progress events.
+- [ ] T510302 Implement the Hspec SQLite progress formatter and diagnostic
+  timeout helper.
+- [ ] T510303 Apply 60-second state-reporting timeouts to blocking Delete and
+  Migration SQLite examples.
+- [ ] T510304 Prove the helper tests, target SQLite modules, and full gate are
+  green.
+- [ ] T510305 Land one signed bisect-safe commit with the required task
+  trailer.


### PR DESCRIPTION
Closes #5103.

## Why

The SQLite unit-test job can occasionally hang without saying which example
is blocked. That makes the first CI failure unactionable and forces a retry
before anyone can diagnose it.

## What this PR delivers

- immediate start and finish lines for SQLite Hspec examples;
- explicit timeouts for tests that can block on a database connection,
  reference count, or backup;
- timeout errors that name the example and print its latest database or lock
  state;
- negative controls proving the timeout and progress signals fire, including
  while an uninterruptible worker is still unwinding;
- preservation of the existing Hspec `checks` output.

## Verification

Fresh verification on the final signed commit:

- `Test.Hspec.Extra`: 21 examples, 0 failures;
- `Cardano.DB.Sqlite.Delete`: 4 examples, 0 failures;
- `Cardano.Wallet.DB.Sqlite.Migration.New`: 1 example, 0 failures;
- `Cardano.Wallet.DB.Sqlite.Types`: 11 examples, 0 failures;
- mutation control: removing pre-cancellation timeout emission produces
  1 example, 1 failure;
- complete local gate: focused suites, formatting, HLint, actionlint, and the
  full Nix build matrix.

The final implementation patch was navigator-approved byte-for-byte and the
amended commit signature and task trailer were independently verified.
