### PR TITLE
fix(wallet): allow re-delegating to previously used DRep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,24 @@ jobs:
         run: nix build --quiet .#devShells.x86_64-linux.default.inputDerivation
 
   # ---------------------------------------------------------------------------
+  # Formal specifications
+  # ---------------------------------------------------------------------------
+
+  delegation-agda:
+    name: "Check Delegation Agda Model"
+    runs-on: nix-enabled-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Typechecks specifications/Cardano/Wallet/Delegation.agda and requires
+      # the same Agda command to reject one deliberate mutation per named
+      # #5350 law, so the check is proven able to fail on every run.
+      - name: Typecheck the delegation model
+        run: nix build --quiet --print-build-logs .#checks.x86_64-linux.delegation-agda
+
+  # ---------------------------------------------------------------------------
   # Nix check
   # ---------------------------------------------------------------------------
 

--- a/flake.nix
+++ b/flake.nix
@@ -650,7 +650,16 @@
 
           # Heinrich: I don't quite understand the 'checks' attribute. See also
           # https://www.reddit.com/r/NixOS/comments/x5cjmz/comment/in0qqm6/?utm_source=share&utm_medium=web2x&context=3
-          checks = packages.checks;
+          checks = packages.checks // {
+            # Formal delegation model of issue #5350. Uses the plain,
+            # overlay-free nixpkgs so that the pinned Agda is a cache hit;
+            # the model itself is library-free.
+            # See specs/5350-redelegate-previous-drep/.
+            delegation-agda = import ./nix/delegation-agda.nix {
+              pkgs = nixpkgs-unstable.legacyPackages.${system};
+              model = ./specifications/Cardano/Wallet/Delegation.agda;
+            };
+          };
 
           mkApp = name: pkg: {
             type = "app";

--- a/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -49,6 +49,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     )
 import Cardano.Wallet.Transaction
     ( ErrCannotJoin (..)
+    , VotingAction (..)
     , Withdrawal (..)
     )
 import Data.Function
@@ -266,7 +267,42 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                         , next = [next1]
                         }
             WD.guardQuit dlg NoWithdrawal (Coin 0) False `shouldBe` Right ()
+
+    describe "joinDRepVotingAction" $ do
+        it "allows re-delegating to A after A -> B delegation (#5350)" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Voting drepA)
+            let next2 = WalletDelegationNext (EpochNo 2) (Voting drepB)
+            let dlg =
+                    WalletDelegation
+                        { active = NotDelegating
+                        , next = [next1, next2]
+                        }
+            WD.joinDRepVotingAction
+                Write.RecentEraConway
+                drepA
+                dlg
+                True
+                `shouldBe` Right (Vote drepA)
+
+        it
+            "rejects re-delegating to B when effective delegation is B (A -> B -> B)"
+            $ do
+                let next1 = WalletDelegationNext (EpochNo 1) (Voting drepA)
+                let next2 = WalletDelegationNext (EpochNo 2) (Voting drepB)
+                let dlg =
+                        WalletDelegation
+                            { active = NotDelegating
+                            , next = [next1, next2]
+                            }
+                WD.joinDRepVotingAction
+                    Write.RecentEraConway
+                    drepB
+                    dlg
+                    True
+                    `shouldBe` Left (W.ErrAlreadyVoted drepB)
   where
+    drepA = FromDRepID (DRepFromKeyHash (DRepKeyHash (BS.replicate 28 1)))
+    drepB = FromDRepID (DRepFromKeyHash (DRepKeyHash (BS.replicate 28 2)))
     pidA = PoolId "A"
     pidB = PoolId "B"
     pidUnknown = PoolId "unknown"

--- a/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -60,6 +60,7 @@ import Data.List.NonEmpty
     )
 import Data.Maybe
     ( fromJust
+    , isJust
     , isNothing
     )
 import Data.Set
@@ -79,6 +80,7 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
+    , shouldNotBe
     )
 import Test.QuickCheck
     ( Arbitrary (..)
@@ -335,14 +337,54 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
             vote drepB dlg True
                 `shouldBe` Left (W.ErrAlreadyVoted drepB)
 
-        it "agrees with last-scheduled-or-active arbitrarily"
-            $ property prop_joinDRepVotingActionEffective
-
         it "voteRequestFor matches joinDRepVotingAction arbitrarily"
             $ property prop_joinDRepParityWithVoteRequest
 
         it "effectiveDelegationStatus is last next, else active"
             $ property prop_effectiveDelegationStatus
+
+    describe "Agda #5350 law mirrors" $ do
+        it "AGDA-5350-EMPTY: empty next selects active"
+            $ property prop_effectiveDelegationStatusEmpty
+
+        it "AGDA-5350-LAST: non-empty next selects its final status"
+            $ property prop_effectiveDelegationStatusLast
+
+        it "AGDA-5350-HISTORY: superseded history cannot change it"
+            $ property prop_voteDecisionIgnoresHistory
+
+        it "AGDA-5350-SAME: only the effective DRep is a duplicate vote"
+            $ property prop_joinDRepVotingActionEffective
+
+        it "control: the historical decision rejects a re-delegation" $ do
+            historicalVoteRequestFor drepA supersededAToB
+                `shouldBe` VotedSameAsBefore
+            WD.voteRequestFor drepA supersededAToB
+                `shouldBe` VotedDifferently
+            vote drepA supersededAToB True
+                `shouldBe` Right (Vote drepA)
+
+        it "control: the historical decision depends on history" $ do
+            let scheduledB = [at 1 (Voting drepB)]
+            let withHistory = WalletDelegation (Voting drepA) scheduledB
+            let withoutHistory = WalletDelegation NotDelegating scheduledB
+            historicalVoteRequestFor drepA withHistory
+                `shouldNotBe` historicalVoteRequestFor drepA withoutHistory
+            WD.voteRequestFor drepA withHistory
+                `shouldBe` WD.voteRequestFor drepA withoutHistory
+
+    describe "Agda #5350 model assumptions" $ do
+        it "INV-5350-DREP-EQ: Eq DRep matches structural identity"
+            $ property prop_drepEqualityMatchesStructure
+
+        it "control: DRep equality separates key from script" $ do
+            let bytes = BS.replicate 28 7
+            let asKey = FromDRepID (DRepFromKeyHash (DRepKeyHash bytes))
+            let asScript =
+                    FromDRepID (DRepFromScriptHash (DRepScriptHash bytes))
+            (asKey == asScript) `shouldBe` False
+            structurallyEqualDRep asKey asScript `shouldBe` False
+            structurallyEqualDRep asKey asKey `shouldBe` True
   where
     pidA = PoolId "A"
     pidB = PoolId "B"
@@ -466,7 +508,10 @@ type GuardJoinFun =
 guardJoinConway :: GuardJoinFun
 guardJoinConway = WD.guardJoin Write.RecentEraConway
 
--- Independent D1 oracle: last scheduled status wins, else active.
+-- Mirror of the Agda law AGDA-5350-SAME in
+-- specifications/Cardano/Wallet/Delegation.agda: a request is rejected
+-- exactly when the target equals the effective DRep. Independent D1
+-- oracle: last scheduled status wins, else active.
 prop_joinDRepVotingActionEffective
     :: DRep -> WalletDelegation -> Bool -> Property
 prop_joinDRepVotingActionEffective target dlg registered =
@@ -492,6 +537,9 @@ prop_joinDRepVotingActionEffective target dlg registered =
         (Just target `elem` historyDreps)
             && (statusDRep (effectiveStatus dlg) /= Just target)
 
+-- The F1/F2 parity surface, not a formal-law mirror: the pure
+-- duplicate-vote verdict consumed by the IO path must agree with the
+-- verdict that the transaction-building path acts on.
 prop_joinDRepParityWithVoteRequest
     :: DRep -> WalletDelegation -> Bool -> Property
 prop_joinDRepParityWithVoteRequest target dlg registered =
@@ -512,6 +560,136 @@ prop_effectiveDelegationStatus
     :: WalletDelegation -> Property
 prop_effectiveDelegationStatus dlg =
     WD.effectiveDelegationStatus dlg === effectiveStatus dlg
+
+-- Mirror of the Agda law AGDA-5350-EMPTY in
+-- specifications/Cardano/Wallet/Delegation.agda: an empty 'next' schedule
+-- selects 'active'. The oracle is the generated status itself, so the two
+-- sides of the equation share no implementation expression.
+prop_effectiveDelegationStatusEmpty
+    :: WalletDelegationStatus -> Property
+prop_effectiveDelegationStatusEmpty status =
+    checkCoverage
+        $ cover
+            20
+            (isJust (statusDRep status))
+            "effective-status-carries-a-drep"
+        $ WD.effectiveDelegationStatus (WalletDelegation status [])
+            === status
+
+-- Mirror of the Agda law AGDA-5350-LAST: a non-empty 'next' schedule selects
+-- its final status, whatever 'active' and the superseded entries are. The
+-- oracle reaches the final entry by reversing the generated list.
+prop_effectiveDelegationStatusLast
+    :: WalletDelegationStatus
+    -> NonEmptyList WalletDelegationNext
+    -> Property
+prop_effectiveDelegationStatusLast status (NonEmpty scheduled) =
+    checkCoverage
+        $ cover
+            20
+            (length scheduled > 1)
+            "superseded-entries-present"
+        $ WD.effectiveDelegationStatus (WalletDelegation status scheduled)
+            === finalStatus
+  where
+    finalStatus = case reverse scheduled of
+        entry : _ -> nextStatus entry
+        [] -> status
+
+-- Mirror of the Agda law AGDA-5350-HISTORY: replacing 'active' and every
+-- superseded 'next' entry, while keeping the final scheduled entry, cannot
+-- change the duplicate-vote verdict. The pre-#5350 @active || any next@
+-- decision violates exactly this law; 'historicalVoteRequestFor' is
+-- registered above as the witness that it does.
+prop_voteDecisionIgnoresHistory
+    :: DRep
+    -> (WalletDelegationStatus, [WalletDelegationNext])
+    -> (WalletDelegationStatus, [WalletDelegationNext])
+    -> WalletDelegationNext
+    -> Property
+prop_voteDecisionIgnoresHistory target one other final =
+    checkCoverage
+        $ cover
+            5
+            targetOnlyInHistory
+            "target-in-superseded-history-only"
+        $ (WD.voteRequestFor target (withFinal one) === expected)
+        .&&. (WD.voteRequestFor target (withFinal other) === expected)
+  where
+    -- Oracle: derived from the final scheduled entry and the target
+    -- alone, never from a second call into the implementation.
+    expected =
+        if statusDRep (nextStatus final) == Just target
+            then VotedSameAsBefore
+            else VotedDifferently
+    withFinal (current, coming) =
+        WalletDelegation current (coming ++ [final])
+    supersededStatuses (current, coming) =
+        current : fmap nextStatus coming
+    supersededDReps =
+        fmap statusDRep (concatMap supersededStatuses [one, other])
+    targetOnlyInHistory =
+        Just target `elem` supersededDReps
+            && statusDRep (nextStatus final) /= Just target
+
+-- Mirror of the Agda model's explicit 'eq-refl' and 'eq-sound' parameters in
+-- specifications/Cardano/Wallet/Delegation.agda. Those are model assumptions,
+-- not a fifth AGDA-5350-* law: 'DRep' is abstract in the model, so its
+-- equality arrives as a parameter, and this property is what pins that
+-- parameter to the real 'Eq DRep' instance (INV-5350-DREP-EQ).
+prop_drepEqualityMatchesStructure :: DRep -> DRep -> Property
+prop_drepEqualityMatchesStructure left right =
+    checkCoverage
+        $ cover
+            10
+            (structurallyEqualDRep left right)
+            "structurally-identical"
+        $ cover
+            20
+            (not (sameDRepConstructor left right))
+            "different-constructors"
+        $ ((left == right) === structurallyEqualDRep left right)
+        .&&. property (left == left)
+        .&&. property (structurallyEqualDRep left left)
+
+-- The pre-#5350 duplicate-vote decision: reject whenever the target occurs in
+-- 'active' or in any scheduled entry. It exists only as the negative control
+-- for the mirrors above; production code never uses it.
+historicalVoteRequestFor
+    :: DRep
+    -> WalletDelegation
+    -> VoteRequest
+historicalVoteRequestFor target dlg =
+    if Just target `elem` fmap statusDRep (historyStatuses dlg)
+        then VotedSameAsBefore
+        else VotedDifferently
+
+nextStatus :: WalletDelegationNext -> WalletDelegationStatus
+nextStatus (WalletDelegationNext _ status) = status
+
+-- Structural identity of a 'DRep', expressed by pattern matching instead of
+-- by the derived instance under test. Credential bytes are compared as
+-- '[Word8]', so no 'Eq DRep', 'Eq DRepID' or 'Eq ByteString' is involved.
+structurallyEqualDRep :: DRep -> DRep -> Bool
+structurallyEqualDRep Abstain Abstain = True
+structurallyEqualDRep NoConfidence NoConfidence = True
+structurallyEqualDRep (FromDRepID left) (FromDRepID right) =
+    structurallyEqualDRepID left right
+structurallyEqualDRep _ _ = False
+
+structurallyEqualDRepID :: DRepID -> DRepID -> Bool
+structurallyEqualDRepID (DRepFromKeyHash left) (DRepFromKeyHash right) =
+    BS.unpack (getDRepKeyHash left) == BS.unpack (getDRepKeyHash right)
+structurallyEqualDRepID (DRepFromScriptHash left) (DRepFromScriptHash right) =
+    BS.unpack (getDRepScriptHash left)
+        == BS.unpack (getDRepScriptHash right)
+structurallyEqualDRepID _ _ = False
+
+sameDRepConstructor :: DRep -> DRep -> Bool
+sameDRepConstructor Abstain Abstain = True
+sameDRepConstructor NoConfidence NoConfidence = True
+sameDRepConstructor (FromDRepID _) (FromDRepID _) = True
+sameDRepConstructor _ _ = False
 
 effectiveStatus :: WalletDelegation -> WalletDelegationStatus
 effectiveStatus (WalletDelegation current scheduled) =

--- a/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -728,7 +728,7 @@ instance Arbitrary WalletDelegationStatus where
     shrink = genericShrink
     arbitrary = genericArbitrary
 
-instance Arbitrary EpochNo => Arbitrary WalletDelegationNext where
+instance Arbitrary WalletDelegationNext where
     shrink = genericShrink
     arbitrary = genericArbitrary
 

--- a/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -49,6 +49,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     )
 import Cardano.Wallet.Transaction
     ( ErrCannotJoin (..)
+    , VotingAction (..)
     , Withdrawal (..)
     )
 import Data.Function
@@ -266,12 +267,111 @@ spec = describe "Cardano.Wallet.DelegationSpec" $ do
                         , next = [next1]
                         }
             WD.guardQuit dlg NoWithdrawal (Coin 0) False `shouldBe` Right ()
+
+    describe "joinDRepVotingAction" $ do
+        it "allows re-delegating to A after scheduled A -> B" $ do
+            vote drepA (scheduled votingAB) True
+                `shouldBe` Right (Vote drepA)
+
+        it "rejects the same vote when effective delegation is B" $ do
+            vote drepB (scheduled votingAB) True
+                `shouldBe` Left (W.ErrAlreadyVoted drepB)
+
+        it "rejects the same vote for active-only A" $ do
+            vote drepA (activeOnly (Voting drepA)) True
+                `shouldBe` Left (W.ErrAlreadyVoted drepA)
+
+        it "allows a different DRep for active-only A" $ do
+            vote drepB (activeOnly (Voting drepA)) True
+                `shouldBe` Right (Vote drepB)
+
+        it "ignores superseded active A when next is B" $ do
+            vote drepA supersededAToB True
+                `shouldBe` Right (Vote drepA)
+
+        it "rejects B when scheduled next supersedes active A" $ do
+            vote drepB supersededAToB True
+                `shouldBe` Left (W.ErrAlreadyVoted drepB)
+
+        it "allows re-delegating to A after a DRep quit" $ do
+            vote drepA supersededAToPool True
+                `shouldBe` Right (Vote drepA)
+
+        it "rejects predefined Abstain when it is effective" $ do
+            vote Abstain supersededAToAbstain True
+                `shouldBe` Left (W.ErrAlreadyVoted Abstain)
+
+        it "allows predefined Abstain when effective DRep is A" $ do
+            vote Abstain (activeOnly (Voting drepA)) True
+                `shouldBe` Right (Vote Abstain)
+
+        it "rejects NoConfidence as last scheduled status" $ do
+            vote NoConfidence (scheduled votingANoConfidence) True
+                `shouldBe` Left (W.ErrAlreadyVoted NoConfidence)
+
+        it "allows A when last DelegatingVoting is B" $ do
+            vote drepA (scheduled delegatingVotingAB) True
+                `shouldBe` Right (Vote drepA)
+
+        it "rejects B when last DelegatingVoting is B" $ do
+            vote drepB (scheduled delegatingVotingAB) True
+                `shouldBe` Left (W.ErrAlreadyVoted drepB)
+
+        it "returns VoteRegisteringKey without a stake key" $ do
+            vote drepA (scheduled votingAB) False
+                `shouldBe` Right (VoteRegisteringKey drepA)
+
+        it "rejects a same vote when stake key is unregistered" $ do
+            vote drepB (scheduled votingAB) False
+                `shouldBe` Left (W.ErrAlreadyVoted drepB)
+
+        it "voteRequestFor matches joinDRep on A -> B" $ do
+            let dlg = scheduled votingAB
+            WD.voteRequestFor drepA dlg
+                `shouldBe` VotedDifferently
+            vote drepA dlg True `shouldBe` Right (Vote drepA)
+            WD.voteRequestFor drepB dlg
+                `shouldBe` VotedSameAsBefore
+            vote drepB dlg True
+                `shouldBe` Left (W.ErrAlreadyVoted drepB)
+
+        it "agrees with last-scheduled-or-active arbitrarily"
+            $ property prop_joinDRepVotingActionEffective
+
+        it "voteRequestFor matches joinDRepVotingAction arbitrarily"
+            $ property prop_joinDRepParityWithVoteRequest
+
+        it "effectiveDelegationStatus is last next, else active"
+            $ property prop_effectiveDelegationStatus
   where
     pidA = PoolId "A"
     pidB = PoolId "B"
     pidUnknown = PoolId "unknown"
     knownPools = Set.fromList [pidA, pidB]
     noRetirementPlanned = Nothing
+    drepA =
+        FromDRepID
+            (DRepFromKeyHash (DRepKeyHash (BS.replicate 28 1)))
+    drepB =
+        FromDRepID
+            (DRepFromKeyHash (DRepKeyHash (BS.replicate 28 2)))
+    at epoch = WalletDelegationNext (EpochNo epoch)
+    scheduled statuses =
+        WalletDelegation NotDelegating (zipWith at [1 ..] statuses)
+    activeOnly status = WalletDelegation status []
+    votingAB = [Voting drepA, Voting drepB]
+    votingANoConfidence = [Voting drepA, Voting NoConfidence]
+    delegatingVotingAB =
+        [ DelegatingVoting pidA drepA
+        , DelegatingVoting pidB drepB
+        ]
+    supersededAToB =
+        WalletDelegation (Voting drepA) [at 1 (Voting drepB)]
+    supersededAToPool =
+        WalletDelegation (Voting drepA) [at 1 (Delegating pidA)]
+    supersededAToAbstain =
+        WalletDelegation (Voting drepA) [at 1 (Voting Abstain)]
+    vote = WD.joinDRepVotingAction Write.RecentEraConway
 
 {-------------------------------------------------------------------------------
                                     Properties
@@ -365,6 +465,72 @@ type GuardJoinFun =
 
 guardJoinConway :: GuardJoinFun
 guardJoinConway = WD.guardJoin Write.RecentEraConway
+
+-- Independent D1 oracle: last scheduled status wins, else active.
+prop_joinDRepVotingActionEffective
+    :: DRep -> WalletDelegation -> Bool -> Property
+prop_joinDRepVotingActionEffective target dlg registered =
+    checkCoverage
+        $ cover
+            5
+            historyMismatch
+            "history-matches-effective-differs"
+        $ WD.joinDRepVotingAction
+            Write.RecentEraConway
+            target
+            dlg
+            registered
+            === expected
+  where
+    expected
+        | statusDRep (effectiveStatus dlg) == Just target =
+            Left (W.ErrAlreadyVoted target)
+        | registered = Right (Vote target)
+        | otherwise = Right (VoteRegisteringKey target)
+    historyDreps = fmap statusDRep (historyStatuses dlg)
+    historyMismatch =
+        (Just target `elem` historyDreps)
+            && (statusDRep (effectiveStatus dlg) /= Just target)
+
+prop_joinDRepParityWithVoteRequest
+    :: DRep -> WalletDelegation -> Bool -> Property
+prop_joinDRepParityWithVoteRequest target dlg registered =
+    case (WD.voteRequestFor target dlg, action) of
+        (VotedSameAsBefore, Left (W.ErrAlreadyVoted drep)) ->
+            drep === target
+        (VotedDifferently, Right _) -> property True
+        _ -> property False
+  where
+    action =
+        WD.joinDRepVotingAction
+            Write.RecentEraConway
+            target
+            dlg
+            registered
+
+prop_effectiveDelegationStatus
+    :: WalletDelegation -> Property
+prop_effectiveDelegationStatus dlg =
+    WD.effectiveDelegationStatus dlg === effectiveStatus dlg
+
+effectiveStatus :: WalletDelegation -> WalletDelegationStatus
+effectiveStatus (WalletDelegation current scheduled) =
+    case reverse scheduled of
+        WalletDelegationNext _ status : _ -> status
+        [] -> current
+
+historyStatuses :: WalletDelegation -> [WalletDelegationStatus]
+historyStatuses (WalletDelegation current scheduled) =
+    current
+        : fmap
+            (\(WalletDelegationNext _ status) -> status)
+            scheduled
+
+statusDRep :: WalletDelegationStatus -> Maybe DRep
+statusDRep status = case status of
+    Voting drep -> Just drep
+    DelegatingVoting _ drep -> Just drep
+    _ -> Nothing
 
 {-------------------------------------------------------------------------------
                     Arbitrary instances

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -267,9 +267,9 @@ joinDRepVotingAction era targetDRep dlg stakeKeyIsRegistered = do
     isDRepSame (W.Voting drep) = drep == targetDRep
     isDRepSame (W.DelegatingVoting _ drep) = drep == targetDRep
     isDRepSame _ = False
-    isSameNext (W.WalletDelegationNext _ deleg) = isDRepSame deleg
+
     sameWalletDelegation (W.WalletDelegation current coming) =
-        isDRepSame current || any isSameNext coming
+        isDRepSame $ maybe current (view #status) (lastMay coming)
 
     guardEraIsConway
         :: Write.IsRecentEra era

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -11,6 +11,8 @@ module Cardano.Wallet.Delegation
     , guardVoting
     , quitStakePoolDelegationAction
     , joinDRepVotingAction
+    , effectiveDelegationStatus
+    , voteRequestFor
     , DelegationRequest (..)
     , VoteRequest (..)
     ) where
@@ -250,6 +252,28 @@ guardVoting optionalDelegationAction votingSameAgainM = do
         $ ErrAlreadyVoted
         $ snd (fromJust votingSameAgainM)
 
+-- | Last scheduled 'next' status when present, otherwise 'active'.
+effectiveDelegationStatus
+    :: W.WalletDelegation
+    -> W.WalletDelegationStatus
+effectiveDelegationStatus (W.WalletDelegation current coming) =
+    maybe current (view #status) (lastMay coming)
+
+-- | Duplicate-vote classification from 'effectiveDelegationStatus'.
+voteRequestFor
+    :: DRep
+    -> W.WalletDelegation
+    -> VoteRequest
+voteRequestFor target dlg =
+    if drepMatches (effectiveDelegationStatus dlg)
+        then VotedSameAsBefore
+        else VotedDifferently
+  where
+    drepMatches status = case status of
+        W.Voting drep -> drep == target
+        W.DelegatingVoting _ drep -> drep == target
+        _ -> False
+
 joinDRepVotingAction
     :: forall era
      . Write.IsRecentEra era
@@ -259,18 +283,11 @@ joinDRepVotingAction
     -> Bool
     -> Either ErrCannotVote Tx.VotingAction
 joinDRepVotingAction era targetDRep dlg stakeKeyIsRegistered = do
-    when (sameWalletDelegation dlg)
+    when (voteRequestFor targetDRep dlg == VotedSameAsBefore)
         $ Left
         $ ErrAlreadyVoted targetDRep
     second (const votingAction) $ guardEraIsConway era
   where
-    isDRepSame (W.Voting drep) = drep == targetDRep
-    isDRepSame (W.DelegatingVoting _ drep) = drep == targetDRep
-    isDRepSame _ = False
-    isSameNext (W.WalletDelegationNext _ deleg) = isDRepSame deleg
-    sameWalletDelegation (W.WalletDelegation current coming) =
-        isDRepSame current || any isSameNext coming
-
     guardEraIsConway
         :: Write.IsRecentEra era
         => Write.RecentEra era

--- a/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
@@ -645,6 +645,7 @@ voteAction ctx action = do
                     <$> readDelegation walletState
                     <*> W.isStakeKeyRegistered walletState
     let dlg = calculateWalletDelegations currentEpochSlotting
+    let request = WD.voteRequestFor action dlg
 
     traceWith tr
         $ W.MsgWallet
@@ -652,22 +653,9 @@ voteAction ctx action = do
 
     pure
         $ if stakeKeyIsRegistered
-            then (Tx.Vote action, sameWalletDelegation dlg)
-            else (Tx.VoteRegisteringKey action, sameWalletDelegation dlg)
+            then (Tx.Vote action, request)
+            else (Tx.VoteRegisteringKey action, request)
   where
     db = ctx ^. dbLayer
     tr = ctx ^. logger
     netLayer = ctx ^. networkLayer
-
-    isDRepSame (Voting drep) = drep == action
-    isDRepSame (DelegatingVoting _ drep) = drep == action
-    isDRepSame _ = False
-
-    isSameNext (WalletDelegationNext _ deleg) = isDRepSame deleg
-
-    sameWalletDelegation (WalletDelegation current coming) =
-        if isDRepSame current || any isSameNext coming
-            then
-                VotedSameAsBefore
-            else
-                VotedDifferently

--- a/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
@@ -663,11 +663,12 @@ voteAction ctx action = do
     isDRepSame (DelegatingVoting _ drep) = drep == action
     isDRepSame _ = False
 
-    isSameNext (WalletDelegationNext _ deleg) = isDRepSame deleg
-
     sameWalletDelegation (WalletDelegation current coming) =
-        if isDRepSame current || any isSameNext coming
-            then
-                VotedSameAsBefore
-            else
-                VotedDifferently
+        let effective = case coming of
+                [] -> current
+                _ -> status (last coming)
+        in  if isDRepSame effective
+                then
+                    VotedSameAsBefore
+                else
+                    VotedDifferently

--- a/nix/delegation-agda.nix
+++ b/nix/delegation-agda.nix
@@ -1,0 +1,94 @@
+# Typecheck the formal delegation model of issue #5350 with a pinned Agda.
+#
+# `specifications/Cardano/Wallet/Delegation.agda` is library-free: it imports
+# nothing, so this check needs no Agda library set, no agda2hs, and no
+# installer fetched at CI time. The Agda version is pinned by the flake's
+# locked `nixpkgs-unstable` input.
+#
+# The check is self-falsifying. After typechecking the model it applies one
+# mutation per named law and requires Agda to reject each mutated model. A
+# mutation whose anchor line has drifted fails the check instead of silently
+# testing nothing, so the negative control cannot become vacuous.
+#
+# Every directory below is created fresh inside the build sandbox and nothing
+# is ever deleted, and `AGDA_DIR` is a task-specific directory so that `HOME`
+# is neither read nor repurposed.
+{
+  pkgs,
+  model,
+}:
+pkgs.runCommand "delegation-agda"
+  {
+    nativeBuildInputs = [ pkgs.agda ];
+    inherit model;
+  }
+  ''
+    export AGDA_DIR="$NIX_BUILD_TOP/agda"
+    mkdir -p "$AGDA_DIR"
+    mkdir -p "$out"
+
+    relative=Cardano/Wallet/Delegation.agda
+
+    # The model imports nothing, so no library needs to resolve; interfaces
+    # are written next to the sources inside the sandbox.
+    typecheck() {
+      ( cd "$1" && agda --local-interfaces --include-path=. "$relative" )
+    }
+
+    echo "+++ delegation-agda: typechecking $relative"
+    mkdir -p model/Cardano/Wallet
+    cp "$model" "model/$relative"
+    typecheck model
+
+    # Negative control: one law-breaking mutation per named law. Each mutation
+    # must apply to exactly one line, and the exact same Agda command must
+    # reject the result. Each mutant lives in its own fresh directory.
+    mutate() {
+      local law=$1 from=$2 to=$3
+      local dir="mutant-$law"
+      local anchors
+
+      anchors=$(awk -v from="$from" '$0 == from { c++ } END { print c+0 }' \
+        "model/$relative")
+      if [ "$anchors" != 1 ]; then
+        echo "delegation-agda: $law anchor matched $anchors lines, wanted 1" >&2
+        echo "  anchor: $from" >&2
+        exit 1
+      fi
+
+      mkdir -p "$dir/Cardano/Wallet"
+      awk -v from="$from" -v to="$to" '$0 == from { print to; next } { print }' \
+        "model/$relative" > "$dir/$relative"
+      if cmp -s "model/$relative" "$dir/$relative"; then
+        echo "delegation-agda: $law mutation did not change the model" >&2
+        exit 1
+      fi
+
+      if typecheck "$dir" > "$out/$law.log" 2>&1; then
+        echo "delegation-agda: $law mutation still typechecks" >&2
+        exit 1
+      fi
+      echo "+++ delegation-agda: $law mutation rejected"
+      cat "$out/$law.log"
+    }
+
+    mutate AGDA-5350-EMPTY \
+      'effectiveDelegationStatus (MkDelegation a []) = a' \
+      'effectiveDelegationStatus (MkDelegation a []) = Inactive'
+
+    mutate AGDA-5350-LAST \
+      'lastStatus s (t ∷ ts) = lastStatus t ts' \
+      'lastStatus s (t ∷ ts) = s'
+
+    mutate AGDA-5350-HISTORY \
+      '    decideAgainst t (statusDRep (effectiveDelegationStatus d))' \
+      '    decideAgainst t (statusDRep (activeStatus d))'
+
+    mutate AGDA-5350-SAME \
+      '  chooseVote True = SameVote' \
+      '  chooseVote True = DifferentVote'
+
+    cp "model/$relative" "$out/Delegation.agda"
+    agda --version > "$out/agda-version.txt"
+    echo "delegation-agda: model typechecks, all 4 law mutations rejected"
+  ''

--- a/nix/delegation-agda.nix
+++ b/nix/delegation-agda.nix
@@ -29,10 +29,12 @@ pkgs.runCommand "delegation-agda"
 
     relative=Cardano/Wallet/Delegation.agda
 
-    # The model imports nothing, so no library needs to resolve; interfaces
-    # are written next to the sources inside the sandbox.
+    # The model imports nothing, so no library needs to resolve. Each caller
+    # passes its own fresh sandbox directory as the include root, so Agda
+    # writes its interface files there and the copies stay independent.
+    # (`--local-interfaces` was removed in Agda 2.8.0 and is not passed.)
     typecheck() {
-      ( cd "$1" && agda --local-interfaces --include-path=. "$relative" )
+      ( cd "$1" && agda --include-path=. "$relative" )
     }
 
     echo "+++ delegation-agda: typechecking $relative"

--- a/specifications/Cardano/Wallet/Delegation.agda
+++ b/specifications/Cardano/Wallet/Delegation.agda
@@ -8,10 +8,63 @@ module
       (Pool : Set)
   where
 
-open import Haskell.Prelude using (_≡_; Maybe; Just; Nothing)
-open import Data.Product public using () renaming
-  ( _×_ to _⋀_
-  )
+{-----------------------------------------------------------------------------
+    Prelude
+
+    This module is deliberately library-free: it imports nothing and defines
+    the handful of types and equality combinators that it needs.  That way the
+    repository-owned, Nix-pinned check
+    (`checks.x86_64-linux.delegation-agda`) typechecks this file with a plain
+    Agda and no library resolution at all — no agda2hs, no standard library,
+    and no unpinned installer.
+------------------------------------------------------------------------------}
+
+data _≡_ {a : Set} (x : a) : a → Set where
+  refl : x ≡ x
+
+infix 4 _≡_
+
+sym : ∀ {a : Set} {x y : a} → x ≡ y → y ≡ x
+sym refl = refl
+
+trans : ∀ {a : Set} {x y z : a} → x ≡ y → y ≡ z → x ≡ z
+trans refl q = q
+
+cong : ∀ {a b : Set} (f : a → b) {x y : a} → x ≡ y → f x ≡ f y
+cong f refl = refl
+
+data Empty : Set where
+
+absurd : ∀ {a : Set} → Empty → a
+absurd ()
+
+data Bool : Set where
+  True  : Bool
+  False : Bool
+
+data Maybe (a : Set) : Set where
+  Nothing : Maybe a
+  Just    : a → Maybe a
+
+data List (a : Set) : Set where
+  []  : List a
+  _∷_ : a → List a → List a
+
+infixr 5 _∷_
+
+_++_ : ∀ {a : Set} → List a → List a → List a
+[] ++ ys = ys
+(x ∷ xs) ++ ys = x ∷ (xs ++ ys)
+
+infixr 5 _++_
+
+record _⋀_ (a b : Set) : Set where
+  constructor _,_
+  field
+    fst : a
+    snd : b
+
+infixr 2 _⋀_
 
 {-----------------------------------------------------------------------------
     Delegation status
@@ -85,3 +138,191 @@ record HistoryLaws (api : HistoryApi) : Set₁ where
       : setsTheFuture api
           Rollback
           (λ old → old)
+
+{-----------------------------------------------------------------------------
+    Issue #5350 — effective delegation and the duplicate-vote decision
+
+    A wallet may re-delegate its voting power to a DRep that occurs earlier in
+    its delegation history, as long as that DRep is not the *effective*
+    delegation.  The named laws below are the formal backend for that rule;
+    each one has a QuickCheck mirror over the Haskell implementation, listed in
+    specs/5350-redelegate-previous-drep/functions-model.md:
+
+      AGDA-5350-EMPTY   → prop_effectiveDelegationStatusEmpty
+      AGDA-5350-LAST    → prop_effectiveDelegationStatusLast
+      AGDA-5350-HISTORY → prop_voteDecisionIgnoresHistory
+      AGDA-5350-SAME    → prop_joinDRepVotingActionEffective
+
+    The DRep-equality parameters below (eq-refl, eq-sound) are model
+    assumptions rather than #5350 laws; their Haskell mirror is the
+    registered prop_drepEqualityMatchesStructure.
+------------------------------------------------------------------------------}
+
+-- | D1 — the projected delegation state that the wallet reports: the
+-- currently active status together with the ordered scheduled statuses.
+-- Epochs are abstracted away, but the ordered-list boundary of
+-- 'WalletDelegation' is preserved.
+record Delegation : Set where
+  constructor MkDelegation
+  field
+    active : Status
+    next   : List Status
+
+-- | D1 projections.  ‘activeStatus’ is what the pre-#5350 decision looked
+-- at directly; the negative control in nix/delegation-agda.nix mutates
+-- ‘voteDecision’ back onto it.
+activeStatus : Delegation → Status
+activeStatus (MkDelegation a _) = a
+
+nextStatuses : Delegation → List Status
+nextStatuses (MkDelegation _ ss) = ss
+
+-- | The final element of a non-empty run of scheduled statuses.
+lastStatus : Status → List Status → Status
+lastStatus s [] = s
+lastStatus s (t ∷ ts) = lastStatus t ts
+
+-- | F3 — the effective delegation status: the final scheduled status when the
+-- schedule is non-empty, otherwise the active status.
+effectiveDelegationStatus : Delegation → Status
+effectiveDelegationStatus (MkDelegation a []) = a
+effectiveDelegationStatus (MkDelegation a (s ∷ ss)) = lastStatus s ss
+
+-- | AGDA-5350-EMPTY — an empty schedule selects the active status.
+AGDA-5350-EMPTY
+  : ∀ (d : Delegation)
+  → nextStatuses d ≡ []
+  → effectiveDelegationStatus d ≡ activeStatus d
+AGDA-5350-EMPTY (MkDelegation a []) scheduleIsEmpty = refl
+AGDA-5350-EMPTY (MkDelegation a (s ∷ ss)) ()
+
+-- | @IsLast x s ss@ holds when @x@ is the final element of @s ∷ ss@.
+-- It is defined independently of 'lastStatus', so that AGDA-5350-LAST relates
+-- the implementation to a specification rather than to itself.
+data IsLast (x : Status) : Status → List Status → Set where
+  here
+    : IsLast x x []
+  there
+    : ∀ {s t : Status} {ts : List Status}
+    → IsLast x t ts
+    → IsLast x s (t ∷ ts)
+
+-- | AGDA-5350-LAST — a non-empty schedule selects its final status, whatever
+-- the active status and the earlier scheduled statuses are.
+AGDA-5350-LAST
+  : ∀ (a : Status) {x s : Status} {ss : List Status}
+  → IsLast x s ss
+  → effectiveDelegationStatus (MkDelegation a (s ∷ ss)) ≡ x
+AGDA-5350-LAST a here = refl
+AGDA-5350-LAST a (there p) = AGDA-5350-LAST a p
+
+-- | Appending a final scheduled status makes it the effective status.
+lastStatus-snoc
+  : ∀ (s : Status) (ss : List Status) (final : Status)
+  → lastStatus s (ss ++ (final ∷ [])) ≡ final
+lastStatus-snoc s [] final = refl
+lastStatus-snoc s (t ∷ ts) final = lastStatus-snoc t ts final
+
+-- | Neither the active status nor any superseded scheduled status can affect
+-- the effective status once a later status is scheduled.
+effective-snoc
+  : ∀ (a : Status) (hs : List Status) (final : Status)
+  → effectiveDelegationStatus (MkDelegation a (hs ++ (final ∷ []))) ≡ final
+effective-snoc a [] final = refl
+effective-snoc a (h ∷ hs) final = lastStatus-snoc h hs final
+
+-- | The DRep carried by a delegation status, if any.
+statusDRep : Status → Maybe DRep
+statusDRep Inactive = Nothing
+statusDRep (Active mdrep _) = mdrep
+
+-- | D2 — the duplicate-vote observation.
+data VoteDecision : Set where
+  SameVote      : VoteDecision
+  DifferentVote : VoteDecision
+
+-- | The duplicate-vote decision needs to compare two 'DRep's.  'DRep' is
+-- abstract here, so its equality is a module parameter together with its
+-- correctness laws — exactly as the surrounding module abstracts the order on
+-- 'Slot'.  Nothing about issue #5350 is assumed.
+module DuplicateVote
+    (_==_ : DRep → DRep → Bool)
+    (eq-sound : ∀ {x y : DRep} → (x == y) ≡ True → x ≡ y)
+    (eq-refl : ∀ (x : DRep) → (x == x) ≡ True)
+  where
+
+  chooseVote : Bool → VoteDecision
+  chooseVote True = SameVote
+  chooseVote False = DifferentVote
+
+  decideAgainst : DRep → Maybe DRep → VoteDecision
+  decideAgainst t Nothing = DifferentVote
+  decideAgainst t (Just d) = chooseVote (t == d)
+
+  -- | F4 — the duplicate-vote decision.  It is derived from F3 alone, so the
+  -- history is not in scope of the decision by construction.
+  voteDecision : DRep → Delegation → VoteDecision
+  voteDecision t d =
+    decideAgainst t (statusDRep (effectiveDelegationStatus d))
+
+  decideAgainst-refl
+    : ∀ (t : DRep)
+    → decideAgainst t (Just t) ≡ SameVote
+  decideAgainst-refl t = cong chooseVote (eq-refl t)
+
+  decideAgainst-differs
+    : ∀ (t : DRep) (md : Maybe DRep)
+    → (md ≡ Just t → Empty)
+    → decideAgainst t md ≡ DifferentVote
+  decideAgainst-differs t Nothing different = refl
+  decideAgainst-differs t (Just d) different = go (t == d) refl
+    where
+      go
+        : ∀ (b : Bool)
+        → (t == d) ≡ b
+        → chooseVote (t == d) ≡ DifferentVote
+      go True observed =
+        absurd (different (cong Just (sym (eq-sound observed))))
+      go False observed = cong chooseVote observed
+
+  -- | AGDA-5350-HISTORY — replacing the active status and every superseded
+  -- scheduled status, while keeping the final scheduled status, cannot change
+  -- the decision.  This is the law that the pre-#5350
+  -- @active || any next@ decision violates.
+  AGDA-5350-HISTORY
+    : ∀ (t : DRep) (a b : Status) (hs ks : List Status) (final : Status)
+    → voteDecision t (MkDelegation a (hs ++ (final ∷ [])))
+      ≡ voteDecision t (MkDelegation b (ks ++ (final ∷ [])))
+  AGDA-5350-HISTORY t a b hs ks final =
+    cong
+      (λ s → decideAgainst t (statusDRep s))
+      (trans (effective-snoc a hs final) (sym (effective-snoc b ks final)))
+
+  -- | AGDA-5350-SAME — the request is a duplicate vote exactly when the
+  -- target equals the effective DRep: rejected in that case, accepted
+  -- otherwise.
+  AGDA-5350-SAME
+    : ∀ (t : DRep) (d : Delegation)
+    → ( (statusDRep (effectiveDelegationStatus d) ≡ Just t)
+        → voteDecision t d ≡ SameVote
+      )
+      ⋀
+      ( ((statusDRep (effectiveDelegationStatus d) ≡ Just t) → Empty)
+        → voteDecision t d ≡ DifferentVote
+      )
+  AGDA-5350-SAME t d = rejects , accepts
+    where
+      rejects
+        : (statusDRep (effectiveDelegationStatus d) ≡ Just t)
+        → voteDecision t d ≡ SameVote
+      rejects same =
+        trans (cong (decideAgainst t) same) (decideAgainst-refl t)
+
+      accepts
+        : ((statusDRep (effectiveDelegationStatus d) ≡ Just t) → Empty)
+        → voteDecision t d ≡ DifferentVote
+      accepts different =
+        decideAgainst-differs
+          t
+          (statusDRep (effectiveDelegationStatus d))
+          different

--- a/specs/5350-redelegate-previous-drep/data-model.md
+++ b/specs/5350-redelegate-previous-drep/data-model.md
@@ -1,0 +1,11 @@
+# Data model
+
+- **D1 — Effective delegation**
+  - `active`: the currently active `WalletDelegationStatus`.
+  - `next`: ordered scheduled `WalletDelegationNext` entries.
+  - `effective`: `status` of the final `next` entry when one exists, otherwise
+    `active`.
+
+State invariant: earlier `next` entries and a superseded `active` value are
+history for duplicate-vote comparison; they remain available for all other
+wallet semantics.

--- a/specs/5350-redelegate-previous-drep/data-model.md
+++ b/specs/5350-redelegate-previous-drep/data-model.md
@@ -9,3 +9,22 @@
 State invariant: earlier `next` entries and a superseded `active` value are
 history for duplicate-vote comparison; they remain available for all other
 wallet semantics.
+
+- **D2 — Formal duplicate-vote observation**
+  - `target`: requested DRep.
+  - `effectiveDRep`: the DRep, if any, carried by D1 `effective`.
+  - `decision`: `same_vote` exactly when `target = effectiveDRep`; otherwise
+    the request is different.
+  - `history`: D1 `active` plus every non-final `next` entry when `next` is
+    non-empty.
+
+Formal invariant: changing D2 `history` while preserving D1 `effective` cannot
+change D2 `decision`. The Agda model abstracts epochs but preserves the ordered
+list boundary used by `WalletDelegation`; the Haskell mirror supplies concrete
+`WalletDelegationNext` epochs and statuses.
+
+Equality reliance: D2's target comparison uses decidable DRep equality. The
+Agda backend takes reflexivity and soundness as explicit parameters because
+`DRep` is abstract there. The Haskell mirror compares the actual `Eq DRep`
+result with an independently pattern-matched structural oracle over predefined,
+key-hash, and script-hash representatives.

--- a/specs/5350-redelegate-previous-drep/functions-model.md
+++ b/specs/5350-redelegate-previous-drep/functions-model.md
@@ -1,0 +1,11 @@
+# Functions model
+
+- **F1 — `joinDRepVotingAction era targetDRep delegation stakeKeyIsRegistered`**
+  - Inputs: recent era, requested `DRep`, `WalletDelegation`, registration flag.
+  - Result: `Either ErrCannotVote VotingAction`.
+  - Constraint: reject only when `targetDRep` matches D1 `effective`; preserve
+    existing era and registration behavior.
+- **F2 — `voteAction context targetDRep`**
+  - Inputs: IO wallet layer and requested `DRep`.
+  - Result: `IO (VotingAction, VoteRequest)`.
+  - Constraint: derive its duplicate verdict from D1 `effective`, matching F1.

--- a/specs/5350-redelegate-previous-drep/functions-model.md
+++ b/specs/5350-redelegate-previous-drep/functions-model.md
@@ -9,3 +9,33 @@
   - Inputs: IO wallet layer and requested `DRep`.
   - Result: `IO (VotingAction, VoteRequest)`.
   - Constraint: derive its duplicate verdict from D1 `effective`, matching F1.
+- **F3 — Agda `effectiveDelegationStatus delegation`**
+  - Inputs: D1 projected delegation (`active`, ordered `next`).
+  - Result: formal delegation status.
+  - Constraint: return `active` exactly when `next` is empty; otherwise return
+    the status of the final `next` entry.
+- **F4 — Agda `voteDecision target delegation`**
+  - Inputs: requested formal DRep and D1 projected delegation.
+  - Result: D2 duplicate-vote observation.
+  - Constraint: derive the result only from F3; history cannot affect it.
+
+## Formal-law to QuickCheck mapping
+
+The implementation may choose Agda-compatible identifier spelling, but the
+stable law IDs and one-to-one QuickCheck mapping are mandatory:
+
+| Formal law | Meaning | QuickCheck mirror |
+|---|---|---|
+| `AGDA-5350-EMPTY` | empty `next` selects `active` | `prop_effectiveDelegationStatusEmpty` |
+| `AGDA-5350-LAST` | non-empty `next` selects its final status | `prop_effectiveDelegationStatusLast` |
+| `AGDA-5350-HISTORY` | changing only superseded history preserves the decision | `prop_voteDecisionIgnoresHistory` |
+| `AGDA-5350-SAME` | target equal to effective DRep is rejected; a different target is accepted | `prop_joinDRepVotingActionEffective` |
+
+`prop_joinDRepParityWithVoteRequest` remains the executable parity property
+between F1 and the shared verdict consumed by F2. Each property must be
+registered in the focused test tree, not merely defined.
+
+The formal backend's `eq-refl` and `eq-sound` parameters are explicit model
+assumptions, not additional `AGDA-5350-*` laws. They map together to the
+registered `prop_drepEqualityMatchesStructure` property, which compares the
+Haskell `Eq DRep` instance with a structural oracle and covers reflexivity.

--- a/specs/5350-redelegate-previous-drep/modules-model.md
+++ b/specs/5350-redelegate-previous-drep/modules-model.md
@@ -1,0 +1,11 @@
+# Modules model
+
+- **M1 — `Cardano.Wallet.Delegation`:** owns the pure duplicate-vote decision
+  used while constructing a DRep voting action. Data: D1. Function: F1.
+- **M2 — `Cardano.Wallet.IO.Delegation`:** keeps the wallet-layer duplicate
+  verdict aligned with M1 for its IO-facing path. Data: D1. Function: F2.
+- **M3 — `Cardano.Wallet.DelegationSpec`:** owns executable examples that
+  distinguish effective state from historical state. Functions: F1, F2.
+
+Dependency direction remains wallet state → effective delegation selection →
+duplicate-vote verdict; no new abstraction or persistence dependency is added.

--- a/specs/5350-redelegate-previous-drep/modules-model.md
+++ b/specs/5350-redelegate-previous-drep/modules-model.md
@@ -6,6 +6,19 @@
   verdict aligned with M1 for its IO-facing path. Data: D1. Function: F2.
 - **M3 — `Cardano.Wallet.DelegationSpec`:** owns executable examples that
   distinguish effective state from historical state. Functions: F1, F2.
+- **M4 — `specifications/Cardano/Wallet/Delegation.agda`:** owns the formal
+  projected-delegation backend, effective-status definition, duplicate-vote
+  decision, and named #5350 laws. Data: D1, D2. Functions: F3, F4.
+- **M5 — Agda check integration:** owns a reproducible, Nix-pinned command that
+  typechecks M4 and a CI edge that actually invokes that command when the
+  formal backend or its mirrors change. It produces no generated Haskell.
+- **M6 — QuickCheck mirror mapping:** M3 owns the focused properties; the
+  #5350 specification records the one-to-one mapping from each M4 law to the
+  property that checks the Haskell implementation. Data: D1, D2. Functions:
+  F1, F3, F4. M6 also checks the explicit DRep-equality assumptions used by M4
+  against the structural Haskell representation.
 
 Dependency direction remains wallet state → effective delegation selection →
-duplicate-vote verdict; no new abstraction or persistence dependency is added.
+duplicate-vote verdict. M4 specifies that direction, M6 checks the Haskell
+realization, and M5 checks M4 itself. No persistence or public API dependency is
+added, and M4/M5 must not depend on generated output from M6.

--- a/specs/5350-redelegate-previous-drep/plan.md
+++ b/specs/5350-redelegate-previous-drep/plan.md
@@ -8,6 +8,14 @@
 - Preserve public API types and database state.
 - Do not start a cold full-gate realization on this host. Focused warm tests,
   formatting, and linting are allowed; full verification is delegated to PR CI.
+- Keep the established delegation formalism: extend
+  `specifications/Cardano/Wallet/Delegation.agda`; do not introduce a new Lean
+  project and do not claim Agda-to-Haskell code generation where none exists.
+- The Agda toolchain and check must be pinned and owned by the repository. CI
+  must not fetch an unpinned installer or depend on `/code/cardano-wallet-agda`.
+- The standing no-local-Nix-build ruling remains binding. Static inspection and
+  negative-control construction are local; Nix-backed execution is delegated
+  to PR CI unless the project owner explicitly lifts that ruling.
 
 ## Strategy
 
@@ -16,8 +24,17 @@
    delegation state and exercises both accepted and rejected outcomes.
 3. Make the smallest pure and IO changes needed to select the effective state.
 4. Run the focused gate, format/lint checks, and independent audit before push.
+5. Extend the existing Agda delegation lineage with the projected effective
+   state and duplicate-vote laws, then map each law to a named QuickCheck
+   property over the Haskell functions.
+6. Add one repository-owned Nix-backed Agda check and invoke it from CI; prove
+   its reachability with an ill-typed negative control and prove the QuickCheck
+   mirror with the historical decision as its negative control.
 
 ## Slice
 
 - **S1 — effective DRep comparison:** tasks T1–T3, one bisect-safe behavior
   commit.
+- **S2 — checked formal backend and mirrors:** tasks T4–T7, one follow-up commit
+  on PR #5363. The change is additive to S1 and does not reopen its accepted
+  production behavior unless a formal/QC mismatch exposes a defect.

--- a/specs/5350-redelegate-previous-drep/plan.md
+++ b/specs/5350-redelegate-previous-drep/plan.md
@@ -1,0 +1,23 @@
+# Plan
+
+## Constraints
+
+- Reuse draft PR #5363 and its existing branch.
+- Treat commit `5366766d1a8dc8f63a88f8bf6f55180eaf9232f7` and the preserved hostile-audit
+  worktree as untrusted seed evidence; fresh Grok ownership is required.
+- Preserve public API types and database state.
+- Do not start a cold full-gate realization on this host. Focused warm tests,
+  formatting, and linting are allowed; full verification is delegated to PR CI.
+
+## Strategy
+
+1. Rebase the legacy draft onto current `master` through a fresh planning base.
+2. Add a RED regression bundle that distinguishes historical from effective
+   delegation state and exercises both accepted and rejected outcomes.
+3. Make the smallest pure and IO changes needed to select the effective state.
+4. Run the focused gate, format/lint checks, and independent audit before push.
+
+## Slice
+
+- **S1 — effective DRep comparison:** tasks T1–T3, one bisect-safe behavior
+  commit.

--- a/specs/5350-redelegate-previous-drep/spec.md
+++ b/specs/5350-redelegate-previous-drep/spec.md
@@ -1,0 +1,42 @@
+# Re-delegate to a previously used DRep
+
+## Outcome
+
+A wallet may delegate voting power to a DRep used earlier in its delegation
+history when that DRep is not the effective delegation. A request matching the
+effective DRep remains rejected as `same_vote`.
+
+## Requirements
+
+- **R1** Determine duplicate voting from the effective delegation: the final
+  scheduled `next` status when present, otherwise `active`.
+- **R2** Ignore earlier historical entries when deciding whether the requested
+  DRep is already effective.
+- **R3** Apply the same rule in the pure transaction-building path and the IO
+  wallet-layer path.
+- **R4** Preserve Conway-era and stake-key registration behavior.
+- **R5** Permanently cover A → B → A acceptance and A → B → B rejection,
+  including active-only, scheduled quit, and predefined DRep cases where they
+  distinguish effective state from history.
+
+## Invariants
+
+- **INV-5350-EFFECTIVE** (`BLOCKING`): duplicate-vote rejection compares the
+  target only with the effective delegation, because the verdict controls
+  whether a fee-bearing transaction may be built.
+- **INV-5350-ORDER** (`BLOCKING`): when `next` is non-empty, only its final
+  ordered status is effective; earlier entries are history.
+- **INV-5350-PARITY** (`BLOCKING`): pure and IO paths return the same duplicate
+  verdict for the same wallet delegation state.
+- **INV-5350-GUARDS** (`BLOCKING`): the change does not weaken era or
+  stake-registration guards around voting actions.
+- **INV-5350-PROOF** (`ADVISORY`): the regression proof runs through the
+  repository unit-test target and is demonstrated RED without the fix and
+  GREEN with it.
+
+## Rejection behavior
+
+- Reject a request matching the effective DRep with `ErrAlreadyVoted` /
+  `same_vote`.
+- Do not reject solely because the target appears in `active` or an earlier
+  scheduled entry superseded by a later status.

--- a/specs/5350-redelegate-previous-drep/spec.md
+++ b/specs/5350-redelegate-previous-drep/spec.md
@@ -18,6 +18,21 @@ effective DRep remains rejected as `same_vote`.
 - **R5** Permanently cover A → B → A acceptance and A → B → B rejection,
   including active-only, scheduled quit, and predefined DRep cases where they
   distinguish effective state from history.
+- **R6** Extend the repository's existing delegation Agda specification with
+  the projected `active`/ordered-`next` state, effective-status selection, and
+  duplicate-vote decision. The Agda source is the formal backend for these
+  rules; it must typecheck through a repository-owned, Nix-pinned check.
+- **R7** Mirror every named #5350 Agda law with an explicitly mapped QuickCheck
+  property over the Haskell implementation. The mapping must cover the empty
+  `next` fallback, final-`next` selection, history irrelevance, and
+  effective-DRep rejection; the existing pure/IO parity property remains
+  required. The Agda model's explicit DRep-equality assumptions must likewise
+  have a registered QuickCheck mirror against an independently expressed
+  structural oracle.
+- **R8** Permanently wire both proof surfaces into CI: the Agda check and the
+  focused QuickCheck properties. A deliberate ill-typed Agda mutation and a
+  deliberate restoration of the historical `active || any next` decision must
+  each make their corresponding check fail.
 
 ## Invariants
 
@@ -33,6 +48,20 @@ effective DRep remains rejected as `same_vote`.
 - **INV-5350-PROOF** (`ADVISORY`): the regression proof runs through the
   repository unit-test target and is demonstrated RED without the fix and
   GREEN with it.
+- **INV-5350-AGDA** (`BLOCKING`): the checked Agda backend defines D1 and proves
+  the empty-`next`, final-`next`, history-irrelevance, and effective-DRep
+  decision laws without postulates standing in for those laws.
+- **INV-5350-MIRROR** (`BLOCKING`): each named Agda law has a named QuickCheck
+  mirror that exercises the corresponding Haskell function over generated
+  values; no mirror may compare two values derived from the same implementation
+  expression or otherwise pass vacuously.
+- **INV-5350-WIRING** (`BLOCKING`): CI invokes the repository-owned Agda check
+  and the unit-test target invokes every mapped QuickCheck property. Both
+  paths have a recorded negative control demonstrating that they can fail.
+- **INV-5350-DREP-EQ** (`BLOCKING`): equality used by the duplicate-vote
+  decision is reflexive and agrees with the structural identity of `DRep`.
+  The formal backend states this reliance explicitly and the Haskell test tree
+  permanently checks the actual `Eq DRep` instance against a structural oracle.
 
 ## Rejection behavior
 

--- a/specs/5350-redelegate-previous-drep/tasks.md
+++ b/specs/5350-redelegate-previous-drep/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## Slice S1 — effective DRep comparison
+
+- [ ] **T1** Add a RED regression bundle covering historical and effective
+  DRep distinctions, with accepted and rejected outcomes.
+- [ ] **T2** Align pure and IO duplicate-vote decisions with the effective
+  delegation state while preserving existing guards.
+- [ ] **T3** Run focused verification, formatting/lint checks, and submit a
+  clean signed candidate for independent audit.

--- a/specs/5350-redelegate-previous-drep/tasks.md
+++ b/specs/5350-redelegate-previous-drep/tasks.md
@@ -11,3 +11,29 @@
 
   Static verification and two independent audits are complete. Host-floor
   interlock deferred executable tests, formatting, and lint checks to PR CI.
+
+## Slice S2 — checked Agda backend and QuickCheck mirrors
+
+- [x] **T4** Extend `specifications/Cardano/Wallet/Delegation.agda` with D1/D2,
+  F3/F4, and proofs for `AGDA-5350-EMPTY`, `AGDA-5350-LAST`,
+  `AGDA-5350-HISTORY`, and `AGDA-5350-SAME` without placeholder postulates.
+- [x] **T5** Add a repository-owned, Nix-pinned Agda check and wire it into PR
+  CI. Record a negative control in which a deliberate Agda type error makes
+  the exact check fail, then restore the valid source.
+- [x] **T6** Add and register the one-to-one QuickCheck mirrors named in the
+  functions model, retain `prop_joinDRepParityWithVoteRequest`, and record a
+  RED control against the historical `active || any next` decision. Register
+  `prop_drepEqualityMatchesStructure` for the formal backend's explicit DRep
+  equality assumptions.
+- [ ] **T7** Run the available non-Nix static gates, obtain CI evidence for the
+  Agda check and focused QuickCheck suite under the standing host ruling, and
+  submit one clean signed S2 candidate for fresh independent audit.
+
+  The static gate, `git diff --check`, `fourmolu --mode check` and `nixfmt`
+  are green locally and one clean signed S2 candidate is submitted. The
+  standing no-local-Nix ruling defers the executed evidence to PR CI: no
+  Agda binary exists on this host, so neither the model typecheck nor the
+  four law mutations of `checks.x86_64-linux.delegation-agda` have been
+  executed, and the focused QuickCheck suite has not been run. This task
+  stays open until the `Check Delegation Agda Model` job and the
+  `wallet-unit / Other Wallet` job report on PR #5363.

--- a/specs/5350-redelegate-previous-drep/tasks.md
+++ b/specs/5350-redelegate-previous-drep/tasks.md
@@ -2,9 +2,12 @@
 
 ## Slice S1 — effective DRep comparison
 
-- [ ] **T1** Add a RED regression bundle covering historical and effective
+- [x] **T1** Add a RED regression bundle covering historical and effective
   DRep distinctions, with accepted and rejected outcomes.
-- [ ] **T2** Align pure and IO duplicate-vote decisions with the effective
+- [x] **T2** Align pure and IO duplicate-vote decisions with the effective
   delegation state while preserving existing guards.
-- [ ] **T3** Run focused verification, formatting/lint checks, and submit a
+- [x] **T3** Run focused verification, formatting/lint checks, and submit a
   clean signed candidate for independent audit.
+
+  Static verification and two independent audits are complete. Host-floor
+  interlock deferred executable tests, formatting, and lint checks to PR CI.


### PR DESCRIPTION
## Summary

- compare a requested DRep with the wallet's effective delegation status instead of superseded history
- derive both pure and IO duplicate-vote decisions from one shared rule
- specify the effective-state rule in Agda and mirror every named law with registered, independently-oracled QuickCheck properties
- add a Nix-pinned `delegation-agda` CI check that typechecks the model and rejects one exact mutation per law
- add regression coverage for allowing A → B → A while continuing to reject A → B → B as `same_vote`

## Root cause

The duplicate-vote check searched every entry in the upcoming delegation sequence. A previously used DRep therefore remained a match even after a later delegation had become effective.

The check now uses the final scheduled status when one exists, falling back to the active status otherwise.

## Formal/executable contract

`specifications/Cardano/Wallet/Delegation.agda` owns the projected delegation state, effective-status selection, duplicate-vote decision, and four stable laws:

- `AGDA-5350-EMPTY` ↔ `prop_effectiveDelegationStatusEmpty`
- `AGDA-5350-LAST` ↔ `prop_effectiveDelegationStatusLast`
- `AGDA-5350-HISTORY` ↔ `prop_voteDecisionIgnoresHistory`
- `AGDA-5350-SAME` ↔ `prop_joinDRepVotingActionEffective`

`prop_joinDRepParityWithVoteRequest` remains the pure/IO parity surface. `prop_drepEqualityMatchesStructure` checks the formal model's explicit DRep-equality assumptions against a structural oracle. The Agda model guides and checks the design; it does not generate production Haskell.

## User impact

Wallet users can delegate back to a previously used DRep without receiving an incorrect `same_vote` error. Requests matching the currently effective DRep remain rejected to avoid unnecessary fees.

## Validation

- signed final candidate `b7e82488e953d310842548dff96799e259a51c34`; audited repair parent `5d226c5ad1201f89efb985a2a1439b41ff9b0eeb`; slice base `b2bc1ce85515d36e49cb77c975a7a0060ba60126`
- frozen static gate, `git diff --check`, Fourmolu, nixfmt, EOL, signature/parent/fence, exact mutation anchors, proof semantics, mirror independence, and generator value coverage passed
- fresh independent Codex audit returned PASS with zero blocking findings and zero advisories (`c77ef2569230adc141a451347d35721e87cfcdb99eac44ba2a28dda27d3cb579`)
- the Agda 2.8 CI check typechecked the model and rejected exact mutants for `AGDA-5350-EMPTY`, `LAST`, `HISTORY`, and `SAME`
- `wallet-unit / Other Wallet` passed: EMPTY, LAST, and HISTORY each ran 100 QuickCheck cases; SAME ran 3,200; pure/IO parity ran 100; structural DRep equality ran 200 with coverage checks
- the full repository workflow and docs workflow passed in PR CI; one unrelated Conway reward-withdrawal failure (`ConwayIncompleteWithdrawals` after an epoch transition) passed on an isolated rerun of the identical commit

Closes #5350
