### PR TITLE
Fix Windows environment-variable case collisions in prop_hspecMain

### DIFF
--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -13,6 +13,9 @@ import Control.Monad.IO.Unlift
 import Data.Bifunctor
     ( first
     )
+import Data.Char
+    ( toUpper
+    )
 import Data.Foldable
     ( traverse_
     )
@@ -541,11 +544,20 @@ prop_hspecMain vars (NiceString other) (HspecArgs argsBefore) (HspecArgs argsAft
     failure = not pass
     argsError = any (\((n, _), _) -> null n || elem '=' n) env
 
-    vars' = nubBy ((==) `on` (fst . fst)) vars
+    -- Environment variable names are case-insensitive on Windows (though
+    -- case-preserving), so two generated names that differ only by case
+    -- would collide into a single variable there -- unlike on POSIX, where
+    -- they're distinct. Compare names case-insensitively everywhere so the
+    -- property holds on every platform, not just the ones where case
+    -- happens to matter.
+    sameName = (==) `on` map toUpper
+    vars' = nubBy (\a b -> nameOf a `sameName` nameOf b) vars
+      where
+        nameOf ((NiceString n, _), _) = n
     env =
         [ ((n, v), s)
         | ((NiceString n, NiceString v), s) <- vars'
-        , n /= other
+        , not (n `sameName` other)
         ]
 
     mainArgs =


### PR DESCRIPTION
## Summary

- compare generated environment-variable names case-insensitively
- apply the same comparison to deduplication and `other`-variable exclusion
- preserve the generated spelling while matching Windows environment semantics

## Root cause

Windows environment-variable names are case-insensitive but case-preserving. `prop_hspecMain` used case-sensitive equality, allowing names such as `"J"` and `"j"` to survive generation as distinct variables even though Windows collapses them into one. That made the property platform-dependent.

## Verification

The prepared change was verified with:

- the full suite: 77 examples, 0 failures
- the `hspecMain` property at 5,000 QuickCheck successes
- the original Windows failure seed `1660825537` plus four additional seeds
- Fourmolu check mode
- HLint

Fixes #5377