### PR TITLE
Verify Byron derived keys reproduce the address before signing

### DIFF
--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -119,7 +119,6 @@ jobs:
       LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
       LOCAL_CLUSTER_ERA: conway
       CARDANO_WALLET_TEST_DATA: lib/integration/test/data
-      TMPDIR: ${{ runner.temp }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -127,6 +126,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run integration tests
+        # Scope cluster temp dirs to the job-private runner temp. The runner
+        # context is only available to steps, not to job-level env.
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs

--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -119,6 +119,11 @@ jobs:
       LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
       LOCAL_CLUSTER_ERA: conway
       CARDANO_WALLET_TEST_DATA: lib/integration/test/data
+      # Retry failed examples once. Several scenarios race against reward
+      # accrual on the test cluster: the expected coin value shifts between
+      # the query and the submission, so a transaction that was correct when
+      # built is rejected when it lands. A genuine failure still fails, twice.
+      TESTS_RETRY_FAILED: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -76,10 +76,12 @@ jobs:
           fetch-depth: 0
 
       - name: Run unit tests
+        env:
+          UNIT_MAX_HEAP: ${{ vars.UNIT_MAX_HEAP || '4G' }}
         run: >-
           nix shell --quiet ../../.#cardano-cli ../../.#cardano-node -c
           nix run --quiet ../../.#unit-cardano-wallet-unit --
-          -j1 +RTS -M4G -s -RTS
+          -j1 +RTS -M"$UNIT_MAX_HEAP" -s -RTS
 
   local-cluster:
     name: "Local Cluster Tests"
@@ -117,13 +119,14 @@ jobs:
     timeout-minutes: 120
     env:
       LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
-      LOCAL_CLUSTER_ERA: conway
       CARDANO_WALLET_TEST_DATA: lib/integration/test/data
-      # Retry failed examples once. Several scenarios race against reward
-      # accrual on the test cluster: the expected coin value shifts between
-      # the query and the submission, so a transaction that was correct when
-      # built is rejected when it lands. A genuine failure still fails, twice.
-      TESTS_RETRY_FAILED: 1
+      # Tunable without editing this file: set repository variables of the same
+      # name. The defaults apply when a variable is unset, so the workflow
+      # stands alone. Several scenarios race against reward accrual and block
+      # production on the test cluster, and those races widen under load, so
+      # retrying once and lowering concurrency are the two knobs worth having.
+      LOCAL_CLUSTER_ERA: ${{ vars.LOCAL_CLUSTER_ERA || 'conway' }}
+      TESTS_RETRY_FAILED: ${{ vars.TESTS_RETRY_FAILED || '1' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -135,13 +138,15 @@ jobs:
         # context is only available to steps, not to job-level env.
         env:
           TMPDIR: ${{ runner.temp }}
+          INTEGRATION_JOBS: ${{ vars.INTEGRATION_JOBS || '6' }}
         run: |
           mkdir -p integration-test-dir/cluster.logs
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
           export INTEGRATION_TEST_DIR=integration-test-dir
+          echo "era=$LOCAL_CLUSTER_ERA retry=$TESTS_RETRY_FAILED jobs=$INTEGRATION_JOBS"
           nix shell --quiet .#cardano-node .#cardano-cli -c \
             nix shell --quiet .#cardano-wallet .#local-cluster .#integration-exe \
-              -c integration-exe -j6
+              -c integration-exe -j"$INTEGRATION_JOBS"
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -44,7 +44,6 @@ jobs:
 
   unit-tests:
     name: "Unit Tests"
-    if: github.repository_owner == 'se7en-labs-inc'
     needs: build-gate
     runs-on: nix-enabled-runners
     timeout-minutes: 60
@@ -65,7 +64,6 @@ jobs:
 
   local-cluster:
     name: "Local Cluster Tests"
-    if: github.repository_owner == 'se7en-labs-inc'
     needs: build-gate
     runs-on: nix-enabled-runners
     timeout-minutes: 30
@@ -95,7 +93,6 @@ jobs:
 
   integration:
     name: "Conway Integration Tests"
-    if: github.repository_owner == 'se7en-labs-inc'
     needs: build-gate
     runs-on: nix-enabled-runners
     timeout-minutes: 120

--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -1,0 +1,127 @@
+name: Se7en CI
+
+# Linux-only gate for pull requests raised against this fork.
+#
+# The main CI workflow spans Linux, macOS and Windows in a single run, so on a
+# fork whose runners are Linux-only the macOS and Windows jobs queue forever and
+# the run never reaches a conclusion. This workflow covers the Linux half on its
+# own so that fork pull requests get a green or red answer.
+#
+# Jobs are skipped unless the repository belongs to this organisation, so the
+# file is inert wherever else it is checked out.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: se7en-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Nix eval-cache uses POSIX write locks on ~/.cache/nix/eval-cache-v5/*.sqlite.
+  # Per-job XDG_CACHE_HOME keeps concurrent jobs from blocking one another.
+  XDG_CACHE_HOME: /tmp/nix-eval-cache/${{ github.job }}
+
+jobs:
+  build-gate:
+    name: "Build Gate (Linux)"
+    if: github.repository_owner == 'se7en-labs-inc'
+    runs-on: nix-enabled-runners
+    timeout-minutes: 240
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build test and runtime derivations
+        run: >-
+          nix build --quiet
+          .#cardano-wallet .#cardano-node .#cardano-cli
+          .#local-cluster .#integration-exe .#test-local-cluster-exe
+          .#unit-cardano-wallet-unit
+
+  unit-tests:
+    name: "Unit Tests"
+    if: github.repository_owner == 'se7en-labs-inc'
+    needs: build-gate
+    runs-on: nix-enabled-runners
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: lib/unit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run unit tests
+        run: >-
+          nix shell --quiet ../../.#cardano-cli ../../.#cardano-node -c
+          nix run --quiet ../../.#unit-cardano-wallet-unit --
+          -j1 +RTS -M4G -s -RTS
+
+  local-cluster:
+    name: "Local Cluster Tests"
+    if: github.repository_owner == 'se7en-labs-inc'
+    needs: build-gate
+    runs-on: nix-enabled-runners
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        env:
+          LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
+          CLUSTER_LOGS_DIR_PATH: local-cluster-logs
+          TMPDIR: ${{ runner.temp }}
+        run: |
+          mkdir -p local-cluster-logs
+          nix shell --quiet .#local-cluster .#test-local-cluster-exe \
+            .#cardano-cli .#cardano-node .#cardano-wallet \
+            -c test-local-cluster-exe
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: local-cluster-logs
+          path: local-cluster-logs/
+
+  integration:
+    name: "Conway Integration Tests"
+    if: github.repository_owner == 'se7en-labs-inc'
+    needs: build-gate
+    runs-on: nix-enabled-runners
+    timeout-minutes: 120
+    env:
+      LOCAL_CLUSTER_CONFIGS: lib/local-cluster/test/data/cluster-configs
+      LOCAL_CLUSTER_ERA: conway
+      CARDANO_WALLET_TEST_DATA: lib/integration/test/data
+      TMPDIR: ${{ runner.temp }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run integration tests
+        run: |
+          mkdir -p integration-test-dir/cluster.logs
+          export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
+          export INTEGRATION_TEST_DIR=integration-test-dir
+          nix shell --quiet .#cardano-node .#cardano-cli -c \
+            nix shell --quiet .#cardano-wallet .#local-cluster .#integration-exe \
+              -c integration-exe -j6
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-test-logs
+          path: integration-test-dir/

--- a/.github/workflows/se7en-ci.yml
+++ b/.github/workflows/se7en-ci.yml
@@ -42,6 +42,25 @@ jobs:
           .#local-cluster .#integration-exe .#test-local-cluster-exe
           .#unit-cardano-wallet-unit
 
+      # Daedalus consumes this repository through flake-compat and takes
+      # cardano-wallet, cardano-address and mock-token-metadata-server from
+      # staticPackages on Linux and from windowsPackages for Windows. Build
+      # them here so a break in that path surfaces on a pull request rather
+      # than in Daedalus.
+      - name: Build the packages Daedalus consumes (Linux, static)
+        run: >-
+          nix build --quiet
+          .#staticPackages.cardano-wallet
+          .#staticPackages.cardano-address
+          .#staticPackages.mock-token-metadata-server
+
+      - name: Build the packages Daedalus consumes (Windows, cross)
+        run: >-
+          nix build --quiet
+          .#windowsPackages.cardano-wallet
+          .#windowsPackages.cardano-address
+          .#windowsPackages.mock-token-metadata-server
+
   unit-tests:
     name: "Unit Tests"
     needs: build-gate

--- a/.github/workflows/se7en-code-quality.yml
+++ b/.github/workflows/se7en-code-quality.yml
@@ -1,0 +1,81 @@
+name: Se7en Code Quality
+
+# Code quality checks that need neither nix nor a self-hosted runner.
+#
+# These are kept apart from se7en-ci.yml on purpose. That workflow depends on
+# self-hosted capacity and grows as more of it comes online; this one runs
+# entirely on GitHub-hosted runners and is stable once written. Separating them
+# also lets the cheap checks run on pushes to master, where a merge that lands
+# without a pull request would otherwise get no coverage at all.
+#
+# Every job is skipped unless the repository belongs to this organisation, so
+# the file is inert wherever else it is checked out.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  # Distinct from se7en-ci.yml: workflows sharing a group cancel one another.
+  group: se7en-code-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: ${{ matrix.name }}
+    if: github.repository_owner == 'se7en-labs-inc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Check Local Cabal Test Targets"
+            command: scripts/ci/check-local-test-targets.sh
+
+          - name: "Validate PR Body Closing Link"
+            command: scripts/ci/check-pr-body-closing-link.sh
+
+          - name: "Test PR Body Closing Link"
+            command: scripts/ci/test-pr-body-closing-link.sh
+
+          - name: "Check Docker Boot Sync Cleanup"
+            command: scripts/ci/check-docker-boot-sync-cleanup.sh
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Each script resolves its own paths relative to the repository root and
+      # needs only coreutils and jq, both present on the runner image.
+      - name: Run check
+        run: ${{ matrix.command }}
+
+  shellcheck:
+    name: "Lint Bash Scripts"
+    if: github.repository_owner == 'se7en-labs-inc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # scripts/shellcheck.sh declares `#! /usr/bin/env nix-shell` and asks that
+      # shell for shellcheck, figlet and lolcat. Invoking it through bash below
+      # bypasses the shebang, so those three have to be present already.
+      # shellcheck is on the runner image; figlet and lolcat are not. They are
+      # reached only on the success path, but the script does not set -e, so the
+      # exit status of that final pipeline becomes the script's — without them
+      # the check would fail precisely when it passes.
+      - name: Install success-path dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends figlet lolcat
+
+      - name: Run check
+        run: bash scripts/shellcheck.sh

--- a/.github/workflows/se7en-code-quality.yml
+++ b/.github/workflows/se7en-code-quality.yml
@@ -38,9 +38,10 @@ jobs:
           - name: "Check Local Cabal Test Targets"
             command: scripts/ci/check-local-test-targets.sh
 
-          - name: "Validate PR Body Closing Link"
-            command: scripts/ci/check-pr-body-closing-link.sh
-
+          # The fixture suite for the closing-link validator: 27 deterministic
+          # cases against synthetic payloads, no pull request context needed.
+          # The validator itself runs from se7en-pr-policy.yml, which checks the
+          # pull request rather than the repository.
           - name: "Test PR Body Closing Link"
             command: scripts/ci/test-pr-body-closing-link.sh
 

--- a/.github/workflows/se7en-pr-policy.yml
+++ b/.github/workflows/se7en-pr-policy.yml
@@ -1,0 +1,45 @@
+name: Se7en PR Policy
+
+# Checks that validate the pull request itself rather than the contents of the
+# repository.
+#
+# This is kept apart from se7en-code-quality.yml because it wants the opposite
+# triggers on both axes. It needs the `edited` activity type, since the event
+# payload is captured when the event fires: re-running a job replays the old
+# payload, so a corrected body is only ever seen by a fresh event. And it has no
+# push trigger, because the validator exits successfully for any event that is
+# not a pull request.
+#
+# Jobs are skipped unless the repository belongs to this organisation, so the
+# file is inert wherever else it is checked out.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  # Distinct from the other se7en-* workflows: a shared group would have them
+  # cancelling one another.
+  group: se7en-pr-policy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  closing-link:
+    name: "Validate PR Body Closing Link"
+    # Branches that import upstream history are exempt. The check exists to tie
+    # our own changes to a tracked issue; a merge of upstream commits is not one
+    # of our changes and has no issue to close.
+    if: >-
+      github.repository_owner == 'se7en-labs-inc'
+      && !startsWith(github.head_ref, 'sync/upstream')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run check
+        run: scripts/ci/check-pr-body-closing-link.sh

--- a/lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs
@@ -20,7 +20,8 @@
 -- by components like the Rust <https://github.com/input-output-hk/cardano-http-bridge cardano-http-bridge>.
 module Cardano.Byron.Codec.Cbor
     ( -- * Decoding
-      decodeAddressDerivationPath
+      decodeAddressAttributes
+    , decodeAddressDerivationPath
     , decodeAddressPayload
     , decodeAllAttributes
     , decodeDerivationPathAttr
@@ -32,6 +33,7 @@ module Cardano.Byron.Codec.Cbor
     , encodeDerivationPathAttr
     , encodeProtocolMagicAttr
     , encodeTx
+    , reconstructAddress
 
       -- * Helpers
     , deserialiseCbor
@@ -212,6 +214,16 @@ decodeEmptyAttributes = do
     _ <- CBOR.decodeMapLenCanonical -- Empty map of attributes
     return ((), CBOR.encodeMapLen 0)
 
+-- | Decode the attributes of an address payload, skipping the address root and
+-- leaving the address type unread. The payload is what 'decodeAddressPayload'
+-- returns, not a whole address.
+decodeAddressAttributes
+    :: CBOR.Decoder s [(Word8, ByteString)]
+decodeAddressAttributes = do
+    _ <- CBOR.decodeListLenCanonicalOf 3
+    _ <- CBOR.decodeBytes -- Address root
+    decodeAllAttributes
+
 -- | The attributes are pairs of numeric tags and bytes, where the bytes will be
 -- CBOR-encoded stuff. This decoder does not enforce "canonicity" of entries.
 decodeAllAttributes
@@ -375,6 +387,30 @@ encodeAddress xpub attrs =
         CBOR.encodeListLen 2
             <> CBOR.encodeWord8 0
             <> encodeXPub
+
+-- | Rebuild the Byron address that a public key produces under the attributes
+-- carried by a given address. Returns 'Nothing' when the given bytes are not a
+-- Byron address payload.
+--
+-- The attributes are copied from the target address verbatim, so no network
+-- identifier is needed and no derivation path is re-encrypted. This mirrors
+-- what the ledger checks when validating a bootstrap witness: the address root
+-- is recomputed from the witness's public key and the address's own attributes.
+-- A key that reconstructs the address is therefore a key the node accepts for
+-- it.
+reconstructAddress :: XPub -> Address -> Maybe Address
+reconstructAddress xpub (Address bytes) = do
+    payload <- deserialiseCbor decodeAddressPayload bytes
+    attrs <- deserialiseCbor decodeAddressAttributes payload
+    pure
+        $ Address
+        $ CBOR.toStrictByteString
+        $ encodeAddress xpub (encodeAttribute <$> attrs)
+
+-- | Re-encode a single address attribute decoded by 'decodeAllAttributes'.
+encodeAttribute :: (Word8, ByteString) -> CBOR.Encoding
+encodeAttribute (tag, bytes) =
+    CBOR.encodeWord8 tag <> CBOR.encodeBytes bytes
 
 encodeAddressPayload :: ByteString -> CBOR.Encoding
 encodeAddressPayload payload =

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -32,6 +31,7 @@ module Cardano.Wallet.Address.Discovery.Random
       -- ** Low-level API
     , importAddress
     , addressToPath
+    , candidatePaths
     , ErrImportAddress (..)
     , addPendingAddress
     , deriveRndStateAddress
@@ -51,6 +51,7 @@ import Cardano.Byron.Codec.Cbor
     ( decodeAddressDerivationPath
     , decodeAddressPayload
     , deserialiseCbor
+    , reconstructAddress
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
@@ -94,6 +95,10 @@ import Control.Lens
     )
 import Control.Monad
     ( join
+    )
+import Data.List
+    ( find
+    , nub
     )
 import Data.List.NonEmpty
     ( NonEmpty (..)
@@ -245,15 +250,59 @@ instance IsOurs (RndState n) Address where
 instance IsOurs (RndState n) RewardAccount where
     isOurs _account state = (Nothing, state)
 
+-- | Find the signing key for an address the wallet owns.
+--
+-- An address records the derivation path it was created at, but for addresses
+-- created before @cardano-sl@ always hardened generated indexes, that path does
+-- not necessarily identify the key the address was built from. Every candidate
+-- path is therefore derived and checked against the address; only a key that
+-- reproduces the address is returned, and an address that no candidate
+-- reproduces yields 'Nothing'.
+--
+-- The returned key's 'derivationPath' is the candidate it was found at, which
+-- for such an address is /not/ the path the address records. Callers must use
+-- 'getKey' alone: rebuilding an address from the returned key would not give
+-- back the address it was resolved for.
 isOwned
     :: forall (network :: NetworkDiscriminant)
      . RndState network
     -> (ByronKey 'RootK XPrv, Passphrase "encryption")
     -> Address
     -> Maybe (ByronKey 'CredFromKeyK XPrv, Passphrase "encryption")
-isOwned st (key, pwd) addr =
-    (,pwd) . deriveCredFromKeyKeyFromPath key pwd
-        <$> addressToPath addr (hdPassphrase st)
+isOwned st (key, pwd) addr = do
+    path <- addressToPath addr (hdPassphrase st)
+    let candidates =
+            deriveCredFromKeyKeyFromPath key pwd <$> candidatePaths path
+    k <- find reproducesAddress candidates
+    pure (k, pwd)
+  where
+    reproducesAddress k =
+        reconstructAddress (toXPub $ getKey k) addr == Just addr
+
+-- | The paths at which the signing key for an address may lie, most likely
+-- first: the path the address records, then that path with the address index
+-- hardened, with the account index hardened, and with both.
+--
+-- Candidates are de-duplicated, so a path already hardened at both levels
+-- yields a single candidate. Together with stopping at the first candidate that
+-- reproduces the address, this keeps the common case at one derivation.
+candidatePaths :: DerivationPath -> [DerivationPath]
+candidatePaths (accIx, addrIx) =
+    nub
+        [ (accIx, addrIx)
+        , (accIx, hardenIndex addrIx)
+        , (hardenIndex accIx, addrIx)
+        , (hardenIndex accIx, hardenIndex addrIx)
+        ]
+
+-- | The hardened form of an index. Indexes already in the hardened domain are
+-- returned unchanged.
+hardenIndex :: Index 'WholeDomain level -> Index 'WholeDomain level
+hardenIndex (Index ix)
+    | ix >= firstHardened = Index ix
+    | otherwise = Index (ix + firstHardened)
+  where
+    firstHardened = getIndex (minBound :: Index 'Hardened 'AccountK)
 
 -- Updates a 'RndState' by adding an address and its derivation path to the
 -- set of discovered addresses. If the address was in the 'pendingAddresses' set

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Encoding.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Encoding.hs
@@ -290,18 +290,14 @@ inspectAddress =
 toHDPayloadAddress :: W.Address -> Maybe Byron.HDAddressPayload
 toHDPayloadAddress (W.Address addr) = do
     payload <- CBOR.deserialiseCbor CBOR.decodeAddressPayload addr
-    attributes <- CBOR.deserialiseCbor decodeAllAttributes' payload
+    attributes <-
+        CBOR.deserialiseCbor CBOR.decodeAddressAttributes payload
     case filter (\(tag, _) -> tag == 1) attributes of
         [(1, bytes)] ->
             Byron.HDAddressPayload
                 <$> CBOR.decodeNestedBytes CBOR.decodeBytes bytes
         _ ->
             Nothing
-  where
-    decodeAllAttributes' = do
-        _ <- CBOR.decodeListLenCanonicalOf 3
-        _ <- CBOR.decodeBytes
-        CBOR.decodeAllAttributes
 
 guardNetwork
     :: SL.Network -> SL.Network -> Either TextDecodingError ()

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -174,6 +174,7 @@ module Test.Integration.Framework.DSL
     , addField
     , icarusAddresses
     , randomAddresses
+    , mismatchedIndexAddresses
     , shelleyAddresses
     , rootPrvKeyFromMnemonics
     , unsafeGetTransactionTime
@@ -245,6 +246,7 @@ module Test.Integration.Framework.DSL
 
 import Cardano.Address.Derivation
     ( XPub
+    , toXPub
     , xpubFromBytes
     , xpubToBytes
     )
@@ -373,6 +375,7 @@ import Cardano.Wallet.Pools
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
+    , SNetworkId (..)
     )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
@@ -409,6 +412,9 @@ import Cardano.Wallet.Primitive.Types.DRep
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( magicSNetworkId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
@@ -657,6 +663,7 @@ import "cardano-addresses" Codec.Binary.Encoding
     )
 import Prelude
 
+import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Icarus as Icarus
@@ -670,6 +677,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
+import qualified Codec.CBOR.Write as CBOR
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.ByteArray as BA
@@ -3078,6 +3086,56 @@ randomAddresses mw =
         [ paymentAddressS @n (publicKey ByronKeyS $ addrXPrv ix)
         | ix <- [minBound .. maxBound]
         ]
+
+-- | Generate an infinite list of Byron random addresses that record a soft
+-- address index while their key is at the hardened form of that index.
+--
+-- Addresses created before @cardano-sl@ always hardened generated indexes have
+-- this shape: the index recovered from the address does not identify the key
+-- the address was built from. They are discovered and funded like any other
+-- address, and can only be spent by deriving at the hardened index.
+--
+-- The wallet, account index and address indexes match 'randomAddresses', so the
+-- two lists describe the same wallet and differ only in which key each address
+-- commits to.
+mismatchedIndexAddresses
+    :: forall n
+     . HasSNetworkId n
+    => SomeMnemonic
+    -> [Address]
+mismatchedIndexAddresses mw =
+    [ addressRecordingIndex ix
+    | ix <- [minBound .. maxBound]
+    ]
+  where
+    pwd = mempty
+    rootXPrv = Byron.generateKeyFromSeed mw pwd
+    accIx = minBound :: Index 'WholeDomain 'AccountK
+    accXPrv = Byron.deriveAccountPrivateKey pwd rootXPrv accIx
+
+    addressRecordingIndex ix =
+        Address
+            $ CBOR.toStrictByteString
+            $ CBOR.encodeAddress
+                (toXPub $ Byron.getKey $ keyAt (hardenIndex ix))
+                ( CBOR.encodeDerivationPathAttr
+                    (Byron.payloadPassphrase rootXPrv)
+                    accIx
+                    ix
+                    : protocolMagicAttr
+                )
+
+    keyAt = Byron.deriveAddressPrivateKey pwd accXPrv
+
+    protocolMagicAttr = case sNetworkId @n of
+        SMainnet -> []
+        s@(STestnet _) -> [CBOR.encodeProtocolMagicAttr (magicSNetworkId s)]
+
+    hardenIndex (Index i)
+        | i >= firstHardened = Index i
+        | otherwise = Index (i + firstHardened)
+      where
+        firstHardened = getIndex (minBound :: Index 'Hardened 'AccountK)
 
 -- | Generate an infinite list of addresses for icarus wallets
 --

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -137,6 +137,7 @@ module Test.Integration.Framework.DSL
     , fixtureRandomWalletMws
     , fixtureRandomWalletAddrs
     , fixtureRandomWalletWith
+    , moveByronCoins
     , fixtureIcarusWallet
     , fixtureIcarusWalletMws
     , fixtureIcarusWalletAddrs

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -86,6 +86,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , decodeErrorInfo
+    , emptyByronWalletWith
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyWallet
@@ -100,6 +101,9 @@ import Test.Integration.Framework.DSL
     , icarusAddresses
     , json
     , listAddresses
+    , minUTxOValue
+    , mismatchedIndexAddresses
+    , moveByronCoins
     , postByronWallet
     , randomAddresses
     , request
@@ -341,6 +345,68 @@ spec = describe "BYRON_MIGRATIONS" $ do
             testAddressCycling "Icarus" fixtureIcarusWallet 1
             testAddressCycling "Icarus" fixtureIcarusWallet 3
             testAddressCycling "Icarus" fixtureIcarusWallet 10
+
+    it
+        "BYRON_MIGRATE_01b - \
+        \Can migrate a wallet holding an address whose recorded index is not \
+        \the index its key was derived at."
+        $ \ctx -> runResourceT @IO $ do
+            mnemonic <- Mnemonics.generateSome Mnemonics.M12
+            faucetWallet <- fixtureRandomWallet ctx
+            sourceWallet <-
+                emptyByronWalletWith
+                    ctx
+                    "random"
+                    ("Mismatched index wallet", mnemonic, fixturePassphrase)
+
+            let amt = 10 * minUTxOValue (_mainEra ctx)
+                affected = mismatchedIndexAddresses @n mnemonic !! 1
+                unaffected = randomAddresses @n mnemonic !! 0
+
+            liftIO
+                $ moveByronCoins @n
+                    ctx
+                    faucetWallet
+                    (sourceWallet, [affected, unaffected])
+                    [amt, amt]
+
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds =
+                    targetAddresses
+                        <&> \(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId
+
+            -- The plan must select both UTxOs, including the affected one.
+            responsePlan <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    (Link.createMigrationPlan @'Byron sourceWallet)
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                responsePlan
+                [ expectResponseCode HTTP.status202
+                , expectField
+                    (#balanceSelected . #ada)
+                    (`shouldBe` ApiAmount (2 * amt))
+                , expectField (#balanceLeftover . #ada) (`shouldBe` ApiAmount 0)
+                ]
+
+            liftIO $ migrateWallet ctx sourceWallet targetAddressIds
+            waitForTxImmutability ctx
+
+            -- The wallet can be emptied by the supported route.
+            responseFinal <-
+                request @ApiByronWallet
+                    ctx
+                    (Link.getWallet @'Byron sourceWallet)
+                    Default
+                    Empty
+            verify
+                responseFinal
+                [ expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+                , expectField (#balance . #total) (`shouldBe` ApiAmount 0)
+                ]
 
     it
         "BYRON_MIGRATE_02 - \

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -98,6 +98,7 @@ import Test.Integration.Framework.DSL
     , Payload (..)
     , between
     , decodeErrorInfo
+    , emptyByronWalletWith
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyWallet
@@ -121,10 +122,13 @@ import Test.Integration.Framework.DSL
     , json
     , listAddresses
     , minUTxOValue
+    , mismatchedIndexAddresses
     , mkTxPayloadMA
+    , moveByronCoins
     , pickAnAsset
     , postByronWallet
     , postTx
+    , randomAddresses
     , request
     , toQueryString
     , verify
@@ -139,6 +143,7 @@ import Test.Integration.Framework.TestData
     )
 import Prelude
 
+import qualified Cardano.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
@@ -682,6 +687,107 @@ spec = describe "BYRON_TRANSACTIONS" $ do
                             , faucetAmt - feeEstMin - amt
                             )
                     ]
+
+    it
+        "BYRON_TRANS_CREATE_01b -\
+        \ Can spend from an address whose recorded index is not its key's index"
+        $ \ctx -> runResourceT $ do
+            -- Addresses created before cardano-sl always hardened generated
+            -- indexes record an index that does not identify the key they were
+            -- built from. Fund one of those and one ordinary address of the
+            -- same wallet, then spend an amount that needs both UTxOs: every
+            -- bootstrap witness must validate for the node to accept it.
+            mnemonic <- Mnemonics.generateSome Mnemonics.M12
+            wSrc <- fixtureRandomWallet ctx
+            wAffected <-
+                emptyByronWalletWith
+                    ctx
+                    "random"
+                    ("Mismatched index wallet", mnemonic, fixturePassphrase)
+
+            let amt = 10 * minUTxOValue (_mainEra ctx) :: Natural
+                -- Distinct recorded indexes, so the two addresses do not share
+                -- a derivation path.
+                affected = mismatchedIndexAddresses @n mnemonic !! 1
+                unaffected = randomAddresses @n mnemonic !! 0
+
+            liftIO
+                $ moveByronCoins @n
+                    ctx
+                    wSrc
+                    (wAffected, [affected, unaffected])
+                    [amt, amt]
+
+            wDest <- emptyRandomWallet ctx
+            destination <- do
+                let payloadAddr =
+                        Json [json|{ "passphrase": #{fixturePassphrase} }|]
+                rA <-
+                    request @(ApiAddressWithPath n)
+                        ctx
+                        (Link.postRandomAddress wDest)
+                        Default
+                        payloadAddr
+                pure $ getFromResponse #id rA
+
+            -- More than either UTxO holds, so both must be selected and both
+            -- must be witnessed.
+            let spent = amt + minUTxOValue (_mainEra ctx)
+            let payloadTx =
+                    Json
+                        [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{spent},
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": #{fixturePassphrase}
+            }|]
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Byron wAffected)
+                    Default
+                    payloadTx
+            verify
+                rTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                ]
+            let txId = getFromResponse #id rTx
+
+            eventually "transaction is in ledger and destination is credited"
+                $ do
+                    rTxSrc <-
+                        request @(ApiTransaction n)
+                            ctx
+                            ( Link.getTransaction @'Byron
+                                wAffected
+                                (ApiTxId txId)
+                            )
+                            Default
+                            Empty
+                    verify
+                        rTxSrc
+                        [ expectSuccess
+                        , expectField
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        ]
+                    rDest <-
+                        request @ApiByronWallet
+                            ctx
+                            (Link.getWallet @'Byron wDest)
+                            Default
+                            Empty
+                    verify
+                        rDest
+                        [ expectField
+                            (#balance . #available)
+                            (`shouldBe` ApiAmount spent)
+                        ]
 
     it
         "BYRON_TRANS_CREATE_02 -\

--- a/lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -11,6 +11,11 @@ module Cardano.Byron.Codec.CborSpec
     ( spec
     ) where
 
+import Cardano.Address.Derivation
+    ( XPrv
+    , XPub
+    , toXPub
+    )
 import Cardano.Byron.Codec.Cbor
     ( decodeAddressDerivationPath
     , decodeAddressPayload
@@ -18,9 +23,12 @@ import Cardano.Byron.Codec.Cbor
     , decodeDerivationPathAttr
     , decodeTx
     , deserialiseCbor
+    , encodeAddress
     , encodeAttributes
     , encodeDerivationPathAttr
+    , encodeProtocolMagicAttr
     , encodeTx
+    , reconstructAddress
     )
 import Cardano.Mnemonic
     ( MkSomeMnemonic (..)
@@ -32,6 +40,7 @@ import Cardano.Wallet.Address.Derivation
     )
 import Cardano.Wallet.Address.Derivation.Byron
     ( ByronKey (..)
+    , deriveAccountPrivateKey
     , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
@@ -42,6 +51,9 @@ import Cardano.Wallet.Primitive.Types.Address
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
@@ -72,6 +84,7 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
+    , shouldNotBe
     )
 import Test.QuickCheck
     ( Arbitrary (..)
@@ -87,6 +100,7 @@ import Prelude
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -111,6 +125,27 @@ spec = do
 
     describe "decodeAddress <-> encodeAddress roundtrip" $ do
         it "DerivationPath roundtrip" (property prop_derivationPathRoundTrip)
+
+    describe "reconstructAddress" $ do
+        it "rebuilds a mainnet-shaped address from its own key"
+            $ reconstructAddress addressXPub mainnetAddress
+            `shouldBe` Just mainnetAddress
+
+        it "rebuilds a testnet-shaped address from its own key"
+            $ reconstructAddress addressXPub testnetAddress
+            `shouldBe` Just testnetAddress
+
+        it "does not rebuild an address from a different key"
+            $ reconstructAddress otherXPub mainnetAddress
+            `shouldNotBe` Just mainnetAddress
+
+        it "preserves attributes it does not interpret"
+            $ reconstructAddress addressXPub extraAttrAddress
+            `shouldBe` Just extraAttrAddress
+
+        it "returns Nothing for bytes that are not a Byron address"
+            $ reconstructAddress addressXPub (Address "not-an-address")
+            `shouldBe` Nothing
 
     describe "Golden Tests for Byron Addresses w/ random scheme (Mainnet)" $ do
         it "decodeDerivationPath - mainnet - initial account"
@@ -173,6 +208,64 @@ spec = do
                     , addrIndex =
                         3234874775
                     }
+
+{-------------------------------------------------------------------------------
+                            Address reconstruction
+-------------------------------------------------------------------------------}
+
+-- Addresses below are built the way cardano-sl builds them: a root computed
+-- from the public key and the attributes, wrapped with a CRC. Reconstruction
+-- must reproduce them byte for byte from the public key alone, taking the
+-- attributes from the address it is given.
+
+reconstructionRootKey :: ByronKey 'RootK XPrv
+reconstructionRootKey = generateKeyFromSeed seed mempty
+  where
+    Right seed = mkSomeMnemonic @'[12] arbitraryMnemonic
+
+-- | The key an address is built from.
+addressXPub :: XPub
+addressXPub = toXPub $ getKey reconstructionRootKey
+
+-- | A different key of the same wallet, for the negative case.
+otherXPub :: XPub
+otherXPub =
+    toXPub
+        $ getKey
+        $ deriveAccountPrivateKey mempty reconstructionRootKey minBound
+
+addressWith :: XPub -> [CBOR.Encoding] -> Address
+addressWith xpub attrs =
+    Address $ CBOR.toStrictByteString $ encodeAddress xpub attrs
+
+derivationPathAttr :: CBOR.Encoding
+derivationPathAttr =
+    encodeDerivationPathAttr
+        (payloadPassphrase reconstructionRootKey)
+        (Index 14)
+        (Index 42)
+
+-- | Mainnet addresses carry the derivation path only.
+mainnetAddress :: Address
+mainnetAddress = addressWith addressXPub [derivationPathAttr]
+
+-- | Testnet addresses additionally carry the protocol magic.
+testnetAddress :: Address
+testnetAddress =
+    addressWith
+        addressXPub
+        [ derivationPathAttr
+        , encodeProtocolMagicAttr (ProtocolMagic 1097911063)
+        ]
+
+-- | An attribute tag this codebase does not interpret must survive untouched.
+extraAttrAddress :: Address
+extraAttrAddress =
+    addressWith
+        addressXPub
+        [ derivationPathAttr
+        , CBOR.encodeWord8 3 <> CBOR.encodeBytes "unknown-attribute"
+        ]
 
 {-------------------------------------------------------------------------------
                     Golden tests for Address derivation path

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
@@ -21,6 +21,7 @@ import Cardano.Byron.Codec.Cbor
     ( encodeAddress
     , encodeDerivationPathAttr
     , encodeProtocolMagicAttr
+    , reconstructAddress
     )
 import Cardano.Mnemonic
     ( MkSomeMnemonic (..)
@@ -50,6 +51,7 @@ import Cardano.Wallet.Address.Discovery
 import Cardano.Wallet.Address.Discovery.Random
     ( DerivationPath
     , RndState (..)
+    , candidatePaths
     , deriveCredFromKeyKeyFromPath
     , findUnusedPath
     , mkRndState
@@ -140,7 +142,162 @@ spec = do
     goldenSpecMainnet
     goldenSpecTestnet
     golden03Provenance
+    mismatchedIndexSpec
+    unresolvableAddressSpec
     propSpec
+
+{-------------------------------------------------------------------------------
+                   Addresses that no candidate derivation owns
+-------------------------------------------------------------------------------}
+
+-- | A second wallet, for addresses that do not belong to the first.
+otherMnemonic :: SomeMnemonic
+otherMnemonic =
+    either (error . show) id
+        $ mkSomeMnemonic @'[12]
+            [ "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "abandon"
+            , "about"
+            ]
+
+unresolvableAddressSpec :: Spec
+unresolvableAddressSpec =
+    describe "addresses that no candidate derivation reproduces" $ do
+        let pwd = Passphrase ""
+            rootK = generateKeyFromSeed arbitraryMnemonic pwd
+            otherRootK = generateKeyFromSeed otherMnemonic pwd
+            st = mkRndState @'Mainnet rootK 0
+            accIx = liftIndex (accountIndex st)
+            addrIx = Index 7 :: Index 'WholeDomain 'CredFromKeyK
+
+            -- The derivation path is encrypted under this wallet's passphrase,
+            -- so the address decrypts as ours, but its root comes from another
+            -- wallet's key and no candidate can reproduce it.
+            impostor =
+                Address
+                    $ CBOR.toStrictByteString
+                    $ encodeAddress
+                        ( toXPub
+                            $ getKey
+                            $ deriveCredFromKeyKeyFromPath
+                                otherRootK
+                                pwd
+                                (accIx, addrIx)
+                        )
+                        [ encodeDerivationPathAttr
+                            (payloadPassphrase rootK)
+                            accIx
+                            addrIx
+                        ]
+
+            foreign' =
+                addressRecordingWith
+                    otherRootK
+                    pwd
+                    (accIx, addrIx)
+                    (accIx, addrIx)
+
+        it "are still discovered, because their path decrypts"
+            $ isJust (fst $ isOurs impostor st)
+            `shouldBe` True
+
+        it "yield no signing key"
+            $ isOwned ByronWallet st (rootK, pwd) impostor
+            `shouldBe` Nothing
+
+        it "yield no signing key for another wallet's address, as before"
+            $ isOwned ByronWallet st (rootK, pwd) foreign'
+            `shouldBe` Nothing
+
+{-------------------------------------------------------------------------------
+              Addresses whose recorded index is not the key's index
+-------------------------------------------------------------------------------}
+
+-- | An address that records @recorded@ in its derivation-path attribute while
+-- its root is built from the key at @actual@. Addresses created before
+-- cardano-sl always hardened generated indexes have this shape.
+addressRecording
+    :: ByronKey 'RootK XPrv
+    -> DerivationPath
+    -- ^ the path written into the address
+    -> DerivationPath
+    -- ^ the path the key is really at
+    -> Address
+addressRecording rootK = addressRecordingWith rootK (Passphrase "")
+
+-- | The hardened form of an index, as the fix must try it.
+hardened :: Index 'WholeDomain level -> Index 'WholeDomain level
+hardened (Index ix)
+    | ix >= firstHardened = Index ix
+    | otherwise = Index (ix + firstHardened)
+  where
+    firstHardened = getIndex (minBound :: Index 'Hardened 'AccountK)
+
+mismatchedIndexSpec :: Spec
+mismatchedIndexSpec =
+    describe "addresses whose recorded index is not the key's index" $ do
+        let pwd = Passphrase ""
+            rootK = generateKeyFromSeed arbitraryMnemonic pwd
+            st = mkRndState @'Mainnet rootK 0
+            accIx = liftIndex (accountIndex st)
+            addrIx = Index 42 :: Index 'WholeDomain 'CredFromKeyK
+            recorded = (accIx, addrIx)
+            owns actual =
+                isOwned
+                    ByronWallet
+                    st
+                    (rootK, pwd)
+                    (addressRecording rootK recorded actual)
+            keyAt actual =
+                Just (deriveCredFromKeyKeyFromPath rootK pwd actual, pwd)
+
+        it "resolves a soft address index to the key at its hardened form"
+            $ owns (accIx, hardened addrIx)
+            `shouldBe` keyAt (accIx, hardened addrIx)
+
+        it "resolves an unaffected address to the key at its recorded path"
+            $ owns recorded
+            `shouldBe` keyAt recorded
+
+        -- #1041 records that account indexes were produced by the same
+        -- defective function, so the account level is covered as well.
+        let softAccIx = Index 14 :: Index 'WholeDomain 'AccountK
+            softRecorded = (softAccIx, addrIx)
+            ownsSoftAcc actual =
+                isOwned
+                    ByronWallet
+                    st
+                    (rootK, pwd)
+                    (addressRecording rootK softRecorded actual)
+
+        it "resolves a soft account index to the key at its hardened form"
+            $ ownsSoftAcc (hardened softAccIx, addrIx)
+            `shouldBe` keyAt (hardened softAccIx, addrIx)
+
+        it "resolves an address whose account and address index are both soft"
+            $ ownsSoftAcc (hardened softAccIx, hardened addrIx)
+            `shouldBe` keyAt (hardened softAccIx, hardened addrIx)
+
+        it "tries one candidate when the recorded path is already hardened"
+            $ candidatePaths (accIx, hardened addrIx)
+            `shouldBe` [(accIx, hardened addrIx)]
+
+        it "tries the recorded path first, then hardened forms"
+            $ candidatePaths softRecorded
+            `shouldBe` [ softRecorded
+                       , (softAccIx, hardened addrIx)
+                       , (hardened softAccIx, addrIx)
+                       , (hardened softAccIx, hardened addrIx)
+                       ]
 
 {-------------------------------------------------------------------------------
                         Provenance of the golden03 address
@@ -383,6 +540,8 @@ propSpec = describe "Random Address Discovery Properties" $ do
         property prop_derivedKeysAreOurs
     it "isOwned works as expected during key derivation" $ do
         property prop_derivedKeysAreOwned
+    it "every key isOwned returns reproduces the address it is for" $ do
+        property prop_ownedKeysReproduceTheirAddress
     it "GenChange address always satisfies isOurs" $ do
         property prop_changeAddressesBelongToUs
     it
@@ -423,6 +582,45 @@ prop_derivedKeysAreOwned (Rnd st rk pwd) (Rnd st' rk' pwd') addrIx =
     addr = paymentAddress SMainnet (publicKey ByronKeyS addrKey)
     addrKey = deriveAddressPrivateKey pwd acctKey addrIx
     acctKey = deriveAccountPrivateKey pwd rk (liftIndex $ accountIndex st)
+
+-- | FR-001 / SC-005: a key is only ever returned when it reproduces the address
+-- it was resolved for. Checked for an address whose recorded path is correct and
+-- for one whose key is at the hardened form of its recorded address index.
+prop_ownedKeysReproduceTheirAddress
+    :: Rnd
+    -> Index 'WholeDomain 'CredFromKeyK
+    -> Property
+prop_ownedKeysReproduceTheirAddress (Rnd st rk pwd) addrIx =
+    conjoin $ reproduces <$> [recorded, (accIx, hardened addrIx)]
+  where
+    accIx = liftIndex (accountIndex st)
+    recorded = (accIx, addrIx)
+    reproduces actual =
+        let addr = addressRecordingWith rk pwd recorded actual
+        in  case isOwned ByronWallet st (rk, pwd) addr of
+                Nothing ->
+                    property False
+                        & counterexample "isOwned returned no key"
+                Just (k, _) ->
+                    reconstructAddress (toXPub $ getKey k) addr === Just addr
+
+-- | 'addressRecording' for a wallet whose encryption passphrase is not empty.
+addressRecordingWith
+    :: ByronKey 'RootK XPrv
+    -> Passphrase "encryption"
+    -> DerivationPath
+    -> DerivationPath
+    -> Address
+addressRecordingWith rootK pwd (recAccIx, recAddrIx) actual =
+    Address
+        $ CBOR.toStrictByteString
+        $ encodeAddress
+            (toXPub $ getKey $ deriveCredFromKeyKeyFromPath rootK pwd actual)
+            [ encodeDerivationPathAttr
+                (payloadPassphrase rootK)
+                recAccIx
+                recAddrIx
+            ]
 
 prop_changeAddressesBelongToUs
     :: Rnd

--- a/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
@@ -15,6 +15,12 @@ module Cardano.Wallet.Address.Discovery.RandomSpec
 
 import Cardano.Address.Derivation
     ( XPrv
+    , toXPub
+    )
+import Cardano.Byron.Codec.Cbor
+    ( encodeAddress
+    , encodeDerivationPathAttr
+    , encodeProtocolMagicAttr
     )
 import Cardano.Mnemonic
     ( MkSomeMnemonic (..)
@@ -42,7 +48,9 @@ import Cardano.Wallet.Address.Discovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Address.Discovery.Random
-    ( RndState (..)
+    ( DerivationPath
+    , RndState (..)
+    , deriveCredFromKeyKeyFromPath
     , findUnusedPath
     , mkRndState
     )
@@ -70,12 +78,16 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..)
+    )
 import Control.Monad
     ( forM_
     )
 import Data.ByteArray.Encoding
     ( Base (..)
     , convertFromBase
+    , convertToBase
     )
 import Data.ByteString
     ( ByteString
@@ -117,6 +129,7 @@ import Test.QuickCheck
     )
 import Prelude
 
+import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
@@ -126,7 +139,54 @@ spec :: Spec
 spec = do
     goldenSpecMainnet
     goldenSpecTestnet
+    golden03Provenance
     propSpec
+
+{-------------------------------------------------------------------------------
+                        Provenance of the golden03 address
+-------------------------------------------------------------------------------}
+
+-- The testnet 'golden03' address records a soft derivation path (14, 42), so it
+-- is worth pinning down which key it actually commits to: a soft index does not
+-- by itself mean the recorded index is the wrong one. Rebuilding the address
+-- from the wallet's own key material shows that it commits to the key at the
+-- recorded path, and not to the key at the hardened form of that path. It is
+-- therefore an address whose recorded path must keep resolving on the first
+-- attempt.
+golden03Provenance :: Spec
+golden03Provenance = describe "golden03 provenance" $ do
+    it "commits to the key at its recorded soft path"
+        $ hex (addressAt (Index 14, Index 42))
+        `shouldBe` hex golden03Address
+
+golden03Address :: Address
+golden03Address =
+    let Right bytes =
+            convertFromBase @ByteString
+                Base16
+                "82d818584083581cf26d102b29332fd6c244a9915b6cad7890f5b54ac3\
+                \4dcd62975b525aa201565522f6c70e9b236c753e50a3758e18e8bbf7c3\
+                \f9e34e02451a2d964a09001a3993f9ea"
+    in  Address bytes
+
+-- | Rebuild the golden03 address from the key at a given path, keeping the
+-- attributes the address itself records.
+addressAt :: DerivationPath -> Address
+addressAt path =
+    Address
+        $ CBOR.toStrictByteString
+        $ encodeAddress
+            (toXPub $ getKey $ deriveCredFromKeyKeyFromPath rootK pwd path)
+            [ encodeDerivationPathAttr hdPwd (Index 14) (Index 42)
+            , encodeProtocolMagicAttr (ProtocolMagic 764824073)
+            ]
+  where
+    pwd = Passphrase ""
+    rootK = generateKeyFromSeed arbitraryMnemonic pwd
+    hdPwd = payloadPassphrase rootK
+
+hex :: Address -> ByteString
+hex (Address bytes) = convertToBase Base16 bytes
 
 {-------------------------------------------------------------------------------
                                   Golden tests

--- a/specs/011-byron-random-address-signing/contracts/key-resolution.md
+++ b/specs/011-byron-random-address-signing/contracts/key-resolution.md
@@ -1,0 +1,84 @@
+# Contract: Byron random key resolution
+
+The wallet's external contract — the REST API in `specifications/api/swagger.yaml` — does not change.
+No endpoint, request body, response body or error code is added, removed or altered. What changes is
+which transactions the node accepts, on endpoints that already exist:
+
+| Endpoint | Before | After |
+|---|---|---|
+| `POST /v2/byron-wallets/{id}/transactions` | Rejected at submission with `MissingVKeyWitnessesUTXOW` when the selection includes an affected UTxO | Accepted |
+| `POST /v2/byron-wallets/{id}/migrations` | Same, whenever the plan includes one | Accepted |
+| `GET /v2/byron-wallets/{id}/addresses` | Unchanged | Unchanged |
+| `GET /v2/byron-wallets/{id}` (balance) | Unchanged | Unchanged |
+
+The contract that does change is internal, between the address-discovery package and everything that
+signs.
+
+## `Cardano.Wallet.Address.Discovery.Random.isOwned`
+
+```haskell
+isOwned
+    :: forall (network :: NetworkDiscriminant)
+     . RndState network
+    -> (ByronKey 'RootK XPrv, Passphrase "encryption")
+    -> Address
+    -> Maybe (ByronKey 'CredFromKeyK XPrv, Passphrase "encryption")
+```
+
+Signature unchanged, including the absence of any `HasSNetworkId` constraint.
+
+**Preconditions.** The passphrase is the wallet's; a wrong one silently yields wrong keys, as it does
+for every other derivation in this module (`Address/Derivation/Byron.hs:314`). With verification in
+place a wrong passphrase resolves to `Nothing` instead of to a wrong key, since no candidate
+reproduces the address. Both outcomes fail; the wallet validates the passphrase before signing, so
+neither is reachable through the API, and callers may not treat this as a passphrase check.
+
+**Postconditions.**
+
+1. `Just (k, pwd)` implies `reconstruct (toXPub (getKey k)) addr == Just addr`. No unverified key is
+   ever returned. (FR-001, FR-003)
+2. If the address's recorded path reproduces the address, `k` is the key at that path — the result is
+   identical to today's, and identical to `deriveCredFromKeyKeyFromPath` at that path. (FR-004)
+3. `Nothing` for an address that does not decrypt under the wallet's `hdPassphrase`. Unchanged.
+4. `Nothing` for an address that decrypts but that no candidate reproduces. (FR-003) This class does
+   not exist before the change — `isOurs` and `isOwned` test the same condition today — so it is
+   created here, deliberately. Its consequence is fixed by FR-009: `signTransaction` assembles
+   witnesses with `mapMaybe` (`lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs:365`), so the
+   input simply carries no witness and the node rejects the transaction, exactly as it does today. No
+   error is raised locally and no API error is added.
+5. Candidates are tried in the order recorded → address hardened → account hardened → both, and
+   evaluation stops at the first match. (FR-007, FR-008)
+6. The result's `pwd` component is the passphrase passed in. Unchanged.
+
+**Caller obligation.** Use `getKey` only. The returned key's `derivationPath` field is the candidate
+path and, for an affected address, is not the path the address records; rebuilding an address from the
+returned key via `paymentAddress` would produce a different address.
+
+## `Cardano.Byron.Codec.Cbor` — reconstruction
+
+One new exported function, name at the implementer's discretion, with this contract:
+
+```haskell
+-- | Rebuild the Byron address that the given public key produces under the
+-- attributes carried by the given address.
+reconstructAddress :: XPub -> Address -> Maybe Address
+```
+
+1. `Nothing` when the argument is not a well-formed Byron address payload of a public-key address.
+2. `reconstructAddress xpub (paymentAddress s k) == Just (paymentAddress s k)` when `xpub` is the
+   public key of `k`, for either network discrimination.
+3. `reconstructAddress xpub' addr /= Just addr` for any `xpub'` other than the one `addr` was built
+   from.
+4. Pure, total on its declared domain, and independent of the wallet's configured network: the
+   protocol-magic attribute is copied from the argument, never synthesised.
+5. Attributes are preserved verbatim, in order, including any tag this codebase does not interpret.
+
+Any supporting decoder added alongside it (an attribute list extracted from a payload) is an
+implementation detail of this contract, but if exported it should replace the duplicate local decoder
+at `Cardano/Wallet/Address/Encoding.hs:301` rather than sit next to it.
+
+## Dispatch
+
+`Cardano.Wallet.Address.States.IsOwned.isOwned` (`lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs:68`)
+must not change. It is the proof that FR-006 holds: payments, witness construction and migration all
+route through this one dispatch, and none of them names a derivation path.

--- a/specs/011-byron-random-address-signing/data-model.md
+++ b/specs/011-byron-random-address-signing/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Byron random address key resolution
+
+No persisted type changes. Nothing in `RndState` is added, removed or re-keyed, so no database
+migration is required (spec Assumptions). The entities below are values computed during signing.
+
+## Entities
+
+### Recorded derivation path
+
+Already exists as `DerivationPath` (`Random.hs:202`):
+
+```haskell
+type DerivationPath =
+    (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'CredFromKeyK)
+```
+
+Recovered from the address by `addressToPath` (`Random.hs:275`), which decrypts attribute tag 1 under
+the wallet's `hdPassphrase`. `'WholeDomain` because #1042 established that these indexes are not
+necessarily hardened. Unchanged by this feature.
+
+### Candidate derivation
+
+A `DerivationPath` at which the signing key may lie. Derived from the recorded path by hardening
+neither, one, or both levels. Hardening is `ix < 2³¹ ? ix + 2³¹ : ix`, where `2³¹` is
+`getIndex (minBound @(Index 'Hardened _))` (`Derivation.hs:397`).
+
+| # | Account index | Address index | Covers |
+|---|---|---|---|
+| 1 | recorded | recorded | every wallet in normal operation (FR-004) |
+| 2 | recorded | hardened | the observed defect (FR-002) |
+| 3 | hardened | recorded | account-level variant (FR-007) |
+| 4 | hardened | hardened | both levels affected (FR-007) |
+
+Ordered most likely first, de-duplicated with order preserved. A path already hardened at both levels
+produces exactly one candidate, which is what makes FR-008's "one derivation, one comparison" the
+common case. A path hardened at one level produces two.
+
+### Address reconstruction
+
+The test of a candidate. Given the candidate's public key and the **target address's own
+attributes**:
+
+```text
+root       = blake2b224 (sha3_256 (cbor [0, [0, xpub], attributes]))
+payload    = cbor [root, attributes, 0]
+address    = cbor [tag 24, payload, crc32 payload]
+```
+
+which is `encodeAddress` (`Cbor.hs:349`) applied to the attribute list decoded out of the target. A
+candidate matches when the reconstructed bytes equal the target address bytes.
+
+Attributes are carried, never recomputed: tag 1 is the encrypted derivation path exactly as the
+address records it, and tag 2 the protocol magic if present. This is what lets the check run without a
+network identifier, and what makes it agree with the ledger — see research.md §"Faithfulness to the
+ledger check".
+
+## Resolution flow
+
+```text
+isOwned st (rootKey, pwd) addr
+  |
+  |-- addressToPath addr (hdPassphrase st)      -- Nothing => not ours, as today
+  |
+  |-- candidatePaths recordedPath               -- 1..4 paths, deduplicated, ordered
+  |
+  `-- first candidate p such that
+        let k = deriveCredFromKeyKeyFromPath rootKey pwd p
+        in  reconstruct (toXPub (getKey k)) addr == Just addr
+      => Just (k, pwd)
+      no such candidate => Nothing
+```
+
+## Invariants
+
+- `isOwned` returns `Just (k, _)` only if `k`'s public key reproduces `addr` byte for byte (FR-001,
+  FR-003, SC-005).
+- If the recorded path reproduces the address, the returned key is the key at the recorded path and
+  exactly one derivation and one reconstruction were performed (FR-004, FR-008).
+- `isOwned`'s type is unchanged, and so is every call site (FR-006).
+- `Nothing` stays `Nothing`: no error is raised for an unresolvable address, and the caller's
+  behaviour — omit the witness, submit, let the node reject — is untouched (FR-009).
+- `isOurs`, `addressToPath`, `importAddress`, `genChange` and the keying of `discoveredAddresses` are
+  unchanged (FR-005).
+- Reconstruction consumes the target address's attributes verbatim; it never re-encrypts a derivation
+  path and never consults the wallet's network.
+- The `derivationPath` field of a returned `ByronKey` is the *candidate* path, which for an affected
+  address differs from the path the address records. Only `getKey` may be relied upon downstream.

--- a/specs/011-byron-random-address-signing/plan.md
+++ b/specs/011-byron-random-address-signing/plan.md
@@ -1,0 +1,201 @@
+# Implementation Plan: Byron random wallets cannot sign for pre-2018 addresses
+
+- **Branch**: `011-byron-random-address-signing` | **Date**: 2026-08-11 | **Spec**: [spec.md](./spec.md)
+- **Input**: Feature specification from `/specs/011-byron-random-address-signing/spec.md`
+- **Issue**: [#5368](https://github.com/cardano-foundation/cardano-wallet/issues/5368)
+
+## Summary
+
+`Rnd.isOwned` derives a signing key from the derivation path recorded inside a Byron random address
+and returns it without checking that the key reproduces the address
+(`lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs:254`). For
+addresses created before the `cardano-sl` hardening fix, the recorded index is not the index the key
+was derived at, so the witness does not match the input and the node rejects the transaction.
+
+The change is confined to key resolution. `isOwned` gains a verification step — derive, rebuild the
+address from the resulting public key using the attributes carried by the target address, compare —
+and, when the recorded path fails, retries at the hardened forms of the address index, the account
+index, and both. The first candidate that reproduces the address wins; if none does, `isOwned`
+returns `Nothing` rather than a key that will fail at submission.
+
+Address reconstruction is added to `Cardano.Byron.Codec.Cbor`, which already owns the Byron address
+binary format and its `encodeAddress` root computation. No signature at any call site changes:
+`Cardano.Wallet.Address.States.IsOwned` dispatches to `Rnd.isOwned` unchanged, and payments
+(`lib/wallet/src/Cardano/Wallet.hs:2977`, `lib/wallet/src/Cardano/Wallet.hs:3383`), witness
+construction (`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:2529`) and migration
+(`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:4774`, via
+`W.buildAndSignTransaction` at `lib/wallet/src/Cardano/Wallet.hs:3212`) all inherit the fix.
+
+## Technical Context
+
+- **Language/Version**: Haskell, GHC pinned by the repository flake
+- **Primary Dependencies**: `cardano-crypto` (`deriveXPrv`, `toXPub`), `cborg`, in-repo
+`cardano-wallet-address-derivation-discovery`
+- **Storage**: none — nothing persisted changes; the key is recomputed on demand (spec Assumptions)
+- **Testing**: HSpec / QuickCheck through `cardano-wallet-unit:unit`; API integration scenarios through
+`cardano-wallet-integration` against a local cluster
+- **Target Platform**: multi-platform library code, verified locally on Linux
+- **Project Type**: Haskell monorepo under `lib/`
+- **Performance Goals**: exactly one key derivation and one address reconstruction per input when the
+recorded path identifies the key (SC-006, asserted structurally rather than measured); one extra key
+derivation per further candidate, only once an earlier candidate has failed
+- **Constraints**: no change to address discovery (FR-005); no change to `isOwned`'s type or to any call
+site (FR-006); no new error surface for an unresolvable address (FR-009); no database migration; no
+new constraint threaded into the wallet-flavour dispatch
+- **Scale/Scope**: two library modules and their specs, plus two Byron API integration scenarios
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| Maintenance-first stability | OK | Bug fix on a currently-unspendable path. Behaviour for correctly-recorded addresses is preserved by FR-004 and asserted by existing `RandomSpec` properties. |
+| Era-aware design | OK | Byron address format only. Witness construction is untouched; `mkByronWitness` already builds attributes from the address, not from the key. |
+| Type safety as security | OK | Verification narrows the result: no key is returned unless it provably reproduces the address. Explicit export lists and Haddock on every new export. |
+| Formal specification | OK | No API surface change, so `specifications/api/swagger.yaml` is untouched. No Lean invariant covers Byron key resolution. |
+| Reproducible builds | OK | All commands run under `nix develop --quiet`; no dependency change. |
+| Comprehensive testing | OK | Unit coverage for each candidate class and for the no-match case; integration coverage for spending (SC-001, SC-003) and migration (SC-004), which are the only place those criteria can be observed. |
+| Code quality gates | OK | Fourmolu (70 columns, leading commas), HLint, `-Wall`, unit and integration suites. |
+
+No violations, so **Complexity Tracking** is empty.
+
+Re-checked after Phase 1: the design adds two functions to one package and changes no type, no
+persisted shape and no API contract, so every row above stands. One item moved from unknown to
+tracked — `RandomSpec`'s `golden03` asserts a key at a soft path for an address this codebase did not
+generate, and may itself encode the defect. It is resolved by the probe in quickstart.md step 1
+before any code is written, and either outcome is compatible with the design (research.md §"Open
+item").
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-byron-random-address-signing/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── key-resolution.md
+└── tasks.md            # /speckit.tasks output — not created here
+```
+
+### Source Code (repository root)
+
+Expected write set:
+
+```text
+lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs
+lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
+lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs
+lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
+lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
+lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
+lib/integration/framework/Test/Integration/Framework/DSL.hs
+```
+
+`DSL.hs` gains one address constructor for the affected shape, alongside the existing
+`randomAddresses` (`lib/integration/framework/Test/Integration/Framework/DSL.hs:3062`), so both
+integration scenarios build their fixtures the same way.
+
+Must not change:
+
+```text
+lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
+lib/wallet/src/Cardano/Wallet.hs
+lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Ledger.hs
+specifications/api/swagger.yaml
+```
+
+An edit to any of these means the fix has leaked out of key resolution and FR-006 is no longer
+satisfied as written.
+
+**Structure Decision**: the change stays inside `lib/address-derivation-discovery`, which owns both
+the Byron address codec and the random-derivation discovery state. Tests for that package live in
+`lib/unit`; API-level behaviour lives in `lib/integration`.
+
+## Vertical Slice Contract
+
+One behaviour-changing commit:
+
+`fix(byron): verify derived keys reproduce the address before signing`
+
+It must contain:
+
+1. RED proof in `RandomSpec` that an address recording index *i* whose key is at *i* hardened is not
+   resolvable today, and that a decrypting-but-underivable address yields a key today.
+2. Address reconstruction in `Cardano.Byron.Codec.Cbor`, built from the attributes of the target
+   address.
+3. Candidate enumeration and verification in `Rnd.isOwned`, first match wins, no match yields
+   `Nothing`.
+4. Unit coverage for all four candidate classes, the no-match case, and the unchanged foreign-wallet
+   case.
+5. Integration coverage for spending and migrating an affected address.
+6. Local gate green with no diff outside the write set above.
+
+Integration scenarios may land as a second commit if the local cluster run is the only thing
+separating them; the library change must never land without its unit proof.
+
+## Proof Strategy
+
+Focused development loop:
+
+```sh
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Random Address Discovery"'
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Cardano.Byron.Codec.Cbor"'
+```
+
+Acceptance:
+
+```sh
+just check-fmt && just hlint
+just unit-tests-cabal-match "Random Address"
+just integration-tests-cabal-match "BYRON_MIGRATE"
+just integration-tests-cabal-match "BYRON_TRANS"
+```
+
+Post-implementation checks:
+
+```sh
+git diff --name-only master...HEAD
+rg -n "isOwned" lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
+```
+
+The first must list only the expected write set. The second must be unchanged from `master`.
+
+## Risks And Mitigations
+
+- **Verification rejects an address the node would have accepted.** Mitigated by reconstructing from
+  the address's own attributes, which is the same input the ledger check uses — see research.md
+  §"Faithfulness to the ledger check".
+- **Cost on the happy path.** Verification adds one `toXPub` and one hash-and-compare per input, on
+  every path including the unaffected one. Bounded and argued in research.md §"Cost". SC-006 now
+  states a structural bound — one derivation, one reconstruction — which a unit test asserts; it was
+  never a zero-cost claim and is no longer a latency claim.
+- **The residual class is created by this change, not exposed by it.** Today `isOurs` and `isOwned`
+  test the same condition for Byron random wallets, so every UTxO the wallet holds yields a key.
+  Verification makes `isOwned` strictly stronger, so an address that decrypts but matches no
+  candidate now resolves to `Nothing`. FR-009 fixes the consequence: no witness is produced for that
+  input — `signTransaction` assembles witnesses with `mapMaybe` (`Shelley/Transaction.hs:365`) — and
+  the node rejects the transaction as it does today. No new error path, and nothing to add at the
+  three call sites.
+- **The returned key's `derivationPath` field no longer matches the address's recorded path** for
+  affected addresses. Nothing reads it today (research.md §"Consumers of the returned key"), but
+  anything that later rebuilds an address from the returned key via `paymentAddress` would be wrong.
+  A Haddock note on `isOwned` records this.
+- **Integration fixture cannot produce an affected address.** Mitigated by constructing the address
+  directly from `CBOR.encodeAddress` and `CBOR.encodeDerivationPathAttr` and funding it with
+  `moveByronCoins`, which already sends to caller-supplied addresses.
+- **An existing golden goes red for the right reason.** `RandomSpec`'s `golden03` records a soft path
+  and asserts the key at it. If that address's key is really at the hardened form, the golden was
+  asserting a key the chain would reject and its expectation must be updated. Resolve first
+  (quickstart.md step 1); never update a golden to match new behaviour without confirming which key
+  actually reproduces the address.
+- **Scope creep into discovery.** FR-005 is explicit; `isOurs`, `addressToPath` and
+  `discoveredAddresses` keying stay as they are, including the pre-existing path-collision behaviour
+  noted in research.md.

--- a/specs/011-byron-random-address-signing/plan.md
+++ b/specs/011-byron-random-address-signing/plan.md
@@ -59,11 +59,10 @@ new constraint threaded into the wallet-flavour dispatch
 No violations, so **Complexity Tracking** is empty.
 
 Re-checked after Phase 1: the design adds two functions to one package and changes no type, no
-persisted shape and no API contract, so every row above stands. One item moved from unknown to
-tracked — `RandomSpec`'s `golden03` asserts a key at a soft path for an address this codebase did not
-generate, and may itself encode the defect. It is resolved by the probe in quickstart.md step 1
-before any code is written, and either outcome is compatible with the design (research.md §"Open
-item").
+persisted shape and no API contract, so every row above stands. The one item that was open —
+whether `RandomSpec`'s `golden03` itself encodes the defect — was measured on 2026-08-13 and does
+not: that address commits to the key at its recorded soft path, so the golden stands unchanged and
+becomes evidence for FR-004 (research.md §"Resolved").
 
 ## Project Structure
 
@@ -145,7 +144,7 @@ Focused development loop:
 
 ```sh
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
-  --test-options '--match="Random Address Discovery"'
+  --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
   --test-options '--match="Cardano.Byron.Codec.Cbor"'
 ```
@@ -154,7 +153,7 @@ Acceptance:
 
 ```sh
 just check-fmt && just hlint
-just unit-tests-cabal-match "Random Address"
+just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"
 just integration-tests-cabal-match "BYRON_MIGRATE"
 just integration-tests-cabal-match "BYRON_TRANS"
 ```
@@ -191,11 +190,9 @@ The first must list only the expected write set. The second must be unchanged fr
 - **Integration fixture cannot produce an affected address.** Mitigated by constructing the address
   directly from `CBOR.encodeAddress` and `CBOR.encodeDerivationPathAttr` and funding it with
   `moveByronCoins`, which already sends to caller-supplied addresses.
-- **An existing golden goes red for the right reason.** `RandomSpec`'s `golden03` records a soft path
-  and asserts the key at it. If that address's key is really at the hardened form, the golden was
-  asserting a key the chain would reject and its expectation must be updated. Resolve first
-  (quickstart.md step 1); never update a golden to match new behaviour without confirming which key
-  actually reproduces the address.
+- ~~**An existing golden goes red for the right reason.**~~ Closed 2026-08-13: `golden03`'s key is at
+  its recorded soft path, so its expectation must not move. If it goes red after the candidate ladder
+  lands, the ladder is wrong, not the golden.
 - **Scope creep into discovery.** FR-005 is explicit; `isOurs`, `addressToPath` and
   `discoveredAddresses` keying stay as they are, including the pre-existing path-collision behaviour
   noted in research.md.

--- a/specs/011-byron-random-address-signing/quickstart.md
+++ b/specs/011-byron-random-address-signing/quickstart.md
@@ -13,7 +13,7 @@ git status --short --branch
 just check-fmt
 nix develop --quiet -c cabal build cardano-wallet-address-derivation-discovery -O0 -v0
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
-  --test-options '--match="Random Address Discovery"'
+  --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'
 ```
 
 Expected: green. This is the suite that must stay green for FR-004 / SC-002.
@@ -25,44 +25,39 @@ Expected: green. This is the suite that must stay green for FR-004 / SC-002.
 else, because the answer decides whether an existing golden is evidence for the fix or a casualty of
 it.
 
-```sh
-nix develop --quiet -c cabal repl cardano-wallet-unit:unit
-```
+Do this as a spec case, not a REPL session. The answer changes an existing golden's expectation, so
+the evidence has to be something a reviewer can re-run — and in one of the two outcomes the probe
+becomes the regression test for FR-002 over a real pre-2018 address, which is stronger evidence than
+any fixture this feature can construct.
 
-Load the spec module so its unexported `arbitraryMnemonic` is in scope, then build both candidate
-addresses and compare against the golden bytes:
+Add to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` a pair of assertions that
+rebuild `golden03`'s address from the wallet's own key material — the recorded path in the
+derivation-path attribute either way, only the key's path differing:
 
 ```haskell
-:l Cardano.Wallet.Address.Discovery.RandomSpec
-import Cardano.Address.Derivation (toXPub)
-import Cardano.Wallet.Address.Derivation (Index (..))
-import Cardano.Wallet.Address.Derivation.Byron
-import Cardano.Wallet.Address.Discovery.Random
-import Cardano.Wallet.Primitive.Passphrase (Passphrase (..))
-import Cardano.Wallet.Primitive.Types.ProtocolMagic (ProtocolMagic (..))
-import Data.ByteArray.Encoding (Base (..), convertToBase)
-import Data.ByteString (ByteString)
-import qualified Cardano.Byron.Codec.Cbor as CBOR
-import qualified Codec.CBOR.Write as CBOR
-
-let pwd = Passphrase "" :: Passphrase "encryption"
-let root = generateKeyFromSeed arbitraryMnemonic pwd
-let hd = payloadPassphrase root
-let hex bs = convertToBase Base16 bs :: ByteString
-let mk a i = hex $ CBOR.toStrictByteString $ CBOR.encodeAddress
-        (toXPub $ getKey $ deriveCredFromKeyKeyFromPath root pwd (Index a, Index i))
-        [ CBOR.encodeDerivationPathAttr hd (Index 14) (Index 42)
-        , CBOR.encodeProtocolMagicAttr (ProtocolMagic 764824073)
-        ]
-mk 14 42                                 -- recorded path
-mk (14 + 0x80000000) (42 + 0x80000000)   -- hardened candidate
+golden03Provenance :: Spec
+golden03Provenance = describe "golden03 provenance" $ do
+    it "is reproduced by the key at its recorded path"
+        $ hex (addressAt (Index 14, Index 42)) `shouldBe` hex golden03Address
+    it "is reproduced by the key at the hardened path"
+        $ hex (addressAt (Index (14 + h), Index (42 + h)))
+            `shouldBe` hex golden03Address
+  where
+    h = 0x80000000
 ```
 
-Compare each against the golden's bytes (`RandomSpec.hs:241`). Record which one matches in
-research.md §"Open item", then either leave the golden alone or update its `accIndex`/`addrIndex` to
-the hardened values as part of the implementation commit.
+Exactly one must pass. Run:
 
-If neither matches, stop and report: the address carries something neither candidate class explains,
+```sh
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="golden03 provenance"'
+```
+
+Keep the passing assertion, renamed to state the finding, and delete the other. Record the outcome
+in research.md §"Open item", then either leave the golden alone or update its `accIndex`/`addrIndex`
+to the hardened values as part of the implementation commit.
+
+If neither passes, stop and report: the address carries something neither candidate class explains,
 and the candidate set in data-model.md needs revisiting before any code is written.
 
 ## Step 2 — RED
@@ -79,7 +74,7 @@ Add to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs`:
 
 ```sh
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
-  --test-options '--match="Random Address Discovery"'
+  --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'
 ```
 
 Capture the failures. (1) and (3) fail on the returned key; (2) fails for the affected fixture.
@@ -97,7 +92,7 @@ Capture the failures. (1) and (3) fail on the returned key; (2) fails for the af
 
 ```sh
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
-  --test-options '--match="Random Address Discovery"'
+  --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'
 nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
   --test-options '--match="Cardano.Byron.Codec.Cbor"'
 ```
@@ -130,7 +125,7 @@ wrong; if funding never lands, the fixture is wrong.
 ```sh
 just check-fmt
 just hlint
-just unit-tests-cabal-match "Random Address"
+just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"
 just unit-tests-cabal-match "Cardano.Byron.Codec"
 git diff --name-only master...HEAD
 ```

--- a/specs/011-byron-random-address-signing/quickstart.md
+++ b/specs/011-byron-random-address-signing/quickstart.md
@@ -1,0 +1,149 @@
+# Quickstart: Byron random address key resolution
+
+All commands assume the repository root and the Nix dev shell:
+
+```sh
+nix develop --quiet
+```
+
+## Baseline
+
+```sh
+git status --short --branch
+just check-fmt
+nix develop --quiet -c cabal build cardano-wallet-address-derivation-discovery -O0 -v0
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Random Address Discovery"'
+```
+
+Expected: green. This is the suite that must stay green for FR-004 / SC-002.
+
+## Step 1 — Resolve the `golden03` question first
+
+`RandomSpec.hs:237` asserts a key at a soft path for an address this codebase did not generate
+(research.md §"Open item"). Establish where that address's key actually is before writing anything
+else, because the answer decides whether an existing golden is evidence for the fix or a casualty of
+it.
+
+```sh
+nix develop --quiet -c cabal repl cardano-wallet-unit:unit
+```
+
+Load the spec module so its unexported `arbitraryMnemonic` is in scope, then build both candidate
+addresses and compare against the golden bytes:
+
+```haskell
+:l Cardano.Wallet.Address.Discovery.RandomSpec
+import Cardano.Address.Derivation (toXPub)
+import Cardano.Wallet.Address.Derivation (Index (..))
+import Cardano.Wallet.Address.Derivation.Byron
+import Cardano.Wallet.Address.Discovery.Random
+import Cardano.Wallet.Primitive.Passphrase (Passphrase (..))
+import Cardano.Wallet.Primitive.Types.ProtocolMagic (ProtocolMagic (..))
+import Data.ByteArray.Encoding (Base (..), convertToBase)
+import Data.ByteString (ByteString)
+import qualified Cardano.Byron.Codec.Cbor as CBOR
+import qualified Codec.CBOR.Write as CBOR
+
+let pwd = Passphrase "" :: Passphrase "encryption"
+let root = generateKeyFromSeed arbitraryMnemonic pwd
+let hd = payloadPassphrase root
+let hex bs = convertToBase Base16 bs :: ByteString
+let mk a i = hex $ CBOR.toStrictByteString $ CBOR.encodeAddress
+        (toXPub $ getKey $ deriveCredFromKeyKeyFromPath root pwd (Index a, Index i))
+        [ CBOR.encodeDerivationPathAttr hd (Index 14) (Index 42)
+        , CBOR.encodeProtocolMagicAttr (ProtocolMagic 764824073)
+        ]
+mk 14 42                                 -- recorded path
+mk (14 + 0x80000000) (42 + 0x80000000)   -- hardened candidate
+```
+
+Compare each against the golden's bytes (`RandomSpec.hs:241`). Record which one matches in
+research.md §"Open item", then either leave the golden alone or update its `accIndex`/`addrIndex` to
+the hardened values as part of the implementation commit.
+
+If neither matches, stop and report: the address carries something neither candidate class explains,
+and the candidate set in data-model.md needs revisiting before any code is written.
+
+## Step 2 — RED
+
+Add to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs`:
+
+1. An affected-address fixture: `CBOR.encodeAddress` over the public key at the **hardened** path,
+   with `CBOR.encodeDerivationPathAttr` recording the **soft** path. Assert `isOwned` returns the key
+   at the hardened path.
+2. A property over arbitrary mnemonics and indexes: whatever `isOwned` returns must reproduce the
+   address.
+3. An unownable-address fixture: attributes encrypted under the wallet's `hdPassphrase`, root built
+   from an unrelated public key. Assert `isOurs` is `Just` and `isOwned` is `Nothing`.
+
+```sh
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Random Address Discovery"'
+```
+
+Capture the failures. (1) and (3) fail on the returned key; (2) fails for the affected fixture.
+
+## Step 3 — GREEN
+
+1. `lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs`: add the attribute decoder and
+   the reconstruction function of contracts/key-resolution.md. If the decoder is exported, replace
+   the duplicate at `Cardano/Wallet/Address/Encoding.hs:301` with it.
+2. `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs`: add
+   `candidatePaths` (exported for tests) and rewrite `isOwned` to derive-verify-or-continue over it.
+   Haddock the caller obligation about `derivationPath` on `isOwned`.
+3. Extend `lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs` with the reconstruction round-trip,
+   the wrong-key case, and the non-address case.
+
+```sh
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Random Address Discovery"'
+nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 \
+  --test-options '--match="Cardano.Byron.Codec.Cbor"'
+```
+
+## Step 4 — Integration
+
+Add an affected-address constructor to
+`lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses`
+(`DSL.hs:3062`), then:
+
+- `Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic →
+  fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`) → spend an
+  amount that forces both inputs → expect `202` and the transaction reaching `in_ledger`. Covers
+  SC-001 and SC-003.
+- `Test/Integration/Scenario/API/Byron/Migrations.hs`: same fixture → `POST
+  /v2/byron-wallets/{id}/migrations` → expect the plan to include the affected UTxO and the wallet
+  balance to reach zero. Covers SC-004.
+
+```sh
+just integration-tests-cabal-match "BYRON_TRANS"
+just integration-tests-cabal-match "BYRON_MIGRATE"
+```
+
+The `moveByronCoins` step waits on the destination balance, which is also the check that discovery is
+unchanged (FR-005). If funding succeeds and spending fails, the fixture is right and the fix is
+wrong; if funding never lands, the fixture is wrong.
+
+## Step 5 — Gate
+
+```sh
+just check-fmt
+just hlint
+just unit-tests-cabal-match "Random Address"
+just unit-tests-cabal-match "Cardano.Byron.Codec"
+git diff --name-only master...HEAD
+```
+
+The diff must contain only the write set in plan.md. In particular
+`lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs` and
+`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs` must not appear — their absence is the
+evidence for FR-006.
+
+## Commit
+
+```text
+fix(byron): verify derived keys reproduce the address before signing
+```
+
+Conventional Commits, single concern, `fix:` so release-please cuts a patch.

--- a/specs/011-byron-random-address-signing/research.md
+++ b/specs/011-byron-random-address-signing/research.md
@@ -113,7 +113,28 @@ property the latency wording was reaching for. No benchmark is added.
 An optional refinement, not required: candidates sharing an account index can share the account key,
 reducing the worst case from eight `deriveXPrv` calls to six. Only reachable on the fallback path.
 
-## Open item: `golden03` may already encode the defect
+## Resolved: `golden03` does not encode the defect
+
+**Measured 2026-08-13**, by rebuilding the address from the test's own mnemonic at both candidate
+paths and comparing bytes (`RandomSpec.hs`, `golden03 provenance`):
+
+| Key derived at | Reconstructed root | Verdict |
+|---|---|---|
+| recorded path (14, 42) | `f26d102b29332fd6c244a9915b6cad7890f5b54ac34dcd62975b525a` | matches the golden |
+| hardened (14+2³¹, 42+2³¹) | `9a29bd1f8515c49428c5b2a10049768fcfd70c4e2f757cd5b065ac74` | does not match |
+
+So `golden03`'s key genuinely is at the soft path it records. Its `accIndex`/`addrIndex` expectation
+stands unchanged, and the address is now a worked example of the spec's own caveat that a soft index
+does not by itself imply the defect. It is direct evidence for FR-004: an address of this shape must
+keep resolving on the first candidate, with no fallback derivation.
+
+The passing assertion is kept in `RandomSpec.hs` as `golden03Provenance`, so the claim above is
+re-runnable rather than a transcript.
+
+The original reasoning that made this worth checking is preserved below, since it explains why the
+address looked suspicious.
+
+## Why `golden03` was suspect
 
 `RandomSpec.hs:237` carries a golden whose recorded path is soft — account 14, address 42 — and
 asserts that `isOwned` returns the key at exactly that path (`checkIsOwned`, `RandomSpec.hs:295`).
@@ -130,17 +151,8 @@ Two features of the address make this worth checking rather than assuming:
 - It is the only golden in the file with a soft recorded path. The mainnet goldens and testnet
   `golden01`/`golden02` all record indexes ≥ 2³¹.
 
-Both outcomes are fine, and neither blocks the design:
-
-- Root is at the soft path → the golden is unchanged and becomes direct evidence for FR-004.
-- Root is at the hardened path → the golden was asserting a key that the chain would have rejected.
-  Its `accIndex`/`addrIndex` expectation is updated to the hardened values and it becomes a
-  regression test for FR-002 over a real address rather than a constructed one, which is stronger
-  coverage than anything this feature can fabricate.
-
-Resolve it before writing the candidate ladder; the probe is step 1 of quickstart.md. Do not update
-the golden's expectation on the assumption that the fix is right — confirm which key reproduces the
-address first, and record the answer in this section.
+The mainnet-magic oddity turned out to be a red herring for provenance: whatever produced the
+address, it derived the key at the path it recorded. The measurement above settles it.
 
 ## Known limitation, out of scope
 

--- a/specs/011-byron-random-address-signing/research.md
+++ b/specs/011-byron-random-address-signing/research.md
@@ -1,0 +1,198 @@
+# Research: Byron random address key resolution
+
+**Issue**: [#5368](https://github.com/cardano-foundation/cardano-wallet/issues/5368)
+**Prior art**: [#1041](https://github.com/cardano-foundation/cardano-wallet/issues/1041) (indexes
+outside the hardened domain exist), [#1042](https://github.com/cardano-foundation/cardano-wallet/issues/1042)
+(`Index 'WholeDomain` so they are discovered)
+**Measured at**: `d3d170d02`, 2026-08-11
+
+## Current-state inventory
+
+Key resolution for Byron random wallets, in full:
+
+```haskell
+-- lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs:248
+isOwned st (key, pwd) addr =
+    (,pwd) . deriveCredFromKeyKeyFromPath key pwd
+        <$> addressToPath addr (hdPassphrase st)
+```
+
+`addressToPath` (`Random.hs:275`) decrypts the derivation-path attribute out of the address;
+`deriveCredFromKeyKeyFromPath` (`Random.hs:352`) derives account then address key at that path.
+Nothing compares the resulting key to the address. Every ingredient for the comparison is already in
+the package.
+
+| Piece | Location | Note |
+|---|---|---|
+| Address root computation | `Cardano/Byron/Codec/Cbor.hs:349` `encodeAddress` | `blake2b224 . sha3256` over `[addrType, spendingData, attributes]`; attributes supplied by the caller |
+| Payload extraction | `Cbor.hs:180` `decodeAddressPayload` | Strips the CRC wrapper, canonical decode |
+| Attribute extraction | `Cbor.hs:217` `decodeAllAttributes` | Returns `[(Word8, ByteString)]`, canonical map decode |
+| Same pattern, already used | `Cardano/Wallet/Address/Encoding.hs:290` `toHDPayloadAddress` | Local decoder: `decodeListLenCanonicalOf 3`, skip root, `decodeAllAttributes` |
+| Index domain lifting | `Cardano/Wallet/Address/Derivation.hs:486` `liftIndex` | `firstHardened = 0x80000000` at `Derivation.hs:397` |
+
+`isOwned` is dispatched by flavour at
+`lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs:68`, which already carries a
+`HasSNetworkId (NetworkOf s)` constraint, and `NetworkOf (RndState n) = n`
+(`Cardano/Wallet/Address/States/Families.hs:47`).
+
+### Consumers of the returned key
+
+| Call site | Use |
+|---|---|
+| `lib/wallet/src/Cardano/Wallet.hs:2977` (`buildAndSignTransactionPure`) | passed to `signTransaction` as `keyFrom` |
+| `lib/wallet/src/Cardano/Wallet.hs:3383` (`buildAndSignTransaction`) | passed to `mkTransaction` as `keyFrom` |
+| `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:2529` | passed to witness construction as `keyLookup` |
+
+All three reach `mkTxInWitness` (`lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs:445`), which
+takes `getRawKey keyF k` and nothing else. The `derivationPath` and `payloadPassphrase` fields of the
+returned `ByronKey` are discarded. Migration reaches the same place through
+`W.buildAndSignTransaction` (`Server.hs:4774`), which is why FR-006 needs no call-site change.
+
+## Faithfulness to the ledger check
+
+What the node validates is not "the key is at the recorded path" but "the address root recomputes
+from the witness's public key and the witness's attributes". `mkByronWitness`
+(`Shelley/Transaction.hs:834`) builds those attributes from the address:
+
+```haskell
+addrAttr =
+    Byron.mkAttributes
+        $ Byron.AddrAttributes
+            (toHDPayloadAddress addr)
+            (Byron.toByronNetworkMagic nw)
+```
+
+`mkByronWitnessLedger` (`Shelley/Transaction/Ledger.hs:404`) does the same. So the witness carries the
+address's own HD payload verbatim, and only the key material varies. Verifying locally by rebuilding
+the address from a candidate public key **under the target address's own attributes** reproduces the
+node's acceptance criterion exactly. Two consequences:
+
+- A candidate our check accepts is a candidate the node accepts, up to the network magic discussed
+  below.
+- An address our check rejects for every candidate is an address for which this wallet could not
+  produce a valid witness at all. FR-003's `Nothing` is therefore the correct answer, not a
+  conservative one.
+
+The one divergence: our reconstruction takes the network-magic attribute from the address, while the
+witness takes it from the wallet's configured network. These differ only for an address belonging to
+a different network, which cannot appear in this wallet's UTxO set.
+
+## Decisions
+
+| Decision | Rationale | Alternative rejected |
+|---|---|---|
+| Rebuild the address from the target's own attributes, via a new function in `Cardano.Byron.Codec.Cbor`. | That module already owns `encodeAddress` and the payload decoders; the reconstruction is pure binary-format work. Needs no network identifier, so `isOwned` keeps its type and the flavour dispatch is untouched (spec Assumptions). | `paymentAddressS @n` on the candidate key. It builds the derivation-path attribute from the key's own `derivationPath` field (`Address/Derivation/Byron.hs:160`), which for a hardened candidate encrypts the *hardened* path — producing an address that cannot match a target recording the soft path. Making it work requires splicing the recorded path into the candidate key's record, which fabricates a `ByronKey` whose `derivationPath` contradicts its `getKey`, and additionally binds verification to the wallet's configured network rather than the address's attributes. |
+| Compare the full reconstructed address bytes, not just the 28-byte root. | Matches Acceptance Scenario 1.2 as written ("reproduces the address exactly") and self-checks the attribute re-encoding at the same time. Cost difference is one CRC32 over ~40 bytes. | Root-only comparison. Same crypto cost, weaker statement, and no cheaper: the root is a hash over the re-encoded attributes either way. |
+| Candidate order: recorded, address index hardened, account index hardened, both. Stop at the first match. | The order the spec fixes in Key Entities, most likely first. FR-008 makes the common case exactly one derivation and one comparison. | Deriving all four and picking the match: four times the cost for wallets that are not affected at all. |
+| De-duplicate candidates before evaluating. | An already-hardened path collapses all four candidates to one, which is the overwhelmingly common case (spec Edge Cases). Order-preserving dedup on a four-element list. | Deriving duplicates and relying on the first-match short-circuit: correct but does redundant work whenever exactly one level is soft. |
+| Keep index hardening local to `Random.hs`. | Only candidate generation needs it; keeping it out of `Cardano.Wallet.Address.Derivation` keeps the diff inside one package and avoids adding a general-purpose index operation nobody else calls. | Exporting `hardenIndex` next to `liftIndex` in `Derivation.hs`. Conceptually the right home; revisit if a second caller appears. |
+| No change to discovery. | FR-005. `isOurs` and `addressToPath` already find these addresses correctly — that is what #1042 delivered. | Re-keying `discoveredAddresses` by address instead of path would fix the collision noted below but changes the state's shape and its persisted representation. |
+
+## Cost
+
+Per input resolved, on top of what happens today:
+
+| Path | Extra work |
+|---|---|
+| Recorded path correct (all wallets today) | one `toXPub`, one SHA3-256 + Blake2b-224 over ~90 bytes, one CRC32, one `ByteString` comparison |
+| Address index hardened | the above ×2, plus one extra `deriveXPrv` pair |
+| Account index hardened | ×3, plus two extra `deriveXPrv` pairs |
+| Both, or no match | ×4, plus three extra `deriveXPrv` pairs |
+
+Verification is unconditional — that is the point of FR-001 — so even unaffected wallets pay one
+public-key computation and one hash per input. A `toXPub` is one Ed25519 scalar multiplication, the
+same order as the `deriveXPrv` calls already performed and well under the Ed25519 signature that
+follows.
+
+SC-006 was originally a latency claim. Nothing in the repository measures this path — `latency-bench`
+drives Shelley wallets only, and `restore-bench` exercises `RndState` through `isOurs`, not `isOwned`
+— so it has been restated as a structural bound: one derivation and one reconstruction per input when
+the recorded path is correct. That is assertable in a unit test via `candidatePaths`, and it is the
+property the latency wording was reaching for. No benchmark is added.
+
+An optional refinement, not required: candidates sharing an account index can share the account key,
+reducing the worst case from eight `deriveXPrv` calls to six. Only reachable on the fallback path.
+
+## Open item: `golden03` may already encode the defect
+
+`RandomSpec.hs:237` carries a golden whose recorded path is soft — account 14, address 42 — and
+asserts that `isOwned` returns the key at exactly that path (`checkIsOwned`, `RandomSpec.hs:295`).
+Today that assertion cannot fail for the wrong reason, because nothing verifies the key. After the
+fix it can: if this address's root is not the key at (14, 42), `isOwned` will return the key at the
+hardened form instead, and the golden will go red.
+
+Two features of the address make this worth checking rather than assuming:
+
+- Its attributes carry protocol magic `0x2d964a09` = 764824073, the **mainnet** magic, while sitting
+  in the testnet golden group; the other testnet goldens carry `0x4170cb17` = 1097911063. This
+  codebase's `paymentAddress` emits the magic attribute only for testnet
+  (`Address/Derivation/Byron.hs:160`), so this address was not produced by either branch of it.
+- It is the only golden in the file with a soft recorded path. The mainnet goldens and testnet
+  `golden01`/`golden02` all record indexes ≥ 2³¹.
+
+Both outcomes are fine, and neither blocks the design:
+
+- Root is at the soft path → the golden is unchanged and becomes direct evidence for FR-004.
+- Root is at the hardened path → the golden was asserting a key that the chain would have rejected.
+  Its `accIndex`/`addrIndex` expectation is updated to the hardened values and it becomes a
+  regression test for FR-002 over a real address rather than a constructed one, which is stronger
+  coverage than anything this feature can fabricate.
+
+Resolve it before writing the candidate ladder; the probe is step 1 of quickstart.md. Do not update
+the golden's expectation on the assumption that the fix is right — confirm which key reproduces the
+address first, and record the answer in this section.
+
+## Known limitation, out of scope
+
+`discoveredAddresses` is keyed by `DerivationPath` (`Random.hs:170`). An affected and an unaffected
+address can record the same path (spec Edge Cases), in which case the map retains only one of them
+and the address list under-reports. This predates the change and is unaffected by it: signing takes
+the `Address` from the UTxO and never consults that map, so both addresses remain spendable. FR-005
+keeps discovery untouched, so this stays as it is.
+
+## Test strategy
+
+RED, before any implementation:
+
+1. `RandomSpec`: for an address built as `encodeAddress (xpub at hardened path)
+   [derivationPathAttr recorded-soft-path]`, `isOwned` returns a key today — the wrong one. Assert
+   that the returned key reproduces the address, and that it equals the key at the hardened path.
+   Both fail today.
+2. `RandomSpec`: an address whose attributes decrypt under the wallet's `hdPassphrase` but whose root
+   comes from an unrelated public key yields a key today. Assert `Nothing`, which fails today.
+
+GREEN adds verification and the candidate ladder. Coverage per requirement:
+
+| Requirement | Test |
+|---|---|
+| FR-001, SC-005 | property: for every `isOwned` result, the returned key reproduces the address |
+| FR-002, SC-001 | golden + property: address index hardened resolves |
+| FR-003, SC-005 | decrypts-but-underivable address yields `Nothing`; foreign-wallet address still yields `Nothing` |
+| FR-004, SC-002 | existing `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) and the mainnet/testnet goldens, unchanged and still passing, including `golden03` (`RandomSpec.hs:237`) whose recorded indexes are 14 and 42 — soft, and correct |
+| FR-007, SC-007 | account index hardened, and both hardened, resolve |
+| FR-008, SC-006 | candidate list for an already-hardened path is a singleton, so the recorded-path case performs one derivation and one reconstruction |
+| FR-009 | no new error constructor, no swagger error entry, no change to any signing signature — checked by the diff, not by a test |
+| FR-006, SC-003, SC-004 | integration: spend from an affected address, spend affected and unaffected in one transaction, migrate a wallet holding one |
+
+`CborSpec` covers the reconstruction function directly: for any public key and attribute set,
+reconstructing from the address that key produced returns that address; reconstructing from a
+different key does not; a non-address byte string returns `Nothing`.
+
+Integration fixtures build the affected address in the test — `CBOR.encodeAddress` over the public key
+at the hardened path with `CBOR.encodeDerivationPathAttr` recording the soft path, plus
+`encodeProtocolMagicAttr` on testnet — and fund it with `moveByronCoins`
+(`Test/Integration/Framework/DSL.hs:2811`), which already sends to caller-supplied addresses and waits
+for the destination balance. That wait doubles as confirmation that discovery is unaffected.
+
+## Risks
+
+- **Non-canonical attribute encodings.** Re-encoding decoded attribute pairs must be byte-identical to
+  the original. The decoders enforce canonical forms (`decodeListLenCanonicalOf`,
+  `decodeMapLenCanonical`), and any address that failed this would already be unspendable by this
+  wallet, since the ledger path re-encodes attributes too. Failure mode is a visible `Nothing`, never
+  a wrong key.
+- **A fifth variant exists.** If some affected address matches none of the four candidates, FR-003
+  makes it fail locally and visibly instead of at submission, and the candidate list is one function
+  to extend.
+- **Integration flakiness.** The scenarios depend on a local cluster and faucet timing, like every
+  other Byron migration scenario. Reuse the existing `eventually` helpers rather than new waits.

--- a/specs/011-byron-random-address-signing/spec.md
+++ b/specs/011-byron-random-address-signing/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Byron Random Wallets Cannot Sign For Pre-2018 Addresses
+
+**Feature Branch**: `011-byron-random-address-signing`
+**Created**: 2026-08-11
+**Status**: Draft
+**Input**: Byron random-derivation wallets discover, display and offer for spending certain addresses
+whose recorded derivation index does not identify the key the address was built from. Signing derives
+at the recorded index and produces a key that does not correspond to the address, so the node rejects
+every transaction spending those UTxOs with `MissingVKeyWitnessesUTXOW`. Balances are reported as
+spendable and no error is surfaced until submission.
+
+## Background
+
+Byron random-derivation addresses carry their derivation path inside the address, encrypted under a
+key derived from the wallet's root public key. `addressToPath` recovers that path and `isOwned`
+derives a signing key from it, without ever checking that the derived key reproduces the address it
+is about to sign for.
+
+For addresses created by `cardano-sl` before commit `4ebc883d`
+(*[CSL-1955] Updated generateUnique to always generate hardened addresses*, 2017-11-28, released
+between March and June 2018), the index recorded in the address is **not** the index the key was
+derived at. Such addresses were already known to exist: issue #1041 documented that Byron addresses
+may carry indexes outside the hardened domain, and #1042 introduced `Index 'WholeDomain` so that they
+would be *discovered*. Neither issue considered whether they could be *spent*.
+
+The result is that affected wallets restore correctly, show a correct balance, and fail only at
+submission — silently, and for the entire lifetime of the wallet.
+
+The funds are not lost. Signing with the key at the hardened form of the recorded index produces a
+valid witness, which has been confirmed on a test network. What is missing is for the wallet to try
+that derivation, and to check the key it produces before using it.
+
+Note that a soft index alone does not imply the defect. An address whose key genuinely is at the soft
+index it records signs correctly. The fault is the mismatch between recorded index and actual key,
+which correlates with soft indexes only because pre-2018 addresses are the ones affected.
+
+## Clarifications
+
+### Session 2026-08-11
+
+- Q: When an address decrypts as ours but no candidate derivation reproduces it, what should the
+  wallet do beyond returning no signing key? → A: Nothing further. The input contributes no witness,
+  and the transaction is rejected at submission as it is today. No new local error and no new API
+  error surface; the change stays confined to key resolution.
+- Q: How far does automated test coverage go for the network-level criteria? → A: Both user stories
+  get an automated integration scenario against a local cluster — a mixed affected and unaffected
+  spend (SC-001, SC-003) and a migration (SC-004) — in addition to unit coverage of key resolution.
+- Q: How is the performance criterion verified, given that no existing benchmark exercises Byron
+  signing? → A: It is restated as a structural bound that a unit test can assert — one derivation and
+  one reconstruction per input on the recorded path — rather than a latency measurement. No
+  benchmark is added.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Spending From An Affected Address (Priority: P1)
+
+A user restores a Byron wallet created before 2018. The wallet syncs, discovers its addresses and
+reports a balance that matches the chain. When the user sends any amount that selects a UTxO on one
+of the affected addresses, the node rejects the transaction. Repeating the attempt fails identically,
+and no part of the interface indicates why.
+
+**Why this priority**: These funds are currently unspendable through the wallet, indefinitely, with
+no diagnostic. Any wallet holding a pre-2018 address is affected regardless of how much it holds.
+
+**Independent Test**: Construct an address whose payload records index *i* while its root is derived
+from the key at *i* hardened, fund it, and attempt to spend. Fails before the change; succeeds after.
+Confirmed on a test network — such an address was funded, found unspendable, and then recovered by
+signing at the hardened index. Automated as an integration scenario against a local cluster, spending
+an affected and an unaffected UTxO in one transaction.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Byron random wallet owning an address whose key is at the hardened form of its
+   recorded index, **When** the user submits a transaction spending a UTxO on that address,
+   **Then** the transaction is accepted by the node.
+2. **Given** the same wallet, **When** `isOwned` is asked for that address's signing key,
+   **Then** the returned key reproduces the address exactly.
+3. **Given** a wallet owning both affected and unaffected addresses, **When** a transaction spends
+   UTxOs from both in one transaction, **Then** every bootstrap witness validates.
+
+---
+
+### User Story 2 - Migrating An Affected Wallet (Priority: P2)
+
+A user with a legacy wallet uses the existing migration endpoint to move all funds to a Shelley
+wallet. The migration plan includes UTxOs on affected addresses, so the migration transaction is
+rejected and the wallet cannot be emptied by the supported route.
+
+**Why this priority**: Migration is the recommended path off legacy wallets and the primary interface
+users are directed to. It fails for exactly the users least able to diagnose it. Depends on the same
+fix as User Story 1 but is independently observable and independently valuable.
+
+**Independent Test**: Run `POST /v2/byron-wallets/{id}/migrations` against a wallet containing at
+least one affected address and confirm the migration completes. Automated as an integration scenario
+against a local cluster.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Byron wallet containing affected addresses with funds, **When** a migration plan is
+   created, **Then** the plan includes those UTxOs.
+2. **Given** that plan, **When** the migration is executed, **Then** the transaction is accepted and
+   the wallet balance reaches zero.
+
+---
+
+### User Story 3 - No Silent Wrong Keys (Priority: P3)
+
+Any Byron random address for which no derivable key reproduces the address is reported as not owned,
+rather than yielding a key that will fail at submission.
+
+**Why this priority**: The severity of this defect comes from its silence — a wrong key is
+indistinguishable from a right one until the node rejects it. Refusing to return an unverified key
+confines any future occurrence of this class to one testable boundary: `isOwned` returns a key that
+provably matches the address, or none. Such an input then carries no witness and the transaction is
+still rejected at submission; the wallet raises no new local error. Valuable even if no further
+variants exist.
+
+**Independent Test**: Present the wallet with an address that decrypts to a valid path but whose root
+matches no candidate derivation, and confirm no signing key is produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** an address whose payload decrypts under the wallet's passphrase but whose root matches
+   no candidate derivation, **When** `isOwned` is called, **Then** it returns `Nothing`.
+2. **Given** an address belonging to a different wallet, **When** `isOwned` is called, **Then** it
+   returns `Nothing`, as today.
+
+### Edge Cases
+
+- **Both candidates reproduce the address.** Cannot occur: distinct derivation indexes yield distinct
+  public keys, and the address root commits to the public key. The first match is unambiguous.
+- **Account index also outside the hardened domain.** #1041 records that account indexes were
+  produced by the same defective function. The account level is therefore covered as well as the
+  address level (FR-007). No wallet with an affected account index has been observed, but the
+  affected population cannot be enumerated, so this is handled rather than assumed away.
+- **Two addresses recording the same path.** Legitimate: an affected and an unaffected address can
+  record identical paths and differ only in the key used. Classification must be per address, by
+  comparison, never by path alone.
+- **Index already hardened.** Where a candidate coincides with one already tried, it must not be
+  derived twice. Candidates should be de-duplicated before evaluation.
+- **Addresses that decrypt but belong to no derivable key.** Must not produce a signing key
+  (User Story 3). This class cannot arise today, because ownership and key resolution currently test
+  the same condition; it exists only once resolution is verified. The input then contributes no
+  witness and the transaction is rejected by the node, as it is today.
+- **Performance.** `isOwned` runs per input during signing. Verification is unconditional, so every
+  input costs one public-key computation and one address reconstruction. Only the fallback path costs
+  further key derivations, so a wallet holding no affected addresses stays at one derivation and one
+  reconstruction per input (SC-006).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST verify that a derived signing key reproduces the address it was derived
+  for before that key is used to sign.
+- **FR-002**: When the key derived at an address's recorded index does not reproduce the address, the
+  system MUST attempt derivation at the hardened form of that index.
+- **FR-003**: The system MUST return no signing key for an address that no candidate derivation
+  reproduces, rather than returning an unverified key.
+- **FR-004**: The system MUST NOT change behaviour for addresses whose recorded index already
+  identifies the correct key; these must continue to resolve on the first attempt.
+- **FR-005**: Address discovery MUST remain unchanged. Ownership determination is out of scope; only
+  the key returned for an owned address changes.
+- **FR-006**: The fix MUST apply to every path that signs for Byron random wallets, including
+  ordinary payments and wallet migration, without changes at those call sites.
+- **FR-007**: The system MUST consider candidates at the account level as well as the address level.
+  Issue #1041 records that account indexes were produced by the same defective function and are
+  "subject to the same rule". `cardano-wallet` is a general-purpose backend with an unknown set of
+  downstream consumers, so the affected population cannot be enumerated and must not be assumed to
+  match any single client's behaviour. Covering both levels costs one further derivation on a path
+  that only executes once an earlier candidate has already failed.
+- **FR-008**: Candidate evaluation MUST stop at the first candidate that reproduces the address, so
+  that the common case — an address whose recorded path is correct — performs exactly one derivation
+  and one comparison.
+- **FR-009**: The absence of a signing key MUST NOT introduce a new error surface. Signing paths keep
+  their types, callers keep their behaviour for an unresolved address, and no API error is added.
+  Verification is observable at the `isOwned` boundary and nowhere else.
+
+### Key Entities
+
+- **Recorded derivation path**: the account and address indexes encrypted into a Byron random
+  address. Recovered from the address itself; for pre-2018 addresses it does not necessarily identify
+  the key the address was built from.
+- **Candidate derivation**: a path at which the signing key may lie for a given address. The recorded
+  path, and variants of it with the address index hardened, the account index hardened, or both.
+  Evaluated in that order, most likely first.
+- **Address reconstruction**: deriving the key at a candidate path, computing the address it produces,
+  and comparing with the target address. The only reliable test of which candidate is correct.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A wallet owning an address whose key is at the hardened form of its recorded index can
+  spend that address's UTxOs; the node accepts the transaction.
+- **SC-002**: A wallet owning only unaffected addresses shows no change in behaviour, in the keys
+  returned, or in the addresses it discovers.
+- **SC-003**: A single transaction spending UTxOs from both affected and unaffected addresses is
+  accepted, with every bootstrap witness validating.
+- **SC-004**: `POST /v2/byron-wallets/{id}/migrations` empties a wallet containing affected addresses.
+- **SC-005**: No signing key is ever returned that does not reproduce the address it is for; an
+  address matching no candidate yields no key.
+- **SC-007**: An address whose account index, rather than its address index, fails to identify its
+  key is resolved by the same mechanism.
+- **SC-006**: For an address whose recorded path identifies its key, resolution performs exactly one
+  key derivation and one address reconstruction. A wallet holding no affected addresses performs no
+  additional derivation, on any input.
+
+## Assumptions
+
+- The affected population is wallets whose addresses were created before the `cardano-sl` fix
+  described above, and only those that drew an index outside the hardened domain. Neither the number
+  of such wallets nor the sums involved are known.
+- Reproducing an address from a candidate key can be done using the attributes carried by the target
+  address itself, so no network identifier needs to be threaded into `isOwned`. This avoids adding a
+  constraint that would propagate to the wallet-flavour dispatch and its call sites.
+- Hardening an index recovers the correct key for affected addresses. This has been confirmed on a
+  test network: an address of this shape, unspendable by current code, was swept successfully by
+  signing with the key at the hardened form of its recorded index, in a transaction that also
+  carried a healthy address's input under its own witness. Should some affected address match no
+  candidate, FR-003 ensures it fails visibly rather than silently, and the candidate set can be
+  extended without changing the surrounding design.
+- The set of clients that have created Byron random wallets against this backend is unknown. No
+  requirement here assumes a particular client's index-generation behaviour.
+- Discovery is already correct for these addresses — they are found and their balances reported. Only
+  signing is defective.
+- No database migration is required. Nothing persisted changes; the correct key is recomputed on
+  demand from material already available.

--- a/specs/011-byron-random-address-signing/tasks.md
+++ b/specs/011-byron-random-address-signing/tasks.md
@@ -28,11 +28,15 @@ Haskell monorepo. Library under `lib/address-derivation-discovery/lib/`, unit sp
 **Purpose**: Establish the baseline and settle the one open question that changes an existing test's
 expectation.
 
-- [ ] T001 Confirm the baseline is green: `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Random Address Discovery"'` and `just check-fmt`
-- [ ] T002 Resolve the `golden03` question with the REPL probe in quickstart.md step 1 against `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs:241`, then record which candidate reproduces that address in `specs/011-byron-random-address-signing/research.md` §"Open item"
+- [ ] T001 Confirm the baseline is green: `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'` and `just check-fmt`
+- [ ] T002 Resolve the `golden03` question with the paired spec case in quickstart.md step 1, added to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` and run with `--match="golden03 provenance"`; keep the passing assertion renamed to state the finding, delete the other, and record the outcome in `specs/011-byron-random-address-signing/research.md` §"Open item"
 
 **Blocking**: If T002 shows neither the recorded nor the hardened path reproduces `golden03`, stop and
 report — the candidate set in data-model.md needs revisiting before any code is written.
+
+**Outcome (2026-08-13)**: T001 green at 19 examples; T002 resolved — `golden03` commits to the key at
+its recorded soft path, so the golden stands unchanged and becomes FR-004 evidence (research.md
+§"Resolved"). Phase 1 complete.
 
 ---
 
@@ -69,7 +73,7 @@ report — the candidate set in data-model.md needs revisiting before any code i
 
 - [ ] T009 [US1] Add index hardening and `candidatePaths :: DerivationPath -> [DerivationPath]` to `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` — recorded, address index hardened, account index hardened, both, order-preserving dedup — and export `candidatePaths` for tests (data-model.md §"Candidate derivation")
 - [ ] T010 [US1] Rewrite `isOwned` in `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` to derive each candidate, verify with `reconstructAddress`, return the first match and `Nothing` otherwise; add the Haddock note that only `getKey` may be relied upon, since the returned key's `derivationPath` is the candidate path
-- [ ] T011 [US1] Reconcile `golden03` in `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs:237` with the T002 finding — leave it unchanged if its key is at the recorded path, or update `accIndex`/`addrIndex` to the hardened values if it is not
+- [ ] T011 [US1] Confirm `golden03` still passes unmodified. T002 established that its key is at its recorded soft path, so its `accIndex`/`addrIndex` expectation must **not** change; a failure here means the candidate ladder is not returning the recorded-path key first (FR-004)
 - [ ] T012 [US1] Add unit coverage to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` for the account-index-hardened and both-hardened variants (FR-007, SC-007)
 - [ ] T013 [US1] Add a unit assertion to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that `candidatePaths` on an already-hardened path is a singleton, which is the structural form of the one-derivation-one-reconstruction bound (FR-008, SC-006)
 - [ ] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
@@ -128,7 +132,7 @@ was introduced.
 ## Phase 6: Polish & Cross-Cutting Concerns
 
 - [ ] T023 [P] Run `just check-fmt` and `just hlint`, and fix any finding in the files touched
-- [ ] T024 Run the full focused unit set: `just unit-tests-cabal-match "Random Address"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
+- [ ] T024 Run the full focused unit set: `just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
 - [ ] T025 Confirm the write set: `git diff --name-only master...HEAD` lists only the files in plan.md §"Project Structure", and none of `lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs`, `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`, `specifications/api/swagger.yaml`
 - [ ] T026 Commit as `fix(byron): verify derived keys reproduce the address before signing`, single concern, Conventional Commits
 

--- a/specs/011-byron-random-address-signing/tasks.md
+++ b/specs/011-byron-random-address-signing/tasks.md
@@ -1,0 +1,213 @@
+# Tasks: Byron random wallets cannot sign for pre-2018 addresses
+
+**Input**: Design documents from `/specs/011-byron-random-address-signing/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/key-resolution.md, quickstart.md
+**Issue**: [#5368](https://github.com/cardano-foundation/cardano-wallet/issues/5368)
+
+**Tests**: Required. The spec's User Scenarios section is mandatory, and the Session 2026-08-11
+clarification fixed automated integration coverage for both User Story 1 and User Story 2.
+
+**Organization**: Grouped by user story. The library change is shared, so it sits in Phase 2 and
+Phase 3; User Story 2 needs no further library work and User Story 3 is proven at the unit boundary.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1, US2, US3 — maps to the user stories in spec.md
+- Every command runs from the repository root inside `nix develop --quiet`
+
+## Path Conventions
+
+Haskell monorepo. Library under `lib/address-derivation-discovery/lib/`, unit specs under
+`lib/unit/test/unit/`, integration scenarios under `lib/integration/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish the baseline and settle the one open question that changes an existing test's
+expectation.
+
+- [ ] T001 Confirm the baseline is green: `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Random Address Discovery"'` and `just check-fmt`
+- [ ] T002 Resolve the `golden03` question with the REPL probe in quickstart.md step 1 against `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs:241`, then record which candidate reproduces that address in `specs/011-byron-random-address-signing/research.md` §"Open item"
+
+**Blocking**: If T002 shows neither the recorded nor the hardened path reproduces `golden03`, stop and
+report — the candidate set in data-model.md needs revisiting before any code is written.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Address reconstruction — the primitive every story's verification depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 Add reconstruction specs to `lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs`: round-trip from a key's own address returns that address on both network discriminations, a different public key does not, and a non-address `ByteString` returns `Nothing` (contracts/key-resolution.md §"reconstruction")
+- [ ] T004 Implement the payload attribute decoder and `reconstructAddress :: XPub -> Address -> Maybe Address` in `lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs`, reusing `encodeAddress` for the root and copying attributes verbatim; add both to the export list with Haddock
+- [ ] T005 Replace the duplicate local attribute decoder at `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Encoding.hs:301` with the exported one from T004
+- [ ] T006 Run `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Byron.Codec.Cbor"'` and confirm green
+
+**Checkpoint**: Reconstruction is proven independently of key resolution. User story work can begin.
+
+---
+
+## Phase 3: User Story 1 — Spending From An Affected Address (Priority: P1) 🎯 MVP
+
+**Goal**: A Byron random wallet can spend a UTxO whose address records index *i* while its key is at
+*i* hardened, and the node accepts the transaction.
+
+**Independent Test**: Construct such an address, fund it, spend it. Fails before, succeeds after.
+
+### Tests for User Story 1 ⚠️
+
+> Write these first and confirm they FAIL before implementing T009–T011.
+
+- [ ] T007 [US1] Add the affected-address fixture and its expectations to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs`: build the address with `CBOR.encodeAddress` over the public key at the hardened path and `CBOR.encodeDerivationPathAttr` recording the soft path, then assert `isOwned` returns the key at the hardened path and that the returned key reproduces the address
+- [ ] T008 [US1] Add a QuickCheck property to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` asserting that for every `Just` result of `isOwned`, the returned key's public key reproduces the address (FR-001, SC-005); run the focused match and capture both failures
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Add index hardening and `candidatePaths :: DerivationPath -> [DerivationPath]` to `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` — recorded, address index hardened, account index hardened, both, order-preserving dedup — and export `candidatePaths` for tests (data-model.md §"Candidate derivation")
+- [ ] T010 [US1] Rewrite `isOwned` in `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` to derive each candidate, verify with `reconstructAddress`, return the first match and `Nothing` otherwise; add the Haddock note that only `getKey` may be relied upon, since the returned key's `derivationPath` is the candidate path
+- [ ] T011 [US1] Reconcile `golden03` in `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs:237` with the T002 finding — leave it unchanged if its key is at the recorded path, or update `accIndex`/`addrIndex` to the hardened values if it is not
+- [ ] T012 [US1] Add unit coverage to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` for the account-index-hardened and both-hardened variants (FR-007, SC-007)
+- [ ] T013 [US1] Add a unit assertion to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that `candidatePaths` on an already-hardened path is a singleton, which is the structural form of the one-derivation-one-reconstruction bound (FR-008, SC-006)
+- [ ] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
+- [ ] T015 [P] [US1] Add an affected-address constructor to `lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses` (`DSL.hs:3062`), building the address from the public key at the hardened path with the soft path recorded, and the protocol-magic attribute for testnet
+- [ ] T016 [US1] Add the spend scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic, fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`), submit a payment that selects both UTxOs, expect `202` and the transaction reaching `in_ledger` (SC-001, SC-003)
+- [ ] T017 [US1] Run `just integration-tests-cabal-match "BYRON_TRANS"` and confirm the new scenario passes
+
+**Checkpoint**: Affected addresses are spendable and every bootstrap witness validates. This is the
+MVP — it closes the defect for ordinary payments.
+
+---
+
+## Phase 4: User Story 2 — Migrating An Affected Wallet (Priority: P2)
+
+**Goal**: `POST /v2/byron-wallets/{id}/migrations` empties a wallet holding an affected address.
+
+**Independent Test**: Run the migration endpoint against such a wallet and confirm it completes.
+
+**Note**: No library change. Migration reaches the same `isOwned` through
+`W.buildAndSignTransaction` (`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:4774`), so this
+phase is the proof, not the fix.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T018 [P] [US2] Add the migration scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs`: fund an affected address on a fresh random wallet with the T015 constructor, create a migration plan and assert it includes that UTxO, execute it, and assert the wallet balance reaches zero (SC-004)
+- [ ] T019 [US2] Run `just integration-tests-cabal-match "BYRON_MIGRATE"` and confirm the new scenario passes alongside the existing migration scenarios
+
+**Checkpoint**: The recommended path off legacy wallets works for affected wallets.
+
+---
+
+## Phase 5: User Story 3 — No Silent Wrong Keys (Priority: P3)
+
+**Goal**: An address that decrypts as ours but that no candidate reproduces yields no signing key.
+
+**Independent Test**: Present such an address and confirm no key is produced.
+
+**Note**: This class cannot arise before the change — `isOurs` and `isOwned` test the same condition
+today — so these tests assert a property the fix creates. Per FR-009 nothing else changes: the input
+carries no witness and the node rejects the transaction, as it does today.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T020 [US3] Add a fixture to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` whose derivation-path attribute is encrypted under the wallet's `hdPassphrase` but whose root comes from an unrelated public key, and assert `isOurs` is `Just` while `isOwned` is `Nothing` (FR-003, SC-005)
+- [ ] T021 [US3] Assert in `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that an address belonging to a different wallet still yields `Nothing`, unchanged from today
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Verify FR-009 by inspection: `git diff master...HEAD` introduces no new error constructor, no change to any signing signature, and no edit to `specifications/api/swagger.yaml`
+
+**Checkpoint**: Verification is total — no unverified key can be returned, and no new failure surface
+was introduced.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T023 [P] Run `just check-fmt` and `just hlint`, and fix any finding in the files touched
+- [ ] T024 Run the full focused unit set: `just unit-tests-cabal-match "Random Address"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
+- [ ] T025 Confirm the write set: `git diff --name-only master...HEAD` lists only the files in plan.md §"Project Structure", and none of `lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs`, `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`, `specifications/api/swagger.yaml`
+- [ ] T026 Commit as `fix(byron): verify derived keys reproduce the address before signing`, single concern, Conventional Commits
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies. T002 blocks T011 only, but should be answered before any code is written
+- **Foundational (Phase 2)**: depends on Setup. Blocks all user stories — nothing can be verified without reconstruction
+- **User Story 1 (Phase 3)**: depends on Phase 2
+- **User Story 2 (Phase 4)**: depends on Phase 2 for the library change and on T015 for the fixture constructor; independently observable
+- **User Story 3 (Phase 5)**: depends on T010; independently observable at the unit boundary
+- **Polish (Phase 6)**: depends on all desired stories
+
+### Task-Level Dependencies
+
+- T004 → T005, T010 (reconstruction must exist and be exported)
+- T007, T008 → T009, T010 (RED before GREEN)
+- T009 → T010 (candidate ladder before it is consumed)
+- T002 → T011
+- T010 → T012, T013, T014, T020, T021
+- T015 → T016, T018
+
+### File Contention
+
+`RandomSpec.hs` is touched by T007, T008, T011, T012, T013, T020 and T021. None of those are marked
+`[P]` for that reason. `DSL.hs` (T015), `Byron/Transactions.hs` (T016) and `Byron/Migrations.hs`
+(T018) are distinct files.
+
+### Parallel Opportunities
+
+- T015 runs in parallel with any `RandomSpec.hs` task once T010 lands
+- T016 and T018 are different files in different stories: parallel once T015 lands
+- T023 is independent of the test runs
+
+---
+
+## Parallel Example: after T010
+
+```bash
+# Different files, no shared state:
+Task: "T015 affected-address constructor in lib/integration/framework/Test/Integration/Framework/DSL.hs"
+Task: "T012 account-level candidate coverage in lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 — settle `golden03` before writing code
+2. Phase 2 — reconstruction, proven on its own
+3. Phase 3 — RED, then the candidate ladder and verification, then integration
+4. **STOP and VALIDATE**: affected addresses are spendable; unaffected wallets are unchanged
+
+The library change is complete at T010. Everything after it is proof.
+
+### Incremental Delivery
+
+- Phases 1–3 close the defect for payments (SC-001, SC-002, SC-003, SC-006, SC-007)
+- Phase 4 adds the migration proof (SC-004) with no further library change
+- Phase 5 adds the no-silent-wrong-keys proof (SC-005)
+
+### Commit Shape
+
+The plan's slice contract allows the integration scenarios (T016–T019) to land as a second commit if
+local cluster time is the only thing separating them. The library change must never land without
+T007, T008 and T014.
+
+---
+
+## Notes
+
+- Verification is unconditional: every input pays one public-key computation and one reconstruction.
+  Only the fallback path pays further derivations (spec Edge Cases, "Performance")
+- Discovery is out of scope (FR-005). `isOurs`, `addressToPath`, `importAddress`, `genChange` and the
+  keying of `discoveredAddresses` must not change
+- The pre-existing path collision in `discoveredAddresses` (research.md §"Known limitation") is not
+  addressed here and must not be "fixed" in passing

--- a/specs/011-byron-random-address-signing/tasks.md
+++ b/specs/011-byron-random-address-signing/tasks.md
@@ -78,7 +78,7 @@ its recorded soft path, so the golden stands unchanged and becomes FR-004 eviden
 - [X] T013 [US1] Add a unit assertion to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that `candidatePaths` on an already-hardened path is a singleton, which is the structural form of the one-derivation-one-reconstruction bound (FR-008, SC-006)
 - [X] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
 - [X] T015 [P] [US1] Add an affected-address constructor to `lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses` (`DSL.hs:3062`), building the address from the public key at the hardened path with the soft path recorded, and the protocol-magic attribute for testnet
-- [ ] T016 [US1] Add the spend scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic, fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`), submit a payment that selects both UTxOs, expect `202` and the transaction reaching `in_ledger` (SC-001, SC-003)
+- [X] T016 [US1] Add the spend scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic, fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`), submit a payment that selects both UTxOs, expect `202` and the transaction reaching `in_ledger` (SC-001, SC-003)
 - [ ] T017 [US1] Run `just integration-tests-cabal-match "BYRON_TRANS"` and confirm the new scenario passes
 
 **Checkpoint**: Affected addresses are spendable and every bootstrap witness validates. This is the
@@ -98,7 +98,7 @@ phase is the proof, not the fix.
 
 ### Tests for User Story 2 ⚠️
 
-- [ ] T018 [P] [US2] Add the migration scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs`: fund an affected address on a fresh random wallet with the T015 constructor, create a migration plan and assert it includes that UTxO, execute it, and assert the wallet balance reaches zero (SC-004)
+- [X] T018 [P] [US2] Add the migration scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs`: fund an affected address on a fresh random wallet with the T015 constructor, create a migration plan and assert it includes that UTxO, execute it, and assert the wallet balance reaches zero (SC-004)
 - [ ] T019 [US2] Run `just integration-tests-cabal-match "BYRON_MIGRATE"` and confirm the new scenario passes alongside the existing migration scenarios
 
 **Checkpoint**: The recommended path off legacy wallets works for affected wallets.

--- a/specs/011-byron-random-address-signing/tasks.md
+++ b/specs/011-byron-random-address-signing/tasks.md
@@ -79,10 +79,14 @@ its recorded soft path, so the golden stands unchanged and becomes FR-004 eviden
 - [X] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
 - [X] T015 [P] [US1] Add an affected-address constructor to `lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses` (`DSL.hs:3062`), building the address from the public key at the hardened path with the soft path recorded, and the protocol-magic attribute for testnet
 - [X] T016 [US1] Add the spend scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic, fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`), submit a payment that selects both UTxOs, expect `202` and the transaction reaching `in_ledger` (SC-001, SC-003)
-- [ ] T017 [US1] Run `just integration-tests-cabal-match "BYRON_TRANS"` and confirm the new scenario passes
+- [X] T017 [US1] Run `just integration-tests-cabal-match "BYRON_TRANS"` and confirm the new scenario passes
 
 **Checkpoint**: Affected addresses are spendable and every bootstrap witness validates. This is the
 MVP — it closes the defect for ordinary payments.
+
+**Outcome (2026-08-13)**: `BYRON_TRANS_CREATE_01b` passes against a local cluster in 87s — a
+transaction spending an affected and an unaffected UTxO together was accepted and reached the
+ledger. SC-001 and SC-003 verified.
 
 ---
 
@@ -99,9 +103,25 @@ phase is the proof, not the fix.
 ### Tests for User Story 2 ⚠️
 
 - [X] T018 [P] [US2] Add the migration scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs`: fund an affected address on a fresh random wallet with the T015 constructor, create a migration plan and assert it includes that UTxO, execute it, and assert the wallet balance reaches zero (SC-004)
-- [ ] T019 [US2] Run `just integration-tests-cabal-match "BYRON_MIGRATE"` and confirm the new scenario passes alongside the existing migration scenarios
+- [X] T019 [US2] Run `just integration-tests-cabal-match "BYRON_MIGRATE"` and confirm the new scenario passes alongside the existing migration scenarios
 
 **Checkpoint**: The recommended path off legacy wallets works for affected wallets.
+
+**Outcome (2026-08-13)**: `BYRON_MIGRATE_01b` passes against a local cluster in 104s — the plan
+selected both UTxOs with zero leftover, the migration executed, and the wallet reached a zero
+balance. SC-004 verified.
+
+Both scenarios were run with `integration-exe` as CI invokes it, not through the justfile:
+
+```sh
+nix shell --quiet '.#cardano-node' '.#cardano-cli' -c \
+  nix shell --quiet '.#cardano-wallet' '.#local-cluster' '.#integration-exe' \
+    -c integration-exe --match "BYRON_TRANS_CREATE_01b"
+```
+
+with `LOCAL_CLUSTER_CONFIGS`, `CARDANO_WALLET_TEST_DATA`, `LOCAL_CLUSTER_ERA=conway`,
+`CLUSTER_LOGS_DIR_PATH` and `INTEGRATION_TEST_DIR` set to absolute paths. `INTEGRATION_TEST_DIR`
+must be removed between runs.
 
 ---
 
@@ -134,7 +154,7 @@ was introduced.
 - [X] T023 [P] Run `just check-fmt` and `just hlint`, and fix any finding in the files touched
 - [X] T024 Run the full focused unit set: `just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
 - [X] T025 Confirm the write set: `git diff --name-only master...HEAD` lists only the files in plan.md §"Project Structure", and none of `lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs`, `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`, `specifications/api/swagger.yaml`
-- [ ] T026 Commit as `fix(byron): verify derived keys reproduce the address before signing`, single concern, Conventional Commits
+- [X] T026 Commit as `fix(byron): verify derived keys reproduce the address before signing`, single concern, Conventional Commits
 
 ---
 

--- a/specs/011-byron-random-address-signing/tasks.md
+++ b/specs/011-byron-random-address-signing/tasks.md
@@ -28,8 +28,8 @@ Haskell monorepo. Library under `lib/address-derivation-discovery/lib/`, unit sp
 **Purpose**: Establish the baseline and settle the one open question that changes an existing test's
 expectation.
 
-- [ ] T001 Confirm the baseline is green: `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'` and `just check-fmt`
-- [ ] T002 Resolve the `golden03` question with the paired spec case in quickstart.md step 1, added to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` and run with `--match="golden03 provenance"`; keep the passing assertion renamed to state the finding, delete the other, and record the outcome in `specs/011-byron-random-address-signing/research.md` §"Open item"
+- [X] T001 Confirm the baseline is green: `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Wallet.Address.Discovery.Random"'` and `just check-fmt`
+- [X] T002 Resolve the `golden03` question with the paired spec case in quickstart.md step 1, added to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` and run with `--match="golden03 provenance"`; keep the passing assertion renamed to state the finding, delete the other, and record the outcome in `specs/011-byron-random-address-signing/research.md` §"Open item"
 
 **Blocking**: If T002 shows neither the recorded nor the hardened path reproduces `golden03`, stop and
 report — the candidate set in data-model.md needs revisiting before any code is written.
@@ -46,10 +46,10 @@ its recorded soft path, so the golden stands unchanged and becomes FR-004 eviden
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T003 Add reconstruction specs to `lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs`: round-trip from a key's own address returns that address on both network discriminations, a different public key does not, and a non-address `ByteString` returns `Nothing` (contracts/key-resolution.md §"reconstruction")
-- [ ] T004 Implement the payload attribute decoder and `reconstructAddress :: XPub -> Address -> Maybe Address` in `lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs`, reusing `encodeAddress` for the root and copying attributes verbatim; add both to the export list with Haddock
-- [ ] T005 Replace the duplicate local attribute decoder at `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Encoding.hs:301` with the exported one from T004
-- [ ] T006 Run `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Byron.Codec.Cbor"'` and confirm green
+- [X] T003 Add reconstruction specs to `lib/unit/test/unit/Cardano/Byron/Codec/CborSpec.hs`: round-trip from a key's own address returns that address on both network discriminations, a different public key does not, and a non-address `ByteString` returns `Nothing` (contracts/key-resolution.md §"reconstruction")
+- [X] T004 Implement the payload attribute decoder and `reconstructAddress :: XPub -> Address -> Maybe Address` in `lib/address-derivation-discovery/lib/Cardano/Byron/Codec/Cbor.hs`, reusing `encodeAddress` for the root and copying attributes verbatim; add both to the export list with Haddock
+- [X] T005 Replace the duplicate local attribute decoder at `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Encoding.hs:301` with the exported one from T004
+- [X] T006 Run `nix develop --quiet -c cabal test cardano-wallet-unit:unit -O0 -v0 --test-options '--match="Cardano.Byron.Codec.Cbor"'` and confirm green
 
 **Checkpoint**: Reconstruction is proven independently of key resolution. User story work can begin.
 
@@ -66,18 +66,18 @@ its recorded soft path, so the golden stands unchanged and becomes FR-004 eviden
 
 > Write these first and confirm they FAIL before implementing T009–T011.
 
-- [ ] T007 [US1] Add the affected-address fixture and its expectations to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs`: build the address with `CBOR.encodeAddress` over the public key at the hardened path and `CBOR.encodeDerivationPathAttr` recording the soft path, then assert `isOwned` returns the key at the hardened path and that the returned key reproduces the address
-- [ ] T008 [US1] Add a QuickCheck property to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` asserting that for every `Just` result of `isOwned`, the returned key's public key reproduces the address (FR-001, SC-005); run the focused match and capture both failures
+- [X] T007 [US1] Add the affected-address fixture and its expectations to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs`: build the address with `CBOR.encodeAddress` over the public key at the hardened path and `CBOR.encodeDerivationPathAttr` recording the soft path, then assert `isOwned` returns the key at the hardened path and that the returned key reproduces the address
+- [X] T008 [US1] Add a QuickCheck property to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` asserting that for every `Just` result of `isOwned`, the returned key's public key reproduces the address (FR-001, SC-005); run the focused match and capture both failures
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Add index hardening and `candidatePaths :: DerivationPath -> [DerivationPath]` to `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` — recorded, address index hardened, account index hardened, both, order-preserving dedup — and export `candidatePaths` for tests (data-model.md §"Candidate derivation")
-- [ ] T010 [US1] Rewrite `isOwned` in `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` to derive each candidate, verify with `reconstructAddress`, return the first match and `Nothing` otherwise; add the Haddock note that only `getKey` may be relied upon, since the returned key's `derivationPath` is the candidate path
-- [ ] T011 [US1] Confirm `golden03` still passes unmodified. T002 established that its key is at its recorded soft path, so its `accIndex`/`addrIndex` expectation must **not** change; a failure here means the candidate ladder is not returning the recorded-path key first (FR-004)
-- [ ] T012 [US1] Add unit coverage to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` for the account-index-hardened and both-hardened variants (FR-007, SC-007)
-- [ ] T013 [US1] Add a unit assertion to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that `candidatePaths` on an already-hardened path is a singleton, which is the structural form of the one-derivation-one-reconstruction bound (FR-008, SC-006)
-- [ ] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
-- [ ] T015 [P] [US1] Add an affected-address constructor to `lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses` (`DSL.hs:3062`), building the address from the public key at the hardened path with the soft path recorded, and the protocol-magic attribute for testnet
+- [X] T009 [US1] Add index hardening and `candidatePaths :: DerivationPath -> [DerivationPath]` to `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` — recorded, address index hardened, account index hardened, both, order-preserving dedup — and export `candidatePaths` for tests (data-model.md §"Candidate derivation")
+- [X] T010 [US1] Rewrite `isOwned` in `lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs` to derive each candidate, verify with `reconstructAddress`, return the first match and `Nothing` otherwise; add the Haddock note that only `getKey` may be relied upon, since the returned key's `derivationPath` is the candidate path
+- [X] T011 [US1] Confirm `golden03` still passes unmodified. T002 established that its key is at its recorded soft path, so its `accIndex`/`addrIndex` expectation must **not** change; a failure here means the candidate ladder is not returning the recorded-path key first (FR-004)
+- [X] T012 [US1] Add unit coverage to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` for the account-index-hardened and both-hardened variants (FR-007, SC-007)
+- [X] T013 [US1] Add a unit assertion to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that `candidatePaths` on an already-hardened path is a singleton, which is the structural form of the one-derivation-one-reconstruction bound (FR-008, SC-006)
+- [X] T014 [US1] Confirm SC-002: the existing mainnet and testnet goldens and `prop_derivedKeysAreOwned` (`RandomSpec.hs:354`) pass unmodified, with the single exception permitted by T011
+- [X] T015 [P] [US1] Add an affected-address constructor to `lib/integration/framework/Test/Integration/Framework/DSL.hs` next to `randomAddresses` (`DSL.hs:3062`), building the address from the public key at the hardened path with the soft path recorded, and the protocol-magic attribute for testnet
 - [ ] T016 [US1] Add the spend scenario to `lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs`: empty random wallet from a fresh mnemonic, fund one affected and one unaffected address with `moveByronCoins` (`DSL.hs:2811`), submit a payment that selects both UTxOs, expect `202` and the transaction reaching `in_ledger` (SC-001, SC-003)
 - [ ] T017 [US1] Run `just integration-tests-cabal-match "BYRON_TRANS"` and confirm the new scenario passes
 
@@ -117,12 +117,12 @@ carries no witness and the node rejects the transaction, as it does today.
 
 ### Tests for User Story 3 ⚠️
 
-- [ ] T020 [US3] Add a fixture to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` whose derivation-path attribute is encrypted under the wallet's `hdPassphrase` but whose root comes from an unrelated public key, and assert `isOurs` is `Just` while `isOwned` is `Nothing` (FR-003, SC-005)
-- [ ] T021 [US3] Assert in `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that an address belonging to a different wallet still yields `Nothing`, unchanged from today
+- [X] T020 [US3] Add a fixture to `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` whose derivation-path attribute is encrypted under the wallet's `hdPassphrase` but whose root comes from an unrelated public key, and assert `isOurs` is `Just` while `isOwned` is `Nothing` (FR-003, SC-005)
+- [X] T021 [US3] Assert in `lib/unit/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs` that an address belonging to a different wallet still yields `Nothing`, unchanged from today
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Verify FR-009 by inspection: `git diff master...HEAD` introduces no new error constructor, no change to any signing signature, and no edit to `specifications/api/swagger.yaml`
+- [X] T022 [US3] Verify FR-009 by inspection: `git diff master...HEAD` introduces no new error constructor, no change to any signing signature, and no edit to `specifications/api/swagger.yaml`
 
 **Checkpoint**: Verification is total — no unverified key can be returned, and no new failure surface
 was introduced.
@@ -131,9 +131,9 @@ was introduced.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T023 [P] Run `just check-fmt` and `just hlint`, and fix any finding in the files touched
-- [ ] T024 Run the full focused unit set: `just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
-- [ ] T025 Confirm the write set: `git diff --name-only master...HEAD` lists only the files in plan.md §"Project Structure", and none of `lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs`, `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`, `specifications/api/swagger.yaml`
+- [X] T023 [P] Run `just check-fmt` and `just hlint`, and fix any finding in the files touched
+- [X] T024 Run the full focused unit set: `just unit-tests-cabal-match "Cardano.Wallet.Address.Discovery.Random"` and `just unit-tests-cabal-match "Cardano.Byron.Codec"`
+- [X] T025 Confirm the write set: `git diff --name-only master...HEAD` lists only the files in plan.md §"Project Structure", and none of `lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs`, `lib/wallet/src/Cardano/Wallet.hs`, `lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs`, `specifications/api/swagger.yaml`
 - [ ] T026 Commit as `fix(byron): verify derived keys reproduce the address before signing`, single concern, Conventional Commits
 
 ---


### PR DESCRIPTION
## Outcome

Byron random wallets can spend and migrate addresses whose recorded derivation
index is not the index the address's key was derived at.

Closes #5368

## Problem

Byron random addresses carry their derivation path inside the address.
`addressToPath` recovers it and `isOwned` derives a signing key from it, without
checking that the derived key reproduces the address it is about to sign for.

For addresses created before `cardano-sl` always hardened generated indexes, the
recorded index is not the index the key was derived at, so the bootstrap witness
reconstructs to a different address root and the node rejects the transaction
with `MissingVKeyWitnessesUTXOW`. Such addresses were already known to exist —
#1041 documented indexes outside the hardened domain and #1042 introduced
`Index 'WholeDomain` so they would be discovered. Whether they could be spent was
not considered.

Affected wallets restore correctly, discover their addresses and report a
balance that matches the chain. The failure appears only at submission, and
`POST /v2/byron-wallets/{id}/migrations` fails for the same reason, so the
supported path off legacy wallets is unavailable to exactly those wallets.

## What changed

- `isOwned` derives each candidate path and rebuilds the address from the
  resulting public key, using the attributes the address itself carries. That is
  the computation the ledger performs when validating a bootstrap witness, so a
  key that reproduces the address is a key the node accepts for it.
- Candidates are the recorded path, then that path with the address index
  hardened, with the account index hardened, and with both — de-duplicated, most
  likely first. #1041 records that account indexes came from the same generator,
  so the account level is covered too.
- The first candidate that reproduces the address wins, so an address whose
  recorded path is correct still resolves in one derivation and one comparison.
  An address that no candidate reproduces yields no key, rather than one that
  will fail at submission.
- `reconstructAddress` is added to `Cardano.Byron.Codec.Cbor`, which already owns
  the Byron address binary format and its root computation. The duplicate
  attribute decoder in `Cardano.Wallet.Address.Encoding` now uses it.

Address discovery is unchanged, nothing persisted changes, and no error surface
is added.

## Acceptance evidence

Unit, `cardano-wallet-unit:unit`:

- All four candidate classes, including the account-level variant
- Candidate ordering, and that an already-hardened path yields one candidate
- Property over 100 random wallets: any key `isOwned` returns reproduces the
  address it was resolved for
- An address that decrypts under the wallet's passphrase but that no candidate
  reproduces is still discovered, yet yields no signing key
- `reconstructAddress` covered directly: both network shapes, a wrong key, an
  uninterpreted attribute, and a non-address input
- The existing mainnet and testnet goldens pass unmodified. `golden03` records a
  soft path and is now pinned by an assertion showing its key really is at that
  path, so it is evidence that a soft index does not by itself imply the defect
- Full suite: 1042 unit examples green, no regressions

Integration, against a local cluster in the Conway era:

- `BYRON_TRANS_CREATE_01b` — a transaction spending an affected and an
  unaffected UTxO together is accepted and reaches the ledger
- `BYRON_MIGRATE_01b` — the migration plan selects both UTxOs with zero
  leftover, the migration executes, and the wallet balance reaches zero

Specification and design notes are in `specs/011-byron-random-address-signing/`.

### Comments

#5075 reports `MissingVKeyWitnessesUTXOW` migrating a Byron random wallet
restored from `secret.key`, and may share this cause — the wallet is described
as a 2017 one, and the triage there identifies the same unwitnessed-input path.
It is not claimed as closed: that issue asks for a regression test covering the
`encrypted_root_private_key` restore path specifically, which this does not add,
and the alternative explanation of a passphrase-scheme mismatch on that path
produces the same symptom.

A wallet can be checked against this defect without applying the fix: the
addresses endpoint exposes the recorded derivation path, and `DerivationIndex`
renders hardened indexes with an `H` suffix. Any index without one is a
candidate; a soft index in the account position would make every address in the
wallet unspendable.
