### PR TITLE
fix: cardano-wallet-benchmarks compile break + gate benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           .#unit-std-gen-seed .#unit-wai-middleware-logging
           .#unit-benchmark-history
           .#wallet-key-export .#wallet-key-export-test
+          .#ci.benchmarks.all
 
   build-gate-artifacts:
     name: "Build Gate (Linux Artifacts)"

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -96,6 +96,9 @@ import Cardano.Wallet.Benchmarks.Latency.Measure
     ( meanAvg
     , withLatencyLogging
     )
+import Cardano.Wallet.DRep.Metadata
+    ( defaultIpfsGatewayUrl
+    )
 import Cardano.Wallet.Faucet
     ( Faucet (massiveWalletMnemonic)
     )
@@ -776,6 +779,7 @@ withShelleyServer tracers action = withFaucet $ \faucetClientEnv -> do
             Nothing -- tls configuration
             Nothing -- settings
             Nothing -- token metadata server
+            defaultIpfsGatewayUrl
             block0
             (setupAction networkParameters)
 


### PR DESCRIPTION
## What

- Fix `cardano-wallet-benchmarks-bench-latency` compile failure: `latency-bench.hs`'s `serveWallet` call was missing the `ipfsGatewayUrl :: String` argument `serveWallet` gained for resolving `ipfs://` DRep anchor URLs, shifting `block0` and the `beforeMainLoop` callback out of position. Pass `defaultIpfsGatewayUrl` (same as the production CLI default, same pattern already used in the integration test framework's `serveWallet` call) at the correct position.
- Add `.#ci.benchmarks.all` to the required "Build Gate (Linux)" job in `ci.yml` so a benchmark-breaking change fails the PR instead of only being caught by the non-required "Attic Cache" job or the weekly `linux-benchmarks.yml` workflow.

## Why

`nix build .#ci.benchmarks.all` was broken on master since at least 2026-08-14 (compile error, not flaky), and nothing in the required PR checks builds `lib/benchmarks`/`cardano-wallet-benchmarks`/`latency-bench` at all, so the break went unnoticed.

## Testing

- `nix develop --quiet -c cabal build cardano-wallet-benchmarks:bench:latency` — fails with the reported error before the fix, succeeds after.
- `nix build --quiet .#ci.benchmarks.all` — succeeds after the fix.
- Confirmed the new gate step actually catches this class of bug: reintroduced the broken call locally, confirmed the build fails the same way, then reverted before pushing.

### Issue Number

Closes #5375
