### PR TITLE
chore: align ProtocolParameters size fields with ledger types

### DIFF
--- a/specs/5252-align-protocol-parameter-types/plan.md
+++ b/specs/5252-align-protocol-parameter-types/plan.md
@@ -1,0 +1,74 @@
+# Plan: Align protocol-parameter size fields with ledger types
+
+One bisect-safe PAIR slice. The final history contains one behavior commit;
+the commit owner may use multiple local RED/GREEN proof rounds before the
+ticket owner accepts and the commit owner squashes them.
+
+## Architecture and boundaries
+
+- Align `TokenBundleMaxSize` with the ledger maximum-value-size domain by
+  giving it a `Word32` payload. Preserve `TxSize`'s existing `Natural` payload
+  for additive transaction-size arithmetic.
+- Align primitive `minimumCollateralPercentage` to `Word16`;
+  `maximumCollateralInputCount` is already correctly typed.
+- Transfer the three fields directly in the recent-era ledger-to-wallet
+  protocol-parameter conversions.
+- Keep any necessary widening localized to downstream consumers such as API
+  projection or transaction-size arithmetic.
+- Preserve the observable `ApiNetworkParameters` JSON contract and its
+  existing golden file.
+- Do not touch SQLite schema or migrations: the current schema does not store
+  any of the aligned fields.
+
+## Behavioral invariants
+
+1. Ledger-to-wallet conversion preserves each aligned field exactly across
+   every supported recent era that exposes it.
+2. The maximum value size has the ledger's full `Word32` domain in the wallet;
+   collateral percentage and maximum collateral input count have the ledger's
+   `Word16` domain.
+3. Downstream widening cannot truncate, wrap, or change transaction-size
+   comparisons.
+4. API encoding remains the same numeric JSON contract, including the checked
+   golden artifact.
+5. Persistence compatibility is preserved by leaving the schema and migration
+   surface untouched.
+6. The targeted obsolete ledger-field conversions are absent, and the proof
+   is reached by the ticket gate rather than existing only as unexecuted test
+   code.
+
+## Slice A — align the primitive domain and preserve boundaries
+
+The commit owner owns proof files and chooses the invariant/test order. Its
+coder owns production changes within the maximum fence identified in the
+PAIR brief. The ticket owner will accept only an alternating RED/GREEN chain
+whose coverage ledger accounts for all invariants above.
+
+Expected production surface:
+
+- primitive protocol-parameter and maximum-value-size types;
+- primitive ledger conversions and Byron default construction;
+- downstream API projection and transaction constraints where widening is
+  genuinely required;
+- generators or non-proof support code that must follow the aligned types.
+
+Expected proof surface:
+
+- primitive conversion/type tests selected by the commit owner;
+- existing API network-parameter golden execution;
+- the frozen compile-time type contract, zero-conversion search, no-schema
+  diff, relevant package builds/tests, format check, and HLint.
+
+## Verification
+
+The frozen gate will run, from their CI working directories:
+
+- the ticket-owned compile-time type contract;
+- focused commit-owner proofs with `--fail-on=empty`;
+- the primitive test suite;
+- the API types/golden test selection;
+- relevant Nix builds;
+- format checking and HLint;
+- the issue's targeted zero-match search;
+- immutable comparisons proving the API golden and SQLite schema/migration
+  files are unchanged from the slice base.

--- a/specs/5252-align-protocol-parameter-types/spec.md
+++ b/specs/5252-align-protocol-parameter-types/spec.md
@@ -1,0 +1,76 @@
+# Spec: Align wallet protocol-parameter size fields with ledger types
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5252
+
+## User story
+
+As a wallet maintainer, I want the wallet's in-memory protocol-parameter
+types to agree with cardano-ledger 1.19 so that ledger values cross into the
+wallet without obsolete integral-conversion shims, while existing API JSON
+and wallet databases remain compatible.
+
+## Current state
+
+Ledger 1.19 exposes the relevant fields as:
+
+- maximum value size: `Word32`;
+- collateral percentage: `Word16`;
+- maximum collateral input count: `Word16`.
+
+The wallet already represents the maximum collateral input count as
+`Word16`, but represents the collateral percentage as `Natural` and wraps
+the maximum value size in `TokenBundleMaxSize` over `TxSize`, whose payload
+is `Natural`. Recent-era ledger conversions therefore contain integral
+conversion shims for all three ledger fields.
+
+The SQLite `ProtocolParameters` table does not persist any of these three
+fields. Its stored columns are fee policy, transaction maximum size,
+decentralization level, desired pool count, minimum UTxO value, hard-fork
+epoch, and key deposit. This ticket therefore does not require a database
+migration or a pre-change database fixture; adding either would change a
+schema boundary that the requested type alignment does not affect.
+
+The network-parameters API currently emits the three values as JSON numbers.
+Its observable JSON representation is a compatibility boundary even where
+the Haskell API-facing type remains wider than the aligned primitive type.
+
+## Functional requirements
+
+- FR1: The primitive wallet representation of maximum value size has a
+  `Word32` payload, matching the ledger field.
+- FR2: `ProtocolParameters.minimumCollateralPercentage` is `Word16`, matching
+  the ledger field.
+- FR3: `ProtocolParameters.maximumCollateralInputCount` remains `Word16` and
+  recent-era ledger conversions transfer all three aligned values without
+  obsolete conversion shims at the ledger-to-wallet boundary.
+- FR4: The issue's targeted search for `fromIntegral` applied to
+  `ppMaxValSizeL`, `ppCollateralPercentageL`, or `ppMaxCollateralInputsL`
+  returns no matches under `lib/`.
+- FR5: Existing network-parameters API JSON keys, number encoding, and golden
+  values remain unchanged.
+- FR6: Transaction-size arithmetic remains safe and retains its existing
+  semantics. Any necessary widening from the aligned `Word32` maximum into a
+  consumer's `Natural`-based size arithmetic is explicit at that downstream
+  boundary rather than hidden in the ledger-to-wallet conversion.
+- FR7: SQLite schema and migration code remain unchanged because the aligned
+  fields are not persisted.
+
+## Observable success criteria
+
+- A compile-time contract accepts the maximum-value-size payload as `Word32`
+  and the primitive collateral percentage as `Word16`.
+- Recent-era protocol-parameter conversion preserves representative and
+  boundary values for maximum value size, collateral percentage, and maximum
+  collateral input count without truncation or reinterpretation.
+- The targeted `fromIntegral` search returns zero matches.
+- The existing `ApiNetworkParameters` JSON golden test passes with the
+  golden file unchanged.
+- Primitive and wallet unit tests, builds, format checking, and HLint pass.
+- No SQLite schema or migration file changes are present in the slice.
+
+## Rejection behavior
+
+Reject an implementation that narrows by truncation, changes public JSON,
+changes SQLite schema without newly discovered persistence evidence, weakens
+the existing `TxSize` arithmetic domain, or merely hides a ledger-boundary
+conversion while leaving the wallet field types unaligned.

--- a/specs/5252-align-protocol-parameter-types/tasks.md
+++ b/specs/5252-align-protocol-parameter-types/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Align wallet protocol-parameter size fields with ledger types
+
+## Slice A — align the primitive domain and preserve boundaries
+
+- [ ] T5252-S1 Prove and align maximum value size to `Word32` and primitive
+      minimum collateral percentage to `Word16`; retain maximum collateral
+      input count as `Word16`
+- [ ] T5252-S2 Prove recent-era ledger-to-wallet conversion preserves all
+      three values exactly and removes their obsolete conversion shims
+- [ ] T5252-S3 Preserve safe transaction-size behavior with widening only at
+      explicit downstream consumer boundaries
+- [ ] T5252-S4 Run the `ApiNetworkParameters` JSON proof and keep its golden
+      file and observable numeric representation unchanged
+- [ ] T5252-S5 Prove the target fields are not persisted; leave SQLite schema
+      and migration files unchanged
+- [ ] T5252-S6 Pass the frozen focused/type/search gate plus relevant builds,
+      primitive and wallet tests, format check, and HLint
+- [ ] T5252-S7 Produce final commit
+      `refactor: align protocol parameter size fields with ledger types` with
+      `Tasks: T5252-S1, T5252-S2, T5252-S3, T5252-S4, T5252-S5, T5252-S6, T5252-S7`


### PR DESCRIPTION
## Outcome

Align the wallet's protocol-parameter size domains with cardano-ledger 1.19
while keeping network-parameter JSON and wallet database compatibility
unchanged.

This draft starts with the ticket contract and will remain draft throughout
the PAIR implementation trial.

## Planned change

- represent maximum value size as `Word32` and minimum collateral percentage
  as `Word16` in the primitive wallet domain;
- remove obsolete ledger-to-wallet conversion shims for the three aligned
  fields;
- preserve downstream transaction-size semantics and API JSON numbers;
- leave SQLite schema and migrations untouched because these fields are not
  persisted.

## Verification

Baseline at `ecf489fad679`:

- relevant dev-shell and primitive/wallet unit derivations build;
- primitive suite: 458 examples, 0 failures using the CI working directory;
- API types/golden selection passes;
- repository format check and HLint pass.

The implementation slice will add an alternating RED/GREEN proof chain and
run the frozen ticket gate before acceptance.

Closes #5252
