### PR TITLE
Gracefully drain wallet database workers on shutdown

### DIFF
--- a/lib/application/shelley/Cardano/Wallet/Application.hs
+++ b/lib/application/shelley/Cardano/Wallet/Application.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -58,6 +59,8 @@ import Cardano.Wallet.Address.MaybeLight
 import Cardano.Wallet.Api
     ( ApiLayer
     , ApiV2
+    , HasWorkerRegistry
+    , workerRegistry
     )
 import Cardano.Wallet.Api.Http.Logging
     ( ApiApplicationLog (..)
@@ -152,6 +155,7 @@ import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
+    , drain
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
@@ -241,7 +245,8 @@ import System.IOManager
     ( withIOManager
     )
 import UnliftIO
-    ( withAsync
+    ( finally
+    , withAsync
     )
 import Prelude
 
@@ -442,21 +447,21 @@ serveWallet
                     $ withListeningSocket hostPref listenUi
 
         withRandomApi netId netLayer =
-            lift
+            withDrainedApiLayer
                 $ apiLayer
                     (newTransactionLayer ByronKeyS netId)
                     netLayer
                     Server.idleWorker
 
         withIcarusApi netId netLayer =
-            lift
+            withDrainedApiLayer
                 $ apiLayer
                     (newTransactionLayer IcarusKeyS netId)
                     netLayer
                     Server.idleWorker
 
         withShelleyApi netId netLayer =
-            lift
+            withDrainedApiLayer
                 $ apiLayer (newTransactionLayer ShelleyKeyS netId) netLayer
                 $ \wrk _ ->
                     Server.manageRewardBalance
@@ -466,7 +471,7 @@ serveWallet
                         $ wrk
 
         withMultisigApi netId netLayer =
-            lift
+            withDrainedApiLayer
                 $ apiLayer
                     (newTransactionLayer SharedKeyS netId)
                     netLayer
@@ -648,6 +653,19 @@ withNtpClient :: Tracer IO NtpTrace -> ContT r IO NtpClient
 withNtpClient tr = do
     iom <- ContT withIOManager
     ContT $ withWalletNtpClient iom tr
+
+-- | Acquire a wallet API layer and drain its worker registry on both
+-- normal and asynchronous release.
+withDrainedApiLayer
+    :: forall s r
+     . HasWorkerRegistry s (ApiLayer s)
+    => IO (ApiLayer s)
+    -> ContT r IO (ApiLayer s)
+withDrainedApiLayer acquire =
+    ContT $ \restore -> do
+        layer <- acquire
+        restore layer
+            `finally` drain (view (workerRegistry @s) layer)
 
 -- | Default DRep metadata fetch interval: 15 minutes in microseconds.
 drepMetadataFetchIntervalMicros :: Int

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -124,6 +124,7 @@ library framework
     Test.Integration.Framework.Preprod
     Test.Integration.Framework.Request
     Test.Integration.Framework.Setup
+    Test.Integration.Framework.ShutdownDrain
     Test.Integration.Framework.TestData
     Test.Integration.Plutus
 

--- a/lib/integration/framework/Test/Integration/Framework/ShutdownDrain.hs
+++ b/lib/integration/framework/Test/Integration/Framework/ShutdownDrain.hs
@@ -1,0 +1,439 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2026 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Bounded smoke: start two wallet workers, send the shipped SIGTERM,
+-- and observe the matching close callbacks before process exit.
+module Test.Integration.Framework.ShutdownDrain
+    ( spec
+    )
+where
+
+import Cardano.Faucet.Mnemonics
+    ( MnemonicLength (..)
+    , generateSome
+    )
+import Cardano.Launcher.Node
+    ( nodeSocketFile
+    )
+import Cardano.Mnemonic.Extended
+    ( someMnemonicToWords
+    )
+import Cardano.Wallet.Launch.Cluster
+    ( FaucetFunds (..)
+    , RunningNode (..)
+    )
+import Cardano.Wallet.Launch.Cluster.Process
+    ( RunMonitorQ
+    , WalletPresence (..)
+    , defaultEnvVars
+    , waitForRunningNode
+    , withLocalCluster
+    )
+import Cardano.Wallet.Network.Ports
+    ( getRandomPort
+    )
+import Control.Monad
+    ( filterM
+    , unless
+    )
+import Control.Monad.Cont
+    ( evalContT
+    )
+import Control.Monad.IO.Class
+    ( liftIO
+    )
+import Data.Aeson
+    ( encode
+    , object
+    , (.=)
+    )
+import Data.Char
+    ( isDigit
+    )
+import Data.List
+    ( isInfixOf
+    , isPrefixOf
+    , isSuffixOf
+    , nub
+    )
+import Data.Maybe
+    ( catMaybes
+    , mapMaybe
+    )
+import Data.Text
+    ( Text
+    )
+import Network.HTTP.Client
+    ( Manager
+    , RequestBody (RequestBodyLBS)
+    , defaultManagerSettings
+    , httpLbs
+    , method
+    , newManager
+    , parseRequest
+    , requestBody
+    , requestHeaders
+    , responseStatus
+    )
+import Network.HTTP.Types.Status
+    ( status200
+    , status201
+    )
+import System.Directory
+    ( canonicalizePath
+    , createDirectory
+    , doesFileExist
+    , getSymbolicLinkTarget
+    , listDirectory
+    )
+import System.Exit
+    ( ExitCode
+    )
+import System.FilePath
+    ( takeDirectory
+    , (</>)
+    )
+import System.IO
+    ( BufferMode (LineBuffering)
+    , Handle
+    , IOMode (AppendMode)
+    , hClose
+    , hSetBuffering
+    , openFile
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.Hspec.Core.Spec
+    ( sequential
+    )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe
+    , shouldSatisfy
+    )
+import UnliftIO.Async
+    ( race
+    )
+import UnliftIO.Concurrent
+    ( threadDelay
+    )
+import UnliftIO.Exception
+    ( SomeException
+    , bracket
+    , catch
+    )
+import UnliftIO.Process
+    ( CreateProcess (..)
+    , ProcessHandle
+    , StdStream (UseHandle)
+    , proc
+    , terminateProcess
+    , waitForProcess
+    , withCreateProcess
+    )
+import UnliftIO.Temporary
+    ( withSystemTempDirectory
+    )
+import Prelude
+
+spec :: Spec
+spec = sequential $ describe "shutdown drain" $ do
+    it
+        "fails when observed acquired wallet files are fewer than two"
+        rejectObservedAcquiredBelowTwo
+    it
+        "fails when observed close files do not match acquired files"
+        rejectObservedCloseMismatch
+    it
+        "SIGTERM drain observes two wallet close callbacks"
+        runSigtermDrainSmoke
+
+rejectObservedAcquiredBelowTwo :: IO ()
+rejectObservedAcquiredBelowTwo =
+    checkObservedDrainCounts [] []
+        `shouldBe` Left "acquired count 0 is below 2"
+
+rejectObservedCloseMismatch :: IO ()
+rejectObservedCloseMismatch =
+    checkObservedDrainCounts
+        ["she.a.sqlite", "she.b.sqlite"]
+        ["she.a.sqlite"]
+        `shouldBe` Left
+            "closed count 1 does not equal acquired count 2"
+
+-- | Both counts must come from observed paths. A literal stand-in for
+-- either side cannot pass these checks.
+checkObservedDrainCounts
+    :: [FilePath]
+    -> [FilePath]
+    -> Either String (Int, Int)
+checkObservedDrainCounts acquiredPaths closedPaths
+    | acquired < 2 =
+        Left $ "acquired count " <> show acquired <> " is below 2"
+    | closed /= acquired =
+        Left
+            $ "closed count "
+                <> show closed
+                <> " does not equal acquired count "
+                <> show acquired
+    | otherwise = Right (acquired, closed)
+  where
+    acquired = length acquiredPaths
+    closed = length closedPaths
+
+runSigtermDrainSmoke :: IO ()
+runSigtermDrainSmoke = evalContT $ do
+    ((runMonitorQ, _), _) <-
+        withLocalCluster
+            "shutdown-drain-smoke"
+            NoWallet
+            defaultEnvVars
+            emptyFunds
+    liftIO $ do
+        node <- waitForCluster runMonitorQ
+        let socket = nodeSocketFile (runningNodeSocketPath node)
+        genesis <- findByronGenesis socket
+        port <- getRandomPort
+        withSystemTempDirectory "shutdown-drain-wallet" $ \dir ->
+            runWalletSmoke
+                socket
+                genesis
+                (fromIntegral port)
+                dir
+
+emptyFunds :: FaucetFunds
+emptyFunds =
+    FaucetFunds
+        { pureAdaFunds = []
+        , maryAllegraFunds = []
+        , massiveWalletFunds = []
+        }
+
+waitForCluster :: RunMonitorQ IO -> IO RunningNode
+waitForCluster runMonitorQ = do
+    outcome <-
+        race
+            (threadDelay 180_000_000)
+            (waitForRunningNode runMonitorQ)
+    case outcome of
+        Left () -> fail "cluster start timed out"
+        Right node -> pure node
+
+runWalletSmoke
+    :: FilePath
+    -> FilePath
+    -> Int
+    -> FilePath
+    -> IO ()
+runWalletSmoke socket genesis port dir = do
+    let dbDir = dir </> "db"
+        logPath = dir </> "wallet.log"
+    createDirectory dbDir
+    manager <- newManager defaultManagerSettings
+    outcome <-
+        bracket
+            ( do
+                h <- openFile logPath AppendMode
+                hSetBuffering h LineBuffering
+                pure h
+            )
+            (\h -> hClose h `catch` (\(_ :: SomeException) -> pure ()))
+            $ \logHandle ->
+                withCreateProcess
+                    (walletProc socket genesis dbDir port logHandle)
+                    $ \_ _ _ ph -> do
+                        waitForApi manager port
+                        createShelleyWallet manager port "drain-one"
+                        createShelleyWallet manager port "drain-two"
+                        acquiredPaths <- sheSqliteFiles dbDir
+                        terminateProcess ph
+                        code <- waitForExit ph
+                        pure (acquiredPaths, code)
+    logs <- readFile logPath
+    let (acquiredPaths, exit) = outcome
+        closedPaths = nub $ mapMaybe closePath (lines logs)
+        sawSigTerm = "Terminated by signal." `isInfixOf` logs
+    counts <- case checkObservedDrainCounts acquiredPaths closedPaths of
+        Left msg -> fail msg
+        Right pair -> pure pair
+    let (acquired, closed) = counts
+    putStrLn
+        $ "shutdown drain acquired="
+            <> show acquired
+            <> " closed="
+            <> show closed
+            <> " acquired_paths="
+            <> show acquiredPaths
+            <> " closed_paths="
+            <> show closedPaths
+            <> " sigterm="
+            <> show sawSigTerm
+            <> " exit="
+            <> show exit
+    sawSigTerm `shouldBe` True
+    acquired `shouldSatisfy` (>= 2)
+    closed `shouldBe` acquired
+
+walletProc
+    :: FilePath
+    -> FilePath
+    -> FilePath
+    -> Int
+    -> Handle
+    -> CreateProcess
+walletProc socket genesis dbDir port logHandle =
+    ( proc
+        "cardano-wallet"
+        [ "serve"
+        , "--node-socket"
+        , socket
+        , "--testnet"
+        , genesis
+        , "--database"
+        , dbDir
+        , "--listen-address"
+        , "127.0.0.1"
+        , "--port"
+        , show port
+        ]
+    )
+        { std_out = UseHandle logHandle
+        , std_err = UseHandle logHandle
+        }
+
+waitForApi :: Manager -> Int -> IO ()
+waitForApi manager port = go 90_000_000
+  where
+    url =
+        "http://127.0.0.1:"
+            <> show port
+            <> "/v2/network/information"
+    step = 200_000
+    go remaining
+        | remaining <= 0 = fail $ "timeout waiting for " <> url
+        | otherwise = do
+            ok <-
+                check
+                    `catch` (\(_ :: SomeException) -> pure False)
+            unless ok $ do
+                threadDelay step
+                go (remaining - step)
+    check = do
+        req <- parseRequest url
+        resp <- httpLbs req manager
+        pure $ responseStatus resp == status200
+
+createShelleyWallet :: Manager -> Int -> Text -> IO ()
+createShelleyWallet manager port name = do
+    mnemonic <- generateSome M15
+    initReq <-
+        parseRequest
+            $ "http://127.0.0.1:"
+                <> show port
+                <> "/v2/wallets"
+    let body =
+            object
+                [ "name" .= name
+                , "mnemonic_sentence"
+                    .= someMnemonicToWords mnemonic
+                , "passphrase" .= ("cardano-wallet" :: Text)
+                ]
+        req =
+            initReq
+                { method = "POST"
+                , requestBody = RequestBodyLBS (encode body)
+                , requestHeaders =
+                    [("Content-Type", "application/json")]
+                }
+    resp <- httpLbs req manager
+    responseStatus resp `shouldBe` status201
+
+waitForExit :: ProcessHandle -> IO ExitCode
+waitForExit ph = do
+    outcome <-
+        race
+            (threadDelay 60_000_000)
+            (waitForProcess ph)
+    case outcome of
+        Left () ->
+            fail "SIGTERM drain timed out waiting for exit"
+        Right code -> pure code
+
+sheSqliteFiles :: FilePath -> IO [FilePath]
+sheSqliteFiles dir = do
+    names <- listDirectory dir
+    let walletFiles =
+            filter isWalletSqlite names
+    pure $ fmap (dir </>) walletFiles
+  where
+    isWalletSqlite name =
+        "she." `isPrefixOf` name
+            && ".sqlite" `isSuffixOf` name
+            && not ("-wal" `isSuffixOf` name)
+            && not ("-shm" `isSuffixOf` name)
+
+closePath :: String -> Maybe FilePath
+closePath line
+    | "Closing single database connection" `isInfixOf` line
+        && "she." `isInfixOf` line =
+        case break (== '(') line of
+            (_, '(' : rest) ->
+                let path = takeWhile (/= ')') rest
+                in  if "she." `isInfixOf` path
+                        then Just path
+                        else Nothing
+            _ -> Nothing
+    | otherwise = Nothing
+
+findByronGenesis :: FilePath -> IO FilePath
+findByronGenesis socketPath = do
+    socket <- canonicalizePath socketPath
+    pids <- filter (all isDigit) <$> listDirectory "/proc"
+    found <- catMaybes <$> mapM (pidOwnsSocket socket) pids
+    case found of
+        [] ->
+            fail $ "no process holds node socket " <> socket
+        (pid : _) -> genesisFromPid pid
+
+pidOwnsSocket :: FilePath -> FilePath -> IO (Maybe FilePath)
+pidOwnsSocket socket pid = do
+    let cmdPath = "/proc" </> pid </> "cmdline"
+    present <- doesFileExist cmdPath
+    if not present
+        then pure Nothing
+        else do
+            raw <-
+                readFile cmdPath
+                    `catch` (\(_ :: SomeException) -> pure "")
+            pure
+                $ if socket `isInfixOf` raw
+                    then Just pid
+                    else Nothing
+
+genesisFromPid :: FilePath -> IO FilePath
+genesisFromPid pid = do
+    nodeCwd <-
+        getSymbolicLinkTarget ("/proc" </> pid </> "cwd")
+            `catch` (\(_ :: SomeException) -> pure "")
+    let candidates =
+            [ nodeCwd </> "byron-genesis.json"
+            , takeDirectory nodeCwd </> "byron-genesis.json"
+            , takeDirectory (takeDirectory nodeCwd)
+                </> "byron-genesis.json"
+            ]
+    existing <- filterM doesFileExist candidates
+    case existing of
+        (path : _) -> canonicalizePath path
+        [] ->
+            fail
+                $ "byron-genesis.json not found from pid "
+                    <> pid
+                    <> " cwd="
+                    <> nodeCwd

--- a/lib/integration/scenarios/Test/Integration/Run.hs
+++ b/lib/integration/scenarios/Test/Integration/Run.hs
@@ -62,6 +62,7 @@ import UnliftIO.STM
 import Prelude
 
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
+import qualified Test.Integration.Framework.ShutdownDrain as ShutdownDrain
 import qualified Test.Integration.Scenario.API.Blocks as Blocks
 import qualified Test.Integration.Scenario.API.Byron.Addresses as ByronAddresses
 import qualified Test.Integration.Scenario.API.Byron.CoinSelections as ByronCoinSelections
@@ -107,6 +108,8 @@ main = withTestsSetup $ \testDir (tr, tracers) -> do
         describe "No backend required"
             $ parallel
             $ describe "Miscellaneous CLI tests" MiscellaneousCLI.spec
+
+        ShutdownDrain.spec
 
         aroundAll (withContext testingCtx) $ do
             describe "API Specifications" $ do

--- a/lib/unit/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -20,8 +20,13 @@ import Cardano.Wallet.Registry
     , MkWorker (..)
     , Worker
     , WorkerLog
+    , WorkerRegistry
+    , drain
     , empty
+    , lookup
     , register
+    , unregister
+    , workerId
     , workerThread
     )
 import Control.Exception.Base
@@ -29,7 +34,8 @@ import Control.Exception.Base
     , asyncExceptionFromException
     )
 import Control.Monad
-    ( replicateM
+    ( forever
+    , replicateM
     , void
     )
 import Control.Tracer
@@ -37,6 +43,9 @@ import Control.Tracer
     )
 import Cryptography.Hash.Core
     ( hash
+    )
+import Data.Maybe
+    ( isNothing
     )
 import Data.Text
     ( Text
@@ -63,7 +72,9 @@ import Test.QuickCheck.Monadic
     , run
     )
 import UnliftIO.Async
-    ( race
+    ( async
+    , race
+    , wait
     )
 import UnliftIO.Concurrent
     ( threadDelay
@@ -71,18 +82,25 @@ import UnliftIO.Concurrent
     )
 import UnliftIO.Exception
     ( SomeException (..)
+    , bracket
+    , finally
     , throwIO
+    , uninterruptibleMask_
     )
 import UnliftIO.MVar
-    ( modifyMVar_
+    ( MVar
+    , modifyMVar_
     , newEmptyMVar
     , newMVar
     , putMVar
     , swapMVar
     , takeMVar
+    , tryPutMVar
     , tryTakeMVar
     )
-import Prelude
+import Prelude hiding
+    ( lookup
+    )
 
 import qualified Data.ByteString as BS
 
@@ -107,6 +125,19 @@ spec = do
         it
             "Does not return until 'before' is completed"
             (property workerIsUsableAfterBefore)
+    describe "drain" $ do
+        it
+            "is idempotent and leaves the registry empty"
+            drainIsIdempotentAndEmpty
+        it
+            "waits for resource release and worker finalizers"
+            drainWaitsForReleaseAndFinalizers
+        it
+            "races with worker self-exit without leftover entries"
+            drainRacesWithSelfExit
+        it
+            "unregister terminates only the selected worker"
+            unregisterDoesNotTerminateAnotherWorker
 
 {-------------------------------------------------------------------------------
                                   Tests
@@ -228,6 +259,168 @@ workerIsUsableAfterBefore (Delay delay) = monadicIO $ do
                 100 * delay
             }
 
+-- | Drain of an empty registry is harmless, and draining workers leaves
+-- no membership.
+drainIsIdempotentAndEmpty :: IO ()
+drainIsIdempotentAndEmpty = do
+    registry <- empty
+    let ctx = DummyCtx nullTracer DummyResource
+    drain registry
+    drain registry
+    wids <- replicateM 3 (generate arbitrary)
+    released <- mapM (const newEmptyMVar) wids
+    finalized <- mapM (const newEmptyMVar) wids
+    mapM_
+        (registerDelayed registry ctx (200 * 1000))
+        (zip3 wids released finalized)
+    drain registry
+    drain registry
+    mapM_ (assertAbsent registry) wids
+    mapM_ assertAlreadyFilled released
+    mapM_ assertAlreadyFilled finalized
+
+-- | Drain must not return until every delayed release and worker-after
+-- action has completed. A drain that only kills threads fails here.
+drainWaitsForReleaseAndFinalizers :: IO ()
+drainWaitsForReleaseAndFinalizers = do
+    registry <- empty
+    let ctx = DummyCtx nullTracer DummyResource
+    wids <- replicateM 3 (generate arbitrary)
+    released <- mapM (const newEmptyMVar) wids
+    finalized <- mapM (const newEmptyMVar) wids
+    mapM_
+        (registerDelayed registry ctx (200 * 1000))
+        (zip3 wids released finalized)
+    drain registry
+    mapM_ assertAlreadyFilled released
+    mapM_ assertAlreadyFilled finalized
+    mapM_ (assertAbsent registry) wids
+
+-- | Worker self-exit must win against drain's stale snapshot: drain has
+-- already listed the worker, the worker then deletes itself, and drain
+-- still calls unregister. A membership-error on that Nothing branch
+-- must go red; repetition without this barrier is not the race.
+drainRacesWithSelfExit :: IO ()
+drainRacesWithSelfExit = go 20
+  where
+    go :: Int -> IO ()
+    go 0 =
+        fail "could not sample blockerId < targetId"
+    go n = do
+        blockerId <- generate arbitrary
+        targetId <- generate arbitrary
+        if blockerId < targetId
+            then drainRacesWithSelfExitOrdered blockerId targetId
+            else go (n - 1)
+
+drainRacesWithSelfExitOrdered
+    :: WalletId
+    -> WalletId
+    -> IO ()
+drainRacesWithSelfExitOrdered blockerId targetId = do
+    registry <- empty
+    let ctx = DummyCtx nullTracer DummyResource
+    releaseBlocker <- newEmptyMVar
+    allowTargetExit <- newEmptyMVar
+    blockerHeld <- newEmptyMVar
+    targetReady <- newEmptyMVar
+    blockerReleased <- newEmptyMVar
+    targetReleased <- newEmptyMVar
+    blockerFinalized <- newEmptyMVar
+    targetFinalized <- newEmptyMVar
+    void
+        $ mustRegister
+            registry
+            ctx
+            blockerId
+            (delayedAcquire blockerReleased 0)
+            ( \_ _ ->
+                uninterruptibleMask_ $ do
+                    putMVar blockerHeld ()
+                    takeMVar releaseBlocker
+            )
+            (\_ _ -> putMVar blockerFinalized ())
+    void
+        $ mustRegister
+            registry
+            ctx
+            targetId
+            (delayedAcquire targetReleased 0)
+            ( \_ _ -> do
+                putMVar targetReady ()
+                takeMVar allowTargetExit
+            )
+            (\_ _ -> putMVar targetFinalized ())
+    takeMVar blockerHeld
+    takeMVar targetReady
+    let releaseWorkers = do
+            void $ tryPutMVar allowTargetExit ()
+            void $ tryPutMVar releaseBlocker ()
+    drainA <- async $ drain registry
+    let body = do
+            waitUntilAbsent
+                registry
+                blockerId
+                "blocker after drain began unregister"
+            putMVar allowTargetExit ()
+            assertFilled
+                "target self-exit finalizer"
+                targetFinalized
+            assertAbsent registry targetId
+            putMVar releaseBlocker ()
+            race (threadDelay (2 * 1000 * 1000)) (wait drainA) >>= \case
+                Left _ ->
+                    fail "drain timed out after caused self-exit"
+                Right () -> pure ()
+            assertAbsent registry blockerId
+            assertAbsent registry targetId
+            assertFilled "blocker resource release" blockerReleased
+            assertFilled "target resource release" targetReleased
+    body
+        `finally` ( do
+                        releaseWorkers
+                        void
+                            $ race
+                                (threadDelay (500 * 1000))
+                                (wait drainA)
+                  )
+
+-- | Selected unregister must not terminate a different worker.
+unregisterDoesNotTerminateAnotherWorker :: IO ()
+unregisterDoesNotTerminateAnotherWorker = do
+    registry <- empty
+    let ctx = DummyCtx nullTracer DummyResource
+    widKeep <- generate arbitrary
+    widDrop <- generate arbitrary
+    keepReleased <- newEmptyMVar
+    dropReleased <- newEmptyMVar
+    keepFinalized <- newEmptyMVar
+    dropFinalized <- newEmptyMVar
+    keep <-
+        mustRegister
+            registry
+            ctx
+            widKeep
+            (delayedAcquire keepReleased 0)
+            (\_ _ -> forever $ threadDelay maxBound)
+            (\_ _ -> putMVar keepFinalized ())
+    void
+        $ mustRegister
+            registry
+            ctx
+            widDrop
+            (delayedAcquire dropReleased 0)
+            (\_ _ -> forever $ threadDelay maxBound)
+            (\_ _ -> putMVar dropFinalized ())
+    unregister registry widDrop
+    remaining <- lookup registry widKeep
+    fmap workerId remaining `shouldBe` Just (workerId keep)
+    fmap workerThread remaining
+        `shouldBe` Just (workerThread keep)
+    drain registry
+    assertAbsent registry widKeep
+    assertAbsent registry widDrop
+
 {-------------------------------------------------------------------------------
                       Tests machinery, Arbitrary instances
 -------------------------------------------------------------------------------}
@@ -276,6 +469,92 @@ defaultWorkerTest =
         , _workerAssertion = \_ -> fail "defaultWorkerTest"
         , _workerTimeout = 250 * 1000 -- 250ms
         }
+
+delayedAcquire
+    :: MVar ()
+    -> Int
+    -> (DummyResource -> IO ())
+    -> IO ()
+delayedAcquire released delayUs =
+    bracket
+        (pure DummyResource)
+        (\_ -> threadDelay delayUs >> putMVar released ())
+
+mustRegister
+    :: WorkerRegistry WalletId DummyResource
+    -> DummyCtx
+    -> WalletId
+    -> ((DummyResource -> IO ()) -> IO ())
+    -> (DummyCtx -> WalletId -> IO ())
+    -> ( Tracer IO (WorkerLog WalletId Text)
+         -> Either SomeException ()
+         -> IO ()
+       )
+    -> IO (Worker WalletId DummyResource)
+mustRegister registry ctx wid acquire mainFn afterFn =
+    register registry ctx wid config >>= \case
+        Nothing -> fail "expected worker to start"
+        Just worker -> pure worker
+  where
+    config =
+        MkWorker
+            { workerBefore = \_ _ -> pure ()
+            , workerMain = mainFn
+            , workerAfter = afterFn
+            , workerAcquire = acquire
+            }
+
+registerDelayed
+    :: WorkerRegistry WalletId DummyResource
+    -> DummyCtx
+    -> Int
+    -> (WalletId, MVar (), MVar ())
+    -> IO (Worker WalletId DummyResource)
+registerDelayed registry ctx delayUs (wid, released, finalized) =
+    mustRegister
+        registry
+        ctx
+        wid
+        (delayedAcquire released delayUs)
+        (\_ _ -> forever $ threadDelay maxBound)
+        (\_ _ -> threadDelay delayUs >> putMVar finalized ())
+
+assertFilled :: String -> MVar () -> IO ()
+assertFilled label mvar =
+    race (threadDelay (2 * 1000 * 1000)) (takeMVar mvar) >>= \case
+        Left _ -> fail $ "timed out waiting for " <> label
+        Right _ -> pure ()
+
+-- | Must already be full when drain returns. A post-drain wait would
+-- hide a drain that only signals workers.
+assertAlreadyFilled :: MVar () -> IO ()
+assertAlreadyFilled mvar =
+    tryTakeMVar mvar `shouldReturn` Just ()
+
+assertAbsent
+    :: WorkerRegistry WalletId DummyResource
+    -> WalletId
+    -> IO ()
+assertAbsent registry wid = do
+    found <- lookup registry wid
+    isNothing found `shouldBe` True
+
+waitUntilAbsent
+    :: WorkerRegistry WalletId DummyResource
+    -> WalletId
+    -> String
+    -> IO ()
+waitUntilAbsent registry wid label =
+    race (threadDelay (2 * 1000 * 1000)) go >>= \case
+        Left _ ->
+            fail $ "timed out waiting for " <> label
+        Right () -> pure ()
+  where
+    go = do
+        found <- lookup registry wid
+        if isNothing found
+            then pure ()
+            else threadDelay 1000 >> go
 
 data WorkerResult
     = WorkerNotStarted

--- a/lib/wallet/src/Cardano/Wallet/Registry.hs
+++ b/lib/wallet/src/Cardano/Wallet/Registry.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Registry
     , register
     , unregister
     , delete
+    , drain
 
       -- * Worker
     , Worker
@@ -91,6 +92,7 @@ import UnliftIO.Concurrent
     )
 import UnliftIO.Exception
     ( SomeException
+    , finally
     , isSyncException
     , withException
     )
@@ -179,6 +181,24 @@ unregister
 unregister registry k =
     delete registry k >>= traverse_ (killThread . workerThread)
 
+-- | Terminate every registered worker and return only after each
+-- selected worker has released its resource and run its finalizer.
+--
+-- Idempotent; the registry is empty when this returns. Safe when a
+-- selected worker exits concurrently.
+drain
+    :: Ord key
+    => WorkerRegistry key resource
+    -> IO ()
+drain registry@(WorkerRegistry mvar) = do
+    workers <- Map.elems <$> readMVar mvar
+    case workers of
+        [] -> pure ()
+        _ -> do
+            traverse_ (unregister registry . workerId) workers
+            traverse_ (readMVar . workerDone) workers
+            drain registry
+
 {-------------------------------------------------------------------------------
                                     Worker
 -------------------------------------------------------------------------------}
@@ -189,6 +209,8 @@ data Worker key resource = Worker
     { workerId :: key
     , workerThread :: ThreadId
     , workerResource :: resource
+    , workerDone :: MVar ()
+    -- ^ Filled after resource release and 'workerAfter'.
     }
     deriving (Generic)
 
@@ -239,28 +261,30 @@ register
     -> IO (Maybe (Worker key resource))
 register registry ctx k (MkWorker before main after acquire) = do
     resourceVar <- newEmptyMVar
+    doneVar <- newEmptyMVar
     let work = acquire $ \resource -> do
             let ctx' = hoistResource resource (MsgFromWorker k) ctx
             before ctx' k `withException` (after tr . Left)
             putMVar resourceVar (Just resource)
             main ctx' k
-    threadId <- work `forkFinally` cleanup resourceVar
-    takeMVar resourceVar >>= traverse (create threadId)
+    threadId <- work `forkFinally` cleanup resourceVar doneVar
+    takeMVar resourceVar >>= traverse (create threadId doneVar)
   where
     tr = ctx ^. logger @IO @(WorkerLog key msg)
-    create threadId resource = do
+    create threadId doneVar resource = do
         let worker =
                 Worker
                     { workerId = k
                     , workerThread = threadId
                     , workerResource = resource
+                    , workerDone = doneVar
                     }
         registry `insert` worker
         return worker
-    cleanup resourceVar result = do
+    cleanup resourceVar doneVar result = do
         void $ registry `delete` k
         void $ tryPutMVar resourceVar Nothing
-        after tr result
+        after tr result `finally` void (tryPutMVar doneVar ())
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/specs/5326-shutdown-drain/data-model.md
+++ b/specs/5326-shutdown-drain/data-model.md
@@ -1,0 +1,45 @@
+# Data model: Shutdown drain
+
+Artifact ceiling: 80 lines / 5 KiB
+
+## DM-5326-REGISTRY
+
+`WorkerRegistry key resource` contains the currently registered workers for
+one wallet flavor.
+
+Relationships and invariants:
+
+- one key identifies at most one registered worker;
+- a registered worker exposes its thread identity, acquired resource, and a
+  completion observation covering resource release and worker finalization;
+- worker self-exit removes its own key safely;
+- drain may race with self-exit without requiring an entry to remain present;
+- drain return establishes an empty registry and completed cleanup for every
+  worker selected by that drain;
+- repeated drain observes the same empty state without additional effects.
+
+No SQLite handle type, schema, retry state, or API-layer type is added to this
+abstraction.
+
+## DM-5326-APPLICATION-LIFETIME
+
+One `serveWallet` invocation owns four wallet API-layer resources:
+
+- Byron / random wallet layer;
+- Icarus wallet layer;
+- Shelley sequential wallet layer;
+- shared/multisig wallet layer.
+
+Each layer owns one `DM-5326-REGISTRY`. Normal return and asynchronous unwind
+both cross the same release boundary. Node, stake-pool, DRep, NTP, and UI
+resources are outside this relationship.
+
+## DM-5326-SMOKE-EVIDENCE
+
+The live smoke's passing observation contains:
+
+- the tested process identity and bounded timeout;
+- proof that the shipped SIGTERM handler ran;
+- an acquired-worker count of at least two;
+- a completed-release count equal to the acquired count before process exit;
+- a non-zero failure on timeout, skip, or count mismatch.

--- a/specs/5326-shutdown-drain/functions-model.md
+++ b/specs/5326-shutdown-drain/functions-model.md
@@ -1,0 +1,39 @@
+# Functions model: Shutdown drain
+
+Artifact ceiling: 70 lines / 5 KiB
+
+## FUN-5326-DRAIN
+
+```text
+drain
+  :: Ord key
+  => WorkerRegistry key resource
+  -> IO ()
+```
+
+Signature constraints and effects:
+
+- exported from `Cardano.Wallet.Registry`;
+- idempotent;
+- terminates every worker belonging to the drain operation;
+- returns only after their resource release and worker-finalization actions;
+- returns with the registry empty;
+- safe when a selected worker exits concurrently.
+
+The exact internal synchronization representation is implementation-owned.
+
+## FUN-5326-UNREGISTER
+
+Existing signature remains unchanged. Its observable scope remains one key;
+the proof must show a different registered worker stays alive.
+
+## FUN-5326-SERVE-WALLET
+
+`serveWallet` keeps its existing public signature and exit result. Its effect
+contract changes so the Byron, Icarus, Shelley, and multisig API-layer
+registries are released through `FUN-5326-DRAIN` on normal and asynchronous
+scope exit.
+
+Any helper introduced solely to express the API-layer resource scope is
+application-owned and must not widen the public application API without a
+contract challenge.

--- a/specs/5326-shutdown-drain/modules-model.md
+++ b/specs/5326-shutdown-drain/modules-model.md
@@ -1,0 +1,20 @@
+# Modules model: Shutdown drain
+
+Artifact ceiling: 90 lines / 6 KiB
+
+| ID | Stable owner | Changed responsibility | Dependency rule |
+|---|---|---|---|
+| MOD-5326-REGISTRY | `Cardano.Wallet.Registry` | Own registry-wide termination and completion-barrier semantics. | May depend on concurrency primitives; must not depend on API, application, or SQLite modules. |
+| MOD-5326-APPLICATION | `Cardano.Wallet.Application` | Own the acquisition/release lifetime of the four wallet API layers used by `serveWallet`. | May consume Registry drain through each API layer's existing registry capability; must not absorb Registry internals. |
+| MOD-5326-REGISTRY-PROOF | `Cardano.Wallet.RegistrySpec` | Own direct multi-worker, idempotence, race, selected-unregister, and finalizer-barrier proofs. | Exercises the public Registry contract and synthetic bracketed resources. |
+| MOD-5326-SIGNAL-PROOF | nearest existing application/integration process-test owner | Own the bounded two-worker shipped-SIGTERM proof and its observable release count. | Uses the shipped signal/lifecycle boundary; must not replace it with direct `killThread` or a hand-thrown exception. |
+
+## Directional invariants
+
+- `MOD-5326-APPLICATION` depends on `MOD-5326-REGISTRY`; the reverse edge is
+  forbidden.
+- SQLite remains an acquired resource behind existing factories. Registry
+  shutdown does not learn SQLite policy.
+- Signal translation remains owned by `Cardano.Startup`; the ticket consumes
+  that boundary without redefining it.
+- Unrelated services retain their present lifetime owners.

--- a/specs/5326-shutdown-drain/plan.md
+++ b/specs/5326-shutdown-drain/plan.md
@@ -1,0 +1,76 @@
+# Plan: Drain wallet database workers on shutdown
+
+Artifact ceiling: 150 lines / 10 KiB
+
+## Topology
+
+One `OWNER` slice, `shutdown-drain`. Concurrency, asynchronous exceptions,
+resource lifetime, and a live process boundary require semantic ownership and
+a fresh independent audit; LIGHT is ineligible.
+
+## Technical strategy
+
+1. Extend the stable Registry owner with one drain operation and the minimum
+   completion observability needed to make its return a resource-release
+   barrier. Preserve selected-wallet `unregister` behavior.
+2. Give each of the four wallet API layers an explicit acquisition/release
+   scope in `serveWallet`. The release observes the layer's existing worker
+   registry and invokes the Registry-owned drain; unrelated service lifetimes
+   remain unchanged.
+3. Ship two proof layers:
+   - focused Registry concurrency/finalizer proofs, including the required
+     deliberately incomplete negative control first;
+   - a bounded process smoke that crosses the shipped SIGTERM handler and
+     observes at least two release callbacks before exit.
+
+## Live-boundary decision
+
+The smoke ships inside the ticket gate, not as an operator follow-up. The
+repository CI already builds the application and provides a local process/test
+boundary; this proof needs no production credentials or live external data.
+The test must use the shipped signal handler rather than directly throwing at
+one worker. It must fail loudly on timeout, skip, an empty match, or fewer than
+two completed releases.
+
+## TDD and invariant order
+
+1. Commit the complete RED proof bundle.
+2. Before production GREEN, freeze evidence showing
+   `INV-5326-FINALIZERS` fails against an implementation that does not await
+   cleanup. This is the load-bearing negative control.
+3. Implement the minimum production change, run focused proofs, then refactor.
+4. Run the immutable slice gate and full ticket gate through durable receipts.
+5. Park the owner at a clean candidate for fresh independent audit.
+
+## Verification contract
+
+- Registry unit proof: exact CI `unit-cardano-wallet-unit` artifact, with
+  empty-match failure enabled.
+- Shutdown smoke/integration proof: the repository integration artifact with a
+  focused shutdown-drain match, finite timeout, and explicit release count.
+- Quality: `git diff --check`, CI format script, HLint, and Cabal/Nix
+  configuration check.
+- Final local build: exact relevant Linux CI Nix outputs plus the focused
+  proofs. The repository has no `just ci` recipe; no claim will describe it as
+  mirroring CI.
+- Final remote proof: all required PR checks green; never use
+  `gh pr checks --watch`.
+
+## Slice boundary
+
+The slice is bisect-safe only as a whole: the Registry barrier, application
+lifetime wiring, and shipped signal proof land in one final behavior commit.
+No production or proof edit is allowed after the accepted audited candidate;
+only the ticket-owner task stamp may be added during final squash.
+
+## Resource and scope fences
+
+- Production: Registry and wallet application/API lifecycle modules only.
+- Proof: Registry unit tests plus the nearest existing integration/process
+  test owner and required Cabal module listing.
+- Runtime gate and evidence: ticket runtime root and ignored `./gate.sh`.
+- `/code/cardano-wallet` is read-only; the protected untracked `.llm` file is
+  never touched. All commands and child panes use the issue worktree.
+- No draft tool. One Grok commit-owner seat, at most two audited submissions.
+- Build budget: four audit/acceptance evidence builds total; focused readiness
+  compiles are uncharged.

--- a/specs/5326-shutdown-drain/spec.md
+++ b/specs/5326-shutdown-drain/spec.md
@@ -1,0 +1,86 @@
+# Spec: Drain wallet database workers on shutdown
+
+Issue: https://github.com/cardano-foundation/cardano-wallet/issues/5326
+
+Base: `origin/master` at `346786a112534347564242ac77c58c32c2788d16`
+
+Artifact ceiling: 180 lines / 12 KiB
+
+## P1 user story
+
+As a wallet operator, when I stop `cardano-wallet serve`, every loaded
+wallet database worker releases its acquired resource before the process
+exits.
+
+## Current defect
+
+`Cardano.Wallet.Registry.register` forks each worker around a bracketed
+resource. Explicit deletion calls `unregister`, but `serveWallet` creates the
+Byron, Icarus, Shelley, and multisig API layers without a matching shutdown
+release. The shipped POSIX path converts SIGTERM to `UserInterrupt` on the
+main thread; sibling wallet workers are therefore abandoned unless the main
+lifecycle drains their registries.
+
+Current locations, re-derived on the bound base:
+
+- registry membership and worker fork: `lib/wallet/src/Cardano/Wallet/Registry.hs`;
+- explicit deletion: `Server.hs:1942-1960`;
+- API-layer worker startup: `Server.hs:5842-5884`;
+- four API layers and server lifetime: `Application.hs:377-468`;
+- SIGTERM conversion: `lib/launcher/src/Cardano/Startup/POSIX.hs:43-49`.
+
+## Requirements
+
+- **R-5326-01 Registry drain.** The registry exposes an idempotent drain
+  operation. It terminates every worker registered for the drain, tolerates
+  workers exiting concurrently, and returns with the registry empty.
+- **R-5326-02 Completion barrier.** Drain does not return until every drained
+  worker's resource release and worker finalization actions have completed.
+  The proof covers multiple workers and is demonstrated RED against an
+  intentionally incomplete implementation that only removes entries or only
+  signals workers without awaiting completion.
+- **R-5326-03 API-layer lifetime.** `serveWallet` brackets all four wallet API
+  layers—Byron, Icarus, Shelley, and multisig—so their registries drain on
+  normal return and asynchronous shutdown.
+- **R-5326-04 Shipped signal smoke.** A bounded smoke starts at least two
+  wallet workers, enters the shipped SIGTERM handling path, and proves both
+  close callbacks complete before the tested process exits. A timeout is
+  finite and a pass reports the callback count.
+- **R-5326-05 Compatibility.** Explicit deletion unregisters only the selected
+  wallet. Existing exit-code and SIGTERM/SIGINT semantics do not change.
+
+## Invariants
+
+All severities are `ADVISORY` under the role taxonomy: none directly changes
+chain state, money, or a signature. They remain mandatory ticket criteria.
+
+- **INV-5326-EMPTY (ADVISORY):** after drain returns, lookup cannot observe a
+  worker that belonged to the drained registry; repeated drain is harmless.
+- **INV-5326-FINALIZERS (ADVISORY):** every acquired resource in a drain has
+  completed release and worker-after actions before drain returns. Its
+  negative control must kill a deliberately non-waiting implementation.
+- **INV-5326-RACE (ADVISORY):** worker self-exit concurrent with drain cannot
+  deadlock, throw a membership error, or leave a registry entry.
+- **INV-5326-FOUR-LAYERS (ADVISORY):** every wallet API-layer registry has the
+  same lifetime as the server scope on normal and exceptional return.
+- **INV-5326-LIVE-SIGNAL (ADVISORY):** the real SIGTERM-to-`UserInterrupt`
+  path observes two completed resource releases before process exit, under a
+  finite deadline.
+- **INV-5326-DELETE-ONE (ADVISORY):** deleting one wallet does not terminate a
+  different wallet worker.
+- **INV-5326-SIGNALS (ADVISORY):** process exit codes and SIGTERM/SIGINT
+  translation remain unchanged.
+
+## Non-goals
+
+- Removing or redesigning `cardano-api`.
+- Changing SQLite schema, migrations, retry policy, or database engine.
+- Redesigning wallet-worker responsibilities or startup concurrency.
+- Draining node, stake-pool, NTP, UI, or DRep services.
+- Any work for issue #5350 / PR #5363 or any secret-bearing configuration.
+
+## Observable completion
+
+The committed proof suite covers every invariant, the final ignored gate is
+green, the focused live smoke executes rather than skips, the exact accepted
+SHA is green in GitHub CI, and the PR remains open for Pawel's review.

--- a/specs/5326-shutdown-drain/tasks.md
+++ b/specs/5326-shutdown-drain/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Drain wallet database workers on shutdown
+
+Artifact ceiling: 80 lines / 5 KiB
+
+## Slice `shutdown-drain` — OWNER
+
+- [ ] T5326-S1 Add the Registry drain contract with idempotent, race-safe,
+      empty-on-return semantics.
+- [ ] T5326-S2 Prove with multiple workers that drain waits for every resource
+      release and worker-finalization action; freeze RED evidence against an
+      intentionally non-waiting implementation before GREEN.
+- [ ] T5326-S3 Preserve selected-wallet unregister behavior and prove a second
+      wallet worker remains registered/alive.
+- [ ] T5326-S4 Bracket the Byron, Icarus, Shelley, and multisig API layers in
+      `serveWallet` so normal and asynchronous exit drain all four registries.
+- [ ] T5326-S5 Ship a finite-timeout smoke/integration proof that starts at
+      least two workers, triggers the shipped SIGTERM path, and observes every
+      close callback before process exit.
+- [ ] T5326-S6 Preserve existing exit-code and SIGTERM/SIGINT semantics and
+      leave unrelated service lifetimes unchanged.
+- [ ] T5326-S7 Pass the immutable focused gate, ticket gate, fresh audit, exact
+      final-tree proof, relevant local CI commands, and GitHub CI.
+- [ ] T5326-S8 Final commit subject `fix: drain wallet workers on shutdown`
+      with a `Tasks:` trailer listing T5326-S1 through T5326-S8.

--- a/specs/5326-shutdown-drain/tasks.md
+++ b/specs/5326-shutdown-drain/tasks.md
@@ -4,21 +4,21 @@ Artifact ceiling: 80 lines / 5 KiB
 
 ## Slice `shutdown-drain` — OWNER
 
-- [ ] T5326-S1 Add the Registry drain contract with idempotent, race-safe,
+- [x] T5326-S1 Add the Registry drain contract with idempotent, race-safe,
       empty-on-return semantics.
-- [ ] T5326-S2 Prove with multiple workers that drain waits for every resource
+- [x] T5326-S2 Prove with multiple workers that drain waits for every resource
       release and worker-finalization action; freeze RED evidence against an
       intentionally non-waiting implementation before GREEN.
-- [ ] T5326-S3 Preserve selected-wallet unregister behavior and prove a second
+- [x] T5326-S3 Preserve selected-wallet unregister behavior and prove a second
       wallet worker remains registered/alive.
-- [ ] T5326-S4 Bracket the Byron, Icarus, Shelley, and multisig API layers in
+- [x] T5326-S4 Bracket the Byron, Icarus, Shelley, and multisig API layers in
       `serveWallet` so normal and asynchronous exit drain all four registries.
-- [ ] T5326-S5 Ship a finite-timeout smoke/integration proof that starts at
+- [x] T5326-S5 Ship a finite-timeout smoke/integration proof that starts at
       least two workers, triggers the shipped SIGTERM path, and observes every
       close callback before process exit.
-- [ ] T5326-S6 Preserve existing exit-code and SIGTERM/SIGINT semantics and
+- [x] T5326-S6 Preserve existing exit-code and SIGTERM/SIGINT semantics and
       leave unrelated service lifetimes unchanged.
-- [ ] T5326-S7 Pass the immutable focused gate, ticket gate, fresh audit, exact
+- [x] T5326-S7 Pass the immutable focused gate, ticket gate, fresh audit, exact
       final-tree proof, relevant local CI commands, and GitHub CI.
-- [ ] T5326-S8 Final commit subject `fix: drain wallet workers on shutdown`
+- [x] T5326-S8 Final commit subject `fix: drain wallet workers on shutdown`
       with a `Tasks:` trailer listing T5326-S1 through T5326-S8.


### PR DESCRIPTION
Fixes #5326.

## Summary

- add an idempotent Registry drain that awaits wallet-worker cleanup
- bracket all four wallet API-layer registries in `serveWallet`
- prove multi-worker finalization and the shipped SIGTERM shutdown boundary

## Required evidence

- negative control: drain tests fail for an implementation that does not await finalizers
- bounded shutdown smoke: at least two workers release before process exit
- focused Registry and integration gates plus relevant local CI

## Review requirement

Required reviewer: Pawel.

Post-delivery state: `AWAITING-EXTERNAL-REVIEW` for the exact accepted head.

## Scope

No SQLite schema/engine changes, no worker-startup redesign, and no lifecycle
changes for node, stake-pool, NTP, DRep, or UI services.
