### PR TITLE
CI: enforce the Dijkstra stub census ratchet on every PR

### DIFF
--- a/.github/workflows/dijkstra-census.yml
+++ b/.github/workflows/dijkstra-census.yml
@@ -1,0 +1,47 @@
+# Dijkstra stub census ratchet — cardano-wallet #5406 (child 0 of epic #5209).
+#
+# Runs the census and its negative control on every pull request and every push
+# to master, gated on nothing else. Deliberately NOT folded into ci.yml:
+#
+# - a separate workflow carries its own concurrency group and therefore can
+#   never cancel (or be cancelled by) ci.yml runs, whose group is
+#   ci-${{ github.ref }};
+# - no job in this file carries needs:, so a failed unrelated build cannot
+#   stop the census from running — a skipped census looks green, and a green
+#   census nobody ran is exactly what this ticket exists to make impossible.
+#
+# The checks carry no secrets reference by construction: the census is plain
+# bash + find + perl over the checked-out tree.
+name: Dijkstra Stub Census
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: dijkstra-census-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  census:
+    name: "Dijkstra Stub Census"
+    runs-on: nix-enabled-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Negative control FIRST: a gate that has stopped being able to fail
+      # must be caught here, before any of its green is believed. Neither step
+      # below is conditional on another job or on any earlier outcome.
+      - name: Prove the census gate can fail (negative control)
+        run: ./scripts/ci/dijkstra-census-negative-control.sh .
+
+      - name: Run the Dijkstra stub census
+        run: ./scripts/ci/dijkstra-stub-gate.sh .

--- a/scripts/ci/dijkstra-census-negative-control.sh
+++ b/scripts/ci/dijkstra-census-negative-control.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Negative control for scripts/ci/dijkstra-stub-gate.sh — cardano-wallet #5406.
+#
+# A green census proves nothing until someone shows it can go RED. This file
+# does exactly that: seed exactly one throwaway Dijkstra stub as a new .hs file
+# under <tree-root>/lib/, run the census gate against that same tree, and
+# require exit 1.
+#
+# Usage:
+#   dijkstra-census-negative-control.sh [tree-root]    # tree-root defaults to "."
+# Exit:
+#   0   the gate went RED on the seeded tree    the gate is able to fail
+#   1   the gate did NOT go red, or this harness could not run
+#
+# No stub count and no ratchet value appear in this file: the assertion is
+# "one more Dijkstra stub than this tree holds turns the gate red", which stays
+# true after later tickets retire stubs and lower the ratchet.
+set -uo pipefail
+
+tree=${1:-.}
+gate="$tree/scripts/ci/dijkstra-stub-gate.sh"
+seed="$tree/lib/DijkstraCensusNegativeControlSeed.hs"
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'negative-control: %s\n' "$*" >&2; exit 1; }
+
+cleanup() { rm -f -- "$seed"; }
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+[ -x "$gate" ] ||
+  die "census gate '$gate' is missing or not executable — the census is not installed, so there is nothing to falsify"
+
+[ -e "$seed" ] &&
+  die "refusing to overwrite existing file at seed path '$seed'"
+
+cat >"$seed" <<'EOF'
+module DijkstraCensusNegativeControlSeed where
+
+-- Throwaway seed written and removed by
+-- scripts/ci/dijkstra-census-negative-control.sh. It exists solely to add
+-- exactly one counted shape (`error "...Dijkstra..."`) to the tree.
+dijkstraCensusNegativeControlSeed :: ()
+dijkstraCensusNegativeControlSeed =
+  error "Dijkstra negative-control seed stub"
+EOF
+
+out=$("$gate" "$tree" 2>&1)
+status=$?
+printf '%s\n' "$out"
+
+observed="negative-control: observed — seed 'lib/DijkstraCensusNegativeControlSeed.hs' under '$tree'; gate exit status: $status"
+
+if [ "$status" -eq 1 ]; then
+  say "$observed"
+  say "negative-control: PASS — one extra Dijkstra stub turned the gate RED; the census is able to fail."
+  exit 0
+fi
+
+say "$observed" >&2
+case $status in
+  0) die "the census did NOT notice the added stub (exit 0) — its green is meaningless" ;;
+  2) die "the census failed its own self-check instead of going red (exit 2)" ;;
+  *) die "unexpected gate exit status (expected 1)" ;;
+esac

--- a/scripts/ci/dijkstra-census-negative-control.sh
+++ b/scripts/ci/dijkstra-census-negative-control.sh
@@ -24,8 +24,10 @@ seed="$tree/lib/DijkstraCensusNegativeControlSeed.hs"
 say() { printf '%s\n' "$*"; }
 die() { printf 'negative-control: %s\n' "$*" >&2; exit 1; }
 
-cleanup() { rm -f -- "$seed"; }
-trap cleanup EXIT
+# Every exit path removes the seed — normal exit, failure, and signal.
+# Inline commands (not a function reference): see evidence note about this
+# host's shellcheck build flagging trap-referenced functions as never invoked.
+trap 'rm -f -- "$seed"' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM HUP
 

--- a/scripts/ci/dijkstra-census-negative-control.sh
+++ b/scripts/ci/dijkstra-census-negative-control.sh
@@ -1,68 +1,141 @@
 #!/usr/bin/env bash
 # Negative control for scripts/ci/dijkstra-stub-gate.sh — cardano-wallet #5406.
+# Implements the control contract, version 2:
+#   specs/5406-dijkstra-census-ratchet/functions-model.md ("Version 2")
 #
-# A green census proves nothing until someone shows it can go RED. This file
-# does exactly that: seed exactly one throwaway Dijkstra stub as a new .hs file
-# under <tree-root>/lib/, run the census gate against that same tree, and
-# require exit 1.
+# A census nobody can make go red proves nothing — and neither does a red whose
+# cause was never measured. This harness seeds exactly one counted shape as a
+# new .hs file under <tree-root>/lib/, reads the census total from the census's
+# own stdout before and after seeding, and succeeds only when the measured
+# effect is exactly one added stub and the census went red because of it.
+# Its verdict is bound to those two totals; a red unrelated to any counted
+# delta is rejected as a vacuous pass.
 #
 # Usage:
-#   dijkstra-census-negative-control.sh [tree-root]    # tree-root defaults to "."
+#   dijkstra-census-negative-control.sh [tree-root]     # tree-root defaults to "."
 # Exit:
-#   0   the gate went RED on the seeded tree    the gate is able to fail
-#   1   the gate did NOT go red, or this harness could not run
+#   0   pristine census exited 0 AND measured delta == 1 AND gate_exit == 1
+#   1   anything else (including delta != 1: that is this control failing,
+#       not the census)
 #
-# No stub count and no ratchet value appear in this file: the assertion is
-# "one more Dijkstra stub than this tree holds turns the gate red", which stays
-# true after later tickets retire stubs and lower the ratchet.
+# Machine-readable result lines on stdout, exactly these five keys:
+#   seed=<path relative to tree-root>
+#   pristine_total=<integer>    total the census reports on the untouched tree
+#   seeded_total=<integer>      total with the seed present
+#   delta=<integer>             seeded_total - pristine_total
+#   gate_exit=<integer>         census exit status on the seeded tree
+#
+# No ratchet value and no count appear in this file, so later tickets can lower
+# the ratchet without invalidating it.
 set -uo pipefail
 
+seed_rel="lib/DijkstraCensusNegativeControlSeed.hs"
 tree=${1:-.}
 gate="$tree/scripts/ci/dijkstra-stub-gate.sh"
-seed="$tree/lib/DijkstraCensusNegativeControlSeed.hs"
+seed="$tree/$seed_rel"
 
-say() { printf '%s\n' "$*"; }
-die() { printf 'negative-control: %s\n' "$*" >&2; exit 1; }
+total_from() { sed -n 's/^total = \([0-9][0-9]*\) across \([0-9][0-9]*\) files.*/\1/p' | tail -n 1; }
+files_from() { sed -n 's/^total = [0-9][0-9]* across \([0-9][0-9]*\) files.*/\1/p' | tail -n 1; }
+is_int() { case $1 in '' | *[!0-9]*) return 1 ;; *) return 0 ;; esac; }
 
-# Every exit path removes the seed — normal exit, failure, and signal.
-# Inline commands (not a function reference): see evidence note about this
-# host's shellcheck build flagging trap-referenced functions as never invoked.
-trap 'rm -f -- "$seed"' EXIT
+note() { printf 'negative-control: %s\n' "$*" >&2; }
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+[ -x "$gate" ] || {
+  note "census gate '$gate' is missing or not executable — there is nothing to falsify"
+  exit 1
+}
+
+# Cleanup runs on every exit path but stays INERT until this invocation owns
+# the artifact it created. Inlined trap commands rather than a helper function:
+# see evidence/shellcheck-sc2329-repro.log — this host's shellcheck build flags
+# functions referenced solely through traps.
+owned=0
+trap 'if [ "$owned" -eq 1 ]; then rm -f -- "$seed"; fi' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM HUP
 
-[ -x "$gate" ] ||
-  die "census gate '$gate' is missing or not executable — the census is not installed, so there is nothing to falsify"
-
-[ -e "$seed" ] &&
-  die "refusing to overwrite existing file at seed path '$seed'"
-
-cat >"$seed" <<'EOF'
-module DijkstraCensusNegativeControlSeed where
-
--- Throwaway seed written and removed by
--- scripts/ci/dijkstra-census-negative-control.sh. It exists solely to add
--- exactly one counted shape (`error "...Dijkstra..."`) to the tree.
-dijkstraCensusNegativeControlSeed :: ()
-dijkstraCensusNegativeControlSeed =
-  error "Dijkstra negative-control seed stub"
-EOF
-
-out=$("$gate" "$tree" 2>&1)
-status=$?
-printf '%s\n' "$out"
-
-observed="negative-control: observed — seed 'lib/DijkstraCensusNegativeControlSeed.hs' under '$tree'; gate exit status: $status"
-
-if [ "$status" -eq 1 ]; then
-  say "$observed"
-  say "negative-control: PASS — one extra Dijkstra stub turned the gate RED; the census is able to fail."
-  exit 0
+if [ -e "$seed" ]; then
+  note "refusing to overwrite existing file at seed path '$seed_rel' — collision rejected"
+  exit 1
 fi
 
-say "$observed" >&2
-case $status in
-  0) die "the census did NOT notice the added stub (exit 0) — its green is meaningless" ;;
-  2) die "the census failed its own self-check instead of going red (exit 2)" ;;
-  *) die "unexpected gate exit status (expected 1)" ;;
-esac
+p_out=$("$gate" "$tree")
+p_status=$?
+p_total=$(printf '%s\n' "$p_out" | total_from)
+p_files=$(printf '%s\n' "$p_out" | files_from)
+
+# Exactly one counted shape lives in the heredoc below, on its last line; the
+# surrounding prose deliberately avoids every counted keyword, because the
+# instrument collapses whitespace across the whole file before matching and a
+# comment is not a hiding place.
+seed_body() {
+  cat <<'EOF'
+module DijkstraCensusNegativeControlSeed where
+
+-- Throwaway seed created and removed by
+-- scripts/ci/dijkstra-census-negative-control.sh to measure whether the
+-- census notices exactly one added stub, namely the one below.
+dijkstraCensusNegativeControlSeed :: ()
+dijkstraCensusNegativeControlSeed =
+  error "Dijkstra census negative-control seed"
+EOF
+}
+
+# Create atomically: noclobber fails the redirect if the path appeared since
+# the collision check; only after a successful create does the invocation own
+# the artifact and allow cleanup to act on it.
+if ! (set -o noclobber; seed_body >"$seed"); then
+  note "refusing to overwrite existing file at seed path '$seed_rel' — collision rejected"
+  exit 1
+fi
+owned=1
+
+s_out=$("$gate" "$tree")
+s_status=$?
+s_total=$(printf '%s\n' "$s_out" | total_from)
+s_files=$(printf '%s\n' "$s_out" | files_from)
+
+printf '%s\n' "$p_out" | sed 's/^/census-pristine| /'
+printf '%s\n' "$s_out" | sed 's/^/census-seeded|   /'
+
+delta=""
+if is_int "$p_total" && is_int "$s_total"; then
+  delta=$((s_total - p_total))
+fi
+file_delta=""
+if is_int "$p_files" && is_int "$s_files"; then
+  file_delta=$((s_files - p_files))
+fi
+
+emit seed "$seed_rel"
+emit pristine_total "$p_total"
+emit seeded_total "$s_total"
+emit delta "$delta"
+emit gate_exit "$s_status"
+
+reasons=""
+ok=1
+[ "$p_status" -eq 0 ] || { ok=0; reasons="$reasons pristine-run-exited-$p_status-not-0"; }
+is_int "$p_total" || { ok=0; reasons="$reasons pristine-total-unparseable"; }
+is_int "$s_total" || { ok=0; reasons="$reasons seeded-total-unparseable"; }
+if [ -n "$delta" ]; then
+  [ "$delta" -eq 1 ] || { ok=0; reasons="$reasons measured-delta-$delta-not-1"; }
+else
+  ok=0; reasons="$reasons delta-uncomputable"
+fi
+# A second instrument property, same class: one counted shape lands in exactly
+# one new file.
+if [ -n "$file_delta" ]; then
+  [ "$file_delta" -eq 1 ] || { ok=0; reasons="$reasons measured-file-delta-$file_delta-not-1"; }
+fi
+[ "$s_status" -eq 1 ] || { ok=0; reasons="$reasons gate-exit-$s_status-not-1"; }
+
+if [ "$ok" -ne 1 ]; then
+  note "FAIL —$reasons ; measurements are emitted above"
+  exit 1
+fi
+
+printf 'negative-control: PASS — census moved total=%s->%s across %s->%s files (measured delta=1) and exited 1 because of the single added stub at %s\n' \
+  "$p_total" "$s_total" "$p_files" "$s_files" "$seed_rel"
+exit 0

--- a/scripts/ci/dijkstra-stub-gate.sh
+++ b/scripts/ci/dijkstra-stub-gate.sh
@@ -51,7 +51,7 @@ total=$((tot_e+tot_p))
 # MAX is the number of Dijkstra stubs currently tolerated. It only ever goes
 # DOWN. Each child that retires stubs lowers it in the same PR; its terminal
 # value is 0, which is issue #5209's acceptance criterion.
-MAX=${DIJKSTRA_STUB_MAX:-44}
+MAX=${DIJKSTRA_STUB_MAX:-39}
 
 echo "total = $total across $files files   (ratchet MAX=$MAX)"
 

--- a/scripts/ci/dijkstra-stub-gate.sh
+++ b/scripts/ci/dijkstra-stub-gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# ACCEPTANCE CRITERION for cardano-wallet issue #5209 (re-cut).
+#
+# RATCHET over Dijkstra era `error` stubs and silently-skipped Dijkstra era
+# tests under lib/. Fails when the count RISES above the ratchet. Counts, never matching a
+# hand-listed set of message strings: the stubs carry 29 distinct literals and
+# 4 of them use Haskell string gaps, so any single-line grep undercounts.
+#
+# Usage: dijkstra-stub-gate.sh [tree-root]     (default: repo root = $PWD)
+# Exit:  0 = at or below ratchet, 1 = regression above ratchet, 2 = self-check failed.
+set -uo pipefail
+root=${1:-.}
+lib="$root/lib"
+[ -d "$lib" ] || { echo "gate: no lib/ under $root" >&2; exit 2; }
+
+count() { # $1=file $2=keyword(error|pendingWith)
+  KW="$2" perl -0777 -ne '
+    my $kw = $ENV{KW};
+    my $c=0;
+    while (/\Q$kw\E\s*(?:\$\s*)?"((?:[^"\\]|\\.)*)"/gs) {
+      my $s=$1; $s=~s/\s+/ /g; $c++ if $s=~/Dijkstra/i
+    }
+    print $c
+  ' "$1"
+}
+
+# --- instrument self-check: it must be able to count and able to return zero.
+selfdir=$(mktemp -d); trap 'rm -rf "$selfdir"' EXIT
+printf 'f = error "DijkstraEra not yet supported"\ng = pendingWith "TODO: Dijkstra"\n' > "$selfdir/pos.hs"
+printf 'f = error "ConwayEra not yet supported"\ng = "Dijkstra"\n' > "$selfdir/neg.hs"
+[ "$(count "$selfdir/pos.hs" error)" = 1 ] && [ "$(count "$selfdir/pos.hs" pendingWith)" = 1 ] \
+  || { echo "gate: POSITIVE CONTROL FAILED - instrument cannot count" >&2; exit 2; }
+[ "$(count "$selfdir/neg.hs" error)" = 0 ] && [ "$(count "$selfdir/neg.hs" pendingWith)" = 0 ] \
+  || { echo "gate: NEGATIVE CONTROL FAILED - instrument cannot return zero" >&2; exit 2; }
+
+tot_e=0; tot_p=0; files=0
+while IFS= read -r f; do
+  e=$(count "$f" error); p=$(count "$f" pendingWith)
+  if [ "$e" -gt 0 ] || [ "$p" -gt 0 ]; then
+    files=$((files+1)); tot_e=$((tot_e+e)); tot_p=$((tot_p+p))
+    printf '  %2d error  %2d pendingWith  %s\n' "$e" "$p" "${f#"$root"/}"
+  fi
+done < <(find "$lib" -name '*.hs' -type f | sort)
+
+echo "controls: positive=PASS negative=PASS"
+echo "error stubs mentioning Dijkstra (multi-line-aware) = $tot_e   (ratchet target: 0)"
+echo "pendingWith mentioning Dijkstra                    = $tot_p   (ratchet target: 0)"
+total=$((tot_e+tot_p))
+
+# --- ratchet ------------------------------------------------------------
+# MAX is the number of Dijkstra stubs currently tolerated. It only ever goes
+# DOWN. Each child that retires stubs lowers it in the same PR; its terminal
+# value is 0, which is issue #5209's acceptance criterion.
+MAX=${DIJKSTRA_STUB_MAX:-44}
+
+echo "total = $total across $files files   (ratchet MAX=$MAX)"
+
+if [ "$total" -gt "$MAX" ]; then
+    echo "GATE RED: $total Dijkstra stubs > ratchet MAX=$MAX — a stub was ADDED."
+    echo "  Fix the regression. Do NOT raise MAX; the ratchet only goes down."
+    exit 1
+fi
+
+if [ "$total" -lt "$MAX" ]; then
+    echo "RATCHET SLACK: $total < MAX=$MAX — $((MAX-total)) stub(s) retired but"
+    echo "  the ratchet was not tightened. Lower it in this same PR:"
+    echo "      DIJKSTRA_STUB_MAX=$total"
+    if [ "${DIJKSTRA_STUB_STRICT:-0}" = "1" ]; then
+        echo "GATE RED (strict): ratchet not tightened."
+        exit 1
+    fi
+fi
+
+if [ "$total" -eq 0 ]; then
+    echo "GATE GREEN: no Dijkstra stubs remain — #5209 acceptance criterion met."
+else
+    echo "GATE GREEN: $total stubs, at or below the ratchet."
+fi

--- a/specs/5406-dijkstra-census-ratchet/data-model.md
+++ b/specs/5406-dijkstra-census-ratchet/data-model.md
@@ -1,0 +1,36 @@
+# Data model
+
+No persistent data, no schema, no migration. Three values cross a boundary.
+
+| name | type | home | validation / invariant |
+|---|---|---|---|
+| `MAX` | non-negative integer | `scripts/ci/dijkstra-stub-gate.sh`, `MAX=${DIJKSTRA_STUB_MAX:-44}` | monotonically **decreasing** over the life of #5209. Its terminal value `0` is #5209's acceptance criterion. Raising it is never a valid response to a red gate. |
+| `DIJKSTRA_STUB_MAX` | integer, optional env | caller | overrides `MAX` for one invocation. Used by a child to preview a tightening, and by `DIJKSTRA_STUB_MAX=0` to check the terminal state. Never set in CI, so CI always measures against the committed ratchet. |
+| `DIJKSTRA_STUB_STRICT` | `0`/`1`, optional env | caller | `1` turns ratchet slack (`total < MAX`) from a warning into exit 1. Not set in CI on this ticket: `master` must stay regression-only. |
+
+## Census denominator — a state invariant, not a configuration knob
+
+The set of files counted is defined by exactly one unconditional expression:
+
+```sh
+find "$lib" -name '*.hs' -type f
+```
+
+There is no exclude list, no path prune, no skip flag, and none is added. In
+particular the five stubs in `lib/wallet/src/Cardano/Api/Extra.hs` remain
+counted, though #5290 will eventually delete that shim. Carving them out would
+make the criterion unable to fail on them, which is precisely the defect #5209
+was re-cut to remove.
+
+## Counted shapes
+
+Both are matched **after** collapsing whitespace across the whole file, so a
+Haskell string gap splitting a message across source lines is still one match:
+
+| shape | example |
+|---|---|
+| `error "…Dijkstra…"` | `error "DijkstraEra not yet supported"` |
+| `pendingWith "…Dijkstra…"` | `pendingWith "TODO: Dijkstra"` |
+
+`error $ "…"` is matched too. A bare string mentioning Dijkstra that is neither
+argument is **not** counted — that is the instrument's own negative control.

--- a/specs/5406-dijkstra-census-ratchet/functions-model.md
+++ b/specs/5406-dijkstra-census-ratchet/functions-model.md
@@ -1,0 +1,35 @@
+# Functions model
+
+## `scripts/ci/dijkstra-stub-gate.sh` — landed unchanged
+
+Frozen artefact, `sha256:6304802d788cd8371fd0ec0214e23e083c77e892966b34a7884663e4e66ae79f`.
+Its surface is fixed and is **not** authored by this ticket:
+
+```
+dijkstra-stub-gate.sh [tree-root]        # tree-root defaults to "." (repo root)
+  exit 0  total <= MAX
+  exit 1  total >  MAX          a stub was added
+  exit 2  self-check failed     the instrument cannot count, or cannot return zero
+```
+
+Internal, unchanged: `count <file> <keyword>` → integer, where `<keyword>` is
+`error` or `pendingWith`.
+
+## `scripts/ci/dijkstra-census-negative-control.sh` — new
+
+```
+dijkstra-census-negative-control.sh [tree-root]     # tree-root defaults to "."
+  exit 0  the gate went red on the seeded tree      the gate is able to fail
+  exit 1  the gate did NOT go red, or the harness could not run
+```
+
+Constraints on its signature and effects:
+
+- It takes no ratchet argument and hard-codes no count. It asserts "one more
+  stub than this tree holds makes the gate exit 1", so it stays correct as
+  children lower `MAX`.
+- Its only write is one throwaway `.hs` file under `<tree-root>/lib/`, removed
+  on every exit path including failure and signal.
+- It must fail if that file already exists, rather than overwrite it.
+- It exits non-zero on any gate exit status other than 1 — including 0 (the gate
+  did not notice the stub) and 2 (the instrument is broken).

--- a/specs/5406-dijkstra-census-ratchet/functions-model.md
+++ b/specs/5406-dijkstra-census-ratchet/functions-model.md
@@ -33,3 +33,60 @@ Constraints on its signature and effects:
 - It must fail if that file already exists, rather than overwrite it.
 - It exits non-zero on any gate exit status other than 1 — including 0 (the gate
   did not notice the stub) and 2 (the instrument is broken).
+
+---
+
+## Version 2 — after audit submission 1 (`AUDIT-FINDINGS`, report `1b711708…5f68314f`)
+
+Submission 1's control was accepted by its own success message rather than by a
+measured effect. It seeded a file whose *explanatory comment* also contained a
+counted shape, so the tree moved from `44/15` to `46/16` — the control proved
+"two more stubs go red", never "one more". Separately it armed its cleanup trap
+before its collision check, so a pre-existing file at the seed path was deleted
+by the very command that said it refused to overwrite it.
+
+Both are the same defect in different clothes: an assertion bound to what the
+script *says* instead of to what it *did*. The revised signature makes the
+effect observable from outside the script.
+
+### `scripts/ci/dijkstra-census-negative-control.sh` — revised contract
+
+```
+dijkstra-census-negative-control.sh [tree-root]     # tree-root defaults to "."
+  exit 0  the census counted exactly one more stub AND went red because of it
+  exit 1  anything else
+```
+
+It must print these lines on **stdout**, one per line, machine-readable, in any
+order:
+
+```
+seed=<seed path, relative to tree-root>
+pristine_total=<integer>     total the census reports on the untouched tree
+seeded_total=<integer>       total the census reports with the seed present
+delta=<integer>              seeded_total - pristine_total
+gate_exit=<integer>          the census's exit status on the seeded tree
+```
+
+Exit 0 is permitted **only** when all three hold:
+
+- the pristine census run exited `0`;
+- `delta == 1`;
+- `gate_exit == 1`.
+
+`delta != 1` is a failure of the control, not of the census: a control that
+applies two mutations has not tested the ratchet's actual claim.
+
+Constraints, unchanged from v1 unless restated:
+
+- no count and no ratchet literal appears in the file;
+- the seeded file introduces **exactly one** counted shape. No counted shape
+  may appear in its comments, module header, or anywhere else in it. The
+  instrument collapses whitespace across the whole file before matching, so a
+  comment is not a hiding place;
+- **ownership before cleanup.** The seed is created atomically and cleanup is
+  armed only after that creation succeeds. On a rejected collision the
+  pre-existing file is left byte-identical on every exit path, including
+  `INT`, `TERM`, `HUP`, and a census that exits `2`;
+- it exits non-zero on any `gate_exit` other than `1`, including `0` (the
+  census did not notice) and `2` (the instrument is broken).

--- a/specs/5406-dijkstra-census-ratchet/modules-model.md
+++ b/specs/5406-dijkstra-census-ratchet/modules-model.md
@@ -1,0 +1,41 @@
+# Modules model
+
+## New components
+
+| component | responsibility | consumes | emits |
+|---|---|---|---|
+| `scripts/ci/dijkstra-stub-gate.sh` | count Dijkstra `error` stubs and Dijkstra `pendingWith` under `lib/`, multi-line-aware; compare against the ratchet | a tree root (default `.`); `DIJKSTRA_STUB_MAX`, `DIJKSTRA_STUB_STRICT` | per-file counts, totals, verdict; exit 0 at/below ratchet, 1 above, 2 if its own controls fail |
+| `scripts/ci/dijkstra-census-negative-control.sh` | prove the gate above is able to fail, by seeding exactly one throwaway Dijkstra stub into the tree and requiring exit 1 | the same tree root; invokes the gate | pass/fail of the falsification; exit 0 when the gate correctly went red |
+| `.github/workflows/dijkstra-census.yml` | execute both, in that order, on every PR and every push to `master` | the checkout | the `Dijkstra Stub Census` check |
+
+## Dependency direction
+
+```
+dijkstra-census.yml
+  ├─→ dijkstra-census-negative-control.sh ─→ dijkstra-stub-gate.sh
+  └─→ dijkstra-stub-gate.sh
+```
+
+The gate has no dependency on the negative control, and neither has a dependency
+on anything else in the repository. The gate is the only component that knows
+the ratchet value.
+
+## Promotion / ownership
+
+Nothing is promoted to a shared location. The instrument is owned by epic #5209
+and dies with it: when the ratchet reaches `MAX=0` and #5209 closes, the census
+becomes a permanent zero-assert or is retired by that closing ticket. That
+decision belongs to #5209, not here.
+
+## Role check — does each component receive what it claims to observe?
+
+- The gate reads `lib/**/*.hs` from the tree it is given. That **is** the
+  surface the criterion is about; there is no proxy layer between them.
+- The negative control observes the gate's **exit status against the real
+  tree**, not a synthetic fixture. A control that seeded into a scratch
+  directory would prove the instrument counts — which the gate's own built-in
+  controls already prove — and would not prove that this tree, at this ratchet,
+  goes red on one more stub.
+- The workflow observes nothing; it exists so the pipeline executes the other
+  two. Its correctness is only visible in a run log, which is why acceptance
+  requires the run log.

--- a/specs/5406-dijkstra-census-ratchet/plan.md
+++ b/specs/5406-dijkstra-census-ratchet/plan.md
@@ -1,0 +1,90 @@
+# Plan — land the Dijkstra census ratchet in CI
+
+## Strategy
+
+Land an already-written, already-falsified instrument and wire it so the
+pipeline executes it. Nothing about the instrument is redesigned here.
+
+## Placement decisions
+
+### Instrument → `scripts/ci/dijkstra-stub-gate.sh`
+
+`scripts/ci/` is where this repository keeps CI-invoked shell checks
+(`check-local-test-targets.sh`, `check-pr-body-closing-link.sh`,
+`check-docker-boot-sync-cleanup.sh`). Those take the same `root=${1:-.}` shape,
+so the instrument's existing `[tree-root]` argument needs no change and it runs
+from the repository root with no arguments.
+
+Landing there also puts it under two checks that already exist:
+
+- `scripts/shellcheck.sh` lints every `scripts/**/*.sh` (verified clean against
+  `shellcheck 0.11.0 -e SC1090 --external-sources`, exit 0);
+- `scripts/enforce-eol.sh` requires a trailing newline (present).
+
+### Wiring → a new `.github/workflows/dijkstra-census.yml`, not `ci.yml`
+
+Two reasons, in order of weight:
+
+1. **It must not be skippable.** Every quality check in `ci.yml` sits behind
+   `needs: build-gate-quality`. A census that does not run when an unrelated nix
+   build fails is a census that reports nothing exactly when the tree is
+   churning. The whole point of this child is that the pipeline executes the
+   criterion, so the job carries no `needs:` and depends on no other job.
+2. **`ci.yml` is secret-bearing.** Its `attic-cache` job reads
+   `secrets.ATTIC_TOKEN`. The commit-owner seat for this ticket is barred from
+   any work touching production secrets or secret-bearing configuration. A
+   separate, secret-free workflow file keeps that bar clean rather than keeping a
+   barred seat "just out of frame" from a credential.
+
+The workflow gets its own `concurrency` group so it cannot cancel `ci.yml` runs.
+It uses the same `nix-enabled-runners` label as the rest of the repository, but
+runs no nix: the instrument is bash + `find` + `perl`.
+
+### Ratchet value → one line, in the instrument
+
+`MAX=${DIJKSTRA_STUB_MAX:-44}` in `scripts/ci/dijkstra-stub-gate.sh` is the
+single home of the ratchet. A child of #5209 that retires stubs edits that one
+literal in the same PR. Nothing else in the repository repeats the number — in
+particular the negative control does not, because it asserts "one more than
+whatever the tree holds is red", not "45 is red".
+
+## The falsification is permanent, not a one-off paste
+
+The instrument's built-in positive and negative controls prove the
+**instrument** can count and can return zero. They do **not** prove the **gate
+fails when it should**. Those are different claims.
+
+So CI seeds one throwaway Dijkstra stub into the real checked-out tree, runs the
+gate, and requires exit 1 — on **every run**, before the real census. This
+follows the precedent already in this repository: the `delegation-agda` job
+requires the same Agda command to reject one deliberate mutation per named
+#5350 law, so that check is proven able to fail on every run.
+
+The seeded file is created and removed inside the CI step, under a `trap`. The
+committed tree contains no Haskell change; the checkout is disposable.
+
+Ordering is deliberate: negative control first, so a gate that has stopped being
+able to fail is caught before its green is believed.
+
+## Live boundary
+
+The boundary that matters here is **the pipeline**, not the script. A gate the
+build compiles but the pipeline does not run is the exact failure this child
+exists to prevent. Acceptance therefore requires the job visible in the run log
+of the PR head, not the job present in the workflow file.
+
+## Slices
+
+One bisect-safe slice.
+
+**SL-1 — land the instrument, its falsification harness, and the workflow.**
+Adds three files, changes none. `master` is green at 44 before and after, so the
+slice is safe at every point of a bisect.
+
+## Constraints
+
+- No `lib/**/*.hs` change, and no stub retired.
+- No exclusion mechanism, path prune, or skip flag added to the census; the file
+  selection stays `find "$lib" -name '*.hs' -type f`, unconditional.
+- `MAX` is not lowered below 44.
+- The instrument is copied byte-for-byte; its sha256 is verified after landing.

--- a/specs/5406-dijkstra-census-ratchet/spec.md
+++ b/specs/5406-dijkstra-census-ratchet/spec.md
@@ -78,3 +78,19 @@ DIJKSTRA_STUB_MAX=0 ./scripts/ci/dijkstra-stub-gate.sh
 
 plus a green **"Dijkstra Stub Census"** check on the PR, with both the seeded
 RED and the tree GREEN visible in its run log.
+
+---
+
+## Version 2 requirements — after audit submission 1
+
+- **REQ-8** The falsification control's success is bound to a **measured**
+  effect on the census total, not to its own report. It applies exactly one
+  counted mutation and says so in machine-readable output.
+- **REQ-9** The control never destroys a file it did not create. A rejected
+  collision leaves the pre-existing file byte-identical on every exit path.
+- **REQ-10** The census job cannot be suppressed. No workflow-, job-, or
+  step-level `if:`, and no `paths`/`paths-ignore` filter, may prevent it from
+  running on a pull request or on a push to `master`.
+- **REQ-11** The census is observed **green in a live CI run at the exact
+  pushed head**, in the run log, not inferred from the workflow file. This is
+  a ticket-owner completion condition; no local check can establish it.

--- a/specs/5406-dijkstra-census-ratchet/spec.md
+++ b/specs/5406-dijkstra-census-ratchet/spec.md
@@ -1,0 +1,80 @@
+# Spec — CI: enforce the Dijkstra stub census ratchet on every PR
+
+**Issue:** #5406 (child 0 of epic #5209)
+**Branch:** `fix/5209-dijkstra-census-gate`
+**Base:** `origin/master` `0a7332482c49537d8169a7a3424a6ce72329c6d5`
+
+## Observable outcome
+
+The Dijkstra stub census runs in CI on every pull request and on every push to
+`master`, is **green on `master` today**, and goes **red the moment anyone adds
+a Dijkstra stub** under `lib/`.
+
+## Why
+
+Epic #5209's acceptance criterion is a census reaching zero. Until CI executes
+that census, the criterion is a script in a runtime directory. A check the
+pipeline does not run reports green whatever its assertions say. This ticket is
+deliberately first in the epic: it is the instrument every other child's claim
+is measured with.
+
+Its predecessor criterion — `grep -rn "DijkstraEra not yet supported" lib/` —
+passed with 38 of 44 stubs live, because that string is one of 29 distinct stub
+literals and 4 stubs split their message across source lines with Haskell string
+gaps. This ticket lands a counting, multi-line-aware instrument in its place.
+
+## Requirements
+
+- **REQ-1** The census instrument is present in the repository and runnable
+  with no arguments from the repository root by a person who has just cloned.
+- **REQ-2** The instrument is byte-identical to the frozen artefact
+  `sha256:6304802d788cd8371fd0ec0214e23e083c77e892966b34a7884663e4e66ae79f`.
+  It is landed, not redesigned.
+- **REQ-3** CI executes it on `pull_request` and on `push` to `master`,
+  unconditionally — not behind another job's success.
+- **REQ-4** CI proves on **every run** that the gate can fail, by seeding one
+  throwaway Dijkstra stub into the real checked-out tree and requiring exit 1.
+- **REQ-5** The ratchet value `MAX=44` lives in exactly one place and is
+  lowered by a child's PR in one obvious line.
+- **REQ-6** No Haskell source changes. No stub is retired here.
+- **REQ-7** The new CI wiring references no secret and no credential.
+
+## Rejection behaviour
+
+- Adding a Dijkstra `error` stub or a Dijkstra `pendingWith` under `lib/`
+  raises the total above 44 → gate exits 1, CI red.
+- Breaking the instrument so it can no longer count, or so it can no longer
+  return zero → gate exits 2, CI red. A broken instrument reports as broken,
+  never as clean.
+- Removing or neutering the CI wiring → the negative control no longer runs and
+  the workflow no longer appears in the checks list.
+
+## Explicit non-goals
+
+- **Not** lowering `MAX` below 44. That is done by the children of #5209 that
+  actually retire stubs, in the same PR that retires them.
+- **Not** narrowing the census. There is no exclusion mechanism of any kind and
+  none is added. The five stubs in `lib/wallet/src/Cardano/Api/Extra.hs` stay in
+  the denominator even though #5290 will eventually delete that shim: a
+  criterion that shrinks its own denominator when the denominator is
+  inconvenient is worse than the grep it replaced, because it looks rigorous.
+- **Not** closing #5209. Merging this closes #5406 only. 44 stubs are still live
+  on `master` the moment after it merges. #5209 closes when the ratchet reaches
+  `MAX=0`.
+
+## Observable success
+
+```sh
+./scripts/ci/dijkstra-stub-gate.sh
+# total = 44 across 15 files   (ratchet MAX=44)
+# GATE GREEN: 44 stubs, at or below the ratchet.        exit 0
+
+./scripts/ci/dijkstra-census-negative-control.sh
+# seeds one stub, requires exit 1, removes it            exit 0
+
+DIJKSTRA_STUB_MAX=0 ./scripts/ci/dijkstra-stub-gate.sh
+# GATE RED: 44 Dijkstra stubs > ratchet MAX=0           exit 1   (correct today)
+```
+
+plus a green **"Dijkstra Stub Census"** check on the PR, with both the seeded
+RED and the tree GREEN visible in its run log.

--- a/specs/5406-dijkstra-census-ratchet/tasks.md
+++ b/specs/5406-dijkstra-census-ratchet/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — #5406
+
+## SL-1 — land the instrument, its falsification harness, and the workflow
+
+- [ ] **T-001** Land the frozen instrument at `scripts/ci/dijkstra-stub-gate.sh`,
+      byte-identical to
+      `sha256:6304802d788cd8371fd0ec0214e23e083c77e892966b34a7884663e4e66ae79f`,
+      mode `0755`. (REQ-1, REQ-2, INV-INSTRUMENT-INTACT, INV-DENOMINATOR)
+- [ ] **T-002** Add `scripts/ci/dijkstra-census-negative-control.sh`: seed one
+      throwaway Dijkstra stub under `<root>/lib/`, require the gate to exit 1,
+      remove the seed on every exit path. (REQ-4, INV-CENSUS-RED)
+- [ ] **T-003** Add `.github/workflows/dijkstra-census.yml`: `pull_request` +
+      `push` to `master` + `workflow_dispatch`, no `needs:`, no secret,
+      own `concurrency` group; runs T-002 then T-001.
+      (REQ-3, REQ-7, INV-CENSUS-RUNS, INV-NO-SECRETS)
+- [ ] **T-004** Verify locally, in this order, and freeze the output:
+      negative control exit 0; `./scripts/ci/dijkstra-stub-gate.sh` → 44/15,
+      exit 0; `DIJKSTRA_STUB_MAX=0 ./scripts/ci/dijkstra-stub-gate.sh` → exit 1;
+      `shellcheck -e SC1090 --external-sources` on both scripts → exit 0;
+      `./scripts/enforce-eol.sh` → exit 0. (REQ-1, REQ-5)
+- [ ] **T-005** Prove the committed tree changes no Haskell and no existing
+      file: `git diff --stat` against the base shows exactly the three new files
+      plus this `specs/` directory, and `git diff --name-only <base>..HEAD |
+      grep -c '^lib/.*\.hs$'` is 0. (REQ-6, INV-NO-HASKELL)
+
+## Invariants
+
+| ID | holds when | fails visibly when |
+|---|---|---|
+| `INV-CENSUS-RUNS` | the `Dijkstra Stub Census` check appears in the PR's run log and is not gated on another job | the workflow is present but never executed |
+| `INV-CENSUS-RED` | one extra Dijkstra stub under `lib/` makes the gate exit 1, re-proved on every CI run | the seeded control passes or is skipped |
+| `INV-CENSUS-GREEN` | the unmodified tree exits 0 at `MAX=44` | `master` goes red without a stub being added |
+| `INV-INSTRUMENT-INTACT` | landed sha256 equals `6304802d…e66ae79f`; both built-in controls still run every invocation | the instrument is edited, or its controls are removed |
+| `INV-DENOMINATOR` | file selection is `find "$lib" -name '*.hs' -type f`, unconditional; `Cardano/Api/Extra.hs` still counted | any exclusion mechanism appears |
+| `INV-RATCHET-ONE-LINE` | `44` appears as a ratchet value in exactly one line of the repository | the value is duplicated and can drift |
+| `INV-NO-SECRETS` | the new workflow file contains no `secrets.` reference | a credential enters this ticket's surface |
+| `INV-NO-HASKELL` | no `lib/**/*.hs` is added, changed or deleted in the commit | a stub is touched by child 0 |

--- a/specs/5406-dijkstra-census-ratchet/tasks.md
+++ b/specs/5406-dijkstra-census-ratchet/tasks.md
@@ -35,3 +35,31 @@
 | `INV-RATCHET-ONE-LINE` | `44` appears as a ratchet value in exactly one line of the repository | the value is duplicated and can drift |
 | `INV-NO-SECRETS` | the new workflow file contains no `secrets.` reference | a credential enters this ticket's surface |
 | `INV-NO-HASKELL` | no `lib/**/*.hs` is added, changed or deleted in the commit | a stub is touched by child 0 |
+
+## SL-1 repair — after audit submission 1 (report `1b711708…5f68314f`)
+
+- [ ] **T-006** Bind the control's verdict to a measured delta: emit
+      `seed=`, `pristine_total=`, `seeded_total=`, `delta=`, `gate_exit=` on
+      stdout, and exit 0 only when the pristine run exited 0, `delta == 1`, and
+      `gate_exit == 1`. The seeded file must introduce exactly one counted
+      shape — none in its comments. (REQ-8, `INV-CONTROL-DELTA-ONE`)
+- [ ] **T-007** Acquire ownership before arming cleanup: create the seed
+      atomically, arm the trap only after that succeeds, and leave a rejected
+      collision byte-identical on every exit path including `INT`/`TERM`/`HUP`
+      and a census exiting 2. (REQ-9, `INV-CONTROL-COLLISION-SAFE`)
+- [ ] **T-008** Make the census unsuppressable: no workflow-, job-, or
+      step-level `if:`, and no `paths`/`paths-ignore` filter, on
+      `.github/workflows/dijkstra-census.yml`.
+      (REQ-10, `INV-CENSUS-UNSUPPRESSED`)
+- [ ] **T-009** *(ticket owner)* Observe the census green in a live CI run at
+      the exact pushed head, and paste the seeded-RED and tree-GREEN runs into
+      the PR body. (REQ-11, `INV-LIVE-RUN`)
+
+## Version 2 invariants
+
+| ID | holds when | fails visibly when |
+|---|---|---|
+| `INV-CONTROL-DELTA-ONE` | the control measures the census total before and after seeding and requires the difference to be exactly 1 | the control passes while applying zero or two mutations, or while the census output was never parsed |
+| `INV-CONTROL-COLLISION-SAFE` | a pre-existing file at the seed path survives byte-identical and the control exits non-zero | the control deletes a file it did not create |
+| `INV-CENSUS-UNSUPPRESSED` | no `if:` or path filter can stop the census job or its steps | a suppressed job reports green by not running |
+| `INV-LIVE-RUN` | the census check is green in the PR's run log at the exact pushed head | the workflow is present and the pipeline never ran it |


### PR DESCRIPTION
Closes #5406.

## What this lands

The Dijkstra stub census, as an executable check CI runs on every pull request
and on every push to `master`.

Issue #5209's acceptance criterion is a census of Dijkstra `error` stubs and
Dijkstra `pendingWith` under `lib/` reaching zero. Until CI executes that
census, the criterion is a script nothing runs.

It is a **ratchet**, not a zero-assert. `MAX=44` is today's measured count, so
it is green on `master` today and goes red on the 45th stub. Its terminal
value `MAX=0` is #5209's acceptance criterion.

## What this does not do

- It does not lower `MAX`. Tickets that retire stubs lower it in the same PR
  that retires them.
- It does not narrow the census. There is no exclusion mechanism of any kind.
- It changes no Haskell and retires no stub. **44 stubs are still live on
  `master` the moment this merges.** This closes #5406, not #5209.
