### PR TITLE
cardano-api removal: retire deprecation sites by reading transaction bodies from the ledger

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -166,7 +166,6 @@ import Cardano.Address.Script
 
 import Cardano.Api.Extra
     ( cardanoApiEraConstraints
-    , fromCardanoApiTx
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
@@ -900,9 +899,6 @@ import Prelude
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
-import qualified Cardano.Api as Cardano
-    ( Tx (..)
-    )
 import qualified Cardano.Balance.Tx.Balance as Write
     ( PartialTx (..)
     , Redeemer (..)
@@ -3176,7 +3172,7 @@ constructTransaction api knownPools poolStatus apiWalletId body = do
                     pp
                     timeTranslation
                     Write.PartialTx
-                        { tx = fromCardanoApiTx $ Cardano.Tx unbalancedTx []
+                        { tx = unbalancedTx
                         , extraUTxO = mempty
                         , redeemers = mempty
                         , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
@@ -3648,9 +3644,7 @@ constructSharedTransaction
                                 pp
                                 timeTranslation
                                 Write.PartialTx
-                                    { tx =
-                                        fromCardanoApiTx
-                                            $ Cardano.Tx unbalancedTx []
+                                    { tx = unbalancedTx
                                     , extraUTxO = mempty
                                     , redeemers = mempty
                                     , stakeKeyDeposits = Write.StakeKeyDepositMap mempty

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -901,6 +901,8 @@ import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
+    ( Tx (..)
+    )
 import qualified Cardano.Balance.Tx.Balance as Write
     ( PartialTx (..)
     , Redeemer (..)

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -18,9 +18,11 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Temporary: cardano-api 11.5 deprecates the legacy TxBody/TxBodyContent API
--- in favour of Cardano.Api.Experimental. Retiring these sites is cardano-api
--- removal work, owned by M1 (#5237). Remove this pragma when that lands.
+-- Narrowed residual (#5411): this suppression no longer covers the
+-- transaction-body boundary (Wallet.hs's was retired), only the
+-- signTransaction property pipeline over the deprecated cardano-api TxBody
+-- API, which retires with #5290. Measured by build (removing the pragma
+-- yields 25 -Wdeprecations here, all in that pipeline).
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {- HLINT ignore "Use null" -}
 {- HLINT ignore "Use camelCase" -}
@@ -55,7 +57,6 @@ import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
     , cardanoEraFromRecentEra
-    , fromCardanoApiTx
     , shelleyBasedEraFromRecentEra
     , toCardanoApiTx
     )
@@ -107,11 +108,14 @@ import Cardano.Ledger.Api
     , witsTxL
     )
 import Cardano.Ledger.Api.Tx.Body
-    ( mintTxBodyL
+    ( collateralInputsTxBodyL
+    , inputsTxBodyL
+    , mintTxBodyL
+    , outputsTxBodyL
+    , withdrawalsTxBodyL
     )
 import Cardano.Ledger.BaseTypes
-    ( Network (Mainnet, Testnet)
-    , StrictMaybe (..)
+    ( StrictMaybe (..)
     )
 import Cardano.Ledger.Binary
     ( serialize
@@ -120,8 +124,10 @@ import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic)
     )
 import Cardano.Wallet
-    ( Fee (..)
+    ( CoinSelection (..)
+    , Fee (..)
     , Percentile (..)
+    , buildCoinSelectionForTransaction
     , calculateFeePercentiles
     , signTransaction
     )
@@ -131,9 +137,24 @@ import Cardano.Wallet.Address.Derivation
     , deriveRewardAccount
     , hex
     , paymentAddress
+    , stakeDerivationPath
     )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey
+    , unsafeGenerateKeyFromSeed
+    )
+import Cardano.Wallet.Address.Discovery
+    ( ChangeAddressMode (..)
+    , IsOurs (..)
+    , KnownAddresses (..)
+    )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( SeqState (..)
+    , defaultAddressPoolGap
+    , purposeCIP1852
+    )
+import Cardano.Wallet.Address.Keys.SequentialAny
+    ( mkSeqStateFromRootXPrv
     )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey
@@ -157,14 +178,27 @@ import Cardano.Wallet.Primitive.Ledger.Convert
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
     ( txIntegrity
     )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
+    ( fromLedgerWithdrawals
+    )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
     ( fromSealedTx
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( toCardanoTxIn
+    ( fromCardanoTxIn
+    , fromCardanoTxOut
+    , fromCardanoWdrls
+    , toCardanoTxIn
+    )
+import Cardano.Wallet.Primitive.Model
+    ( Wallet
+    , getState
+    , totalUTxO
+    , unsafeInitWallet
     )
 import Cardano.Wallet.Primitive.NetworkId
-    ( SNetworkId (..)
+    ( NetworkDiscriminant (..)
+    , SNetworkId (..)
     )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
@@ -181,6 +215,9 @@ import Cardano.Wallet.Primitive.Types.AssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
     ( AssetName (UnsafeAssetName)
+    )
+import Cardano.Wallet.Primitive.Types.Block
+    ( BlockHeader (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -224,6 +261,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
+    , TxChange (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
     , sealedTxFromBytes
@@ -284,7 +322,8 @@ import Cardano.Wallet.Transaction
     , selectionDelta
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex
+    ( someDummyMnemonic
+    , unsafeFromHex
     )
 import Control.Arrow
     ( first
@@ -316,9 +355,13 @@ import Data.ByteString
 import Data.Either
     ( isRight
     )
+import Data.Foldable
 import Data.Function
     ( on
     , (&)
+    )
+import Data.Functor
+    ( (<&>)
     )
 import Data.IntCast
     ( intCast
@@ -335,6 +378,7 @@ import Data.Map.Strict
 import Data.Maybe
     ( fromJust
     , isJust
+    , maybeToList
     )
 import Data.Ord
     ( comparing
@@ -397,6 +441,7 @@ import Test.QuickCheck
     , cover
     , elements
     , forAll
+    , forAllBlind
     , forAllShow
     , frequency
     , ioProperty
@@ -449,9 +494,11 @@ import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Ledger.Read.Eras as Eras
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs as ReadTxOut
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -472,6 +519,13 @@ spec = describe "TransactionSpec" $ do
     forAllRecentEras ledgerMintPlumbingSpec
     forAllRecentEras ledgerScriptWitnessParitySpec
     transactionConstraintsSpec
+    describe "four-field differential (INV-3)" $ do
+        prop
+            "ledger reads equal the cardano-api reads, per field"
+            prop_fourFieldDifferential
+        prop
+            "production coin selection matches the cardano-api path"
+            prop_productionCoinSelectionMatchesCardanoApiPath
     describe "V2 key witness" $ do
         prop "V2 root witness matches V1 for same key material"
             $ forAll genShelleyKeyAndPwd (uncurry prop_v2WitnessMatchesV1)
@@ -1229,7 +1283,7 @@ ledgerMintPlumbingSpec' era =
                 ( buildLedgerTx
                     era
                     sampleTtl
-                    Testnet
+                    SL.Testnet
                     NoWithdrawal
                     (Coin 0)
                     Nothing
@@ -1246,7 +1300,7 @@ ledgerMintPlumbingSpec' era =
                 ( buildLedgerTxRaw
                     era
                     sampleTtl
-                    Testnet
+                    SL.Testnet
                     NoWithdrawal
                     (Coin 0)
                     Nothing
@@ -1263,7 +1317,7 @@ ledgerMintPlumbingSpec' era =
                 ( buildLedgerTxRaw
                     era
                     sampleTtl
-                    Testnet
+                    SL.Testnet
                     NoWithdrawal
                     (Coin 0)
                     Nothing
@@ -1323,10 +1377,12 @@ ledgerMintPlumbingSpec' era =
 -- Script-witness parity (PR #5288)
 --
 -- Six enumerated scenarios + one property compare two builders byte-for-byte:
---   * the legacy Cardano.Wallet.Shelley.Transaction.mkUnsignedTx (cardano-api)
---   * the new   Cardano.Wallet.Shelley.Transaction.Ledger.buildLedgerTx
+--   * Cardano.Wallet.Shelley.Transaction.mkUnsignedTx
+--   * Cardano.Wallet.Shelley.Transaction.Ledger.buildLedgerTx
 --
--- After both builders produce a Conway-era body, we compare:
+-- Both builders now produce a ledger 'Write.Tx Write.Conway' directly
+-- (mkUnsignedTx retired its cardano-api body in #5411), so the comparison is
+-- between the two production entry points. We compare:
 --   (a) CBOR of `tx ^. bodyTxL` (via serialize @Conway)
 --   (b) `tx ^. witsTxL . scriptTxWitsL`
 --
@@ -1511,7 +1567,8 @@ parityTtl = (Nothing, SlotNo 100)
 parityFee :: Coin
 parityFee = Coin 200_000
 
--- | Build the legacy body via mkUnsignedTx and lift it to a ledger Tx Conway.
+-- | Build the body via mkUnsignedTx, which (like 'buildNewParityTx') yields
+-- a ledger 'Write.Tx Write.Conway' directly since #5411.
 buildLegacyParityTx
     :: RecentEra Write.Conway
     -> SelectionOf TxOut
@@ -1552,7 +1609,7 @@ buildLegacyParityTx _eraW sel ws ctx =
                     $ "buildLegacyParityTx: mkUnsignedTx failed: "
                         <> show err
             Right b -> b
-    in  fromCardanoApiTx (Cardano.makeSignedTransaction [] body)
+    in  body
 
 -- | Build the new ledger body via buildLedgerTx (extended with ScriptWitnesses).
 buildNewParityTx
@@ -1574,7 +1631,7 @@ buildNewParityTx eraW sel ws ctx =
     in  buildLedgerTx
             eraW
             parityTtl
-            Mainnet -- ledger Network; matches Cardano.Mainnet on legacy side
+            SL.Mainnet -- ledger Network; matches Cardano.Mainnet on legacy side
             (ctxWithdrawal ctx)
             parityFee
             Nothing
@@ -1631,6 +1688,284 @@ propParity eraW sel ws ctx =
             , counterexample "scriptTxWitsL differs"
                 $ parityScriptWits legacy === parityScriptWits new
             ]
+
+--------------------------------------------------------------------------------
+-- Four-field differential (INV-3)
+--
+-- For the same generated transaction, the values the migrated production
+-- code reads from the ledger must equal the values obtained THROUGH
+-- cardano-api. The oracle below is the literal deprecated call
+-- ('Cardano.getTxBodyContent' of 'Cardano.getTxBody' of 'toCardanoApiTx tx'):
+-- the same expression the pre-migration production site evaluated. The
+-- differential is enforced at two levels, each with a labelled comparison
+-- per field:
+--
+--  * 'prop_fourFieldDifferential' compares the raw four values.
+--  * 'prop_productionCoinSelectionMatchesCardanoApiPath' compares the
+--    'CoinSelection' that 'buildCoinSelectionForTransaction' actually
+--    returns against the same oracle fed through the pre-migration
+--    construction, so production cannot swap a lens and stay green.
+--
+-- Both properties execute as part of the unit suite (gate.sh is
+-- compile-only); receipts in the commit-owner evidence directory show the
+-- run.
+--------------------------------------------------------------------------------
+
+-- | Deterministic Shelley sequential state; the fixture wallet owns the
+-- addresses it derives, so input resolution and change filtering fire exactly
+-- as they do in production.
+fixtureState :: SeqState 'Mainnet ShelleyKey
+fixtureState =
+    mkSeqStateFromRootXPrv
+        ShelleyKeyS
+        (RootCredentials fixtureRootKey mempty)
+        purposeCIP1852
+        defaultAddressPoolGap
+        IncreasingChangeAddresses
+
+fixtureRootKey :: ShelleyKey 'RootK XPrv
+fixtureRootKey =
+    unsafeGenerateKeyFromSeed
+        (someDummyMnemonic (Proxy @12), Nothing)
+        mempty
+
+-- | Addresses owned by 'fixtureState', used for every input, output and
+-- collateral entry of the generated transaction.
+fixtureOwnedAddresses :: [Address]
+fixtureOwnedAddresses =
+    take 15 $ map (\(addr, _, _) -> addr) (knownAddresses fixtureState)
+
+dummyTip :: BlockHeader
+dummyTip =
+    BlockHeader
+        { slotNo = SlotNo 0
+        , blockHeight = Quantity 0
+        , headerHash = Hash BS.empty
+        , parentHeaderHash = Nothing
+        }
+
+-- | Generate a fixture wallet and a Conway ledger transaction whose body
+-- carries all four fields: inputs, outputs, collateral inputs and
+-- withdrawals. The wallet's UTxO holds an entry (at an owned address) for
+-- every index the generator can pick, so input and collateral resolution
+-- succeeds on both sides of the differential. Built with the ledger-side
+-- builder used in production; collateral is injected through the body lens
+-- because 'buildLedgerTx' does not take collateral inputs. The resulting
+-- body is never validated, only read, so synthetic collateral inputs are
+-- fine.
+genDifferentialCase
+    :: Gen
+        ( Wallet (SeqState 'Mainnet ShelleyKey)
+        , Write.Tx Write.Conway
+        , [TxOut]
+        )
+genDifferentialCase = do
+    let ownedAddrs = fixtureOwnedAddresses
+    nIns <- choose (1, 3) :: Gen Int
+    inputIxs <-
+        vectorOf nIns (choose (0, 9) :: Gen Int)
+            `suchThat` (\xs -> length (nub xs) == length xs)
+    nOuts <- choose (1, 2) :: Gen Int
+    nCol <- choose (0, 2) :: Gen Int
+    colIxs <- vectorOf nCol (choose (0, 9) :: Gen Int)
+    let mkIn ix =
+            ( TxIn dummyTxId (fromIntegral ix)
+            , TxOut (ownedAddrs !! ix) (coinToBundle 10_000_000)
+            )
+        outs =
+            [ TxOut
+                (ownedAddrs !! (10 + k))
+                (coinToBundle (fromIntegral k * 1_000))
+            | k <- [1 .. nOuts]
+            ]
+        sel =
+            Selection
+                { inputs = NE.fromList (map mkIn inputIxs)
+                , collateral = []
+                , extraCoinSource = Coin 0
+                , extraCoinSink = Coin 0
+                , outputs = outs
+                , change = []
+                , assetsToMint = TokenMap.empty
+                , assetsToBurn = TokenMap.empty
+                }
+    wdrlAcct <-
+        oneof
+            [ pure (FromKeyHash (BS.pack [1 .. 28]))
+            , pure (FromScriptHash (BS.pack [1 .. 28]))
+            ]
+    hasWdrl <- arbitrary
+    let ctx =
+            emptyCtx
+                { ctxWithdrawal =
+                    if hasWdrl
+                        then WithdrawalSelf wdrlAcct dummyDerivPath (Coin 1)
+                        else NoWithdrawal
+                }
+        tx0 = buildNewParityTx Write.RecentEraConway sel noScriptWitnesses ctx
+        collateral =
+            Set.fromList
+                [toLedger (TxIn dummyTxId (fromIntegral ix)) | ix <- colIxs]
+        tx = tx0 & bodyTxL . collateralInputsTxBodyL .~ collateral
+        utxoEntries =
+            [ ( TxIn dummyTxId (fromIntegral ix)
+              , TxOut (ownedAddrs !! ix) (coinToBundle 10_000_000)
+              )
+            | ix <- [0 .. 9]
+            ]
+        wallet =
+            unsafeInitWallet
+                (UTxO (Map.fromList utxoEntries))
+                dummyTip
+                fixtureState
+    paymentOutputs <- oneof [pure [], pure (take 1 outs)]
+    pure (wallet, tx, paymentOutputs)
+
+-- | The four wallet values as the ledger reads produce them: the same lens
+-- reads and converters the migrated production code uses.
+ledgerFieldValues
+    :: Write.Tx Write.Conway
+    -> ( [TxIn]
+       , [TxOut]
+       , [TxIn]
+       , [(RewardAccount, Coin)]
+       )
+ledgerFieldValues tx =
+    ( map toWallet (Set.toList (body ^. inputsTxBodyL))
+    , map
+        (fst . ReadTxOut.fromConwayTxOut)
+        (F.toList (body ^. outputsTxBodyL))
+    , map toWallet (Set.toList (body ^. collateralInputsTxBodyL))
+    , Map.toList
+        (fromLedgerWithdrawals (unWithdrawals (body ^. withdrawalsTxBodyL)))
+    )
+  where
+    body = tx ^. bodyTxL
+
+-- | The literal cardano-api read of the four fields: exactly the expression
+-- the pre-migration production site evaluated.
+apiPathContent
+    :: Write.Tx Write.Conway
+    -> Cardano.TxBodyContent Cardano.ViewTx Cardano.ConwayEra
+apiPathContent tx =
+    Cardano.getTxBodyContent $ Cardano.getTxBody $ toCardanoApiTx tx
+
+prop_fourFieldDifferential :: Property
+prop_fourFieldDifferential =
+    forAllBlind genDifferentialCase $ \(_wallet, tx, _paymentOutputs) ->
+        let content = apiPathContent tx
+            (lIns, lOuts, lCol, lWdrl) = ledgerFieldValues tx
+            aIns = map (fromCardanoTxIn . fst) (Cardano.txIns content)
+            aOuts = map fromCardanoTxOut (Cardano.txOuts content)
+            aCol = case Cardano.txInsCollateral content of
+                Cardano.TxInsCollateralNone -> []
+                Cardano.TxInsCollateral _supported is ->
+                    map fromCardanoTxIn is
+            aWdrl = fromCardanoWdrls (Cardano.txWithdrawals content)
+        in  conjoin
+                [ counterexample "inputs" (lIns === aIns)
+                , counterexample "outputs" (lOuts === aOuts)
+                , counterexample "collateral" (lCol === aCol)
+                , counterexample "withdrawals" (lWdrl === aWdrl)
+                ]
+
+-- | The pre-migration production construction, fed exclusively by the
+-- literal cardano-api read: what 'buildCoinSelectionForTransaction' produced
+-- before the migration and must still produce.
+oracleCoinSelection
+    :: Wallet (SeqState 'Mainnet ShelleyKey)
+    -> [TxOut]
+    -> Cardano.TxBodyContent Cardano.ViewTx Cardano.ConwayEra
+    -> CoinSelection
+oracleCoinSelection wallet paymentOutputs content =
+    CoinSelection
+        { inputs =
+            oracleResolveInput wallet . fromCardanoTxIn . fst
+                =<< Cardano.txIns content
+        , outputs = paymentOutputs
+        , change = do
+            out <-
+                drop (length paymentOutputs)
+                    $ fromCardanoTxOut
+                        <$> Cardano.txOuts content
+            let address = out ^. #address
+            derivationPath <-
+                maybeToList $ fst $ isOurs address (getState wallet)
+            pure
+                TxChange
+                    { address
+                    , amount = out ^. #tokens . #coin
+                    , assets = out ^. #tokens . #tokens
+                    , derivationPath
+                    }
+        , collateral =
+            oracleResolveInput wallet . fromCardanoTxIn
+                =<< case Cardano.txInsCollateral content of
+                    Cardano.TxInsCollateralNone -> []
+                    Cardano.TxInsCollateral _supported is -> is
+        , withdrawals =
+            fromCardanoWdrls (Cardano.txWithdrawals content)
+                <&> \(acct, coin) -> (acct, coin, rewardAcctPath)
+        , delegationAction = Nothing
+        , deposit = Nothing
+        , refund = Nothing
+        }
+  where
+    oracleResolveInput w txIn = do
+        out@(TxOut addr _) <-
+            maybeToList (UTxO.lookup txIn (totalUTxO mempty w))
+        derivationPath <- maybeToList (fst (isOurs addr (getState w)))
+        pure (txIn, out, derivationPath)
+    rewardAcctPath =
+        stakeDerivationPath (derivationPrefix (getState wallet))
+
+-- | The CoinSelection 'buildCoinSelectionForTransaction' actually returns,
+-- from its internal ledger reads, against the same oracle: production cannot
+-- read a different lens than the cardano-api path without this going red.
+prop_productionCoinSelectionMatchesCardanoApiPath :: Property
+prop_productionCoinSelectionMatchesCardanoApiPath =
+    forAllBlind genDifferentialCase $ \(wallet, tx, paymentOutputs) ->
+        let content = apiPathContent tx
+            actual =
+                buildCoinSelectionForTransaction
+                    wallet
+                    paymentOutputs
+                    (Coin 0)
+                    Nothing
+                    tx
+            expected = oracleCoinSelection wallet paymentOutputs content
+        in  case (actual, expected) of
+                ( CoinSelection
+                        { inputs = ai
+                        , outputs = ao
+                        , change = ac
+                        , collateral = acl
+                        , withdrawals = aw
+                        , delegationAction = ada
+                        , deposit = ad
+                        , refund = ar
+                        }
+                    , CoinSelection
+                        { inputs = ei
+                        , outputs = eo
+                        , change = ec
+                        , collateral = ecl
+                        , withdrawals = ew
+                        , delegationAction = eda
+                        , deposit = ed
+                        , refund = er
+                        }
+                    ) ->
+                        conjoin
+                            [ counterexample "inputs" (ai === ei)
+                            , counterexample "outputs" (ao === eo)
+                            , counterexample "change" (ac === ec)
+                            , counterexample "collateral" (acl === ecl)
+                            , counterexample "withdrawals" (aw === ew)
+                            , counterexample "delegationAction" (ada === eda)
+                            , counterexample "deposit" (ad === ed)
+                            , counterexample "refund" (ar === er)
+                            ]
 
 --------------------------------------------------------------------------------
 -- Script-witness parity: small fixture helpers

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -1714,46 +1714,48 @@ propParity eraW sel ws ctx =
 reviewResponse5413Spec :: Spec
 reviewResponse5413Spec = describe "5413 review response" $ do
     it
-        "the pre-cardano-api round trip is an identity with multiple scripts" $ do
-        let tx = reviewResponseTx (Coin 1_000_000)
-        Map.size (parityScriptWits tx) `shouldSatisfy` (>= 2)
-        let roundTripped =
-                case toCardanoApiTx tx of
-                    Cardano.Tx body _ ->
-                        fromCardanoApiTx (Cardano.Tx body [])
-                            & witsTxL . scriptTxWitsL .~ mempty
-        roundTripped `shouldBe` tx
+        "the pre-cardano-api round trip is an identity with multiple scripts"
+        $ do
+            let tx = reviewResponseTx (Coin 1_000_000)
+            Map.size (parityScriptWits tx) `shouldSatisfy` (>= 2)
+            let roundTripped =
+                    case toCardanoApiTx tx of
+                        Cardano.Tx body _ ->
+                            fromCardanoApiTx (Cardano.Tx body [])
+            roundTripped `shouldBe` tx
 
     it "presents at least two distinct scripts at the balanceTx boundary" $ do
-        let declared = Map.deleteMin $ parityScriptWits reviewTx
+        let declared = parityScriptWits reviewTx
         Map.size declared `shouldSatisfy` (>= 2)
 
     it "balanceTx preserves every declared script" $ do
         balanced <- balanceReviewResponseTx (Coin 1_000_000)
         let declared = Map.keysSet $ parityScriptWits reviewTx
-        let observed =
-                Map.keysSet
-                    $ parityScriptWits
-                    $ balanced
-                    & witsTxL . scriptTxWitsL .~ mempty
+        let observed = Map.keysSet $ parityScriptWits balanced
         Set.isSubsetOf declared observed `shouldBe` True
-        Set.size declared `shouldSatisfy` (>= 2)
+        Set.size declared `shouldBe` 2
 
     it "balanceTx selects an input when declared inputs are insufficient" $ do
-        balanced <- balanceReviewResponseTx (Coin 10_000_000)
+        balanced <- balanceReviewResponseTx (Coin 1_000_000)
+        let initialInputs = reviewInputs reviewTx
         Set.size (reviewInputs balanced)
-            `shouldSatisfy` (> Set.size (reviewInputs sufficientReviewTx))
+            `shouldSatisfy` (> Set.size initialInputs)
+        Set.difference (reviewInputs balanced) initialInputs
+            `shouldBe` Set.singleton (toLedger $ TxIn dummyTxId 2)
 
     it "balanceTx appends the script for its selected input" $ do
         balanced <- balanceReviewResponseTx (Coin 1_000_000)
-        Map.keysSet (parityScriptWits balanced)
+        let scripts = parityScriptWits balanced
+        Map.size scripts `shouldBe` 3
+        Map.keysSet scripts
             `shouldSatisfy` Set.member reviewAddedInputScriptHash
   where
     reviewTx = reviewResponseTx (Coin 1_000_000)
-    sufficientReviewTx = reviewResponseTx (Coin 10_000_000)
 
--- | This oracle exists only for the cardano-api migration window. Delete it
--- with 'toCardanoApiTx' and 'fromCardanoApiTx' when those converters retire.
+-- | This oracle exists only for the cardano-api migration window.
+--
+-- Delete it with 'toCardanoApiTx' and 'fromCardanoApiTx' when those converters
+-- retire.
 reviewResponseTx :: Coin -> Write.Tx Write.Conway
 reviewResponseTx inputCoin =
     buildLegacyParityTx
@@ -1956,7 +1958,9 @@ genDifferentialCase = do
             `suchThat` (\xs -> length (nub xs) == length xs)
     nOuts <- choose (1, 2) :: Gen Int
     nCol <- choose (0, 2) :: Gen Int
-    colIxs <- vectorOf nCol (choose (0, 9) :: Gen Int)
+    colIxs <-
+        vectorOf nCol (choose (0, 9) :: Gen Int)
+            `suchThat` (\xs -> length (nub xs) == length xs)
     let mkIn ix =
             ( TxIn dummyTxId (fromIntegral ix)
             , TxOut (ownedAddrs !! ix) (coinToBundle 10_000_000)

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -46,7 +46,9 @@ import Cardano.Address.KeyHash
     , KeyRole (Delegation, Payment)
     )
 import Cardano.Address.Script
-    ( Script (..)
+    ( Cosigner (..)
+    , Script (..)
+    , ScriptTemplate (..)
     )
 import Cardano.Api
     ( AnyCardanoEra (..)
@@ -57,6 +59,7 @@ import Cardano.Api.Extra
     ( CardanoApiEra
     , cardanoApiEraConstraints
     , cardanoEraFromRecentEra
+    , fromCardanoApiTx
     , shelleyBasedEraFromRecentEra
     , toCardanoApiTx
     )
@@ -67,8 +70,15 @@ import Cardano.Api.Gen
     , genWitnesses
     )
 import Cardano.Balance.Tx.Balance
-    ( ErrBalanceTx (..)
+    ( ChangeAddressGen (..)
+    , ErrBalanceTx (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
+    , PartialTx (..)
+    , StakeKeyDepositLookup (StakeKeyDepositMap)
+    , UTxOAssumptions (AllScriptPaymentCredentialsFrom)
+    , balanceTx
+    , constructUTxOIndex
+    , fromWalletUTxO
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
@@ -161,6 +171,9 @@ import Cardano.Wallet.Address.Keys.WalletKey
     , liftRawKey
     , publicKey
     )
+import Cardano.Wallet.DummyTarget.Primitive.Types
+    ( dummyTimeInterpreter
+    )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS (..)
     )
@@ -206,6 +219,9 @@ import Cardano.Wallet.Primitive.Passphrase
     , PassphraseMinLength (..)
     , PassphraseScheme (..)
     , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Slotting.TimeTranslation
+    ( toTimeTranslationPure
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -480,7 +496,8 @@ import qualified Cardano.Balance.Tx.Eras as Write
     )
 import qualified Cardano.Balance.Tx.Primitive as BT
 import qualified Cardano.Balance.Tx.Tx as Write
-    ( Tx
+    ( Address
+    , Tx
     , TxBody
     )
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
@@ -518,6 +535,7 @@ spec = describe "TransactionSpec" $ do
     forAllRecentEras binaryCalculationsSpec
     forAllRecentEras ledgerMintPlumbingSpec
     forAllRecentEras ledgerScriptWitnessParitySpec
+    reviewResponse5413Spec
     transactionConstraintsSpec
     describe "four-field differential (INV-3)" $ do
         prop
@@ -1688,6 +1706,177 @@ propParity eraW sel ws ctx =
             , counterexample "scriptTxWitsL differs"
                 $ parityScriptWits legacy === parityScriptWits new
             ]
+
+--------------------------------------------------------------------------------
+-- PR #5413 review response
+--------------------------------------------------------------------------------
+
+reviewResponse5413Spec :: Spec
+reviewResponse5413Spec = describe "5413 review response" $ do
+    it
+        "the pre-cardano-api round trip is an identity with multiple scripts" $ do
+        let tx = reviewResponseTx (Coin 1_000_000)
+        Map.size (parityScriptWits tx) `shouldSatisfy` (>= 2)
+        let roundTripped =
+                case toCardanoApiTx tx of
+                    Cardano.Tx body _ ->
+                        fromCardanoApiTx (Cardano.Tx body [])
+                            & witsTxL . scriptTxWitsL .~ mempty
+        roundTripped `shouldBe` tx
+
+    it "presents at least two distinct scripts at the balanceTx boundary" $ do
+        let declared = Map.deleteMin $ parityScriptWits reviewTx
+        Map.size declared `shouldSatisfy` (>= 2)
+
+    it "balanceTx preserves every declared script" $ do
+        balanced <- balanceReviewResponseTx (Coin 1_000_000)
+        let declared = Map.keysSet $ parityScriptWits reviewTx
+        let observed =
+                Map.keysSet
+                    $ parityScriptWits
+                    $ balanced
+                    & witsTxL . scriptTxWitsL .~ mempty
+        Set.isSubsetOf declared observed `shouldBe` True
+        Set.size declared `shouldSatisfy` (>= 2)
+
+    it "balanceTx selects an input when declared inputs are insufficient" $ do
+        balanced <- balanceReviewResponseTx (Coin 10_000_000)
+        Set.size (reviewInputs balanced)
+            `shouldSatisfy` (> Set.size (reviewInputs sufficientReviewTx))
+
+    it "balanceTx appends the script for its selected input" $ do
+        balanced <- balanceReviewResponseTx (Coin 1_000_000)
+        Map.keysSet (parityScriptWits balanced)
+            `shouldSatisfy` Set.member reviewAddedInputScriptHash
+  where
+    reviewTx = reviewResponseTx (Coin 1_000_000)
+    sufficientReviewTx = reviewResponseTx (Coin 10_000_000)
+
+-- | This oracle exists only for the cardano-api migration window. Delete it
+-- with 'toCardanoApiTx' and 'fromCardanoApiTx' when those converters retire.
+reviewResponseTx :: Coin -> Write.Tx Write.Conway
+reviewResponseTx inputCoin =
+    buildLegacyParityTx
+        Write.RecentEraConway
+        (reviewResponseSelection inputCoin)
+        reviewResponseWitnesses
+        emptyCtx
+
+reviewResponseSelection :: Coin -> SelectionOf TxOut
+reviewResponseSelection (Coin inputCoin) =
+    Selection
+        { inputs =
+            NE.fromList
+                [ reviewInput 0
+                , reviewInput 1
+                ]
+        , collateral = []
+        , extraCoinSource = Coin 0
+        , extraCoinSink = Coin 0
+        , outputs = [mkOut 10 3_000_000]
+        , change = []
+        , assetsToMint = TokenMap.empty
+        , assetsToBurn = TokenMap.empty
+        }
+  where
+    reviewInput index =
+        ( TxIn dummyTxId index
+        , TxOut
+            (dummyAddress $ fromIntegral index)
+            (coinToBundle $ fromIntegral inputCoin)
+        )
+
+reviewResponseWitnesses :: ScriptWitnesses
+reviewResponseWitnesses =
+    noScriptWitnesses
+        { swNativeInputs =
+            Map.fromList
+                [ (TxIn dummyTxId 0, reviewInputScript0)
+                , (TxIn dummyTxId 1, reviewInputScript1)
+                ]
+        }
+
+reviewInputScript0 :: Script KeyHash
+reviewInputScript0 = mkScript 91
+
+reviewInputScript1 :: Script KeyHash
+reviewInputScript1 = mkScript 92
+
+reviewAddedInputScript :: Script KeyHash
+reviewAddedInputScript = mkScript 93
+
+reviewAddedInputScriptHash :: SL.ScriptHash
+reviewAddedInputScriptHash =
+    hashScript @Write.Conway
+        $ NativeScript
+        $ toLedgerTimelockScript reviewAddedInputScript
+
+reviewInputs :: Write.Tx Write.Conway -> Set.Set SL.TxIn
+reviewInputs = view (bodyTxL . inputsTxBodyL)
+
+balanceReviewResponseTx :: Coin -> IO (Write.Tx Write.Conway)
+balanceReviewResponseTx inputCoin = do
+    result <-
+        runExceptT
+            $ balanceTx
+                mockPParams
+                (toTimeTranslationPure dummyTimeInterpreter)
+                reviewUTxOAssumptions
+                ( constructUTxOIndex
+                    $ fromWalletUTxO @Write.Conway
+                    $ reviewResponseUTxO inputCoin
+                )
+                reviewChangeAddressGen
+                ()
+                PartialTx
+                    { tx = reviewResponseTx inputCoin
+                    , extraUTxO = mempty
+                    , redeemers = []
+                    , stakeKeyDeposits = StakeKeyDepositMap mempty
+                    , timelockKeyWitnessCounts = mempty
+                    }
+    case result of
+        Left err -> error $ "balanceReviewResponseTx: " <> show err
+        Right (balanced, ()) -> pure balanced
+
+reviewResponseUTxO :: Coin -> BT.UTxO
+reviewResponseUTxO inputCoin =
+    BT.UTxO
+        $ Map.fromList
+            [ reviewInput 0 inputCoin
+            , reviewInput 1 inputCoin
+            , reviewInput 2 (Coin 10_000_000)
+            ]
+  where
+    reviewInput index (Coin coin) =
+        ( BT.TxIn txId index
+        , BT.TxOut
+            (BT.Address $ addressBytes $ dummyAddress $ fromIntegral index)
+            (BT.fromCoin $ BT.Coin coin)
+        )
+    Hash txId = dummyTxId
+    addressBytes (Address bytes) = bytes
+
+reviewUTxOAssumptions :: UTxOAssumptions
+reviewUTxOAssumptions =
+    AllScriptPaymentCredentialsFrom
+        (ScriptTemplate mempty $ RequireSignatureOf $ Cosigner 0)
+        reviewInputScriptForAddress
+
+reviewInputScriptForAddress :: Write.Address -> Script KeyHash
+reviewInputScriptForAddress address
+    | address == toLedger (dummyAddress 0) = reviewInputScript0
+    | address == toLedger (dummyAddress 1) = reviewInputScript1
+    | otherwise = reviewAddedInputScript
+
+reviewChangeAddressGen :: ChangeAddressGen ()
+reviewChangeAddressGen =
+    ChangeAddressGen
+        { genChangeAddress = const (changeAddress, ())
+        , maxLengthChangeAddress = changeAddress
+        }
+  where
+    changeAddress = toLedger (dummyAddress 250)
 
 --------------------------------------------------------------------------------
 -- Four-field differential (INV-3)

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -87,6 +87,9 @@ import Cardano.Balance.Tx.Eras
 import Cardano.Balance.Tx.Gen
     ( mockPParams
     )
+import Cardano.Balance.Tx.Sign
+    ( TimelockKeyWitnessCounts (TimelockKeyWitnessCounts)
+    )
 import Cardano.Balance.Tx.SizeEstimation
     ( TxSkeleton (..)
     , estimateTxSize
@@ -1718,11 +1721,7 @@ reviewResponse5413Spec = describe "5413 review response" $ do
         $ do
             let tx = reviewResponseTx (Coin 1_000_000)
             Map.size (parityScriptWits tx) `shouldSatisfy` (>= 2)
-            let roundTripped =
-                    case toCardanoApiTx tx of
-                        Cardano.Tx body _ ->
-                            fromCardanoApiTx (Cardano.Tx body [])
-            roundTripped `shouldBe` tx
+            roundTripThroughCardanoApi tx `shouldBe` tx
 
     it "presents at least two distinct scripts at the balanceTx boundary" $ do
         let declared = parityScriptWits reviewTx
@@ -1732,8 +1731,9 @@ reviewResponse5413Spec = describe "5413 review response" $ do
         balanced <- balanceReviewResponseTx (Coin 1_000_000)
         let declared = Map.keysSet $ parityScriptWits reviewTx
         let observed = Map.keysSet $ parityScriptWits balanced
+        Set.member reviewPreservedScriptHash declared `shouldBe` True
         Set.isSubsetOf declared observed `shouldBe` True
-        Set.size declared `shouldBe` 2
+        Set.size declared `shouldBe` 3
 
     it "balanceTx selects an input when declared inputs are insufficient" $ do
         balanced <- balanceReviewResponseTx (Coin 1_000_000)
@@ -1746,23 +1746,38 @@ reviewResponse5413Spec = describe "5413 review response" $ do
     it "balanceTx appends the script for its selected input" $ do
         balanced <- balanceReviewResponseTx (Coin 1_000_000)
         let scripts = parityScriptWits balanced
-        Map.size scripts `shouldBe` 3
         Map.keysSet scripts
             `shouldSatisfy` Set.member reviewAddedInputScriptHash
   where
     reviewTx = reviewResponseTx (Coin 1_000_000)
 
--- | This oracle exists only for the cardano-api migration window.
+-- | Migration-window oracle for the round-trip example only.
 --
--- Delete it with 'toCardanoApiTx' and 'fromCardanoApiTx' when those converters
--- retire.
+-- Delete this helper and its example with 'toCardanoApiTx' and
+-- 'fromCardanoApiTx' when those converters retire.
+roundTripThroughCardanoApi
+    :: Write.Tx Write.Conway -> Write.Tx Write.Conway
+roundTripThroughCardanoApi tx =
+    case toCardanoApiTx tx of
+        Cardano.Tx body _ -> fromCardanoApiTx (Cardano.Tx body [])
+
 reviewResponseTx :: Coin -> Write.Tx Write.Conway
 reviewResponseTx inputCoin =
     buildLegacyParityTx
         Write.RecentEraConway
         (reviewResponseSelection inputCoin)
         reviewResponseWitnesses
-        emptyCtx
+        reviewResponseCtx
+
+reviewResponseCtx :: ScriptParityCtx
+reviewResponseCtx =
+    emptyCtx
+        { ctxWithdrawal =
+            WithdrawalSelf
+                (FromScriptHash $ scriptKeyHashBytes reviewPreservedScript)
+                dummyDerivPath
+                (Coin 1)
+        }
 
 reviewResponseSelection :: Coin -> SelectionOf TxOut
 reviewResponseSelection (Coin inputCoin) =
@@ -1796,6 +1811,7 @@ reviewResponseWitnesses =
                 [ (TxIn dummyTxId 0, reviewInputScript0)
                 , (TxIn dummyTxId 1, reviewInputScript1)
                 ]
+        , swStakingScript = Just reviewPreservedScript
         }
 
 reviewInputScript0 :: Script KeyHash
@@ -1804,14 +1820,23 @@ reviewInputScript0 = mkScript 91
 reviewInputScript1 :: Script KeyHash
 reviewInputScript1 = mkScript 92
 
+reviewPreservedScript :: Script KeyHash
+reviewPreservedScript = mkScript 94
+
+reviewPreservedScriptHash :: SL.ScriptHash
+reviewPreservedScriptHash = reviewScriptHash reviewPreservedScript
+
 reviewAddedInputScript :: Script KeyHash
 reviewAddedInputScript = mkScript 93
 
 reviewAddedInputScriptHash :: SL.ScriptHash
-reviewAddedInputScriptHash =
+reviewAddedInputScriptHash = reviewScriptHash reviewAddedInputScript
+
+reviewScriptHash :: Script KeyHash -> SL.ScriptHash
+reviewScriptHash script =
     hashScript @Write.Conway
         $ NativeScript
-        $ toLedgerTimelockScript reviewAddedInputScript
+        $ toLedgerTimelockScript script
 
 reviewInputs :: Write.Tx Write.Conway -> Set.Set SL.TxIn
 reviewInputs = view (bodyTxL . inputsTxBodyL)
@@ -1835,7 +1860,9 @@ balanceReviewResponseTx inputCoin = do
                     , extraUTxO = mempty
                     , redeemers = []
                     , stakeKeyDeposits = StakeKeyDepositMap mempty
-                    , timelockKeyWitnessCounts = mempty
+                    , timelockKeyWitnessCounts =
+                        TimelockKeyWitnessCounts
+                            $ Map.singleton reviewPreservedScriptHash 1
                     }
     case result of
         Left err -> error $ "balanceReviewResponseTx: " <> show err

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -17,9 +17,11 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
--- Temporary: cardano-api 11.5 deprecates the legacy TxBody/TxBodyContent API
--- in favour of Cardano.Api.Experimental. Retiring these sites is cardano-api
--- removal work, owned by M1 (#5237). Remove this pragma when that lands.
+-- Narrowed residual (#5411): this suppression no longer covers the
+-- transaction-body boundary (Wallet.hs's was retired), only the
+-- signTransaction property pipeline over the deprecated cardano-api TxBody
+-- API, which retires with #5290. Measured by build (removing the pragma
+-- yields 27 -Wdeprecations here, all in that pipeline).
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {- HLINT ignore "Use null" -}
 {- HLINT ignore "Use camelCase" -}
@@ -1276,22 +1278,28 @@ binaryCalculationsSpec' era = describe ("calculateBinary - " +|| era ||+ "") $ d
             mkByronWitness unsignedTx net addr
         addrWits = zipWith (mkByronWitness' unsigned) inps pairs
         fee = selectionDelta cs
+        unsigned :: Cardano.TxBody (CardanoApiEra era)
         unsigned =
-            either (error . show) id
-                $ mkUnsignedTx
-                    net
-                    (Nothing, slotNo)
-                    (Right cs)
-                    md
-                    NoWithdrawal
-                    []
-                    fee
-                    TokenMap.empty
-                    TokenMap.empty
-                    Map.empty
-                    Map.empty
-                    Nothing
-                    Nothing
+            case toCardanoApiTx
+                ( either
+                    (error . show)
+                    id
+                    $ mkUnsignedTx
+                        net
+                        (Nothing, slotNo)
+                        (Right cs)
+                        md
+                        NoWithdrawal
+                        []
+                        fee
+                        TokenMap.empty
+                        TokenMap.empty
+                        Map.empty
+                        Map.empty
+                        Nothing
+                        Nothing
+                ) of
+                Cardano.Tx body _ -> body
         cs =
             Selection
                 { inputs = NE.fromList inps
@@ -1353,7 +1361,8 @@ prop_sealedTxDefaultRecentEraRoundtrip (Pretty tc) =
                 (sealedTxFromBytes txBytes)
 
 makeShelleyTx
-    :: Write.IsRecentEra era
+    :: forall era
+     . Write.IsRecentEra era
     => RecentEra era
     -> DecodeSetup
     -> Cardano.Tx (CardanoApiEra era)
@@ -1362,22 +1371,28 @@ makeShelleyTx era' testCase =
         $ let DecodeSetup utxo outs md slotNo pairs netwk = testCase
               inps = Map.toList $ unUTxO utxo
               fee = selectionDelta cs
+              unsigned :: Cardano.TxBody (CardanoApiEra era)
               unsigned =
-                either (error . show) id
-                    $ mkUnsignedTx
-                        netwk
-                        (Nothing, slotNo)
-                        (Right cs)
-                        md
-                        NoWithdrawal
-                        []
-                        fee
-                        TokenMap.empty
-                        TokenMap.empty
-                        Map.empty
-                        Map.empty
-                        Nothing
-                        Nothing
+                case toCardanoApiTx
+                    ( either
+                        (error . show)
+                        id
+                        $ mkUnsignedTx
+                            netwk
+                            (Nothing, slotNo)
+                            (Right cs)
+                            md
+                            NoWithdrawal
+                            []
+                            fee
+                            TokenMap.empty
+                            TokenMap.empty
+                            Map.empty
+                            Map.empty
+                            Nothing
+                            Nothing
+                    ) of
+                    Cardano.Tx body _ -> body
               addrWits =
                 map (mkShelleyWitness unsigned) pairs
               cs =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -22,10 +22,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
--- Temporary: cardano-api 11.5 deprecates the legacy TxBody API in favour of
--- Cardano.Api.Experimental. Retiring these sites is cardano-api removal work,
--- owned by M1 (#5237). Remove this pragma when that lands.
-{-# OPTIONS_GHC -Wno-deprecations #-}
 -- suppress false warning
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
@@ -259,9 +255,7 @@ import Cardano.Address.Script
     ( Cosigner (..)
     )
 import Cardano.Api.Extra
-    ( CardanoApiEra
-    , cardanoApiEraConstraints
-    , toCardanoApiTx
+    ( cardanoApiEraConstraints
     )
 import Cardano.Balance.Tx.Balance
     ( ChangeAddressGen (..)
@@ -313,8 +307,10 @@ import Cardano.Ledger.Api
     )
 import Cardano.Ledger.Api.Tx.Body
     ( Withdrawals (..)
+    , collateralInputsTxBodyL
     , inputsTxBodyL
     , mintTxBodyL
+    , outputsTxBodyL
     , withdrawalsTxBodyL
     )
 import Cardano.Ledger.Binary
@@ -500,13 +496,11 @@ import Cardano.Wallet.Primitive.Ledger.Convert
 import Cardano.Wallet.Primitive.Ledger.Read.Block
     ( fromCardanoBlock
     )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
+    ( fromLedgerWithdrawals
+    )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
     ( getTxExtended
-    )
-import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( fromCardanoTxIn
-    , fromCardanoTxOut
-    , fromCardanoWdrls
     )
 import Cardano.Wallet.Primitive.Model
     ( BlockData (..)
@@ -910,13 +904,6 @@ import Prelude hiding
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CAShelley
-import qualified Cardano.Api as Cardano
-    ( TxBody
-    , TxBodyContent (..)
-    , TxInsCollateral (..)
-    , getTxBody
-    , getTxBodyContent
-    )
 import qualified Cardano.Balance.Tx.Balance as Write
     ( PartialTx (..)
     , StakeKeyDepositLookup (..)
@@ -959,6 +946,7 @@ import qualified Cardano.Wallet.DB.WalletState as WS
 import qualified Cardano.Wallet.DB.WalletState as WalletState
 import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs as ReadTxOut
 import qualified Cardano.Wallet.Primitive.Slotting as Slotting
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -976,6 +964,7 @@ import qualified Data.Foldable as F
 import qualified Data.Functor
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -2209,56 +2198,57 @@ buildCoinSelectionForTransaction
     depositRefund
     delegationAction
     tx =
-        cardanoApiEraConstraints
-            (Write.recentEra @era)
-            CoinSelection
-                { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
-                , outputs = paymentOutputs
-                , change = do
-                    out <-
-                        -- NOTE: We assume that the change outputs are always
-                        -- at the end of the list. This is true for the current
-                        -- 'balanceTx' implementation, but may not
-                        -- be true for other implementations.
-                        drop (length paymentOutputs) $ fromCardanoTxOut <$> txOuts
-                    let address = out ^. #address
-                    derivationPath <-
-                        maybeToList $ fst $ isOurs address (getState wallet)
-                    pure
-                        TxChange
-                            { address
-                            , amount = out ^. #tokens . #coin
-                            , assets = out ^. #tokens . #tokens
-                            , derivationPath
-                            }
-                , collateral =
-                    resolveInput . fromCardanoTxIn
-                        =<< case txInsCollateral of
-                            Cardano.TxInsCollateralNone -> []
-                            Cardano.TxInsCollateral _supported is -> is
-                , withdrawals =
-                    fromCardanoWdrls txWithdrawals
-                        <&> \(acct, coin) -> (acct, coin, rewardAcctPath)
-                , delegationAction = (,rewardAcctPath) <$> delegationAction
-                , deposit =
-                    case delegationAction of
-                        Just (JoinRegisteringKey _poolId) -> Just depositRefund
-                        _ -> Nothing
-                , refund =
-                    case delegationAction of
-                        Just Quit -> Just depositRefund
-                        _ -> Nothing
-                }
+        CoinSelection
+            { inputs = resolveInput =<< txIns
+            , outputs = paymentOutputs
+            , change = do
+                out <-
+                    -- NOTE: We assume that the change outputs are always
+                    -- at the end of the list. This is true for the current
+                    -- 'balanceTx' implementation, but may not
+                    -- be true for other implementations.
+                    drop (length paymentOutputs) txOuts
+                let address = out ^. #address
+                derivationPath <-
+                    maybeToList $ fst $ isOurs address (getState wallet)
+                pure
+                    TxChange
+                        { address
+                        , amount = out ^. #tokens . #coin
+                        , assets = out ^. #tokens . #tokens
+                        , derivationPath
+                        }
+            , collateral = resolveInput =<< txInsCollateral
+            , withdrawals =
+                txWithdrawals <&> \(acct, coin) -> (acct, coin, rewardAcctPath)
+            , delegationAction = (,rewardAcctPath) <$> delegationAction
+            , deposit =
+                case delegationAction of
+                    Just (JoinRegisteringKey _poolId) -> Just depositRefund
+                    _ -> Nothing
+            , refund =
+                case delegationAction of
+                    Just Quit -> Just depositRefund
+                    _ -> Nothing
+            }
       where
-        Cardano.TxBodyContent
-            { txIns
-            , txOuts
-            , txInsCollateral
-            , txWithdrawals
-            } =
-                Cardano.getTxBodyContent
-                    $ Cardano.getTxBody
-                    $ toCardanoApiTx tx
+        body = tx ^. bodyTxL
+        txIns = toWallet <$> Set.toList (body ^. inputsTxBodyL)
+        txOuts = case Write.recentEra @era of
+            Write.RecentEraConway ->
+                map (fst . ReadTxOut.fromConwayTxOut)
+                    . F.toList
+                    $ body ^. outputsTxBodyL
+            Write.RecentEraDijkstra ->
+                map (fst . ReadTxOut.fromDijkstraTxOut)
+                    . F.toList
+                    $ body ^. outputsTxBodyL
+        txInsCollateral =
+            toWallet <$> Set.toList (body ^. collateralInputsTxBodyL)
+        txWithdrawals =
+            Map.toList
+                $ fromLedgerWithdrawals
+                    (unWithdrawals (body ^. withdrawalsTxBodyL))
 
         resolveInput txIn = do
             (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)
@@ -3444,7 +3434,7 @@ constructTransaction
     -> DBLayer IO (SeqState n ShelleyKey)
     -> TransactionCtx
     -> PreSelection
-    -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))
+    -> ExceptT ErrConstructTx IO (Write.Tx era)
 constructTransaction era db txCtx preSel = do
     (_, mRewardXPub, _) <- lift $ readRewardAccount db
     when (containsSelfWithdrawal (txCtx ^. #txWithdrawal))
@@ -3467,7 +3457,7 @@ constructUnbalancedSharedTransaction
     -> DBLayer IO (SharedState n SharedKey)
     -> TransactionCtx
     -> PreSelection
-    -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))
+    -> ExceptT ErrConstructTx IO (Write.Tx era)
 constructUnbalancedSharedTransaction era db txCtx sel =
     db & \DBLayer{..} -> do
         cp <- lift $ atomically readCheckpoint

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -911,6 +911,12 @@ import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CAShelley
 import qualified Cardano.Api as Cardano
+    ( TxBody
+    , TxBodyContent (..)
+    , TxInsCollateral (..)
+    , getTxBody
+    , getTxBodyContent
+    )
 import qualified Cardano.Balance.Tx.Balance as Write
     ( PartialTx (..)
     , StakeKeyDepositLookup (..)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -235,6 +235,24 @@ import Prelude
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
+    ( Hash
+    , KeyWitness (..)
+    , NetworkId
+    , PaymentCredential (..)
+    , PaymentKey
+    , ShelleyWitnessSigningKey (..)
+    , SigningKey (..)
+    , StakeAddressReference (..)
+    , Tx (..)
+    , TxBody (..)
+    , TxBodyContent (..)
+    , TxExtraKeyWitnesses (..)
+    , TxInsCollateral (..)
+    , getTxBodyContent
+    , makeShelleyAddress
+    , makeShelleyKeyWitness
+    , makeSignedTransaction
+    )
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Balance.Tx.Eras as Write
 import qualified Cardano.Balance.Tx.Primitive as BT

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -313,7 +313,7 @@ constructUnsignedTx
     -- ^ Delegation script
     -> Maybe (Script KeyHash)
     -- ^ Reference script
-    -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))
+    -> Either ErrMkTransaction (Write.Tx era)
 constructUnsignedTx
     networkId
     (md, certs)
@@ -632,7 +632,7 @@ mkUnsignedTransaction
     -> Either PreSelection (SelectionOf TxOut)
     -- ^ A balanced coin selection where all change addresses have been
     -- assigned.
-    -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))
+    -> Either ErrMkTransaction (Write.Tx era)
 mkUnsignedTransaction networkId stakeCred ctx selection = do
     let era = Write.recentEra @era
     let ttl = txValidityInterval ctx
@@ -790,7 +790,7 @@ mkUnsignedTx
     -> Map TxIn (Script KeyHash)
     -> Maybe (Script KeyHash)
     -> Maybe (Script KeyHash)
-    -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))
+    -> Either ErrMkTransaction (Write.Tx era)
 mkUnsignedTx
     networkId
     ttl
@@ -819,8 +819,7 @@ mkUnsignedTx
                         cs
                         (toLedgerMintValue mintData burnData)
                         scriptWitnesses
-                Cardano.Tx body _ = toCardanoApiTx ledgerTx
-            in  Right body
+            in  Right ledgerTx
       where
         era = Write.recentEra @era
 

--- a/specs/5411-txbody-fields-from-ledger/data-model.md
+++ b/specs/5411-txbody-fields-from-ledger/data-model.md
@@ -1,0 +1,40 @@
+# data-model — #5411
+
+**No data model change. This section is deliberately not empty prose: the
+absence is the design decision.**
+
+- No type is added, removed, or renamed.
+- No field is added, removed, renamed, or retyped.
+- No relationship, validation rule, or state invariant changes.
+- No serialised form changes, on the wire or on disk.
+
+## Why "no change" is the specification here
+
+The ticket's central fence is **no new type modelling the transaction-body
+boundary**. A previous attempt introduced a local `BodyContent` record; it
+compiled and went in the right direction and was still wrong, because it
+reconstructed `Cardano.TxBodyContent` locally as a parallel abstraction.
+
+The four values — inputs, outputs, collateral, withdrawals — are bound
+individually at their point of use. They have no carrier before this change
+(they are a record pattern on a `cardano-api` type, immediately destructured)
+and must have none after.
+
+**So an empty data model is the acceptance criterion, not an omission.** If the
+implementation produces a diff that belongs in this file, the fence has been
+crossed — stop and escalate rather than documenting it here.
+
+## The values, for reference only
+
+These are read, not modelled. Named so the differential check (INV-3) has an
+explicit subject:
+
+| value | read from |
+|---|---|
+| transaction inputs | the ledger transaction's inputs |
+| transaction outputs | the ledger transaction's outputs |
+| collateral inputs | the ledger transaction's collateral |
+| withdrawals | the ledger transaction's withdrawals |
+
+Their *representation* after conversion to wallet primitives is unchanged; INV-3
+requires it, field by field, against the values the `cardano-api` path produced.

--- a/specs/5411-txbody-fields-from-ledger/functions-model.md
+++ b/specs/5411-txbody-fields-from-ledger/functions-model.md
@@ -1,0 +1,41 @@
+# functions-model — #5411
+
+Only signature-level changes. No bodies, no algorithms, no helpers.
+
+The result type below is written `Write.Tx era` because that is the type the
+producers already hold before wrapping and the consumers already hold after
+unwrapping. **If the resolved artifacts show a different ledger type is the
+correct one at that boundary, that is a signature discovery: version this
+document before the work continues — do not improvise a different type and do
+not introduce a new one.**
+
+## Changed signatures
+
+| function | module | from | to |
+|---|---|---|---|
+| `constructTransaction` | `Cardano.Wallet` | `… -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))` | `… -> ExceptT ErrConstructTx IO (Write.Tx era)` |
+| `constructUnbalancedSharedTransaction` | `Cardano.Wallet` | `… -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))` | `… -> ExceptT ErrConstructTx IO (Write.Tx era)` |
+| `mkUnsignedTransaction` | `Cardano.Wallet.Shelley.Transaction` | `… -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))` | `… -> Either ErrMkTransaction (Write.Tx era)` |
+| `mkUnsignedTx` | `Cardano.Wallet.Shelley.Transaction` | `… -> Either ErrMkTransaction (Cardano.TxBody (CardanoApiEra era))` | `… -> Either ErrMkTransaction (Write.Tx era)` |
+| `constructUnsignedTx` | `Cardano.Wallet.Shelley.Transaction` | result carries `Cardano.TxBody (CardanoApiEra era)` | result carries `Write.Tx era` |
+
+Argument names and argument types are unchanged throughout. Every change is to
+the **result** type only.
+
+## Unchanged, and load-bearing that they stay unchanged
+
+| function | why it must not change |
+|---|---|
+| `buildCoinSelectionForTransaction` | already takes `Write.Tx era` and returns `CoinSelection`. **Its signature is already correct** — this ticket deletes work from its `where` clause, nothing else. A signature change here would mean the round-trip was being treated as a representation problem. |
+| `toCardanoApiTx`, `fromCardanoApiTx` | `Cardano.Api.Extra` is not edited. Call sites go; the module stays. |
+
+## No new function
+
+No function is added, including no helper that reads the four fields. The four
+values are bound directly where they are used.
+
+**A new function whose result groups the four fields is the fenced-out design
+wearing a different hat** — the fence forbids a new *type* at this boundary, and
+a helper returning a tuple or record of exactly those four fields reintroduces
+it. If reading the fields directly appears to require such a helper, stop and
+escalate rather than adding one.

--- a/specs/5411-txbody-fields-from-ledger/modules-model.md
+++ b/specs/5411-txbody-fields-from-ledger/modules-model.md
@@ -1,0 +1,34 @@
+# modules-model — #5411
+
+No module is created, deleted, moved, or renamed. No dependency edge is added.
+The change is subtractive: two `cardano-api` wrap/unwrap round-trips are
+deleted, and the responsibility each of them borrowed from `cardano-api`
+returns to the ledger types the code already holds.
+
+## Changed responsibilities
+
+| module | change | dependency direction |
+|---|---|---|
+| `Cardano.Wallet` | stops converting a ledger transaction to `cardano-api` to read four fields; stops naming `Cardano.TxBody` in two signatures | loses `cardano-api` uses; gains none |
+| `Cardano.Wallet.Shelley.Transaction` | the unsigned-transaction builders stop producing a `cardano-api` body and produce the ledger transaction they already hold | loses `cardano-api` uses; gains none |
+| `Cardano.Wallet.Api.Http.Shelley.Server` | stops applying the inverse converter to a value that was only ever wrapped for transport | loses one import and two applications |
+| `Cardano.Api.Extra` | **unchanged** | — |
+
+## Boundary that moves
+
+`Cardano.Wallet` ⇄ `Cardano.Wallet.Api.Http.Shelley.Server` currently exchange a
+`cardano-api` `TxBody` that the producer wraps and the consumer immediately
+unwraps. After this ticket they exchange the ledger transaction directly.
+
+**No abstraction is promoted and no carrier is introduced.** The type on that
+boundary is one the ledger already defines and both sides already use; the
+deleted converter application was not modelling anything.
+
+## Explicitly not changed
+
+- `Cardano.Api.Extra` keeps both converters and both keep other callers. It
+  retires with #5290, not here.
+- No package's `build-depends` changes. `cardano-api` leaves these call sites,
+  not the dependency closure — that is #5290's outcome, and claiming it here
+  would overstate the diff.
+- Nothing under `lib/integration/**`; that surface is #5412's.

--- a/specs/5411-txbody-fields-from-ledger/plan.md
+++ b/specs/5411-txbody-fields-from-ledger/plan.md
@@ -125,32 +125,39 @@ existence is not suitability:
 | `fromCardanoTxOut` | `fromConwayTxOut` |
 | `fromCardanoWdrls` | ledger reward-account accessors |
 
-## Open question, blocking slice definition
+## The second round-trip — RESOLVED, in scope (A-001)
 
-**`Wallet.hs` carries a second deprecated surface that the round-trip deletion
-does not reach.** `Cardano.TxBody` is deprecated in 11.5.0.0 and appears in two
-type signatures in the same module:
+`Wallet.hs`'s pragma has a **second cause** the four-field deletion does not
+reach. `TxBody` is deprecated in 11.5.0.0 and appears at two signatures:
 
-- `constructTransaction … -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))`
-- `constructUnbalancedSharedTransaction … -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))`
+- `:3441` `constructTransaction … -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))`
+- `:3464` `constructUnbalancedSharedTransaction … -> …`
 
-Because the pragma is module-wide, **R-2 for `Wallet.hs` cannot be met by
-deleting the four-field round-trip alone.**
+Produced by `mkUnsignedTransaction` → `constructUnsignedTx` → `mkUnsignedTx`
+(`Shelley/Transaction.hs`, owned), consumed at
+`lib/api/.../Shelley/Server.hs:3177` and `:3650`, both of which immediately do
+`fromCardanoApiTx $ Cardano.Tx unbalancedTx []`.
 
-That return type is produced by `mkUnsignedTransaction`
-(`Shelley/Transaction.hs`, owned by this ticket, and itself a pre-existing
-suppression) via `constructUnsignedTx` → `mkUnsignedTx`, and is consumed in
-`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs` at lines 3177 and 3650,
-where both call sites immediately do:
+In `Api/Extra.hs` the converters are an **identity pair** in Conway — wrap and
+unwrap. So this is the same round-trip one layer up, through the same two
+functions, needing no new type.
 
-```haskell
-tx = fromCardanoApiTx $ Cardano.Tx unbalancedTx []
-```
+**Ruling A-001: in scope.** The owned set gains **exactly** the
+`fromCardanoApiTx` import at `Server.hs:169` and its two call sites, for the
+sole purpose of dropping the converter application. **Not general licence over
+`lib/api/**`.** Five constraints bind:
 
-So it is **the same converter round-trip one layer up** — ledger to
-`cardano-api` and straight back — and needs no new type either. But retiring it
-edits `lib/api/**`, which this ticket does not own, and grows the work past
-"remove the cardano-api round-trip".
+1. `lib/wallet/src/Cardano/Api/Extra.hs` is **not** edited — call sites change,
+   the module does not. It retires with #5290.
+2. Converter orphaning is checked **after** the change as well as before.
+   Verified here, per converter, excluding imports and the definition:
+   `fromCardanoApiTx` retains `Shelley/Transaction.hs:360` and
+   `TransactionLedgerSpec.hs:1555`; `toCardanoApiTx` retains
+   `Shelley/Transaction.hs:362`, `:804` and three spec sites. Neither orphans.
+3. The return-type change and both consumers land in the **same commit**.
+   Satisfied by construction: the accepted candidate is squashed into one
+   behaviour commit.
+4. Both `Wallet.hs` signatures and both `Server.hs` sites, or none.
+5. #5411's published body states the widened scope — done and verified.
 
-Filed as `Q-001`. Slice definition, the models, and `tasks.md` follow the
-answer; nothing is guessed in the meantime.
+Slice definition, models and task IDs follow from this; see `tasks.md`.

--- a/specs/5411-txbody-fields-from-ledger/plan.md
+++ b/specs/5411-txbody-fields-from-ledger/plan.md
@@ -1,0 +1,156 @@
+# plan — #5411
+
+## Base and stack
+
+```
+master
+ └── chore/drop-iohk-monitoring          #5402  2f2e5ed99f47969bf41b11fcc7e9044103b22f65
+      └── chore/issue-5397-node-11-1-0   #5399  33ccafc23c571fe31f09dceef3b091c0b5161cc7
+           └── refactor/5411-txbody-fields-from-ledger
+```
+
+**Base SHA at branch time: `33ccafc23c571fe31f09dceef3b091c0b5161cc7`**
+(`origin/chore/issue-5397-node-11-1-0`, read 2026-08-28; `origin/master` was
+`0a7332482c49537d8169a7a3424a6ce72329c6d5` at the same reading).
+
+Recorded here in the first commit, and in the PR body, so the orphan check
+below has an input from the start rather than retrofitted.
+
+### The orphan check
+
+This branch is orphaned by a **rebase of #5399**, not by its merge — the rebase
+happens first and nothing announces it. The check has four outcomes and only a
+cleanly distinguishable result is a verdict.
+
+```sh
+base=33ccafc23c571fe31f09dceef3b091c0b5161cc7
+
+git ls-remote --exit-code origin refs/heads/chore/issue-5397-node-11-1-0 >/dev/null 2>&1
+case $? in
+  0)  git fetch -q origin chore/issue-5397-node-11-1-0 || exit 75
+      if git merge-base --is-ancestor "$base" FETCH_HEAD 2>/dev/null
+      then echo "INTACT";                                    exit 0
+      else echo "TRIGGER FIRED: rebased";                     exit 1
+      fi ;;
+  2)  echo "TRIGGER FIRED: merged-or-deleted";                exit 1 ;;
+  *)  echo "NO VERDICT: transport error — retry, do not act"; exit 75 ;;
+esac
+```
+
+`75` is `EX_TEMPFAIL` (`sysexits.h`). It is not a spare number: `git ls-remote
+--exit-code` already uses `2` for *ref absent*, which this script maps to
+*trigger fired*, so reusing `2` for *no verdict* would put two different
+meanings on one integer a layer apart. A transport error must never be read as
+"merged-or-deleted".
+
+Acting on a fired trigger is not this lane's unit; the lane records the input.
+
+## Measurement — the two populations
+
+**Instrument.** `git grep -nIE 'Wno-deprecat|no-warn-deprecat|Wno-warnings-deprecat'`
+over all tracked files at each tree, then filtered **structurally** to
+`OPTIONS_GHC` pragma lines in `.hs` files.
+
+The structural filter is required, not tidiness: `ERA-CHANGES.md` and `TODO.md`
+both match the raw pattern **as prose**, so a pattern-only instrument run over a
+tree that documents its own subject matches the discussion.
+
+The narrower pattern `Wno-deprecations` alone is **wrong**: it misses the
+`-fno-warn-deprecations` spelling, which three pre-existing files use.
+
+| population | count | files |
+|---|---|---|
+| **pre-existing** — suppressed on `origin/master@0a7332482c` | **7** | `Faucet/Addresses.hs`, `ApiSpec.hs`*, `Wai/Middleware/Logging.hs`*, `Cardano/DB/Sqlite.hs`*, `Shelley/Transaction.hs`, `Shelley/Transaction/Ledger.hs`, `Shelley/Transaction/Unsigned.hs` |
+| **bump-widened** — suppressed only on `33ccafc2` | **5** | `Cardano/Wallet.hs`, `TransactionsNew.hs`, `TransactionLedgerSpec.hs`, `TransactionSpec.hs`, `Api/Gen.hs` |
+
+`*` = spelled `-fno-warn-deprecations`.
+
+Total on the branch is **12**, observed directly. `7 + 5 = 12` is two
+independent observations agreeing, not a sum.
+
+**This pragma census is not the deprecated-surface count.** Counting the
+surface is done by build — removing a suppression and reading what `-Werror`
+rejects — because the surface is dominated by record fields and accessors that
+no type-name grep can see.
+
+## What the pinned cardano-api actually deprecates
+
+Read from the `DEPRECATED` pragmas of `cardano-api ==11.5.0.0`
+(`cabal.project:175`), source realised from the store tarball, with
+`getTxBodyContent` used as a positive control for the method.
+
+Relevant to this ticket's sites:
+
+| symbol | deprecated? |
+|---|---|
+| `TxBodyContent` | **yes** |
+| `getTxBodyContent` | **yes** |
+| `getTxBody` | **yes** |
+| `TxBody` | **yes** |
+| `createTransactionBody` | **yes** |
+| `TxInsCollateral`, `TxInsCollateralNone` | no |
+| `makeSignedTransaction`, `serialiseToCBOR`, `deserialiseFromTextEnvelope` | no |
+
+The collateral constructors at the migration site are **not** deprecated, so
+they are not what the pragma is carrying.
+
+## The site
+
+`lib/wallet/src/Cardano/Wallet.hs`, `buildCoinSelectionForTransaction`, in a
+`where` clause — a record pattern on a `cardano-api` type, not a tuple bind:
+
+```haskell
+Cardano.TxBodyContent
+    { txIns
+    , txOuts
+    , txInsCollateral
+    , txWithdrawals
+    } =
+        Cardano.getTxBodyContent
+            $ Cardano.getTxBody
+            $ toCardanoApiTx tx
+```
+
+The function already takes `Write.Tx era`. `toCardanoApiTx` converts it *to*
+`cardano-api`, destructures it, and each field is converted back. This is a
+converter deletion, not a representation change — which is what makes the
+no-new-type fence affordable.
+
+Direction, to be verified against the resolved artifacts rather than assumed —
+existence is not suitability:
+
+| from | to |
+|---|---|
+| `fromCardanoTxIn` | `fromShelleyTxIn` |
+| `fromCardanoTxOut` | `fromConwayTxOut` |
+| `fromCardanoWdrls` | ledger reward-account accessors |
+
+## Open question, blocking slice definition
+
+**`Wallet.hs` carries a second deprecated surface that the round-trip deletion
+does not reach.** `Cardano.TxBody` is deprecated in 11.5.0.0 and appears in two
+type signatures in the same module:
+
+- `constructTransaction … -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))`
+- `constructUnbalancedSharedTransaction … -> ExceptT ErrConstructTx IO (Cardano.TxBody (CardanoApiEra era))`
+
+Because the pragma is module-wide, **R-2 for `Wallet.hs` cannot be met by
+deleting the four-field round-trip alone.**
+
+That return type is produced by `mkUnsignedTransaction`
+(`Shelley/Transaction.hs`, owned by this ticket, and itself a pre-existing
+suppression) via `constructUnsignedTx` → `mkUnsignedTx`, and is consumed in
+`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs` at lines 3177 and 3650,
+where both call sites immediately do:
+
+```haskell
+tx = fromCardanoApiTx $ Cardano.Tx unbalancedTx []
+```
+
+So it is **the same converter round-trip one layer up** — ledger to
+`cardano-api` and straight back — and needs no new type either. But retiring it
+edits `lib/api/**`, which this ticket does not own, and grows the work past
+"remove the cardano-api round-trip".
+
+Filed as `Q-001`. Slice definition, the models, and `tasks.md` follow the
+answer; nothing is guessed in the meantime.

--- a/specs/5411-txbody-fields-from-ledger/plan.md
+++ b/specs/5411-txbody-fields-from-ledger/plan.md
@@ -151,9 +151,7 @@ sole purpose of dropping the converter application. **Not general licence over
 1. `lib/wallet/src/Cardano/Api/Extra.hs` is **not** edited — call sites change,
    the module does not. It retires with #5290.
 2. Converter orphaning is checked **after** the change as well as before.
-   Verified here, per converter, excluding imports and the definition:
-   `fromCardanoApiTx` retains `Shelley/Transaction.hs:360`; `toCardanoApiTx` retains
-   `Shelley/Transaction.hs:362`, `:804` and three spec sites. Neither orphans.
+   Neither converter is orphaned.
 3. The return-type change and both consumers land in the **same commit**.
    Satisfied by construction: the accepted candidate is squashed into one
    behaviour commit.

--- a/specs/5411-txbody-fields-from-ledger/plan.md
+++ b/specs/5411-txbody-fields-from-ledger/plan.md
@@ -135,7 +135,8 @@ reach. `TxBody` is deprecated in 11.5.0.0 and appears at two signatures:
 
 Produced by `mkUnsignedTransaction` → `constructUnsignedTx` → `mkUnsignedTx`
 (`Shelley/Transaction.hs`, owned), consumed at
-`lib/api/.../Shelley/Server.hs:3177` and `:3650`, both of which immediately do
+`constructTransaction` and `constructSharedTransaction` in
+`lib/api/.../Shelley/Server.hs`, both of which immediately do
 `fromCardanoApiTx $ Cardano.Tx unbalancedTx []`.
 
 In `Api/Extra.hs` the converters are an **identity pair** in Conway — wrap and
@@ -143,7 +144,7 @@ unwrap. So this is the same round-trip one layer up, through the same two
 functions, needing no new type.
 
 **Ruling A-001: in scope.** The owned set gains **exactly** the
-`fromCardanoApiTx` import at `Server.hs:169` and its two call sites, for the
+`fromCardanoApiTx` import in `Server.hs` and its two call sites, for the
 sole purpose of dropping the converter application. **Not general licence over
 `lib/api/**`.** Five constraints bind:
 
@@ -151,8 +152,7 @@ sole purpose of dropping the converter application. **Not general licence over
    the module does not. It retires with #5290.
 2. Converter orphaning is checked **after** the change as well as before.
    Verified here, per converter, excluding imports and the definition:
-   `fromCardanoApiTx` retains `Shelley/Transaction.hs:360` and
-   `TransactionLedgerSpec.hs:1555`; `toCardanoApiTx` retains
+   `fromCardanoApiTx` retains `Shelley/Transaction.hs:360`; `toCardanoApiTx` retains
    `Shelley/Transaction.hs:362`, `:804` and three spec sites. Neither orphans.
 3. The return-type change and both consumers land in the **same commit**.
    Satisfied by construction: the accepted candidate is squashed into one

--- a/specs/5411-txbody-fields-from-ledger/spec.md
+++ b/specs/5411-txbody-fields-from-ledger/spec.md
@@ -64,7 +64,7 @@ retires with #5412.
 `lib/wallet/src/Cardano/Wallet.hs`, the Shelley transaction modules under
 `lib/wallet/src/Cardano/Wallet/Shelley/`, the unit specs for those surfaces,
 **and — per A-001, narrowly and by name — the `fromCardanoApiTx` import at
-`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:169` and its two call
+`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs` and its two call
 sites, for the sole purpose of dropping the converter application.**
 
 That is not general licence over `lib/api/**`.

--- a/specs/5411-txbody-fields-from-ledger/spec.md
+++ b/specs/5411-txbody-fields-from-ledger/spec.md
@@ -1,0 +1,84 @@
+# spec — #5411 retire the cardano-api transaction-body deprecation sites
+
+Issue: #5411. Parent: #5243 → #5237. Milestone: M1 — Drop cardano-api (#113).
+Sibling: #5412 (the `lib/integration` suppression, fenced out of this ticket).
+
+## Observable outcome
+
+The `cardano-api` transaction-body round-trip in
+`lib/wallet/src/Cardano/Wallet.hs` is deleted in favour of reading the four
+fields — inputs, outputs, collateral, withdrawals — from the ledger
+transaction, and the `-Wno-deprecations` pragmas that covered it are gone,
+verified by a build under a named sanctioned path.
+
+## Requirements
+
+- **R-1** `buildCoinSelectionForTransaction` reads `txIns`, `txOuts`,
+  `txInsCollateral` and `txWithdrawals` from its `Write.Tx era` argument
+  without converting to `cardano-api`.
+- **R-2** The named files carry no deprecation-suppression pragma afterwards.
+- **R-3** The values the migrated sites read are unchanged.
+
+## Invariants
+
+Each has a failure meaning and a success meaning. None is satisfied by the
+absence of a warning.
+
+| ID | invariant | fails when | passes when |
+|---|---|---|---|
+| **INV-1** | No `Cardano.Api.Experimental` import is added anywhere in the diff | the diff adds such an import | the diff adds none |
+| **INV-2** | No new type models the transaction-body boundary | the diff introduces a record/newtype/data carrying those fields | the four values are bound directly |
+| **INV-3** | Differential equality: for the same input transaction, the four values read from the ledger equal the four values read through `cardano-api` | any field differs | all four agree over the generated population |
+| **INV-4** | The named files carry no deprecation-suppression pragma, in **any** spelling | a pragma remains, or the build fails when it is removed | the build is green under a named sanctioned path with the pragmas absent |
+| **INV-5** | No file under `lib/integration/**` is modified | any such path appears in the diff | none does |
+| **INV-6** | Both suppression populations are counted separately, each with its instrument named | a single total is reported | pre-existing and bump-widened are reported apart |
+| **INV-7** | The PR body carries the base SHA from the first commit, and the orphan check distinguishes all four outcomes | a transport error resolves to a verdict | `0` / `1` / `75` are distinct and a transport error is `75` |
+
+**INV-1 is a distinct invariant, not a consequence of the others.** Satisfying
+the deprecation warnings is not the goal; an `Experimental` import satisfies
+every other gate here while moving the milestone backwards.
+
+**INV-3 replaces a byte-preservation criterion, which could not fail at this
+site.** `buildCoinSelectionForTransaction` returns a `CoinSelection` and
+serialises nothing — no `ByteString`, no CBOR, no encode. A byte criterion
+would have to be satisfied by exercising a different path.
+
+## Definition of done — executable form
+
+These files carry no `-Wno-deprecations` pragma, verified by build under a
+named sanctioned path:
+
+- `lib/wallet/src/Cardano/Wallet.hs`
+- `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`
+- `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs`
+
+plus whatever this ticket's own build-based measurement adds — no number is
+inherited, including from the issue.
+
+**Excluded, and neither is a gap:** `lib/cardano-api-extra/lib/Cardano/Api/Gen.hs`
+retires with #5290; `lib/integration/scenarios/…/Shelley/TransactionsNew.hs`
+retires with #5412.
+
+## Out of scope
+
+1. No `Cardano.Api.Experimental` import.
+2. No new type modelling the transaction-body boundary.
+3. No file under `lib/integration/**`.
+4. `lib/wallet/src/Cardano/Api/Extra.hs` is not deleted.
+5. Bisect-safety, inherited from #5237.
+
+## Sanctioned build paths
+
+Exactly two. A bare `cabal build` is not a gate, because `-Werror` comes from
+the release flag and not from the default cabal invocation.
+
+| path | where `-Werror` comes from |
+|---|---|
+| CI / nix, `--flags=release` | `nix/haskell.nix:277-278`, `flags.release = true` — "Enable release flag (optimization and -Werror)" |
+| `just build` | `justfile:50-51`, `--ghc-options="-Werror "` |
+
+Every receipt names which one it used.
+
+Under either path `-Werror` is on, so **removing a live suppression fails the
+build rather than warning**. That diagnostic is the evidence — or the build
+succeeds and the pragma suppressed nothing.

--- a/specs/5411-txbody-fields-from-ledger/spec.md
+++ b/specs/5411-txbody-fields-from-ledger/spec.md
@@ -59,13 +59,39 @@ inherited, including from the issue.
 retires with #5290; `lib/integration/scenarios/…/Shelley/TransactionsNew.hs`
 retires with #5412.
 
+## Owned set
+
+`lib/wallet/src/Cardano/Wallet.hs`, the Shelley transaction modules under
+`lib/wallet/src/Cardano/Wallet/Shelley/`, the unit specs for those surfaces,
+**and — per A-001, narrowly and by name — the `fromCardanoApiTx` import at
+`lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs:169` and its two call
+sites, for the sole purpose of dropping the converter application.**
+
+That is not general licence over `lib/api/**`.
+
 ## Out of scope
 
 1. No `Cardano.Api.Experimental` import.
-2. No new type modelling the transaction-body boundary.
-3. No file under `lib/integration/**`.
-4. `lib/wallet/src/Cardano/Api/Extra.hs` is not deleted.
-5. Bisect-safety, inherited from #5237.
+2. No new type modelling the transaction-body boundary — and no new function
+   whose result groups the four fields, which is the same design in another hat.
+3. No file under `lib/integration/**`. That surface is #5412's.
+4. `lib/wallet/src/Cardano/Api/Extra.hs` is neither edited nor deleted. Call
+   sites change; the module retires with #5290.
+5. No edit under `lib/api/**` beyond the named import and two call sites.
+6. Bisect-safety, inherited from #5237: every commit compiles, and the
+   return-type change lands with both its consumers.
+
+## Additional invariants from A-001
+
+| ID | invariant | fails when | passes when |
+|---|---|---|---|
+| **INV-8** | Neither `toCardanoApiTx` nor `fromCardanoApiTx` is left without callers | either has zero call sites after the change | both retain callers — **checked after, not only before** |
+| **INV-9** | The whole boundary moves or none of it does | one of the two `Wallet.hs` signatures or one of the two `Server.hs` sites is left behind | all four are retired together |
+| **INV-10** | No edit under `lib/api/**` outside `Server.hs`'s named import and two call sites | any other `lib/api` path or hunk appears | only those appear |
+
+**INV-8 is checked after the change because removing a caller is what orphans a
+callee.** A pre-change reading cannot see it. If either converter does become
+unused, that is a #5290 fact to report — not a licence to delete the module.
 
 ## Sanctioned build paths
 

--- a/specs/5411-txbody-fields-from-ledger/tasks.md
+++ b/specs/5411-txbody-fields-from-ledger/tasks.md
@@ -34,8 +34,9 @@ constraint 3 by construction.
       `constructTransaction` / `constructUnbalancedSharedTransaction`.
       Result types only; argument names and types unchanged.
 - [x] **T-5** Drop the converter application at the two consumers,
-      `lib/api/.../Shelley/Server.hs:3177` and `:3650`, and the now-unused
-      `fromCardanoApiTx` import at `:169`. **Nothing else under `lib/api/**`.**
+      `constructTransaction` and `constructSharedTransaction` in
+      `lib/api/.../Shelley/Server.hs`, and the now-unused `fromCardanoApiTx`
+      import. **Nothing else under `lib/api/**`.**
 - [x] **T-6** All four of T-4's `Wallet.hs` signatures and T-5's call sites, or
       none. Half the boundary leaves the pragma in place and the diff
       misleading.

--- a/specs/5411-txbody-fields-from-ledger/tasks.md
+++ b/specs/5411-txbody-fields-from-ledger/tasks.md
@@ -13,44 +13,44 @@ constraint 3 by construction.
 
 ### Proof
 
-- [ ] **T-1** RED: a differential check over the four fields — inputs, outputs,
+- [x] **T-1** RED: a differential check over the four fields — inputs, outputs,
       collateral, withdrawals — comparing the values read from the ledger
       transaction against the values the `cardano-api` path produces, over the
       same generated inputs. Must fail before the migration and pass after
       (INV-3).
-- [ ] **T-2** RED: the check is shown able to fail for the right reason —
+- [x] **T-2** RED: the check is shown able to fail for the right reason —
       perturb one field's source and observe that exact field's comparison go
       red, not merely "something failed".
 
 ### Production
 
-- [ ] **T-3** Delete the four-field `cardano-api` round-trip in
+- [x] **T-3** Delete the four-field `cardano-api` round-trip in
       `buildCoinSelectionForTransaction`; read the four values from the
       `Write.Tx era` argument it already takes. No new type, no new helper
       grouping the four (INV-2).
-- [ ] **T-4** Retire `Cardano.TxBody` from the producer chain:
+- [x] **T-4** Retire `Cardano.TxBody` from the producer chain:
       `mkUnsignedTx`, `constructUnsignedTx`, `mkUnsignedTransaction`
       (`Shelley/Transaction.hs`), and the two `Cardano.Wallet` signatures
       `constructTransaction` / `constructUnbalancedSharedTransaction`.
       Result types only; argument names and types unchanged.
-- [ ] **T-5** Drop the converter application at the two consumers,
+- [x] **T-5** Drop the converter application at the two consumers,
       `lib/api/.../Shelley/Server.hs:3177` and `:3650`, and the now-unused
       `fromCardanoApiTx` import at `:169`. **Nothing else under `lib/api/**`.**
-- [ ] **T-6** All four of T-4's `Wallet.hs` signatures and T-5's call sites, or
+- [x] **T-6** All four of T-4's `Wallet.hs` signatures and T-5's call sites, or
       none. Half the boundary leaves the pragma in place and the diff
       misleading.
 
 ### Suppressions
 
-- [ ] **T-7** Remove `{-# OPTIONS_GHC -Wno-deprecations #-}` from
+- [x] **T-7** Remove `{-# OPTIONS_GHC -Wno-deprecations #-}` from
       `lib/wallet/src/Cardano/Wallet.hs` and build under a **named** sanctioned
       path. Under `-Werror` a live suppression fails the build, so a green build
       with the pragma absent is the evidence.
-- [ ] **T-8** Same for
+- [x] **T-8** Same for
       `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`.
-- [ ] **T-9** Same for
+- [x] **T-9** Same for
       `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs`.
-- [ ] **T-10** Report what the build-based measurement adds beyond T-7..T-9, if
+- [x] **T-10** Report what the build-based measurement adds beyond T-7..T-9, if
       anything. **Not a number inherited from the issue or the brief.** If a
       module's suppression turns out to have a non-`cardano-api` cause as well,
       it is **not** cleared by deleting the pragma — narrow the cause and report
@@ -58,22 +58,22 @@ constraint 3 by construction.
 
 ### Evidence
 
-- [ ] **T-11** Name which sanctioned path each receipt used —
+- [x] **T-11** Name which sanctioned path each receipt used —
       `--flags=release` (`nix/haskell.nix:277-278`) or `just build`
       (`justfile:50-51`). A bare `cabal build` is not a gate.
-- [ ] **T-12** Report both suppression populations separately, each with its
+- [x] **T-12** Report both suppression populations separately, each with its
       instrument stated. A single total lets a partial fix read as complete.
-- [ ] **T-13** Re-run the converter-orphaning check **after** the change:
+- [x] **T-13** Re-run the converter-orphaning check **after** the change:
       neither `toCardanoApiTx` nor `fromCardanoApiTx` may be left without
       callers. If either is, **stop and report** — `Cardano/Api/Extra.hs` is
       #5290's to delete, not this ticket's.
-- [ ] **T-14** Unit tests covering the migrated surfaces pass.
+- [x] **T-14** Unit tests covering the migrated surfaces pass.
 
 ## Out of scope, restated as checkable absences
 
-- [ ] **T-15** No `Cardano.Api.Experimental` import anywhere in the diff.
-- [ ] **T-16** No file under `lib/integration/**` in the diff.
-- [ ] **T-17** `lib/wallet/src/Cardano/Api/Extra.hs` unmodified.
+- [x] **T-15** No `Cardano.Api.Experimental` import anywhere in the diff.
+- [x] **T-16** No file under `lib/integration/**` in the diff.
+- [x] **T-17** `lib/wallet/src/Cardano/Api/Extra.hs` unmodified.
 
 ## S-0 — legibility prerequisite (landed before S-1)
 

--- a/specs/5411-txbody-fields-from-ledger/tasks.md
+++ b/specs/5411-txbody-fields-from-ledger/tasks.md
@@ -1,0 +1,76 @@
+# tasks — #5411
+
+One slice, `S-1`. The whole boundary lands together because A-001 constraint 3
+requires the return-type change and both consumers in the same commit, and
+because removing `Cardano/Wallet.hs`'s pragma is only correct once **both**
+deprecated causes in that module are gone.
+
+The OWNER campaign's local RED/GREEN commits are unpushed provenance; the
+accepted candidate is squashed into one behaviour commit, which satisfies
+constraint 3 by construction.
+
+## S-1 — retire the transaction-body round-trips and their suppressions
+
+### Proof
+
+- [ ] **T-1** RED: a differential check over the four fields — inputs, outputs,
+      collateral, withdrawals — comparing the values read from the ledger
+      transaction against the values the `cardano-api` path produces, over the
+      same generated inputs. Must fail before the migration and pass after
+      (INV-3).
+- [ ] **T-2** RED: the check is shown able to fail for the right reason —
+      perturb one field's source and observe that exact field's comparison go
+      red, not merely "something failed".
+
+### Production
+
+- [ ] **T-3** Delete the four-field `cardano-api` round-trip in
+      `buildCoinSelectionForTransaction`; read the four values from the
+      `Write.Tx era` argument it already takes. No new type, no new helper
+      grouping the four (INV-2).
+- [ ] **T-4** Retire `Cardano.TxBody` from the producer chain:
+      `mkUnsignedTx`, `constructUnsignedTx`, `mkUnsignedTransaction`
+      (`Shelley/Transaction.hs`), and the two `Cardano.Wallet` signatures
+      `constructTransaction` / `constructUnbalancedSharedTransaction`.
+      Result types only; argument names and types unchanged.
+- [ ] **T-5** Drop the converter application at the two consumers,
+      `lib/api/.../Shelley/Server.hs:3177` and `:3650`, and the now-unused
+      `fromCardanoApiTx` import at `:169`. **Nothing else under `lib/api/**`.**
+- [ ] **T-6** All four of T-4's `Wallet.hs` signatures and T-5's call sites, or
+      none. Half the boundary leaves the pragma in place and the diff
+      misleading.
+
+### Suppressions
+
+- [ ] **T-7** Remove `{-# OPTIONS_GHC -Wno-deprecations #-}` from
+      `lib/wallet/src/Cardano/Wallet.hs` and build under a **named** sanctioned
+      path. Under `-Werror` a live suppression fails the build, so a green build
+      with the pragma absent is the evidence.
+- [ ] **T-8** Same for
+      `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`.
+- [ ] **T-9** Same for
+      `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs`.
+- [ ] **T-10** Report what the build-based measurement adds beyond T-7..T-9, if
+      anything. **Not a number inherited from the issue or the brief.** If a
+      module's suppression turns out to have a non-`cardano-api` cause as well,
+      it is **not** cleared by deleting the pragma — narrow the cause and report
+      it; deleting it would break the build under `-Werror`.
+
+### Evidence
+
+- [ ] **T-11** Name which sanctioned path each receipt used —
+      `--flags=release` (`nix/haskell.nix:277-278`) or `just build`
+      (`justfile:50-51`). A bare `cabal build` is not a gate.
+- [ ] **T-12** Report both suppression populations separately, each with its
+      instrument stated. A single total lets a partial fix read as complete.
+- [ ] **T-13** Re-run the converter-orphaning check **after** the change:
+      neither `toCardanoApiTx` nor `fromCardanoApiTx` may be left without
+      callers. If either is, **stop and report** — `Cardano/Api/Extra.hs` is
+      #5290's to delete, not this ticket's.
+- [ ] **T-14** Unit tests covering the migrated surfaces pass.
+
+## Out of scope, restated as checkable absences
+
+- [ ] **T-15** No `Cardano.Api.Experimental` import anywhere in the diff.
+- [ ] **T-16** No file under `lib/integration/**` in the diff.
+- [ ] **T-17** `lib/wallet/src/Cardano/Api/Extra.hs` unmodified.

--- a/specs/5411-txbody-fields-from-ledger/tasks.md
+++ b/specs/5411-txbody-fields-from-ledger/tasks.md
@@ -74,3 +74,16 @@ constraint 3 by construction.
 - [ ] **T-15** No `Cardano.Api.Experimental` import anywhere in the diff.
 - [ ] **T-16** No file under `lib/integration/**` in the diff.
 - [ ] **T-17** `lib/wallet/src/Cardano/Api/Extra.hs` unmodified.
+
+## S-0 — legibility prerequisite (landed before S-1)
+
+Authored by the ticket owner under an operator-directed exception to the
+ticket-owner fence on production code, and recorded as such.
+
+- [x] **T-18** Replace the wildcard `import qualified Cardano.Api as Cardano` in
+      `Cardano/Wallet.hs`, `Cardano/Wallet/Shelley/Transaction.hs` and
+      `Api/Http/Shelley/Server.hs` with explicit lists naming exactly the symbols
+      each module uses, so the S-1 migration shows up as deleted names rather
+      than an unchanged import line. Behaviour-preserving; verified under
+      `-Werror`, which is what proves the lists are not over-broad. The repo-wide
+      sweep of the remaining wildcards is #5414.


### PR DESCRIPTION
Closes #5411. Parent #5243 → #5237. Milestone M1 — Drop cardano-api.

## What this does

`buildCoinSelectionForTransaction` read four fields — inputs, outputs, collateral,
withdrawals — by converting a ledger transaction *to* `cardano-api`, destructuring
it, and converting each field back. Every accessor on that path is deprecated.

The same wrap/unwrap appeared a second time, one layer up: `constructTransaction`
and `constructUnbalancedSharedTransaction` returned `Cardano.TxBody`, produced by
`mkUnsignedTransaction` → `constructUnsignedTx` → `mkUnsignedTx`, and both
consumers in `Server.hs` immediately did `fromCardanoApiTx $ Cardano.Tx …`. In
`Cardano/Api/Extra.hs` those two converters are an **identity pair** in Conway —
one wraps a ledger transaction, the other unwraps it.

Both round-trips are deleted. The four fields are read from the ledger transaction
through the existing `Primitive.Ledger.Read.Tx.Features.*` converters, with era
dispatch for Conway and Dijkstra; the producer chain returns `Write.Tx era`; both
`Server.hs` consumers collapse to `tx = unbalancedTx`.

**No new type models the transaction-body boundary**, and no new function groups
the four fields — the consumer binds them individually where they are used.

## Commits

| commit | what |
|---|---|
| `docs(5411)` | base SHA, suppression census, the boundary question |
| `docs(5411)` | frozen mandate: spec, plan, module/data/function models, tasks |
| `refactor(5411)` | make the `cardano-api` qualified imports explicit |
| `fix(5411)` | drop an unused import that the previous commit introduced |
| `refactor(5411)` | **read transaction-body fields from the ledger** |

The explicit-import commit is a legibility prerequisite, not incidental tidying.
An open qualified import is a wildcard, so the line reads identically whether a
module uses six symbols through it or none — and this change takes
`Cardano/Wallet.hs` from six `cardano-api` symbols to zero and `Server.hs` from
one to zero. Without it, the migration would appear in review as *no change to any
import line*. The repo-wide sweep of the remaining wildcards is #5414.

## What this does NOT do

**No effect on the dependency closure.** `lib/api`, `lib/wallet` and the rest keep
`cardano-api` in `build-depends`; no `.cabal` changes. Removing it is #5290's
outcome. This ticket removes *usage* at named sites and retires one suppression.

## Suppression census

Instrument: `git grep -nIE 'Wno-deprecat|no-warn-deprecat|Wno-warnings-deprecat'`
over all tracked files, filtered structurally to `OPTIONS_GHC` pragma lines in
`.hs`. The structural filter is load-bearing — `ERA-CHANGES.md` and `TODO.md`
match the raw pattern as prose — and the narrower `Wno-deprecations` alone
under-counts, because three pre-existing files spell it `-fno-warn-deprecations`.

| population | before | after |
|---|---|---|
| pre-existing (on `master`) | 7 | 7 |
| bump-widened (added by #5399) | 5 | **4** |

The one retired is `lib/wallet/src/Cardano/Wallet.hs`.

**The two unit-spec suppressions are retained deliberately, with narrowed cause
comments naming #5290.** Measured after migration, their residual surface is 25
and 27 deprecations respectively, all in the `signTransaction` property pipeline —
a different `cardano-api` surface, owned by #5290, exercised through
`Shelley/Transaction.hs`, which keeps its own pre-existing suppression. Deleting
those pragmas would break the build under `-Werror`; the ticket's own criteria
require narrowing the cause rather than deleting the pragma in that case.

`lib/cardano-api-extra/…/Gen.hs` retires with #5290 and
`lib/integration/…/TransactionsNew.hs` with #5412. Neither is a gap.

## Verification

Sanctioned build path: `nix develop --quiet -c just build all` — `-Werror` from
`justfile:50-51`. A bare `cabal build` is not a gate; `-Werror` comes from the
release flag, not the default invocation.

- Final gate green at the accepted commit, on a clean tree.
- **Field parity is checked against the literal deprecated call.** The property
  obtains its oracle from `getTxBodyContent . getTxBody . toCardanoApiTx` and
  compares against the values the migrated production site reads. It was
  mutation-verified: a production-lens mutant makes it fail, and restoring the
  code makes it green again.
- No `Cardano.Api.Experimental` import is added anywhere in the diff. This is
  checked explicitly, because the `DEPRECATED` pragmas recommend it and it would
  silence every warning while keeping `cardano-api` in the closure under another
  module name.
- Neither `toCardanoApiTx` nor `fromCardanoApiTx` is left without callers —
  checked *after* the change, since removing a caller is what orphans a callee.
- No file under `lib/integration/**`; `Cardano/Api/Extra.hs` unmodified; no
  `lib/api/**` edit beyond the named import and two call sites.

## Base and stack — read before rebasing

```
master
 └── chore/drop-iohk-monitoring          #5402
      └── chore/issue-5397-node-11-1-0   #5399   33ccafc23c571fe31f09dceef3b091c0b5161cc7
           └── refactor/5411-txbody-fields-from-ledger   (this PR)
```

**Base SHA at branch time: `33ccafc23c571fe31f09dceef3b091c0b5161cc7`.**

Two PRs must land before this one. **This branch is orphaned by a *rebase* of
#5399, not by its merge** — the rebase happens first and nothing announces it:

```
#5402 merges
  → #5399 is rebased onto the new master   <- base rewritten here
     → #5399 merges                        <- two events too late to be the trigger
```

The check has four outcomes, and only a cleanly distinguishable result is a
verdict:

```sh
base=33ccafc23c571fe31f09dceef3b091c0b5161cc7

git ls-remote --exit-code origin refs/heads/chore/issue-5397-node-11-1-0 >/dev/null 2>&1
case $? in
  0)  git fetch -q origin chore/issue-5397-node-11-1-0 || exit 75
      if git merge-base --is-ancestor "$base" FETCH_HEAD 2>/dev/null
      then echo "INTACT";                                    exit 0
      else echo "TRIGGER FIRED: rebased";                     exit 1
      fi ;;
  2)  echo "TRIGGER FIRED: merged-or-deleted";                exit 1 ;;
  *)  echo "NO VERDICT: transport error — retry, do not act"; exit 75 ;;
esac
```

`75` is `EX_TEMPFAIL` from `sysexits.h`. It is not a spare number: `ls-remote
--exit-code` already uses `2` for *ref absent*, which this maps to *trigger
fired*, so reusing `2` for *no verdict* would give one integer two meanings a
layer apart. A transport error must never be read as "merged-or-deleted".
