### PR TITLE
fix: read waitForTimeoutLine capture as bytes, not chars

### DIFF
--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -94,6 +94,7 @@ test-suite unit
 
   build-depends:
       base
+    , bytestring
     , cardano-wallet-test-utils
     , containers
     , extra
@@ -108,6 +109,7 @@ test-suite unit
     , QuickCheck
     , safe
     , silently
+    , text
     , unliftio
     , unliftio-core
 

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -5,7 +5,6 @@ module Test.Hspec.ExtraSpec (spec) where
 
 import Control.Monad
     ( forM_
-    , replicateM
     , unless
     )
 import Control.Monad.IO.Unlift
@@ -62,7 +61,6 @@ import System.IO
     , hClose
     , hFileSize
     , hFlush
-    , hGetChar
     , hSeek
     , hSetBuffering
     , stderr
@@ -160,6 +158,9 @@ import UnliftIO.Temporary
     )
 import Prelude
 
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified Test.Hspec.Extra as Extra
 
 spec :: Spec
@@ -495,7 +496,13 @@ waitForTimeoutLine attempts captureHandle = do
     hFlush stdout
     size <- hFileSize captureHandle
     hSeek captureHandle AbsoluteSeek 0
-    output <- replicateM (fromIntegral size) $ hGetChar captureHandle
+    -- Read exactly 'size' *bytes*, not characters: on a text-mode handle
+    -- (e.g. Windows, where CRLF is translated to LF on read) the byte
+    -- count reported by 'hFileSize' can exceed the number of characters
+    -- actually obtainable, which would make a character-oriented read
+    -- run past EOF. Bytes are decoded afterwards instead.
+    bytes <- BS.hGet captureHandle (fromIntegral size)
+    let output = T.unpack $ T.decodeLatin1 bytes
     if "timed out" `isInfixOf` output || attempts <= 0
         then pure output
         else do


### PR DESCRIPTION
Fixes #5373

## Bug

`waitForTimeoutLine` in `lib/test-utils/test/Test/Hspec/ExtraSpec.hs`
read `hFileSize` bytes via `replicateM size hGetChar` on the captured
stdout handle. On Windows, `hGetChar` performs CRLF -> LF translation
on the text-mode handle, so each `\r\n` pair on disk yields one `\n`
character. Once the captured output contains any newline, the byte
count overstates the achievable character count and the read runs
past EOF, throwing `hGetChar: end of file`. POSIX has no CRLF
translation, so byte and character counts coincide there and the bug
never fires on Linux/macOS.

## Fix

Read exactly `size` bytes via `Data.ByteString.hGet` and decode with
`Data.Text.Encoding.decodeLatin1` (total, cannot throw on arbitrary
bytes), instead of counting characters. This keeps the read
byte-exact regardless of platform newline handling.

## Verification

- `cabal test cardano-wallet-test-utils:unit -O0` — 77 examples, 0
  failures (Linux), including all 5 `diagnostic timeout` siblings.
- `fourmolu --mode check`, `cabal-fmt --check`, `hlint` all pass on
  the changed files.
- The Windows-specific manifestation of this bug cannot be reproduced
  or proven fixed on this (Linux) host — only Windows CI on this PR
  can confirm the fix.
