### PR TITLE
Bump cardano-addresses to 4.0.8

### DIFF
--- a/specs/5381-cardano-addresses-bump/data-model.md
+++ b/specs/5381-cardano-addresses-bump/data-model.md
@@ -1,0 +1,10 @@
+# Data model
+
+| ID | Data | Fields | Invariant |
+| --- | --- | --- | --- |
+| D1 | CHaP horizon | Git revision, index timestamp, content hash | I1 |
+| D2 | Resolved dependency | package name, version, dependency edges | I2, I3 |
+
+The Git revision must contain every package revision visible at the recorded
+index timestamp. The resolved dependency record must name
+`cardano-addresses` 4.0.8.

--- a/specs/5381-cardano-addresses-bump/functions-model.md
+++ b/specs/5381-cardano-addresses-bump/functions-model.md
@@ -1,0 +1,5 @@
+# Functions model
+
+No application function signatures change in this ticket. The release bump is
+expressed entirely through dependency inputs unless the solver reveals a
+contract change that requires mandate revision.

--- a/specs/5381-cardano-addresses-bump/modules-model.md
+++ b/specs/5381-cardano-addresses-bump/modules-model.md
@@ -1,0 +1,9 @@
+# Modules model
+
+| ID | Component | Changed responsibility | Dependencies |
+| --- | --- | --- | --- |
+| M1 | Dependency inputs | Select one minimal CHaP history horizon for Cabal and Nix | CHaP repository history |
+| M2 | Cabal solver plan | Demonstrate the exact compatible package closure | M1 |
+
+No Haskell module responsibility changes are authorized unless a forced
+compatibility break is escalated and the mandate is revised.

--- a/specs/5381-cardano-addresses-bump/plan.md
+++ b/specs/5381-cardano-addresses-bump/plan.md
@@ -1,0 +1,25 @@
+# Plan
+
+## Strategy
+
+Refresh the old pre-release candidate against current `origin/master`, locate
+the first CHaP history point containing the released compatible package set,
+and update only the dependency inputs and any direct pins proven necessary by
+the solver. Preserve the common CHaP horizon across Cabal and Nix.
+
+## Live boundaries
+
+- CHaP package-index history determines availability and revised bounds.
+- Cabal solver output proves the concrete dependency closure.
+- Nix input metadata proves that the second resolver sees the same CHaP
+  history; CI supplies the expensive Nix build proof.
+
+## Slice S1
+
+Produce one reviewable dependency bump with plan-resolution, affected-build,
+and focused-test evidence. No wallet behaviour changes are planned.
+
+## Resource constraints
+
+Check root free space before build-inducing commands and stop below 40 GiB.
+Use `-O0`; do not run a full local `nix flake check` or full Nix artifact build.

--- a/specs/5381-cardano-addresses-bump/spec.md
+++ b/specs/5381-cardano-addresses-bump/spec.md
@@ -1,0 +1,37 @@
+# Specification: cardano-addresses 4.0.8
+
+## Outcome
+
+The Cabal and Nix dependency inputs resolve `cardano-addresses` 4.0.8 from the
+same minimal CHaP snapshot, without unrelated source changes or unsafe solver
+overrides.
+
+## Requirements
+
+- **R1:** Both dependency paths use one CHaP revision/index-state pair that
+  contains `cardano-addresses` 4.0.8.
+- **R2:** The Cabal plan records `cardano-addresses` 4.0.8.
+- **R3:** Any additional Cardano package movement is limited to the smallest
+  compatibility closure forced by 4.0.8; unrelated major ecosystem churn is
+  rejected.
+- **R4:** Directly affected wallet packages build and their focused unit tests
+  pass with optimisation disabled.
+- **R5:** No `allow-newer`, dependency-bound weakening, or unrelated cleanup is
+  introduced.
+
+## Invariants
+
+- **I1 Pin alignment:** the CHaP flake revision and Cabal CHaP index-state name
+  the same repository history horizon. A mismatched pair fails the gate.
+- **I2 Exact resolution:** plan evidence reports version 4.0.8, not merely that
+  the package exists in an index.
+- **I3 Minimal closure:** the final diff and plan explain every changed direct
+  Cardano pin; unexplained package movement fails acceptance.
+- **I4 Buildability:** the affected build and focused tests run against the
+  resolved plan and exit successfully.
+
+## Rejection behaviour
+
+Stop with evidence if the released compatibility closure requires a
+non-trivial ecosystem upgrade or Haskell call-site redesign. Do not hide the
+conflict with solver overrides.

--- a/specs/5381-cardano-addresses-bump/tasks.md
+++ b/specs/5381-cardano-addresses-bump/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## Slice S1: compatible release bump
+
+- [ ] **T1** Identify the minimal released CHaP horizon and explain its forced
+  compatibility closure.
+- [ ] **T2** Align Cabal and Nix CHaP inputs and prove exact 4.0.8 resolution.
+- [ ] **T3** Build affected packages and run focused unit tests with `-O0`.
+- [ ] **T4** Record verification evidence and leave a clean, signed candidate
+  for independent audit.


### PR DESCRIPTION
## Summary

- bump `cardano-addresses` to 4.0.8 through aligned Cabal and Nix CHaP inputs
- keep any forced compatibility closure minimal and documented
- verify exact solver resolution and affected wallet packages

## Verification

Implementation and verification are in progress. This PR is intentionally a draft.

Closes #5381
