### PR TITLE
Keep focused Cabal test recipes limited to local test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,6 +681,9 @@ jobs:
           - name: "Check Cabal Configure"
             command: nix develop --quiet --command scripts/ci/check-haskell-nix-cabal.sh
 
+          - name: "Check Local Cabal Test Targets"
+            command: scripts/ci/check-local-test-targets.sh
+
           - name: "Lint Bash Scripts"
             command: ./scripts/shellcheck.sh
 

--- a/justfile
+++ b/justfile
@@ -87,7 +87,6 @@ unit-tests-cabal-match match:
   LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
   cabal test \
     cardano-wallet-application-tls:unit \
-    cardano-balance-tx:unit \
     cardano-numeric:unit \
     cardano-wallet-blackbox-benchmarks:unit \
     cardano-wallet-launcher:unit \

--- a/scripts/ci/check-local-test-targets.sh
+++ b/scripts/ci/check-local-test-targets.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+root=${1:-.}
+project_file="$root/cabal.project"
+justfile="$root/justfile"
+
+fail() {
+    echo "Local test target check failed: $*" >&2
+    exit 1
+}
+
+[ -f "$project_file" ] || fail "missing $project_file"
+[ -f "$justfile" ] || fail "missing $justfile"
+
+declared_local_targets() {
+    local package_dir cabal_file package_name
+
+    awk '
+        /^[[:space:]]*packages[[:space:]]*:/ {
+            in_packages = 1
+            line = $0
+            sub(/^[^:]*:/, "", line)
+            gsub(/^[[:space:],]+|[[:space:],]+$/, "", line)
+            if (line != "") print line
+            next
+        }
+        in_packages && /^[[:space:]]*$/ { exit }
+        in_packages && /^[^[:space:]]/ { exit }
+        in_packages {
+            line = $0
+            sub(/[[:space:]]*--.*/, "", line)
+            gsub(/^[[:space:],]+|[[:space:],]+$/, "", line)
+            if (line != "") print line
+        }
+    ' "$project_file" | while IFS= read -r package_dir; do
+        for cabal_file in "$root/$package_dir"/*.cabal; do
+            [ -f "$cabal_file" ] || continue
+            package_name=$(
+                awk 'tolower($1) == "name:" { print $2; exit }' "$cabal_file"
+            )
+            [ -n "$package_name" ] || continue
+            awk -v package="$package_name" '
+                tolower($1) == "test-suite" && NF >= 2 {
+                    print package ":" $2
+                }
+            ' "$cabal_file"
+        done
+    done | sort -u
+}
+
+selected_targets() {
+    awk '
+        /^unit-tests-cabal-match[[:space:]].*:$/ {
+            in_recipe = 1
+            next
+        }
+        in_recipe && /^[^[:space:]]/ { exit }
+        in_recipe {
+            for (i = 1; i <= NF; i++) {
+                target = $i
+                sub(/\\$/, "", target)
+                if (target ~ /^[A-Za-z][A-Za-z0-9_-]*:[A-Za-z][A-Za-z0-9_-]*$/) {
+                    print target
+                }
+            }
+        }
+    ' "$justfile" | sort -u
+}
+
+declared=$(declared_local_targets)
+selected=$(selected_targets)
+
+[ -n "$declared" ] || fail "parsed zero locally declared test suites"
+[ -n "$selected" ] || fail "parsed zero selected targets from unit-tests-cabal-match"
+
+nonlocal=$(
+    comm -23 \
+        <(printf '%s\n' "$selected") \
+        <(printf '%s\n' "$declared")
+)
+
+if [ -n "$nonlocal" ]; then
+    echo "Targets not declared by local project packages:" >&2
+    while IFS= read -r target; do
+        echo "  $target" >&2
+    done <<< "$nonlocal"
+    fail "unit-tests-cabal-match selects targets Cabal cannot test locally"
+fi
+
+echo "Local test targets are valid: $(printf '%s\n' "$selected" | wc -l) selected, $(printf '%s\n' "$declared" | wc -l) locally declared."

--- a/specs/5358-local-cabal-test-targets/plan.md
+++ b/specs/5358-local-cabal-test-targets/plan.md
@@ -1,0 +1,146 @@
+# Plan — Keep focused Cabal test recipes limited to local test suites
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5358
+Base: `75cd99bd1754cbda5e255d4bd38d0c6c7bc65c13`
+
+## Shape of the change
+
+Two things must land together, in one bisect-safe commit:
+
+1. **The detector** — a committed script that reconciles the suites named in
+   `justfile`'s Cabal test recipes against the set of test suites declared by
+   local project packages, and fails naming any non-local selection.
+2. **The fix** — removing `cardano-balance-tx:unit` from
+   `unit-tests-cabal-match`.
+
+They land together because either alone leaves the tree red: the detector alone
+fails CI on the unfixed recipe, and the fix alone leaves the defect undetected
+and free to return. Within the slice the detector is written *first* and
+observed failing on the unfixed recipe — that failure is the slice's RED.
+
+## Why a derived detector rather than an assertion about one package
+
+A check that hardcodes "`cardano-balance-tx:unit` must be absent" would pass
+forever after the fix and could never fail again for the reason we care about.
+It would be a check that cannot fail — manufactured confidence.
+
+The detector instead computes both sides:
+
+- **declared-local** — parse `packages:` from `cabal.project`, then read each
+  directory's `.cabal` file for `test-suite` stanzas, producing the set of
+  `package:suite` pairs Cabal can actually run locally;
+- **selected** — parse the `package:suite` arguments out of the `cabal test`
+  invocation in the `unit-tests-cabal-match` recipe;
+
+and asserts `selected ⊆ declared-local`. This is
+`reconcile(declared, observed)` with a comparator that fails whenever anyone
+adds a target Cabal cannot run — including a target that does not exist today.
+It stays live because both sides are recomputed from the repository, not frozen
+into the script.
+
+The detector must also refuse to pass vacuously: if either side parses to the
+empty set, that means the parse broke, not that the invariant holds, and it must
+exit non-zero. Both directions get a negative control (see the gate).
+
+## Reachability
+
+A detector that exists but is never executed reports green regardless of what it
+asserts. It is therefore wired into `.github/workflows/ci.yml`'s existing
+`quality-checks` matrix, the same place `check-code-format.sh`,
+`check-haskell-nix-cabal.sh`, `enforce-eol.sh` and `shellcheck.sh` are wired.
+That is one added matrix entry, not a CI redesign.
+
+`scripts/shellcheck.sh` already lints repository shell scripts, so the new
+script inherits shell linting automatically — confirm this rather than assume
+it.
+
+## Invariants
+
+- **INV1** Every `package:suite` the recipe names is runnable by Cabal from this
+  project. Enforced by the detector; falsified by the negative control.
+- **INV2** The focused match actually runs examples. Exit 0 is not sufficient:
+  the recipe passes no `--fail-on=empty`, so a pattern matching nothing would
+  exit 0 and look identical to success. The gate must observe a non-zero
+  executed-example count for `"Store"`.
+- **INV3** The set of locally testable suites the recipe covers does not shrink.
+  Enforced by comparing the post-change selection against the frozen baseline
+  list of 11 in `spec.md`.
+- **INV4** The detector cannot pass by parsing nothing.
+
+## Live boundary
+
+The real boundary is Cabal's target resolution — the thing that emitted
+`Cabal-7043`. Static reconciliation (INV1) is fast and general but is a *model*
+of that boundary; it cannot prove Cabal accepts the result. So the gate also
+runs the real recipe end to end (AC1/INV2). Both are required: the static check
+generalizes, the live run proves the model matches reality.
+
+## Slices
+
+One behavior slice. It is small but relational — it spans a shell script, a
+justfile recipe, and a CI workflow — so it runs as PAIR, not LIGHT.
+
+### Slice `local-test-targets`
+
+Owned files:
+
+- `scripts/ci/check-local-test-targets.sh` (new)
+- `justfile` (remove exactly one selection line)
+- `.github/workflows/ci.yml` (add exactly one `quality-checks` matrix entry)
+
+Forbidden: `cabal.project`, any `.cabal` file, any Haskell source, any other
+recipe, any other workflow or workflow job, dependency pins.
+
+Order inside the slice:
+
+1. Write the detector.
+2. Run it against the **unfixed** justfile → must fail naming
+   `cardano-balance-tx:unit`. This is RED.
+3. Run the detector's negative controls → must fail (see gate section 4).
+4. Remove `cardano-balance-tx:unit` from the recipe.
+5. Run the detector → passes.
+6. Run the real focused recipe → exits 0 with non-zero `Store` example count.
+7. Wire the detector into `quality-checks`.
+
+## Risks
+
+- **Cost.** Post-fix, the focused recipe must actually build 11 suites under
+  `cabal` in the dev shell. The failing baseline reproduction alone consumed
+  3.66 GiB on `/`. Every build command is metered per the machine-resource
+  contract; the expensive live section is run by the driver once for GREEN and
+  by the ticket owner once at acceptance, never concurrently.
+- **Pre-existing hang.** A project note records `cardano-wallet-unit:unit`
+  hanging after all specs pass on master. If the focused run reproduces that,
+  it is a pre-existing condition, recorded honestly and escalated, not a ticket
+  failure — and the `"Store"` match is a small subset, which should avoid it.
+- **Parser brittleness.** The detector parses `justfile` and `.cabal` text. INV4
+  and its negative controls exist precisely because a silently-broken parser
+  would otherwise report green.
+
+## Verification
+
+See the frozen gate under the ticket runtime root. In summary: static
+reconciliation, live focused run with a non-vacuity assertion, unfiltered
+selection comparison against the frozen baseline of 11, the negative control,
+and the repository's format/lint/quality checks.
+
+### There is no `just ci` in this repository
+
+Planning documents from older tickets refer to a `just ci` recipe. It does not
+exist in `justfile` at this ticket's base, and `specs/007-ledger-minting`
+already records that `just ci` was never equivalent to the flake checks.
+Repository CI is `.github/workflows/ci.yml`, which has no single-command local
+form.
+
+The local full-CI stand-in for this ticket is therefore the set of checks the
+`quality-checks` matrix actually invokes and that this diff can affect:
+
+- `nix develop --quiet -c scripts/ci/check-code-format.sh`
+- `nix develop --quiet -c bash -c 'hlint lib'`
+- `nix develop --quiet -c scripts/ci/check-haskell-nix-cabal.sh`
+- `./scripts/shellcheck.sh`
+- `nix develop --quiet -c scripts/enforce-eol.sh`
+
+plus the ticket-focused Cabal proof, the coverage oracle, and the falsified
+negative control. The fresh exact-head GitHub check rollup remains the
+authoritative full repository CI result. Nothing here adds a new recipe.

--- a/specs/5358-local-cabal-test-targets/spec.md
+++ b/specs/5358-local-cabal-test-targets/spec.md
@@ -1,0 +1,111 @@
+# Spec — Keep focused Cabal test recipes limited to local test suites
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5358
+
+## Problem
+
+`just unit-tests-cabal-match` names twelve test suites explicitly. Eleven belong
+to packages listed under `packages:` in `cabal.project`. One,
+`cardano-balance-tx:unit`, belongs to a package that enters the build as a
+`source-repository-package` (`cardano-balance-transaction`). Cabal cannot build
+or run test suites of non-local dependencies, so the recipe aborts during target
+resolution:
+
+```text
+Error: [Cabal-7043]
+Cannot test the test suite 'unit' because the package cardano-balance-tx-0.1.0
+is not local to the project, and cabal does not currently support building test
+suites or benchmarks of non-local dependencies.
+```
+
+The failure happens before any suite runs, so the whole focused-match harness is
+unusable: a developer asking for `"Store"` gets zero executed examples. This was
+isolated while gating #5063, which had to work around it by invoking
+`cabal test cardano-wallet-unit:unit` directly.
+
+This is a developer-harness defect only. Repository CI does not use these
+recipes — `.github/workflows/ci.yml` runs the Nix flake apps `.#unit-<pkg>` —
+which is why CI stayed green while the recipe was broken.
+
+## User story (P1)
+
+As a cardano-wallet developer, I run a focused Cabal unit-test match and observe
+matching local tests execute, without Cabal rejecting a non-local dependency's
+test suite.
+
+## Functional requirements
+
+- **FR1** `just unit-tests-cabal-match <pattern>` selects only test suites of
+  packages that `cabal.project` lists under `packages:`.
+- **FR2** `just unit-tests-cabal-match "Store"` completes successfully and
+  executes at least one matching `Store` example.
+- **FR3** No locally testable suite that the recipe selected before this change
+  is dropped. The selection changes by exactly one removal:
+  `cardano-balance-tx:unit`.
+- **FR4** The repository permanently detects a reintroduced non-local target.
+  The detector is committed, runs in CI, and is derived from `cabal.project`
+  rather than from a hardcoded package list, so it also catches a *new*
+  non-local target that does not exist today.
+
+## Rejection behavior
+
+The detector must fail, with a message naming the offending `package:suite`,
+when the recipe selects any suite whose package is not a local project package.
+It must not fail for any selection that is entirely local.
+
+## Observable success criteria
+
+Mapped from the frozen issue body's acceptance criteria:
+
+- **AC1** `nix develop --quiet -c just unit-tests-cabal-match "Store"` exits 0,
+  executes at least one matching `Store` example, and emits no `Cabal-7043`.
+- **AC2** Every suite selected by `unit-tests-cabal-match` is a locally testable
+  project suite; `cardano-balance-tx:unit` is not selected while the package
+  remains a non-local `source-repository-package` dependency.
+- **AC3** The unfiltered `just unit-tests-cabal` recipe retains coverage of
+  every locally testable suite the focused recipe covered before this change.
+- **AC4** A negative control that restores a non-local test target fails the
+  focused gate, proving the regression check can detect the original defect.
+- **AC5** Formatting, lint, the focused gate, and repository CI pass at the
+  exact proposed head.
+
+## Baseline facts (verified at 75cd99bd1754cbda5e255d4bd38d0c6c7bc65c13)
+
+Selected by the recipe today — 11 local, 1 non-local:
+
+| Suite | Package location | Local? |
+|---|---|---|
+| `cardano-wallet-application-tls:unit` | `lib/application-tls` | yes |
+| `cardano-balance-tx:unit` | `source-repository-package` | **no** |
+| `cardano-numeric:unit` | `lib/numeric` | yes |
+| `cardano-wallet-blackbox-benchmarks:unit` | `lib/wallet-benchmarks` | yes |
+| `cardano-wallet-launcher:unit` | `lib/launcher` | yes |
+| `cardano-wallet-network-layer:unit` | `lib/network-layer` | yes |
+| `cardano-wallet-primitive:test` | `lib/primitive` | yes |
+| `cardano-wallet-secrets:test` | `lib/secrets` | yes |
+| `cardano-wallet-test-utils:unit` | `lib/test-utils` | yes |
+| `cardano-wallet-unit:unit` | `lib/unit` | yes |
+| `std-gen-seed:unit` | `lib/std-gen-seed` | yes |
+| `wai-middleware-logging:unit` | `lib/wai-middleware-logging` | yes |
+
+The repository declares 20 test suites across local packages. The recipe
+deliberately selects a subset of 11; the other 9 need a node, a cluster, or are
+otherwise out of the focused-unit-test scope. **FR3 forbids dropping any of the
+11 — it does not require adding the other 9.** Widening the selection is out of
+scope.
+
+## Non-goals
+
+- Changing, vendoring, or publishing `cardano-balance-tx`.
+- Changing dependency pins, `source-repository-package` entries, or package
+  semantics.
+- Removing or redesigning `cardano-api`.
+- Splitting or renaming the cardano-wallet unit-test suites.
+- Adding the 9 currently unselected local suites to the recipe.
+- Redesigning CI. The detector is added as one entry in the existing
+  `quality-checks` matrix, matching how every other repository guard is wired.
+
+## Review requirement
+
+Pawel review is not required. This is a mechanical developer-test harness
+correction with no product or wallet semantic change.

--- a/specs/5358-local-cabal-test-targets/tasks.md
+++ b/specs/5358-local-cabal-test-targets/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — Keep focused Cabal test recipes limited to local test suites
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5358
+
+## Planning (ticket owner)
+
+- [x] T001 Verify the lane, refresh the recipe facts, and reproduce Cabal-7043
+      on the untouched base
+- [x] T002 Derive the locally-declared test-suite oracle from `cabal.project`
+      and the local `.cabal` files
+- [x] T003 Author `spec.md` and `plan.md`
+- [x] T004 Record the `just ci` substitution ruled by A-001
+- [x] T005 Freeze the executable slice gate and prove it can fail
+
+## Slice `local-test-targets` (PAIR)
+
+- [ ] T010 Add `scripts/ci/check-local-test-targets.sh` reconciling the suites
+      selected by the Cabal test recipes against the suites declared by local
+      project packages
+- [ ] T011 Observe the detector fail on the unfixed `justfile`, naming
+      `cardano-balance-tx:unit` — the slice RED
+- [ ] T012 Prove the detector refuses to pass vacuously when either side parses
+      to the empty set
+- [ ] T013 Remove `cardano-balance-tx:unit` from `unit-tests-cabal-match`
+- [ ] T014 Observe the detector pass and
+      `just unit-tests-cabal-match "Store"` exit 0 with a non-zero executed
+      example count and no `Cabal-7043`
+- [ ] T015 Confirm the selection still covers all 11 locally testable suites
+      listed in `spec.md`
+- [ ] T016 Wire the detector into the existing `quality-checks` matrix in
+      `.github/workflows/ci.yml`
+- [ ] T017 Confirm `scripts/shellcheck.sh` covers the new script and passes
+
+## Acceptance (ticket owner)
+
+- [ ] T020 Re-run the frozen gate independently, including the negative control
+- [ ] T021 Run the A-001 local check set at the accepted head
+- [ ] T022 Rebase on current master, re-run the gate and local checks at the
+      exact rebased head
+- [ ] T023 Confirm a fresh exact-head GitHub rollup has zero failing or pending
+      required checks

--- a/specs/5358-local-cabal-test-targets/tasks.md
+++ b/specs/5358-local-cabal-test-targets/tasks.md
@@ -14,22 +14,22 @@ Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5358
 
 ## Slice `local-test-targets` (PAIR)
 
-- [ ] T010 Add `scripts/ci/check-local-test-targets.sh` reconciling the suites
+- [x] T010 Add `scripts/ci/check-local-test-targets.sh` reconciling the suites
       selected by the Cabal test recipes against the suites declared by local
       project packages
-- [ ] T011 Observe the detector fail on the unfixed `justfile`, naming
+- [x] T011 Observe the detector fail on the unfixed `justfile`, naming
       `cardano-balance-tx:unit` — the slice RED
-- [ ] T012 Prove the detector refuses to pass vacuously when either side parses
+- [x] T012 Prove the detector refuses to pass vacuously when either side parses
       to the empty set
-- [ ] T013 Remove `cardano-balance-tx:unit` from `unit-tests-cabal-match`
-- [ ] T014 Observe the detector pass and
+- [x] T013 Remove `cardano-balance-tx:unit` from `unit-tests-cabal-match`
+- [x] T014 Observe the detector pass and
       `just unit-tests-cabal-match "Store"` exit 0 with a non-zero executed
       example count and no `Cabal-7043`
-- [ ] T015 Confirm the selection still covers all 11 locally testable suites
+- [x] T015 Confirm the selection still covers all 11 locally testable suites
       listed in `spec.md`
-- [ ] T016 Wire the detector into the existing `quality-checks` matrix in
+- [x] T016 Wire the detector into the existing `quality-checks` matrix in
       `.github/workflows/ci.yml`
-- [ ] T017 Confirm `scripts/shellcheck.sh` covers the new script and passes
+- [x] T017 Confirm `scripts/shellcheck.sh` covers the new script and passes
 
 ## Acceptance (ticket owner)
 


### PR DESCRIPTION
## What this makes possible

A cardano-wallet developer can run a focused Cabal unit-test match and actually
get tests.

Today they cannot. `just unit-tests-cabal-match "Store"` names twelve test
suites, and one of them — `cardano-balance-tx:unit` — belongs to a package that
enters the build as a `source-repository-package` rather than as a local
`packages:` entry in `cabal.project`. Cabal cannot build or run test suites of
non-local dependencies, so it rejects the entire invocation while it is still
resolving targets:

```text
Error: [Cabal-7043]
Cannot test the test suite 'unit' because the package cardano-balance-tx-0.1.0
is not local to the project, and cabal does not currently support building test
suites or benchmarks of non-local dependencies.
```

The failure happens before any suite runs, so the developer gets zero executed
examples no matter what pattern they ask for. This was isolated while gating
#5063, which had to work around it by calling `cabal test cardano-wallet-unit:unit`
directly.

Repository CI never noticed, because CI does not use these recipes at all — it
runs the Nix flake apps `.#unit-<pkg>`. The justfile Cabal recipes are a
developer-only harness, which is exactly how they stayed broken while the board
stayed green.

Closes #5358.

## What changed

The implementation slice landed in a single bisect-safe commit
(`fix: keep focused cabal test recipes to local suites`).

**The slice — `local-test-targets`**

1. **A committed detector**, `scripts/ci/check-local-test-targets.sh`. It
   computes two sets from the repository — the `package:suite` targets the
   Cabal test recipes select, and the test suites declared by packages listed
   under `packages:` in `cabal.project` — and fails naming any selection that
   is not locally testable.
2. **The one-line fix** — dropping `cardano-balance-tx:unit` from
   `unit-tests-cabal-match`.

They land together because either alone leaves the tree red: the detector alone
fails on the unfixed recipe, and the fix alone leaves the defect undetected and
free to come back.

### Why the detector is derived rather than hardcoded

A check that asserted "`cardano-balance-tx:unit` must be absent" would pass
forever after the fix and could never again fail for the reason we care about.
It would look like evidence while being inert.

The detector instead recomputes both sides from `cabal.project` and the local
`.cabal` files every run, and asserts that the selected set is a subset of the
locally testable set. That means it also rejects a *new* non-local target that
nobody has added yet — the actual invariant the issue title asks for, rather
than a fact about one package.

It is wired into the existing `quality-checks` matrix in
`.github/workflows/ci.yml`, alongside `check-code-format.sh`,
`check-haskell-nix-cabal.sh` and `enforce-eol.sh`. A check CI never executes
reports green whatever it asserts, so reachability is part of the change, not a
follow-up.

## Scope

Deliberately unchanged: `cardano-balance-tx` itself, dependency pins,
`source-repository-package` entries, package semantics, `cardano-api`, and the
names or contents of any test suite.

The repository declares 20 test suites across local packages; the focused
recipe deliberately selects 11 of them. This PR does not widen that selection —
it only removes the target Cabal cannot run. The other nine remain out of scope.

## Review

Pawel review is not required: this is a mechanical developer-test harness
correction with no product or wallet semantic change.

---

## Technical appendix

### Baseline reproduction (untouched base `75cd99bd17`)

```text
$ nix develop --quiet -c just unit-tests-cabal-match "Store"
Error: [Cabal-7043]
Cannot test the test suite 'unit' because the package cardano-balance-tx-0.1.0
is not local to the project...
error: Recipe `unit-tests-cabal-match` failed on line 102 with exit code 1
exit 1
```

Zero examples executed — the log ends at the resolution error.

### Selection at the base — 11 local, 1 non-local

`cardano-wallet-application-tls:unit`, `cardano-numeric:unit`,
`cardano-wallet-blackbox-benchmarks:unit`, `cardano-wallet-launcher:unit`,
`cardano-wallet-network-layer:unit`, `cardano-wallet-primitive:test`,
`cardano-wallet-secrets:test`, `cardano-wallet-test-utils:unit`,
`cardano-wallet-unit:unit`, `std-gen-seed:unit`, `wai-middleware-logging:unit`
— all under `lib/` and listed in `packages:`.

`cardano-balance-tx:unit` — from the `cardano-balance-transaction`
`source-repository-package`. Not local. This is the only removal.

### Gate and its falsification

The ticket runs against a frozen, ignored `gate.sh` (never committed). Its
reconciliation oracle is implemented independently of the committed detector on
purpose: if the gate simply called the script under test, a broken script would
agree with itself and the gate could not fail. The gate separately proves the
committed detector agrees with the independent oracle and that both can fail.

Proven before any implementation was written:

- the gate exits 1 on the untouched baseline, naming `cardano-balance-tx:unit`;
- a 7-case falsification harness passes 7/7 — it rejects the real defect,
  accepts the fix, **rejects an invented non-local target** (proving the oracle
  is derived, not hardcoded), raises no false positive on local suites, detects
  a dropped baseline suite, refuses to pass when either side parses empty, and
  enumerates the expected 20 declared suites.

The gate also runs the real recipe end to end, because static reconciliation is
a *model* of Cabal's target resolution and cannot prove Cabal accepts the
result.

### Non-vacuity

`unit-tests-cabal-match` passes no `--fail-on=empty`, so a pattern matching
nothing exits 0 and is indistinguishable from success. The gate therefore also
asserts a non-empty executed-example count for `Store` via
`--match="Store" --fail-on=empty` against `cardano-wallet-unit:unit`, where the
`Cardano.Wallet.DB.Store.*` specs live.

### On `just ci`

This repository has no `ci` recipe in its `justfile`. The string appears only in
stale planning documents from unrelated tickets, one of which already records
that `just ci` was never equivalent to the flake checks. Repository CI is
`.github/workflows/ci.yml` and has no single-command local form.

The local stand-in used for this ticket is the set of checks the
`quality-checks` matrix actually invokes and that this diff can affect:
`scripts/ci/check-code-format.sh`, `hlint lib`,
`scripts/ci/check-haskell-nix-cabal.sh`, `scripts/shellcheck.sh`,
`scripts/enforce-eol.sh` — plus the focused Cabal proof, the coverage oracle and
the negative control. The exact-head GitHub check rollup remains the
authoritative repository CI result. No new recipe was added.

### Acceptance evidence (frozen gate v2 `f0bfbd1a`, head `11636783a1`)

- **Sections 1–3, 6–7** (whitespace, independent oracle reconciliation, no lost
  coverage, detector wiring, all negative/positive/vacuity controls): ticket
  owner's independent rerun, exit 0. 20 declared / 11 selected; the detector
  accepts a genuinely local suite outside the 11 and rejects a reintroduced, an
  invented, and both empty-parse cases.
- **Section 4** (live focused recipe): `just unit-tests-cabal-match "Store"`
  exit 0, zero `Cabal-7043`, 39 Store examples executed with per-item timings;
  cold-store cost 3.28 GiB, inside the machine's 8 GiB single-command limit.
- **Section 5** (non-vacuity):
  `cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Store" --fail-on=empty'`
  exit 0 — under `--fail-on=empty`, exit 0 entails at least one Store example
  executed.
- **Section 8** (the A-001 local check set at the committed head):
  `check-code-format.sh` (fourmolu/cabal-fmt/nixfmt, no drift), `hlint lib`
  (no hints), `check-haskell-nix-cabal.sh` (update + both configures),
  `shellcheck.sh` (39 scripts), `enforce-eol.sh` — all exit 0.
