### PR TITLE
docs: add macOS integration badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
     <a href="https://github.com/cardano-foundation/cardano-wallet/actions/workflows/macos-unit-tests.yml">
         <img src="https://img.shields.io/github/actions/workflow/status/cardano-foundation/cardano-wallet/macos-unit-tests.yml?label=macOS&style=for-the-badge&branch=master"/>
     </a>
+    <a href="https://github.com/cardano-foundation/cardano-wallet/actions/workflows/macos-integration.yml">
+        <img src="https://img.shields.io/github/actions/workflow/status/cardano-foundation/cardano-wallet/macos-integration.yml?label=macOS%20Integration&style=for-the-badge&branch=master"/>
+    </a>
 </p>
 
 <hr/>


### PR DESCRIPTION
Closes #5352

## Summary

Add a `macOS Integration` workflow-status badge beside the existing macOS
unit-test badge in the README. It reports the dedicated
`macos-integration.yml` workflow on `master` and links directly to that
workflow's GitHub Actions page.

The workflow earned a badge after its first automatic master-push run
completed successfully:
https://github.com/cardano-foundation/cardano-wallet/actions/runs/30464793708

No existing badges or workflows change.

## Verification

- The README-only checker rejects the badge-free base README and accepts the
  new badge in the expected position.
- The workflow link resolves successfully.
- The Shields.io URL resolves as an SVG and is explicitly filtered to
  `branch=master`.
- The PR contains one signed docs commit changing only `README.md`.
