### PR TITLE
Use mithril-client from PATH when available, download as fallback

### DIFF
--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -93,6 +93,7 @@ test-suite unit
   hs-source-dirs:     test/unit
   main-is:            launcher-unit-test.hs
   other-modules:
+    Cardano.Launcher.MithrilSpec
     Cardano.LauncherSpec
     Cardano.StartupSpec
 

--- a/lib/launcher/src/Cardano/Launcher/Mithril.hs
+++ b/lib/launcher/src/Cardano/Launcher/Mithril.hs
@@ -3,6 +3,7 @@
 module Cardano.Launcher.Mithril
     ( downloadLatestSnapshot
     , downloadMithril
+    , downloadMithrilWith
     , MithrilExePath (..)
     )
 where
@@ -17,6 +18,7 @@ import Network.HTTP.Simple
     )
 import System.Directory
     ( doesFileExist
+    , findExecutable
     , withCurrentDirectory
     )
 import System.FilePath
@@ -48,13 +50,46 @@ downloadLatestSnapshot outputParentDir (MithrilExePath mithril) = do
         , outputParentDir
         ]
 
--- | Downloads the latest Mithril release package,
--- extracts it, and returns the path to the mithril client executable.
+-- | Prefer PATH, then fall back to downloading the Mithril client.
+--
+-- Looks up @mithril-client@ via 'findExecutable'. When present, returns that
+-- path without downloading. When absent, downloads the release package into
+-- the supplied working directory.
 --
 -- May interactively ask how to handle conflicts if items in the supplied
 -- working directory conflict with items in the mithril release archive.
 downloadMithril :: FilePath -> IO MithrilExePath
-downloadMithril workingDir = withCurrentDirectory workingDir $ do
+downloadMithril =
+    downloadMithrilWith findExecutable downloadMithrilFromGitHub
+
+-- | PATH-first Mithril client resolution with an injectable finder and
+-- download action (for unit tests).
+--
+-- * When @finder "mithril-client"@ yields @Just path@, logs and returns that
+--   path without calling @download@.
+-- * When the finder yields @Nothing@, logs and calls @download workingDir@.
+downloadMithrilWith
+    :: (String -> IO (Maybe FilePath))
+    -- ^ Executable lookup (production: 'findExecutable')
+    -> (FilePath -> IO MithrilExePath)
+    -- ^ Download fallback
+    -> FilePath
+    -- ^ Working directory for downloads
+    -> IO MithrilExePath
+downloadMithrilWith findExe download workingDir = do
+    mPath <- findExe "mithril-client"
+    case mPath of
+        Just path -> do
+            putStrLn $ "Using mithril-client from PATH: " <> path
+            pure $ MithrilExePath path
+        Nothing -> do
+            putStrLn "mithril-client not found on PATH, downloading..."
+            download workingDir
+
+-- | Download the latest Mithril release package into @workingDir@ and return
+-- the path to the extracted client.
+downloadMithrilFromGitHub :: FilePath -> IO MithrilExePath
+downloadMithrilFromGitHub workingDir = withCurrentDirectory workingDir $ do
     putStrLn $ "Downloading " <> mithrilPackage <> " from " <> downloadUrl
     -- On Windows, crypton-x509-system reads the current user's ROOT
     -- certificate store which may be empty when running as SYSTEM.

--- a/lib/launcher/test/unit/Cardano/Launcher/MithrilSpec.hs
+++ b/lib/launcher/test/unit/Cardano/Launcher/MithrilSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Launcher.MithrilSpec
+    ( spec
+    ) where
+
+import Cardano.Launcher.Mithril
+    ( MithrilExePath (..)
+    , downloadMithrilWith
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Prelude
+
+spec :: Spec
+spec = describe "downloadMithrilWith PATH lookup" $ do
+    it "skips download when finder returns Just path" $ do
+        let foundPath = "/fake/mithril-client"
+            finder query = do
+                query `shouldBe` "mithril-client"
+                pure (Just foundPath)
+            download _ =
+                fail
+                    "download should not be called when mithril-client is on PATH"
+        result <- downloadMithrilWith finder download "/tmp/unused-workdir"
+        mithrilExePath result `shouldBe` foundPath
+
+    it "falls through to download when finder returns Nothing" $ do
+        let sentinel = "/downloaded/mithril-client"
+            workDir = "/tmp/test-workdir"
+            finder _ = pure Nothing
+            download dir = do
+                dir `shouldBe` workDir
+                pure (MithrilExePath sentinel)
+        result <- downloadMithrilWith finder download workDir
+        mithrilExePath result `shouldBe` sentinel

--- a/specs/5246-mithril-path/plan.md
+++ b/specs/5246-mithril-path/plan.md
@@ -1,0 +1,116 @@
+# Plan: Use mithril-client from PATH when available
+
+## Tech Stack
+
+- Haskell (`Cardano.Launcher.Mithril` module)
+- `System.Directory.findExecutable` for PATH lookup
+- Existing HTTP download logic as fallback
+
+## Architecture
+
+The change is localized to `lib/launcher/src/Cardano/Launcher/Mithril.hs`:
+
+1. Add PATH lookup at the start of `downloadMithril`
+2. If found, log and return immediately (no download)
+3. If not found, proceed with existing download logic
+4. Add stdout log output so the path taken is observable
+
+Production wiring:
+
+```haskell
+downloadMithril =
+    downloadMithrilWith findExecutable downloadMithrilFromGitHub
+```
+
+## Task ID map (canonical)
+
+| ID | Meaning |
+|----|---------|
+| T001 | Planning/bootstrap (spec, plan, tasks) |
+| T002 | PATH-hit unit proof (exact `"mithril-client"` + no download) |
+| T003 | Fallback/working-directory unit proof |
+| T004 | Implementation + observable branch logs |
+| T005 | Focused gate/format |
+| T006 | Production-wiring live PATH proof |
+| T007 | Finalization |
+
+## Slice Breakdown
+
+### Slice 1: PATH lookup with fallback (T002–T005)
+
+**Goal**: Implement PATH-first lookup with download fallback, with observable logging and non-vacuous unit proofs.
+
+**Changes**:
+- Import `System.Directory.findExecutable`
+- At the start of resolution, call finder with `"mithril-client"`
+- If `Just path`, log `Using mithril-client from PATH: <path>` and return `MithrilExePath path`
+- If `Nothing`, log `mithril-client not found on PATH, downloading...` and call download with the supplied working directory
+- Unit tests inject finder/download and assert exact lookup name, workdir forwarding, and fail-if-download-called on PATH hit
+
+**Owned files**:
+- `lib/launcher/src/Cardano/Launcher/Mithril.hs`
+- `lib/launcher/test/unit/Cardano/Launcher/MithrilSpec.hs`
+- `lib/launcher/cardano-wallet-launcher.cabal` (test module registration only)
+
+**Gate**:
+```bash
+nix develop --quiet -c cabal test cardano-wallet-launcher:unit --test-show-details=direct
+nix develop --quiet -c just check-fmt
+```
+
+**Commit**: `feat(launcher): check PATH for mithril-client before downloading`  
+**Trailer**: `Tasks: T002, T003, T004`
+
+### Slice 2: Production-wiring / boundary verification (T006)
+
+**Goal**: Prove production `downloadMithril` uses PATH when available, without claiming a full E2E snapshot download.
+
+**Truthful boundary**:
+
+1. **Static E2E call site** (unchanged product wiring):
+
+   ```haskell
+   downloadLatestSnapshot dir =<< downloadMithril dir
+   ```
+
+   at `lib/integration/exe/e2e.hs` (launch path inside `launchNodeAndWalletViaMithril` / `configureContext`).
+
+2. **Live production probe** (not `e2e -- --help`):
+
+   Call the real library entrypoint:
+
+   ```haskell
+   downloadMithril
+       "/definitely/nonexistent/t5246-download-fallback-must-not-run"
+   ```
+
+   Expected under `nix develop` with flake-provided `mithril-client` on PATH:
+
+   - stdout contains `Using mithril-client from PATH: …`
+   - resolved path is under the nix store (flake pin)
+   - impossible working directory proves fallback did **not** run (fallback would fail before HTTP)
+
+3. **Do not claim** a full E2E preprod snapshot download was executed.
+
+**Invalid (vacuous) command — do not use**:
+
+```bash
+# WRONG: hspec --help never enters aroundAll / downloadMithril
+cabal run e2e -- --help
+```
+
+**Owned files**: None for code (verification + docs only).
+
+**Commit**: No code commit required for T006 when probe is recorded in WIP/desk evidence.
+
+## Dependencies
+
+- Slice 2 (T006) depends on Slice 1 implementation (T004)
+- No external dependency changes
+
+## Risks
+
+- **Risk**: `findExecutable` may not find mithril-client in some environments  
+  - **Mitigation**: Fallback download remains
+- **Risk**: PATH hit trusts any `mithril-client` without version check  
+  - **Mitigation**: Acceptable under FR5; flake pin is SoT inside `nix develop`

--- a/specs/5246-mithril-path/spec.md
+++ b/specs/5246-mithril-path/spec.md
@@ -1,0 +1,51 @@
+# Spec: Use mithril-client from PATH when available, download as fallback
+
+## P1 User Story
+
+As a developer running E2E tests inside `nix develop`, I want the test suite to use the mithril-client binary already available on PATH (from the flake input) instead of downloading it from GitHub releases, so that:
+- Tests start faster (no network download)
+- There is no version drift between the flake pin (2617.0) and the hardcoded download URL (2603.1)
+- The Nix flake pin is the single source of truth for the mithril-client version
+
+## User Stories
+
+1. **Nix shell developer**: When I run E2E tests inside `nix develop`, the test suite finds `mithril-client` on PATH and uses it directly without making any HTTP request to GitHub releases.
+
+2. **Windows/non-Nix user**: When I run E2E tests outside a Nix environment (e.g., on Windows or a system without Nix), the test suite falls back to downloading mithril-client from GitHub releases, preserving the existing behavior.
+
+3. **CI/CD pipeline**: When the E2E tests run in an environment where mithril-client is pre-installed on PATH, the tests use it; otherwise, they download it.
+
+## Functional Requirements
+
+### FR1: PATH lookup before download
+`Cardano.Launcher.Mithril.downloadMithril` MUST check for `mithril-client` on PATH using `System.Directory.findExecutable` BEFORE attempting any download.
+
+### FR2: No HTTP request when PATH hit
+When `mithril-client` is found on PATH, the function MUST return immediately without making any HTTP request (no `httpBS`, no `curl.exe` invocation).
+
+### FR3: Fallback download preserved
+When `mithril-client` is NOT found on PATH, the function MUST fall back to the existing download logic (GitHub releases via `httpBS` on Unix, `curl.exe` on Windows).
+
+### FR4: Observable behavior
+The function MUST log/trace which path was taken (PATH hit vs. download fallback) so that the "no HTTP request" requirement can be verified.
+
+### FR5: Version source of truth
+When PATH is used, the Nix flake pin (currently 2617.0) is the source of truth. When download fallback is used, the hardcoded version (currently 2603.1) applies. This is acceptable because the fallback is only for non-Nix environments.
+
+## Success Criteria
+
+1. **AC1**: `Cardano.Launcher.Mithril` checks PATH (`findExecutable "mithril-client"`) before downloading (unit: exact lookup string; production wiring by inspection + live probe).
+2. **AC2**: When `mithril-client` is on PATH (e.g., inside `nix develop`), production `downloadMithril` returns the PATH binary and does not run the download fallback (verified via PATH log line and a live probe with an impossible working directory that would fail if fallback ran). Static E2E wiring remains `downloadLatestSnapshot dir =<< downloadMithril dir` in `lib/integration/exe/e2e.hs`. Full preprod snapshot download is **not** required for this AC.
+3. **AC3**: Fallback download path still works on Windows and non-Nix environments (fallback body preserved; unit proves fallthrough + working-directory forwarding).
+4. **AC4**: No hardcoded version drift when PATH is used: the Nix flake pin is the source of truth for the PATH binary.
+
+## Task IDs
+
+Canonical unique numeric IDs: **T001**–**T007** (see `tasks.md` / `plan.md`).
+
+## Non-Goals
+
+- Changing the hardcoded download version (2603.1) to match the flake pin (2617.0) — the fallback is for non-Nix environments where the flake pin doesn't apply.
+- Modifying the flake.nix or Nix configuration.
+- Changing the E2E test logic beyond the mithril-client acquisition path.
+- Using `e2e -- --help` as PATH proof (does not enter `downloadMithril`).

--- a/specs/5246-mithril-path/tasks.md
+++ b/specs/5246-mithril-path/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Use mithril-client from PATH when available
+
+## Planning
+
+- [X] T001: Add spec, plan, and tasks for mithril-path (bootstrap)
+
+## Slice 1 — PATH lookup with fallback
+
+- [X] T002: Strengthen unit proof: PATH-hit asserts exact lookup string `"mithril-client"` and download is not called
+- [X] T003: Strengthen unit proof: PATH-miss asserts download receives the exact working directory and returns its result
+- [X] T004: Implement PATH lookup in `downloadMithril` with observable branch logs (stdout)
+- [X] T005: Focused launcher unit gate + format check green
+
+## Slice 2 — Production-wiring / boundary verification
+
+- [X] T006: Production live PATH probe via `downloadMithril` with impossible working dir (no fallback/HTTP); record static E2E call site
+- [ ] T007: Finalization (commit-gate trailers, signed commits, desk push authorization)
+
+## Notes
+
+- Do **not** use `e2e -- --help` as PATH proof: `main` runs `getConfig` then `hspec`; `--help` does not enter `aroundAll` / `configureContext` / `downloadMithril`.
+- Static E2E call site (unchanged): `downloadLatestSnapshot dir =<< downloadMithril dir` in `lib/integration/exe/e2e.hs`.

--- a/specs/5246-mithril-path/tasks.md
+++ b/specs/5246-mithril-path/tasks.md
@@ -14,7 +14,7 @@
 ## Slice 2 — Production-wiring / boundary verification
 
 - [X] T006: Production live PATH probe via `downloadMithril` with impossible working dir (no fallback/HTTP); record static E2E call site
-- [ ] T007: Finalization (commit-gate trailers, signed commits, desk push authorization)
+- [X] T007: Finalization (commit-gate trailers, signed commits, desk push authorization)
 
 ## Notes
 


### PR DESCRIPTION
# Use mithril-client from PATH when available, download as fallback

Implements #5246.

## Summary

`Cardano.Launcher.Mithril.downloadMithril` now resolves
`mithril-client` from `PATH` before using the existing GitHub-release
download path.

- A PATH hit returns the discovered executable without invoking the download
  action.
- A PATH miss preserves the existing Unix/Windows download and extraction
  behavior.
- Both branches emit an observable log line.

## Semantics and coverage

- Production wiring:
  `downloadMithril = downloadMithrilWith findExecutable downloadMithrilFromGitHub`
- PATH-hit unit proof asserts the exact lookup string
  `"mithril-client"` and fails if the download action is called.
- PATH-miss unit proof asserts that the exact caller-supplied working
  directory reaches the unchanged download fallback.
- The extracted `downloadMithrilFromGitHub` body is unchanged from the
  pre-PR fallback implementation.
- The unchanged E2E call site remains:
  `downloadLatestSnapshot dir =<< downloadMithril dir`.

## Live-boundary proof

The real production `downloadMithril` entrypoint was called under
`nix develop` with:

```haskell
downloadMithril
    "/definitely/nonexistent/t5246-download-fallback-must-not-run"
```

It resolved:

```text
Using mithril-client from PATH: /nix/store/.../bin/mithril-client
PROBE_RESOLVED=/nix/store/.../bin/mithril-client
```

The impossible working directory proves the fallback did not run; fallback
would fail before making an HTTP request. This is a production-wiring PATH
proof, not a claim that a full preprod snapshot download was executed.

## Verification

Final signed head: `cf1297c71af54b8f8a7ff9879a125228a1ea2e03`  
Exact base: `efe473937feea6260cfb5e64cb6d0a9d1655aab0`

- launcher unit suite: 25 examples, 0 failures;
- `just check-fmt`: pass;
- production PATH probe: pass;
- canonical frozen feature handoff and commit binding: pass;
- both commits signed and `commit-gate` clean;
- finalization audit: pass;
- Grok crazy-eagle test/spec review: pass;
- feature files byte-identical across the final rebase; only the T007
  finalization checkbox changed afterward.

## Scope

Only the launcher production module, its unit test/registration, and issue
specification artifacts change. No dependency, flake, E2E scenario, or
hardcoded fallback-version change is included.

