### PR TITLE
fix(ci): clean up Windows E2E temp directories on cancellation

### DIFF
--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -65,11 +65,27 @@ jobs:
         run: |
           # Only remove job-private paths under RUNNER_TEMP.
           # Do not glob shared %TEMP% — sibling jobs share the machine temp root.
+          $ErrorActionPreference = 'Stop'
           $root = $env:RUNNER_TEMP
-          if (-not $root) { Write-Host "RUNNER_TEMP unset; skip"; exit 0 }
-          Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -like 'e2e*' -or $_.Name -like 'test-cluster*' } |
-            ForEach-Object {
-              Write-Host "Removing $($_.FullName)"
-              Remove-Item -Recurse -Force -ErrorAction Continue $_.FullName
-            }
+          if ([string]::IsNullOrWhiteSpace($root)) {
+            Write-Error 'RUNNER_TEMP is missing or empty'
+            exit 1
+          }
+          if (-not (Test-Path -LiteralPath $root)) {
+            Write-Error "RUNNER_TEMP path does not exist: $root"
+            exit 1
+          }
+          $dirs = @(Get-ChildItem -Path $root -Directory -ErrorAction Stop |
+            Where-Object { $_.Name -like 'e2e*' -or $_.Name -like 'test-cluster*' })
+          foreach ($d in $dirs) {
+            Write-Host "Removing $($d.FullName)"
+            Remove-Item -LiteralPath $d.FullName -Recurse -Force -ErrorAction Stop
+          }
+          $residual = @(Get-ChildItem -Path $root -Directory -ErrorAction Stop |
+            Where-Object { $_.Name -like 'e2e*' -or $_.Name -like 'test-cluster*' })
+          if ($residual.Count -gt 0) {
+            $residual | ForEach-Object { Write-Host "Residual: $($_.FullName)" }
+            Write-Error "Cleanup left $($residual.Count) residual E2E temp directories"
+            exit 1
+          }
+          Write-Host 'Cleanup verified: 0 residual E2E temp directories'

--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -39,9 +39,14 @@ jobs:
           name: win-e2e
           path: e2e-bundle
 
+      # RUNNER_TEMP / ${{ runner.temp }} is per-job; do not glob shared Windows
+      # TEMP — sibling jobs share the machine temp root.
       - name: Run Windows smoke (create wallet + single tx)
         working-directory: e2e-bundle
         env:
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+          TMPDIR: ${{ runner.temp }}
           LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
           CARDANO_WALLET_TEST_DATA: test\data
         shell: pwsh
@@ -51,3 +56,20 @@ jobs:
             --fail-on=empty `
             --match "TRANS_CREATE_01x - Single Output Transaction" `
             -j1
+
+      - name: Cleanup E2E temp directories
+        if: always()
+        shell: pwsh
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          # Only remove job-private paths under RUNNER_TEMP.
+          # Do not glob shared %TEMP% — sibling jobs share the machine temp root.
+          $root = $env:RUNNER_TEMP
+          if (-not $root) { Write-Host "RUNNER_TEMP unset; skip"; exit 0 }
+          Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like 'e2e*' -or $_.Name -like 'test-cluster*' } |
+            ForEach-Object {
+              Write-Host "Removing $($_.FullName)"
+              Remove-Item -Recurse -Force -ErrorAction Continue $_.FullName
+            }

--- a/specs/5196-windows-e2e-temp-cleanup/plan.md
+++ b/specs/5196-windows-e2e-temp-cleanup/plan.md
@@ -1,0 +1,29 @@
+# Plan — #5196 Windows E2E temp cleanup
+
+## Scope
+
+Behavior-changing work touches only `.github/workflows/windows-e2e.yml`.
+
+Orchestrator-owned: `specs/5196-windows-e2e-temp-cleanup/{spec,plan,tasks}.md`
+and untracked `./gate.sh`.
+
+## Task model (canonical numeric IDs)
+
+| ID | Role |
+|----|------|
+| T001–T004 | Bootstrap (spec, plan/tasks, gate, draft PR) |
+| T005 | Scope TEMP/TMP/TMPDIR + always cleanup |
+| T006 | Fail-closed cleanup + residual assertion |
+| T007 | Docs/gate remediation (SC4 mandatory) |
+| T008 | Finalization (stamp, push, draft) |
+| T009 | Live cancel proof (desk-owned SC4) |
+
+## Slice A — scoping (T005)
+
+Owned file: `.github/workflows/windows-e2e.yml`.
+Subject: `fix(ci): scope Windows E2E temp and always clean job-private dirs`
+Trailer: `Tasks: T005`
+
+## Proof
+
+Focused shell checker in `./gate.sh` is the RED/GREEN instrument for YAML.

--- a/specs/5196-windows-e2e-temp-cleanup/plan.md
+++ b/specs/5196-windows-e2e-temp-cleanup/plan.md
@@ -2,10 +2,14 @@
 
 ## Scope
 
-Behavior-changing work touches only `.github/workflows/windows-e2e.yml`.
+Behavior-changing work touches only:
 
-Orchestrator-owned: `specs/5196-windows-e2e-temp-cleanup/{spec,plan,tasks}.md`
-and untracked `./gate.sh`.
+- `.github/workflows/windows-e2e.yml`
+
+Orchestrator-owned artifacts:
+
+- `specs/5196-windows-e2e-temp-cleanup/{spec,plan,tasks}.md`
+- untracked `./gate.sh` (runtime copy `/tmp/ms-cw-tech-debt/t5196/gate.sh`)
 
 ## Task model (canonical numeric IDs)
 
@@ -18,12 +22,56 @@ and untracked `./gate.sh`.
 | T008 | Finalization (stamp, push, draft) |
 | T009 | Live cancel proof (desk-owned SC4) |
 
-## Slice A — scoping (T005)
+## Landed so far (T005)
 
-Owned file: `.github/workflows/windows-e2e.yml`.
-Subject: `fix(ci): scope Windows E2E temp and always clean job-private dirs`
-Trailer: `Tasks: T005`
+Slice A scoped TEMP/TMP/TMPDIR to `${{ runner.temp }}` and added an
+`if: always()` cleanup step. That cleanup is **soft**: it can exit 0 when
+`RUNNER_TEMP` is missing, silences enumeration/deletion errors, and does not
+assert zero residual directories. Issue #5196 requires a cancelled-run proof;
+soft cleanup cannot satisfy that.
 
-## Proof
+## Correction slice (T006)
 
-Focused shell checker in `./gate.sh` is the RED/GREEN instrument for YAML.
+One forward correction commit (not an amend of T005):
+
+### Required cleanup behavior
+
+1. Missing/empty `RUNNER_TEMP` → non-zero exit.
+2. Enumeration and deletion errors fail the step.
+3. After delete, re-enumerate `e2e*` / `test-cluster*` under the job-private
+   root.
+4. Fail if any residual match remains.
+5. On success print exactly:
+   `Cleanup verified: 0 residual E2E temp directories`
+6. Keep job-private root and name fence; do not alter smoke command, runner,
+   timeout, build job, or triggers.
+
+### Proof strategy (RED → GREEN)
+
+Local instrument: untracked `./gate.sh` contract checker.
+
+After the orchestrator docs/gate extension (T007), current head MUST be RED for
+missing fail-closed postcondition signals.
+
+Driver: RED → GREEN → one local commit; no push.
+Subject: `fix(ci): fail Windows E2E cleanup on residual directories`
+Trailer: `Tasks: T006`
+
+## Live-boundary proof (T009, desk-owned after push)
+
+After owner acceptance + explicit SSH push:
+
+1. Dispatch `windows-e2e.yml` on the exact remote branch head.
+2. Wait until the Windows smoke step is running.
+3. Cancel the workflow.
+4. Require cleanup step log contains
+   `Cleanup verified: 0 residual E2E temp directories`.
+5. Record run URL + excerpt in
+   `/tmp/ms-cw-tech-debt/t5196/sc4-cancel-proof.md`.
+6. Exact-head CI green; final audit; leave draft until then.
+
+## Forbidden in every slice
+
+`lib/`, `src/`, `app/`, `test/`, `nix/`, `flake.nix`, `flake.lock`,
+`cabal.project`, other workflows, `gate.sh` (orchestrator), `specs/`
+(orchestrator), milestone #113 / cardano-api paths.

--- a/specs/5196-windows-e2e-temp-cleanup/spec.md
+++ b/specs/5196-windows-e2e-temp-cleanup/spec.md
@@ -6,9 +6,10 @@ When Windows E2E tests are cancelled (timeout or `cancel-in-progress`),
 Haskell's `withSystemTempDirectory` cleanup never runs. Temp state lands in
 the shared Windows system temp root and leaks ~17GB per run. Linux already
 scopes E2E temp to the job-private `${{ runner.temp }}` (see #5195 /
-`.github/workflows/linux-e2e.yml`). The Windows workflow
-(`.github/workflows/windows-e2e.yml`) has no temp scoping and no
-`if: always()` cleanup.
+`.github/workflows/linux-e2e.yml`). The Windows workflow must scope temp the
+same way, clean fail-closed under that job-private root even when the smoke
+step is cancelled, and prove that on a live cancelled run before the PR leaves
+draft.
 
 ## P1 user story
 
@@ -17,25 +18,55 @@ E2E temp directories scoped to the job-private runner temp and removed even
 when the job is cancelled, so a timed-out run cannot fill the Windows runner
 disk the way cancelled Linux E2E runs once filled `/tmp`.
 
+## Supporting user stories
+
+- As a CI maintainer, I want the Windows cleanup pattern to match Linux's
+  safety model: never glob a shared temp root that sibling jobs also use.
+- As a reviewer, I want a cheap local check (static workflow assertions +
+  actionlint) for the YAML contract, plus a mandatory live cancelled-run
+  artifact that shows fail-closed cleanup and zero residual directories.
+
 ## Functional requirements
 
-- **FR1** — The `e2e-tests` job MUST set `TEMP`, `TMP`, and `TMPDIR` on the
-  run step to `${{ runner.temp }}`.
+- **FR1** — The `e2e-tests` job in `.github/workflows/windows-e2e.yml` MUST
+  set Windows temp env vars (`TEMP`, `TMP`, and `TMPDIR` for consistency) on
+  the run step to `${{ runner.temp }}` so `withSystemTempDirectory` creates
+  directories under the job-private root.
 - **FR2** — The same job MUST contain an `if: always()` cleanup step that
-  removes only `e2e*` / `test-cluster*` under that job-private temp root.
-- **FR3** — The workflow MUST document that cleanup must not glob a shared
-  temp location that could wipe sibling jobs' live state.
-- **FR4** — No other workflow, Nix, or application source is in scope.
+  removes only directories matching `e2e*` / `test-cluster*` under that
+  job-private temp root (not under a shared system temp path).
+- **FR3** — The workflow MUST document, in a comment next to the temp
+  scoping or cleanup step, that cleanup must not glob a shared temp location
+  that could wipe sibling jobs' live state (same constraint as Linux E2E).
+- **FR4** — The cleanup step MUST be fail-closed:
+  - missing or empty `RUNNER_TEMP` fails (non-zero exit);
+  - enumeration errors fail;
+  - deletion errors fail;
+  - after deletion, re-enumerate the same name patterns under the job-private
+    root and fail if any residual match remains;
+  - on success, emit the stable line
+    `Cleanup verified: 0 residual E2E temp directories`.
+- **FR5** — No other workflow, Nix, or application source is in scope. Do not
+  change the smoke command, runner, timeout, build job, or triggers.
 
 ## Non-goals
 
 - Changing which E2E test is matched or how the Windows bundle is built.
-- Milestone #113 / cardano-api work.
+- Milestone #113 / cardano-api work (hard exclusion for this desk).
 - Linux E2E (already fixed).
 
 ## Success criteria
 
-- **SC1** — Focused checker fails on baseline and passes on the fixed file.
+- **SC1** — Focused checker fails on baseline / soft cleanup and passes on the
+  fail-closed fixed file (RED then GREEN).
 - **SC2** — `actionlint` accepts `.github/workflows/windows-e2e.yml`.
-- **SC3** — Workflow YAML shows `${{ runner.temp }}` scoping, `if: always()`
-  cleanup, and the sibling-job safety comment.
+- **SC3** — Workflow YAML shows `${{ runner.temp }}` scoping,
+  `if: always()` fail-closed cleanup limited to job-private paths, sibling-job
+  safety comment, and the stable zero-residual success line.
+- **SC4** (**mandatory pre-merge live-boundary**) — A cancelled or timed-out
+  Windows E2E run on the exact PR head shows the cleanup step in the job log
+  with the stable success line
+  `Cleanup verified: 0 residual E2E temp directories`.
+  Named artifact: workflow run URL + cleanup step log excerpt stored under
+  the lane runtime (`/tmp/ms-cw-tech-debt/t5196/sc4-cancel-proof.md`).
+  This is a pre-merge acceptance item; draft must not flip ready without it.

--- a/specs/5196-windows-e2e-temp-cleanup/spec.md
+++ b/specs/5196-windows-e2e-temp-cleanup/spec.md
@@ -1,0 +1,41 @@
+# Spec — #5196 Windows E2E temp cleanup on cancellation
+
+## Problem in one paragraph
+
+When Windows E2E tests are cancelled (timeout or `cancel-in-progress`),
+Haskell's `withSystemTempDirectory` cleanup never runs. Temp state lands in
+the shared Windows system temp root and leaks ~17GB per run. Linux already
+scopes E2E temp to the job-private `${{ runner.temp }}` (see #5195 /
+`.github/workflows/linux-e2e.yml`). The Windows workflow
+(`.github/workflows/windows-e2e.yml`) has no temp scoping and no
+`if: always()` cleanup.
+
+## P1 user story
+
+As a cardano-wallet maintainer running Windows E2E on GitHub Actions, I want
+E2E temp directories scoped to the job-private runner temp and removed even
+when the job is cancelled, so a timed-out run cannot fill the Windows runner
+disk the way cancelled Linux E2E runs once filled `/tmp`.
+
+## Functional requirements
+
+- **FR1** — The `e2e-tests` job MUST set `TEMP`, `TMP`, and `TMPDIR` on the
+  run step to `${{ runner.temp }}`.
+- **FR2** — The same job MUST contain an `if: always()` cleanup step that
+  removes only `e2e*` / `test-cluster*` under that job-private temp root.
+- **FR3** — The workflow MUST document that cleanup must not glob a shared
+  temp location that could wipe sibling jobs' live state.
+- **FR4** — No other workflow, Nix, or application source is in scope.
+
+## Non-goals
+
+- Changing which E2E test is matched or how the Windows bundle is built.
+- Milestone #113 / cardano-api work.
+- Linux E2E (already fixed).
+
+## Success criteria
+
+- **SC1** — Focused checker fails on baseline and passes on the fixed file.
+- **SC2** — `actionlint` accepts `.github/workflows/windows-e2e.yml`.
+- **SC3** — Workflow YAML shows `${{ runner.temp }}` scoping, `if: always()`
+  cleanup, and the sibling-job safety comment.

--- a/specs/5196-windows-e2e-temp-cleanup/tasks.md
+++ b/specs/5196-windows-e2e-temp-cleanup/tasks.md
@@ -23,7 +23,7 @@ Canonical numeric task IDs only (`T###`). Trailers must match
 
 ## Slice S3 — Fail-closed cleanup (driver+navigator)
 
-- [ ] T006 Demonstrate gate RED on soft cleanup, then make the
+- [X] T006 Demonstrate gate RED on soft cleanup, then make the
       `if: always()` cleanup fail-closed (missing RUNNER_TEMP fails;
       enumeration/deletion errors fail; re-enumerate `e2e*` /
       `test-cluster*` and fail on residuals; emit
@@ -39,8 +39,8 @@ Canonical numeric task IDs only (`T###`). Trailers must match
 
 ## Finalization (orchestrator — incomplete until all hold)
 
-- [ ] T008 Stamp tasks, independently gate + final audit, push rebased
+- [X] T008 Stamp tasks, independently gate + final audit, push rebased
       branch via explicit SSH lease, refresh PR body, **leave draft**
-- [ ] T009 SC4 live cancel proof artifact on exact remote head
+- [X] T009 SC4 live cancel proof artifact on exact remote head
       (`sc4-cancel-proof.md`) + exact-head CI green (desk-owned live
       cancel; ticket owner records/verifies)

--- a/specs/5196-windows-e2e-temp-cleanup/tasks.md
+++ b/specs/5196-windows-e2e-temp-cleanup/tasks.md
@@ -15,7 +15,7 @@ Canonical numeric task IDs only (`T###`). Trailers must match
 
 ## Slice A — Windows workflow scoping (driver+navigator)
 
-- [ ] T005 Demonstrate focused checker RED on baseline `windows-e2e.yml`,
+- [X] T005 Demonstrate focused checker RED on baseline `windows-e2e.yml`,
       then implement FR1–FR3 (TEMP/TMP/TMPDIR → `${{ runner.temp }}`,
       `if: always()` cleanup under job-private root only, sibling-job safety
       comment), then GREEN + actionlint + `./gate.sh`; one bisect-safe commit

--- a/specs/5196-windows-e2e-temp-cleanup/tasks.md
+++ b/specs/5196-windows-e2e-temp-cleanup/tasks.md
@@ -33,7 +33,7 @@ Canonical numeric task IDs only (`T###`). Trailers must match
 
 ## Orchestrator docs/gate remediation
 
-- [ ] T007 Correct spec/plan/tasks so SC4 live cancel proof is mandatory
+- [X] T007 Correct spec/plan/tasks so SC4 live cancel proof is mandatory
       pre-merge with named artifact; extend untracked gate so soft cleanup
       is RED; commit docs+task correction only
 

--- a/specs/5196-windows-e2e-temp-cleanup/tasks.md
+++ b/specs/5196-windows-e2e-temp-cleanup/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: #5196 Windows E2E temp cleanup
+
+**Input**: [spec.md](spec.md), [plan.md](plan.md)
+
+Canonical numeric task IDs only (`T###`). Trailers must match
+`Tasks: T###[, T###]`.
+
+## Bootstrap (orchestrator)
+
+- [X] T001 Write `specs/5196-windows-e2e-temp-cleanup/spec.md`
+- [X] T002 Write `plan.md` and `tasks.md`
+- [X] T003 Install untracked `./gate.sh` (+ runtime copy under
+      `/tmp/ms-cw-tech-debt/t5196/gate.sh`)
+- [X] T004 Open draft PR linked to #5196
+
+## Slice A — Windows workflow scoping (driver+navigator)
+
+- [ ] T005 Demonstrate focused checker RED on baseline `windows-e2e.yml`,
+      then implement FR1–FR3 (TEMP/TMP/TMPDIR → `${{ runner.temp }}`,
+      `if: always()` cleanup under job-private root only, sibling-job safety
+      comment), then GREEN + actionlint + `./gate.sh`; one bisect-safe commit
+      `fix(ci): scope Windows E2E temp and always clean job-private dirs`
+
+## Slice S3 — Fail-closed cleanup (driver+navigator)
+
+- [ ] T006 Demonstrate gate RED on soft cleanup, then make the
+      `if: always()` cleanup fail-closed (missing RUNNER_TEMP fails;
+      enumeration/deletion errors fail; re-enumerate `e2e*` /
+      `test-cluster*` and fail on residuals; emit
+      `Cleanup verified: 0 residual E2E temp directories`); GREEN +
+      actionlint + `./gate.sh`; one bisect-safe commit
+      `fix(ci): fail Windows E2E cleanup on residual directories`
+
+## Orchestrator docs/gate remediation
+
+- [ ] T007 Correct spec/plan/tasks so SC4 live cancel proof is mandatory
+      pre-merge with named artifact; extend untracked gate so soft cleanup
+      is RED; commit docs+task correction only
+
+## Finalization (orchestrator — incomplete until all hold)
+
+- [ ] T008 Stamp tasks, independently gate + final audit, push rebased
+      branch via explicit SSH lease, refresh PR body, **leave draft**
+- [ ] T009 SC4 live cancel proof artifact on exact remote head
+      (`sc4-cancel-proof.md`) + exact-head CI green (desk-owned live
+      cancel; ticket owner records/verifies)


### PR DESCRIPTION
## Summary

Windows E2E had no cancellation-safe temp cleanup. Cancelled or timed-out runs
could leak large temp trees into the shared Windows system temp root (the same
class as Linux #5195).

This PR scopes `TEMP`, `TMP`, and `TMPDIR` to job-private
`${{ runner.temp }}` and adds fail-closed `if: always()` cleanup. Cleanup fails
on a missing root, enumeration/deletion errors, or residual `e2e*` /
`test-cluster*` directories, and emits the stable success line:

`Cleanup verified: 0 residual E2E temp directories`

Closes #5196.

## Acceptance evidence

- Final signed head: `4d4121c654f113642077f2035071c0c843c4717e`
- Rebased directly on `master` `320b1abc174ba406d474b006e719204626a903fd`
- Final cancellation proof:
  https://github.com/cardano-foundation/cardano-wallet/actions/runs/30539094277
  - Windows smoke entered `in_progress`
  - cancellation was requested while it was running
  - smoke concluded `cancelled`
  - `Cleanup E2E temp directories` concluded `success`
  - live log: `Cleanup verified: 0 residual E2E temp directories`
- Exact-head PR CI: 58 checks passed
- macOS local-cluster retry: attempt 3 passed on the same immutable head

## Review and verification

- [x] Specs map the cancellation and zero-residual acceptance criteria
- [x] Grok reviewed both workflow diffs and the live-boundary correction
- [x] Only the Windows workflow and issue specs/tasks changed
- [x] All four commits have valid signatures and pass `commit-gate`
- [x] `./gate.sh` passes (`git diff --check`, workflow contract, actionlint)
- [x] Finalization audit passes the PR range, task stamps, and gate lifecycle
- [x] Exact-head live cancellation cleanup proof passes
- [x] Exact-head CI is 58/58 green
