### PR TITLE
Create release merge-back PR automatically after publication

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   push-docker:
     name: "Push Docker Image"
@@ -62,6 +66,8 @@ jobs:
     name: "Update Documentation Links"
     if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: nix-enabled-runners
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
@@ -84,3 +90,28 @@ jobs:
 
       - name: Push updates
         run: git push origin gh-pages
+
+  merge-back:
+    name: "Create merge-back PR"
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: nix-enabled-runners
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      MERGE_BACK_HEAD_BRANCH: release-candidate/${{ github.event.inputs.tag || github.event.release.tag_name }}
+      MERGE_BACK_PRERELEASE: ${{ github.event_name == 'release' && github.event.release.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Ensure merge-back pull request
+        shell: nix shell --quiet nixpkgs#gh -c bash -e {0}
+        run: ./scripts/release/merge-back-pr.sh

--- a/scripts/release/merge-back-pr.sh
+++ b/scripts/release/merge-back-pr.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Validate published-tag identity, ensure one tag-specific tracking
+# issue, and ensure one merge-back PR exists. GitHub mutation is
+# gh issue create and gh pr create only when those records are absent.
+
+set -euo pipefail
+
+GIT=${MERGE_BACK_GIT:-git}
+GH=${MERGE_BACK_GH:-gh}
+EVENT_NAME=${GITHUB_EVENT_NAME:-}
+PRERELEASE=${MERGE_BACK_PRERELEASE:-false}
+REPO=${GITHUB_REPOSITORY:-}
+TAG=${TAG:-}
+BASE_BRANCH=${MERGE_BACK_BASE_BRANCH:-master}
+HEAD_BRANCH=
+EXPECTED_ISSUE_TITLE=
+ISSUE_NUMBER=
+
+skip_prerelease_if_needed() {
+    if [[ "$EVENT_NAME" == release ]]; then
+        case "$PRERELEASE" in
+            true | True | TRUE | yes | 1)
+                echo "skip: prerelease publication does not create a merge-back PR"
+                exit 0
+                ;;
+        esac
+    elif [[ "$EVENT_NAME" != workflow_dispatch ]]; then
+        echo "error: unsupported event: ${EVENT_NAME:-<empty>}" >&2
+        exit 1
+    fi
+}
+
+require_identity_inputs() {
+    if [[ -z "$TAG" ]]; then
+        echo "error: TAG is required; use the published tag, not the calendar date" >&2
+        exit 1
+    fi
+    if [[ -z "$REPO" ]]; then
+        echo "error: GITHUB_REPOSITORY is required" >&2
+        exit 1
+    fi
+    HEAD_BRANCH=${MERGE_BACK_HEAD_BRANCH:-release-candidate/${TAG}}
+    if [[ "$HEAD_BRANCH" != "release-candidate/${TAG}" ]]; then
+        echo "error: head branch ${HEAD_BRANCH} is not release-candidate/${TAG}" >&2
+        exit 1
+    fi
+    EXPECTED_ISSUE_TITLE="Merge ${TAG} version bumps back to master"
+}
+
+fetch_and_validate_identity() {
+    local tag_sha branch_sha
+    "$GIT" fetch --quiet origin "+refs/tags/${TAG}:refs/tags/${TAG}"
+    "$GIT" fetch --quiet origin \
+        "+refs/heads/${HEAD_BRANCH}:refs/remotes/origin/${HEAD_BRANCH}"
+    tag_sha=$("$GIT" rev-parse --verify "${TAG}^{commit}")
+    branch_sha=$("$GIT" rev-parse --verify "origin/${HEAD_BRANCH}")
+    if [[ "$tag_sha" != "$branch_sha" ]]; then
+        echo "error: tag ${TAG} peeled to ${tag_sha} but ${HEAD_BRANCH} is at ${branch_sha} (mismatch)" >&2
+        exit 1
+    fi
+    echo "identity: tag=${TAG} sha=${tag_sha} head=${HEAD_BRANCH}"
+}
+
+is_merged_timestamp() {
+    local merged_at=$1
+    [[ -n "$merged_at" && "$merged_at" != null && "$merged_at" != NULL ]]
+}
+
+ensure_pr() {
+    local list existing_number existing_state existing_url closed_number
+    local number state url merged_at state_u
+    list=$("$GH" pr list \
+        --repo "$REPO" \
+        --base "$BASE_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --state all \
+        --json number,state,url,mergedAt \
+        --jq '.[] | [.number, .state, .url, (.mergedAt // "")] | @tsv')
+    existing_number=
+    existing_state=
+    existing_url=
+    closed_number=
+    if [[ -n "$list" ]]; then
+        while IFS=$'\t' read -r number state url merged_at; do
+            state_u=$(printf '%s' "$state" | tr '[:lower:]' '[:upper:]')
+            case "$state_u" in
+                OPEN | MERGED)
+                    existing_number=$number
+                    existing_state=$state_u
+                    existing_url=$url
+                    break
+                    ;;
+                CLOSED)
+                    if is_merged_timestamp "${merged_at:-}"; then
+                        existing_number=$number
+                        existing_state=MERGED
+                        existing_url=$url
+                        break
+                    fi
+                    closed_number=$number
+                    ;;
+                *)
+                    echo "error: unexpected PR state '${state}' for #${number}" >&2
+                    exit 1
+                    ;;
+            esac
+        done <<<"$list"
+    fi
+    if [[ -n "$existing_number" ]]; then
+        echo "existing: PR #${existing_number} (${existing_state}) ${existing_url}"
+        return 0
+    fi
+    if [[ -n "$closed_number" ]]; then
+        echo "error: closed unmerged merge-back PR #${closed_number} for ${HEAD_BRANCH}; not creating a duplicate" >&2
+        exit 1
+    fi
+    ensure_tracking_issue
+    create_pr
+}
+
+list_issues() {
+    local query=$1
+    "$GH" issue list \
+        --repo "$REPO" \
+        --state all \
+        --limit 50 \
+        --search "$query" \
+        --json number,state,title,url \
+        --jq '.[] | [.number, .state, .title, .url] | @tsv'
+}
+
+select_matching_issue() {
+    local list=$1
+    local number state title url
+    [[ -n "$list" ]] || return 1
+    while IFS=$'\t' read -r number state title url; do
+        if [[ "$title" == "$EXPECTED_ISSUE_TITLE" ]]; then
+            ISSUE_NUMBER=$number
+            echo "existing-issue: #${ISSUE_NUMBER} (${state}) ${url}"
+            return 0
+        fi
+    done <<<"$list"
+    return 1
+}
+
+find_tracking_issue() {
+    local list
+    ISSUE_NUMBER=
+    list=$(list_issues "$EXPECTED_ISSUE_TITLE")
+    select_matching_issue "$list" && return 0
+    list=$(list_issues "merge-back-tracking/${TAG}")
+    select_matching_issue "$list" && return 0
+    return 0
+}
+
+create_tracking_issue() {
+    local body_file url
+    body_file=$(mktemp)
+    cat >"$body_file" <<EOF
+## Goal
+
+Merge the already-published \`${TAG}\` release-candidate version
+metadata back into \`${BASE_BRANCH}\` so the next release run does
+not fail its version-drift guard.
+
+merge-back-tracking/${TAG}
+EOF
+    url=$("$GH" issue create \
+        --repo "$REPO" \
+        --title "$EXPECTED_ISSUE_TITLE" \
+        --body-file "$body_file" \
+        --label Release \
+        --label CI/CD)
+    rm -f -- "$body_file"
+    ISSUE_NUMBER=${url##*/}
+    ISSUE_NUMBER=${ISSUE_NUMBER//$'\r'/}
+    ISSUE_NUMBER=${ISSUE_NUMBER//$'\n'/}
+    if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+        echo "error: issue create did not return a number: ${url}" >&2
+        exit 1
+    fi
+    echo "created-issue: #${ISSUE_NUMBER} ${url}"
+}
+
+ensure_tracking_issue() {
+    find_tracking_issue
+    if [[ -n "$ISSUE_NUMBER" ]]; then
+        return 0
+    fi
+    create_tracking_issue
+}
+
+create_pr() {
+    local body_file title url
+    if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+        echo "error: tracking issue number is missing" >&2
+        exit 1
+    fi
+    body_file=$(mktemp)
+    title="chore(release): merge back ${HEAD_BRANCH} version bumps"
+    cat >"$body_file" <<EOF
+## Summary
+
+Merge the release automation's version updates from
+\`${HEAD_BRANCH}\` back into \`${BASE_BRANCH}\` after publishing
+\`${TAG}\`.
+
+This keeps \`${BASE_BRANCH}\` aligned with the latest stable
+cardano-wallet release and prevents the next scheduled Release
+workflow from stopping on its cabal-version drift guard.
+
+Closes #${ISSUE_NUMBER}
+EOF
+    url=$("$GH" pr create \
+        --repo "$REPO" \
+        --base "$BASE_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$title" \
+        --body-file "$body_file" \
+        --label Release \
+        --label CI/CD \
+        --assignee paolino)
+    rm -f -- "$body_file"
+    echo "created: ${url}"
+}
+
+skip_prerelease_if_needed
+require_identity_inputs
+fetch_and_validate_identity
+ensure_pr

--- a/scripts/release/test-merge-back-pr.sh
+++ b/scripts/release/test-merge-back-pr.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Focused proof for merge-back PR selection, identity, and
+# idempotency. Substitutes git/gh; never mutates GitHub.
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/../.." && pwd)
+helper=$script_dir/merge-back-pr.sh
+workflow=$repo_root/.github/workflows/publish-release.yml
+closing_validator=$repo_root/scripts/ci/check-pr-body-closing-link.sh
+cases_exercised=0
+failures=0
+created_issue=6000
+forbidden_issues='5385 5387'
+
+tag=v2020-01-01
+head_branch=release-candidate/$tag
+tag_sha=49e06790051ea64abb2029dd29a0bdaa7befb19a
+other_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+repo=cardano-foundation/cardano-wallet
+today=$(date +%Y-%m-%d)
+
+fail_case() {
+    echo "FAIL [$1] $2" >&2
+    failures=$((failures + 1))
+}
+
+pass_case() {
+    echo "PASS [$1]"
+    cases_exercised=$((cases_exercised + 1))
+}
+
+write_fakes() {
+    local bin=$1
+    mkdir -p -- "$bin"
+    cat >"$bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${FAKE_DIR:?}"
+printf 'git %s\n' "$*" >>"$FAKE_DIR/git.log"
+if [[ "${1:-}" == fetch ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == rev-parse && "${2:-}" == --verify ]]; then
+    ref=${3:-}
+    if [[ "$ref" == "${FAKE_TAG}^{commit}" ]]; then
+        if [[ -z "${FAKE_TAG_SHA:-}" ]]; then
+            echo "fatal: Needed a single revision" >&2
+            exit 128
+        fi
+        printf '%s\n' "$FAKE_TAG_SHA"
+        exit 0
+    fi
+    if [[ "$ref" == "origin/release-candidate/${FAKE_TAG}" ]]; then
+        if [[ -z "${FAKE_BRANCH_SHA:-}" ]]; then
+            echo "fatal: Needed a single revision" >&2
+            exit 128
+        fi
+        printf '%s\n' "$FAKE_BRANCH_SHA"
+        exit 0
+    fi
+    echo "fatal: Needed a single revision" >&2
+    exit 128
+fi
+echo "unexpected git $*" >&2
+exit 1
+EOF
+    cat >"$bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${FAKE_DIR:?}"
+printf 'gh %s\n' "$*" >>"$FAKE_DIR/gh.log"
+if [[ "${1:-}" == pr && "${2:-}" == list ]]; then
+    if [[ -f "$FAKE_DIR/pr-list.tsv" ]]; then
+        cat -- "$FAKE_DIR/pr-list.tsv"
+    fi
+    exit 0
+fi
+if [[ "${1:-}" == pr && "${2:-}" == create ]]; then
+    : >"$FAKE_DIR/create.args"
+    prev=
+    for arg in "$@"; do
+        printf '%s\n' "$arg" >>"$FAKE_DIR/create.args"
+        if [[ "$prev" == --body-file ]]; then
+            cp -- "$arg" "$FAKE_DIR/create.body"
+        fi
+        prev=$arg
+    done
+    printf '%s\n' "https://github.com/cardano-foundation/cardano-wallet/pull/9999"
+    exit 0
+fi
+if [[ "${1:-}" == issue && "${2:-}" == list ]]; then
+    if [[ -f "$FAKE_DIR/issue-list.tsv" ]]; then
+        cat -- "$FAKE_DIR/issue-list.tsv"
+    fi
+    exit 0
+fi
+if [[ "${1:-}" == issue && "${2:-}" == create ]]; then
+    : >"$FAKE_DIR/issue-create.args"
+    prev=
+    for arg in "$@"; do
+        printf '%s\n' "$arg" >>"$FAKE_DIR/issue-create.args"
+        if [[ "$prev" == --body-file ]]; then
+            cp -- "$arg" "$FAKE_DIR/issue-create.body"
+        fi
+        prev=$arg
+    done
+    printf '%s\n' "https://github.com/cardano-foundation/cardano-wallet/issues/6000"
+    exit 0
+fi
+if [[ "${1:-}" == pr && "${2:-}" =~ ^(merge|review|ready|lock|close)$ ]]; then
+    printf '%s\n' "$*" >>"$FAKE_DIR/forbidden.log"
+    echo "forbidden gh $*" >&2
+    exit 1
+fi
+if [[ "${1:-}" == issue && "${2:-}" =~ ^(close|reopen|delete|edit)$ ]]; then
+    printf '%s\n' "$*" >>"$FAKE_DIR/forbidden.log"
+    echo "forbidden gh $*" >&2
+    exit 1
+fi
+echo "unexpected gh $*" >&2
+exit 1
+EOF
+    cat >"$bin/date" <<'EOF'
+#!/usr/bin/env bash
+echo "date must not select the merge-back tag: $*" >&2
+exit 99
+EOF
+    chmod +x -- "$bin/git" "$bin/gh" "$bin/date"
+}
+
+has_arg_pair() {
+    local file=$1
+    local flag=$2
+    local value=$3
+    local prev=
+    local line
+    while IFS= read -r line; do
+        if [[ "$prev" == "$flag" && "$line" == "$value" ]]; then
+            return 0
+        fi
+        prev=$line
+    done <"$file"
+    return 1
+}
+
+validate_closing_body() {
+    local body_file=$1
+    local event_file=$2
+    jq -n --rawfile body "$body_file" '{pull_request: {body: $body}}' >"$event_file"
+    GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=$event_file \
+        "$closing_validator" >/dev/null 2>&1
+}
+
+assert_closes_issue() {
+    local body_file=$1
+    local issue=$2
+    local event_file=$3
+    local stripped=$4
+    local n
+    grep -Eq "(^|[^[:alnum:]_])[Cc]loses[[:space:]]+#${issue}([^[:alnum:]_]|$)" \
+        "$body_file" || return 1
+    for n in $forbidden_issues; do
+        if [[ "$n" != "$issue" ]] \
+            && grep -Eq "(^|[^[:alnum:]_])(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?[[:space:]]+#${n}([^[:alnum:]_]|$)" \
+                "$body_file"; then
+            return 1
+        fi
+    done
+    validate_closing_body "$body_file" "$event_file" || return 1
+    grep -vE "(^|[^[:alnum:]_])[Cc]loses[[:space:]]+#[1-9][0-9]*" \
+        "$body_file" >"$stripped" || true
+    if validate_closing_body "$stripped" "$event_file"; then
+        return 1
+    fi
+    return 0
+}
+
+run_helper() {
+    local work=$1
+    local event_name=$2
+    local prerelease=$3
+    local output_file=$4
+    local status_file=$5
+    local status
+
+    write_fakes "$work/bin"
+    : >"$work/git.log"
+    : >"$work/gh.log"
+
+    set +e
+    (
+        cd -- "$repo_root"
+        export FAKE_DIR=$work
+        export FAKE_TAG=$tag
+        export FAKE_TAG_SHA="${FAKE_TAG_SHA:-}"
+        export FAKE_BRANCH_SHA="${FAKE_BRANCH_SHA:-}"
+        export PATH="$work/bin:$PATH"
+        TAG=$tag \
+            GITHUB_EVENT_NAME=$event_name \
+            MERGE_BACK_PRERELEASE=$prerelease \
+            GITHUB_REPOSITORY=$repo \
+            MERGE_BACK_GIT="$work/bin/git" \
+            MERGE_BACK_GH="$work/bin/gh" \
+            "$helper"
+    ) >"$output_file" 2>&1
+    status=$?
+    set -e
+    printf '%s\n' "$status" >"$status_file"
+}
+
+expect_create() {
+    local name=$1
+    local event_name=$2
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" "$event_name" false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        fail_case "$name" "expected create, exit=$status; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fq "identity: tag=$tag sha=$tag_sha head=$head_branch" "$output"; then
+        fail_case "$name" "missing identity line; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fq 'created: https://github.com/cardano-foundation/cardano-wallet/pull/9999' "$output"; then
+        fail_case "$name" "missing created URL; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/create.args" ]]; then
+        fail_case "$name" "gh pr create was not invoked"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$tag" == "v$today" ]]; then
+        fail_case "$name" "fixture tag unexpectedly matches calendar date"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! has_arg_pair "$work/create.args" --repo "$repo" \
+        || ! has_arg_pair "$work/create.args" --base master \
+        || ! has_arg_pair "$work/create.args" --head "$head_branch" \
+        || ! has_arg_pair "$work/create.args" --title "chore(release): merge back $head_branch version bumps" \
+        || ! has_arg_pair "$work/create.args" --label Release \
+        || ! has_arg_pair "$work/create.args" --label CI/CD \
+        || ! has_arg_pair "$work/create.args" --assignee paolino; then
+        fail_case "$name" "create args missing required metadata; $(cat -- "$work/create.args")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/create.body" ]] \
+        || ! grep -Fq "$tag" "$work/create.body" \
+        || ! grep -Fqi drift "$work/create.body"; then
+        fail_case "$name" "body must identify the tag and version-drift invariant"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "tracking issue was not created"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! has_arg_pair "$work/issue-create.args" --title "Merge $tag version bumps back to master" \
+        || [[ ! -f "$work/issue-create.body" ]] \
+        || ! grep -Fq "merge-back-tracking/${tag}" "$work/issue-create.body"; then
+        fail_case "$name" "tracking issue missing tag identity; $(cat -- "$work/issue-create.args" 2>/dev/null || true)"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! assert_closes_issue "$work/create.body" "$created_issue" \
+        "$work/event.json" "$work/stripped.body"; then
+        fail_case "$name" "PR body must visibly Closes #$created_issue and fail the closing-link check without it"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ -f "$work/forbidden.log" ]]; then
+        fail_case "$name" "forbidden gh mutation: $(cat -- "$work/forbidden.log")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_skip_prerelease() {
+    local name=prerelease-exclusion
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" release true "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        fail_case "$name" "prerelease must skip successfully, exit=$status; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fqi skip "$output"; then
+        fail_case "$name" "prerelease skip omitted skip signal; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if grep -Fqi created "$output" || [[ -f "$work/create.args" ]]; then
+        fail_case "$name" "prerelease publication created a merge-back PR"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if grep -Eq 'git (fetch|rev-parse)' "$work/git.log"; then
+        fail_case "$name" "prerelease must not fetch release identity"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if grep -Eq 'gh (pr|issue) ' "$work/gh.log"; then
+        fail_case "$name" "prerelease must not query or create PRs or issues"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_mismatch() {
+    local name=tag-head-mismatch
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$other_sha \
+        run_helper "$work" release false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -eq 0 ]]; then
+        fail_case "$name" "mismatch was accepted; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fqi mismatch "$output" && ! grep -Fq "$tag_sha" "$output"; then
+        fail_case "$name" "mismatch did not name the identity failure; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ -f "$work/create.args" || -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "mismatch created a PR or tracking issue"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_existing() {
+    local name=$1
+    local state=$2
+    local merged_at=$3
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    printf '%s\t%s\t%s\t%s\n' \
+        5384 "$state" \
+        "https://github.com/cardano-foundation/cardano-wallet/pull/5384" \
+        "$merged_at" >"$work/pr-list.tsv"
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" release false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        fail_case "$name" "existing $state PR must be idempotent, exit=$status; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fq 'existing: PR #5384' "$output"; then
+        fail_case "$name" "missing existing PR signal; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ -f "$work/create.args" || -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "existing $state PR was duplicated or grew a tracking issue"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_closed_unmerged() {
+    local name=closed-unmerged
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    printf '%s\t%s\t%s\t%s\n' \
+        5370 CLOSED \
+        "https://github.com/cardano-foundation/cardano-wallet/pull/5370" \
+        "" >"$work/pr-list.tsv"
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" release false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -eq 0 ]]; then
+        fail_case "$name" "closed unmerged PR was accepted; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if ! grep -Fqi closed "$output"; then
+        fail_case "$name" "closed unmerged failure was unclear; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ -f "$work/create.args" || -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "closed unmerged PR was duplicated or grew a tracking issue"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_issue_reuse() {
+    local name=$1
+    local state=$2
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    printf '%s\t%s\t%s\t%s\n' \
+        5400 "$state" \
+        "Merge $tag version bumps back to master" \
+        "https://github.com/cardano-foundation/cardano-wallet/issues/5400" \
+        >"$work/issue-list.tsv"
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" release false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        fail_case "$name" "expected PR create with reused issue, exit=$status; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "existing $state tracking issue was duplicated"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/create.body" ]] \
+        || ! assert_closes_issue "$work/create.body" 5400 \
+            "$work/event.json" "$work/stripped.body"; then
+        fail_case "$name" "reused issue was not closed by the PR body"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_ignore_unrelated_issues() {
+    local name=ignore-unrelated-issues
+    local work output status
+    work=$(mktemp -d)
+    output=$work/output
+    {
+        printf '%s\t%s\t%s\t%s\n' \
+            5385 OPEN \
+            "Create release merge-back PR automatically after publication" \
+            "https://github.com/cardano-foundation/cardano-wallet/issues/5385"
+        printf '%s\t%s\t%s\t%s\n' \
+            5387 OPEN \
+            "Merge v2026-08-21 version bumps back to master" \
+            "https://github.com/cardano-foundation/cardano-wallet/issues/5387"
+    } >"$work/issue-list.tsv"
+    FAKE_TAG_SHA=$tag_sha FAKE_BRANCH_SHA=$tag_sha \
+        run_helper "$work" release false "$output" "$work/status"
+    status=$(cat -- "$work/status")
+
+    if [[ ! -x "$helper" ]]; then
+        fail_case "$name" "merge-back helper is absent; expected $helper"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+        fail_case "$name" "expected a tag-specific issue, exit=$status; $(cat -- "$output")"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/issue-create.args" ]]; then
+        fail_case "$name" "unrelated issues were reused instead of creating a tag-specific tracker"
+        rm -rf -- "$work"
+        return 0
+    fi
+    if [[ ! -f "$work/create.body" ]] \
+        || ! assert_closes_issue "$work/create.body" "$created_issue" \
+            "$work/event.json" "$work/stripped.body"; then
+        fail_case "$name" "PR reused #5385/#5387 or omitted Closes #$created_issue"
+        rm -rf -- "$work"
+        return 0
+    fi
+    pass_case "$name"
+    rm -rf -- "$work"
+}
+
+expect_workflow_wiring() {
+    local name=workflow-wiring
+    local missing=()
+
+    if [[ ! -f "$workflow" ]]; then
+        fail_case "$name" "publish-release workflow is absent"
+        return 0
+    fi
+    grep -Eq '^  merge-back:' "$workflow" || missing+=('merge-back job')
+    grep -Fq 'scripts/release/merge-back-pr.sh' "$workflow" \
+        || missing+=('helper invocation')
+    grep -Fq 'pull-requests: write' "$workflow" \
+        || missing+=('pull-requests: write')
+    grep -Fq 'issues: write' "$workflow" || missing+=('issues: write')
+    grep -Fq 'contents: read' "$workflow" || missing+=('contents: read')
+    grep -Fq 'release-candidate/' "$workflow" \
+        || missing+=('release-candidate/ head')
+    grep -Fq 'github.event.inputs.tag || github.event.release.tag_name' \
+        "$workflow" || missing+=('published tag selection')
+    if grep -Fq 'date +%Y-%m-%d' "$workflow"; then
+        missing+=('workflow uses calendar date')
+    fi
+    if grep -Eq 'gh pr (merge|review)' "$workflow"; then
+        missing+=('workflow requests merge or review')
+    fi
+    if ((${#missing[@]} > 0)); then
+        fail_case "$name" "missing behavior: ${missing[*]}"
+        return 0
+    fi
+    pass_case "$name"
+}
+
+expect_create stable-publication release
+expect_create manual-recovery workflow_dispatch
+expect_skip_prerelease
+expect_mismatch
+expect_existing existing-open OPEN ""
+expect_existing existing-merged MERGED "2026-08-21T00:00:00Z"
+expect_closed_unmerged
+expect_issue_reuse issue-reuse-open OPEN
+expect_issue_reuse issue-reuse-closed CLOSED
+expect_ignore_unrelated_issues
+expect_workflow_wiring
+
+if [[ "$cases_exercised" -eq 0 || "$failures" -ne 0 ]]; then
+    echo "merge-back proof failed: passed=$cases_exercised failed=$failures" >&2
+    exit 1
+fi
+echo "merge-back proof passed: $cases_exercised cases."

--- a/specs/5385-auto-release-mergeback/data-model.md
+++ b/specs/5385-auto-release-mergeback/data-model.md
@@ -1,0 +1,10 @@
+# Data model
+
+| ID | Record | Fields | Invariants |
+| --- | --- | --- | --- |
+| D1 | Release identity | tag, peeled tag SHA, release-candidate branch, branch-head SHA | I1, I3 |
+| D2 | Merge-back request | base, head, title, body, labels, assignee | I2, I4 |
+
+An existing PR in any non-closed successful disposition satisfies D2 and makes
+creation a no-op. A closed unmerged PR may be reported for maintainer action
+rather than silently duplicated.

--- a/specs/5385-auto-release-mergeback/functions-model.md
+++ b/specs/5385-auto-release-mergeback/functions-model.md
@@ -1,0 +1,9 @@
+# Functions model
+
+| ID | Function | Arguments | Result / effects |
+| --- | --- | --- | --- |
+| F1 | prepare merge-back | tag: text; repository: text | validated release identity or explicit failure; read-only |
+| F2 | ensure merge-back PR | validated identity; PR metadata | existing PR identity or newly created PR identity; GitHub PR write only when absent |
+
+Exact implementation names are not mandated; these rows define the changed
+interfaces and effects.

--- a/specs/5385-auto-release-mergeback/modules-model.md
+++ b/specs/5385-auto-release-mergeback/modules-model.md
@@ -1,0 +1,7 @@
+# Modules model
+
+| ID | Component | Responsibility | Depends on |
+| --- | --- | --- | --- |
+| M1 | Publish Release workflow | Invoke merge-back creation for eligible releases with scoped authority | M2 |
+| M2 | Merge-back operation | Validate release identity, detect an existing PR, and request creation when absent | Git/GitHub public metadata |
+| M3 | Regression proof | Exercise M2 decisions without GitHub mutation | M2 |

--- a/specs/5385-auto-release-mergeback/plan.md
+++ b/specs/5385-auto-release-mergeback/plan.md
@@ -1,0 +1,18 @@
+# Plan
+
+## Strategy
+
+Extend the existing post-publication workflow with a separately testable
+merge-back operation. Keep GitHub mutation at the workflow boundary and put
+deterministic tag/branch/duplicate decisions behind a local test surface.
+
+## Live boundary
+
+The GitHub release event, Git refs, and pull-request API are the live boundary.
+Tests substitute frozen command responses; the workflow remains responsible
+for authenticated mutation.
+
+## Slice S1
+
+Add stable-release selection, tag/head validation, idempotent PR creation,
+focused regression tests, and the minimum workflow permissions.

--- a/specs/5385-auto-release-mergeback/spec.md
+++ b/specs/5385-auto-release-mergeback/spec.md
@@ -1,0 +1,35 @@
+# Specification: automatic release merge-back PR
+
+## P1 outcome
+
+When a maintainer publishes a stable release, the repository opens the
+corresponding release-candidate merge-back pull request to `master` without a
+manual `gh pr create` step.
+
+## Requirements
+
+- **R1:** Stable `release.published` events and explicit manual recovery runs
+  select `release-candidate/<tag>` as the PR head and `master` as its base.
+- **R2:** Existing open or merged PRs for that head prevent duplicate creation.
+- **R3:** The tag's peeled commit must equal the release-candidate branch head;
+  a mismatch fails before PR creation.
+- **R4:** Prerelease publication does not create a merge-back PR.
+- **R5:** The created PR is unapproved and unmerged, assigned to `paolino`, and
+  labelled `Release` and `CI/CD`.
+- **R6:** Tests exercise selection, validation, and idempotency without writing
+  to GitHub.
+
+## Invariants
+
+- **I1 Identity:** tag, head branch, and head SHA describe the same released
+  commit.
+- **I2 At most one:** a release branch has at most one merge-back PR regardless
+  of workflow retries.
+- **I3 Stable only:** publication side effects exclude prereleases.
+- **I4 Least authority:** workflow permissions are limited to contents read and
+  pull-request write.
+
+## Non-goals
+
+No automatic merge or approval, ref rewriting, tag rewriting, release-note
+changes, version generation changes, or prerelease merge-back PRs.

--- a/specs/5385-auto-release-mergeback/tasks.md
+++ b/specs/5385-auto-release-mergeback/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## Slice S1
+
+- [ ] **T1** Add a failing regression proof for stable/prerelease selection,
+  tag-branch mismatch, and duplicate handling.
+- [ ] **T2** Implement idempotent merge-back PR creation in the publication
+  workflow with least permissions.
+- [ ] **T3** Verify focused tests and repository CI, then submit a clean signed
+  candidate for independent audit.

--- a/specs/5385-auto-release-mergeback/tasks.md
+++ b/specs/5385-auto-release-mergeback/tasks.md
@@ -2,9 +2,9 @@
 
 ## Slice S1
 
-- [ ] **T1** Add a failing regression proof for stable/prerelease selection,
+- [x] **T1** Add a failing regression proof for stable/prerelease selection,
   tag-branch mismatch, and duplicate handling.
-- [ ] **T2** Implement idempotent merge-back PR creation in the publication
+- [x] **T2** Implement idempotent merge-back PR creation in the publication
   workflow with least permissions.
-- [ ] **T3** Verify focused tests and repository CI, then submit a clean signed
+- [x] **T3** Verify focused tests and repository CI, then submit a clean signed
   candidate for independent audit.


### PR DESCRIPTION
## Summary

- create the cardano-wallet merge-back pull request automatically after a stable release is published
- validate that the published tag and its `release-candidate/<tag>` branch identify the same commit
- create or reuse a release-specific tracking issue and include its visible `Closes #...` link in the generated pull request
- make retries idempotent by reusing open or merged pull requests and refusing to duplicate a closed, unmerged pull request
- skip merge-back creation for prereleases

## Verification

- `scripts/release/test-merge-back-pr.sh` — 11 cases passed
- `./scripts/shellcheck.sh` — passed
- frozen ticket gate — passed
- independent full commit audit — 0 blocking findings

Closes #5385
