### PR TITLE
Accept spec prefixes wider than three digits

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -78,7 +78,7 @@ get_current_branch() {
                         latest_timestamp="$ts"
                         latest_feature=$dirname
                     fi
-                elif [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+                elif [[ "$dirname" =~ ^([0-9]{3,6})- ]]; then
                     local number=${BASH_REMATCH[1]}
                     number=$((10#$number))
                     if [[ "$number" -gt "$highest" ]]; then
@@ -124,9 +124,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+    if [[ ! "$branch" =~ ^[0-9]{3,6}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name" >&2
+        echo "Feature branches should be named like: 001-feature-name, 5063-feature-name or 20260319-143022-feature-name" >&2
         return 1
     fi
 
@@ -146,7 +146,7 @@ find_feature_dir_by_prefix() {
     local prefix=""
     if [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
         prefix="${BASH_REMATCH[1]}"
-    elif [[ "$branch_name" =~ ^([0-9]{3})- ]]; then
+    elif [[ "$branch_name" =~ ^([0-9]{3,6})- ]]; then
         prefix="${BASH_REMATCH[1]}"
     else
         # If branch doesn't have a recognized prefix, fall back to exact match


### PR DESCRIPTION
## Outcome

Speckit commands work on branches whose spec prefix is not exactly three
digits, including this repository's own issue-numbered specs.

Closes #5371

## Problem

`check-prerequisites.sh` is the entry point for `clarify`, `plan`, `tasks` and
`implement`, and it rejects any branch whose numeric prefix is not exactly three
digits:

```
ERROR: Not on a feature branch. Current branch: 5303-byron-rndstate-reseed-on-load
```

A four-digit prefix fails because `[0-9]{3}` matches the first three digits and
then requires `-`, which is a digit. That excludes the issue-numbered specs this
repository already uses — `5063`, `5088`, `5103`, `5126`, `5196`, `5242`,
`5246`, `5303`, `5309`, `5322`, `5325`, `5328` and others all exist under
`specs/`, and none of them passes the check.

`create-new-feature.sh` applies no such restriction, so a branch can be created
that the rest of the tooling then refuses to operate on.

## What changed

Widened the three places in `common.sh` that assume a three-digit prefix, to
accept three to six digits:

- branch validation, so the commands run at all
- feature-directory lookup, so the correct `specs/` directory is resolved
- latest-feature selection, so wider prefixes participate in the comparison

Fixing only the first would let commands start and then resolve the wrong
directory, so all three move together. The timestamp form
(`20260319-143022-…`) is untouched, and branches with no numeric prefix are
still rejected.

## Acceptance evidence

Prefix shapes against the new condition:

| Branch | Result |
|---|---|
| `001-foo` | accepted |
| `5063-bar` | accepted |
| `70002-baz` | accepted |
| `20260319-143022-ts` | accepted |
| `1234567-toolong` | rejected |
| `nonnumeric-x` | rejected |

`check-prerequisites.sh --json --paths-only` resolves `FEATURE_DIR` and
`FEATURE_SPEC` correctly on a five-digit branch after the change, and fails
before it. `shellcheck` reports nothing new on the modified lines.
