### PR TITLE
fix: restore Mithril ledger snapshot

### DIFF
--- a/.github/workflows/linux-mithril-sync.yml
+++ b/.github/workflows/linux-mithril-sync.yml
@@ -31,6 +31,7 @@ jobs:
       NODE_LOGS_FILE: ./logs/node.log
       WALLET_LOGS_FILE: ./logs/wallet.log
       CLEANUP_DB: "true"
+      MITHRIL_UTXO_HD_FLAVOR: LMDB
       NETWORK: mainnet
     steps:
       - name: Checkout
@@ -44,7 +45,9 @@ jobs:
           rm -rf logs databases
           mkdir -p logs
           ./snapshot.sh
-          ./run.sh sync 14400
+          runtime_path=$(nix shell --quiet .#cardano-wallet .#cardano-node .#cardano-cli --command printenv PATH)
+          export PATH="$runtime_path"
+          exec bash ./run.sh sync 14400
 
       - name: Upload logs
         if: always()

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -71,7 +71,7 @@ cleanup() {
         rm -rf "${NODE_DB:?}"/* || echo "Failed to clean node db"
         rm -rf "${WALLET_DB:?}"/* || echo "Failed to clean wallet db"
     fi
-    trap - ERR INT EXIT
+    trap - ERR INT TERM EXIT
     exit $exit_status
 }
 
@@ -82,7 +82,7 @@ mithril() {
 }
 
 # Trap the cleanup function on exit
-trap cleanup ERR INT EXIT
+trap cleanup ERR INT TERM EXIT
 if [[ -z ${NO_NODE-} ]]; then
 
     if [[ -n "${USE_MITHRIL-}" ]]; then
@@ -94,9 +94,10 @@ if [[ -z ${NO_NODE-} ]]; then
         rm -rf "${NODE_DB:?}"/*
         export AGGREGATOR_ENDPOINT
         export GENESIS_VERIFICATION_KEY
+        export ANCILLARY_VERIFICATION_KEY
         mithril echo "mithril is available" || exit 44
         digest=$(mithril mithril-client cdb snapshot list --json | jq -r .[0].digest)
-        (cd "${NODE_DB}" && mithril mithril-client cdb download "$digest")
+        (cd "${NODE_DB}" && mithril mithril-client cdb download --include-ancillary "$digest")
         (cd "${NODE_DB}" && mv db/* . && rmdir db)
     fi
 


### PR DESCRIPTION
## Summary

- activate the existing Mithril ledger-state converter for the mainnet node's LMDB backend
- include ancillary ledger-state data in the direct `run.sh` Mithril download path
- make GitHub timeout signals reach Bash directly and handle `TERM` in database cleanup

The failing workflow already downloaded ancillary data, but `cardano-node` rejected its ledger
snapshot with `MetadataBackendMismatch` because the snapshot had not been converted to the
configured `V1LMDB` backend. That forced a replay from genesis. This change wires the existing
converter with `MITHRIL_UTXO_HD_FLAVOR=LMDB` and starts `run.sh` as the runner-facing Bash process
after resolving the equivalent Nix-shell PATH.

## Verification

Full mainnet workflow (success in 34m20s):

https://github.com/cardano-foundation/cardano-wallet/actions/runs/32179162885

The workflow log confirms:

- pinned `mithril-client 0.13.9` downloaded and verified snapshot
  `478c9aaed6aed547e89e6f6fb477c5f9a7237d73e110b6e6b8a2563f882772b6`
- `Ledger state have been successfully converted to LMDB format.`
- `Result: success`
- successful happy-path `Cleaning up...` and `Cleaning up databases...`

The downloaded `mithril-sync-logs` artifact confirms:

- no `MetadataBackendMismatch`
- no `Replaying ledger from genesis`
- node replayed only from the certified snapshot at slot 195455153 to the immutable tip at
  195458511, completing in 0.60 seconds
- node emitted `GsmEventEnterCaughtUp`
- wallet served 70 successful `GET /v2/network/information 200 OK` responses

Real one-minute timeout cleanup probe:

https://github.com/cardano-foundation/cardano-wallet/actions/runs/32178856554

The probe shows `Cleaning up...`, `Cleaning up databases...`, a successful
`TIMEOUT_CLEANUP_DB_EMPTY` sentinel check for both node and wallet databases, and the subsequent
`Upload logs` step executing successfully under `if: always()`.

Local checks:

- RED/GREEN regression assertions for the ancillary flag, ancillary key export, LMDB workflow
  wiring, direct-Bash launch, and TERM trap
- `bash -n run/common/nix/run.sh`
- ShellCheck on `run/common/nix/run.sh`
- Actionlint on `linux-mithril-sync.yml` (allowing the repository's custom runner label)
- `git diff --check`

### Issue Number

Closes #5379
