### PR TITLE
CI: ratchet the cardano-api closure and its deprecation suppressions

### DIFF
--- a/specs/5423-closure-ratchet/data-model.md
+++ b/specs/5423-closure-ratchet/data-model.md
@@ -1,0 +1,67 @@
+# 5423 — Data model
+
+## Entities
+
+### Package
+Read out of the tree, never hard-listed (INV-14).
+
+| field | source | validation |
+|---|---|---|
+| `name` | the `name:` field of a `lib/*/*.cabal` file | non-empty; unique across the population |
+| `cabal_path` | the file it was read from | exists and is readable |
+| `stanzas` | see below | at least one |
+
+The population is every `lib/*/*.cabal` in the tree root. Its size is reported.
+A population of zero, or one smaller than the number of `.cabal` files found, is
+an instrument failure, not a zero count.
+
+### Stanza
+
+| field | values | note |
+|---|---|---|
+| `kind` | `LIB`, `ANY`, `COMMON` | `library` and `library <name>` are both `LIB`; `test-suite`, `benchmark`, `executable`, `foreign-library` are `ANY`; `common <name>` is `COMMON` and carries no membership of its own |
+| `imports` | names of `COMMON` stanzas | a stanza's inherited `build-depends` take the **importing** stanza's kind (INV-13) |
+| `deps` | package names from `build-depends` | version constraints stripped; `pkg:sublib` and `pkg:{a,b}` normalised to `pkg`; comparison is whole-name equality (INV-12) |
+
+`build-tool-depends` is **not** a `deps` source. A tool dependency is recorded
+and reported separately so its exclusion is visible rather than silent.
+
+Dependencies inside `if`/`else` blocks are counted unconditionally. A ratchet
+that under-counts a conditional edge would go green on a dependency the build
+takes on some platform; over-approximating is the conservative direction.
+
+## Derived sets
+
+Let `T` = `cardano-api`.
+
+- `L` (`closure-lib`) — least set with `T ∈ L` and `P ∈ L` whenever some `LIB`
+  stanza of `P` has a dep in `L`. The reported row is `|L ∩ Packages|`, so `T`
+  itself never counts.
+- `A` (`closure-any`) — `(L ∩ Packages)` ∪ `{ P : some stanza of P has a dep in L }`.
+  `A` takes exactly one arbitrary-stanza hop and then only library hops:
+  depending on a package does not build that package's test-suite, so a further
+  `ANY` hop would over-count.
+- `S` (`suppressions`) — occurrences, not files: lines matching `^{-# OPTIONS_GHC`
+  in `*.hs`, plus lines matching an anchored `ghc-options:` in `*.cabal` and
+  `cabal.project*`, that name `-Wno-deprecations` or `-fno-warn-deprecations`.
+
+## State invariants
+
+- `L ∩ Packages ⊆ A`. Any perturbation raising `closure-lib` also raises
+  `closure-any`; the converse is false, and INV-3 is proved by a perturbation
+  that raises `closure-any` alone.
+- Computation of `L` is a fixpoint over a finite population, so it terminates on
+  self-edges and cycles (INV-11). `cardano-wallet-read` is a live self-edge.
+- Every counter is a non-negative integer parsed from the gate's own stdout by
+  the negative control; an unparseable count is a control failure, never a pass.
+
+## Ratchet
+
+| row | env override | land-time value |
+|---|---|---|
+| `closure-lib` | `CARDANO_API_CLOSURE_LIB_MAX` | measured at land time |
+| `closure-any` | `CARDANO_API_CLOSURE_ANY_MAX` | measured at land time |
+| `suppressions` | `CARDANO_API_SUPPRESSIONS_MAX` | measured at land time |
+
+Planning-time measurement at `6b42c36b58`: 12 / 13 / 9. Recorded as the value to
+**reproduce or supersede**, never to copy.

--- a/specs/5423-closure-ratchet/functions-model.md
+++ b/specs/5423-closure-ratchet/functions-model.md
@@ -1,0 +1,87 @@
+# 5423 — Functions model
+
+Signature-level contract only: names, arguments, and what each returns or emits.
+No bodies, no algorithms.
+
+## M-1 `scripts/ci/cardano-api-closure-gate.sh`
+
+**Invocation:** `cardano-api-closure-gate.sh [tree-root]` — `tree-root`
+defaults to `.`.
+
+**Exit:** `0` at or below every ratchet · `1` any row above its ratchet ·
+`2` a self-check failed, i.e. the instrument is not trustworthy and no count it
+printed may be believed.
+
+**Environment:** `CARDANO_API_CLOSURE_LIB_MAX`, `CARDANO_API_CLOSURE_ANY_MAX`,
+`CARDANO_API_SUPPRESSIONS_MAX` — each an integer overriding that row's ratchet.
+
+**Required stdout, machine-readable, one key per line.** These are the contract
+M-2 and the ticket gate parse; their spelling is part of the interface.
+
+| line | meaning |
+|---|---|
+| `packages = <n>` | size of the discovered `lib/*` population |
+| `closure-lib = <n>   (MAX=<n>)` | row value and its ratchet |
+| `closure-any = <n>   (MAX=<n>)` | row value and its ratchet |
+| `suppressions = <n>   (MAX=<n>)` | row value and its ratchet |
+| `licence closure-lib: ...` | what a zero on that row licenses |
+| `licence closure-any: ...` | what a zero on that row licenses |
+| `licence suppressions: ...` | what a zero on that row licenses |
+| `witness cardano-wallet-read: in-closure-dependents=<n> closure-lib=<yes\|no> closure-any=<yes\|no>` | measured, reported, never asserted |
+| `witness cardano-wallet-blackbox-benchmarks: closure-lib=<yes\|no> closure-any=<yes\|no>` | measured, reported, never asserted |
+| `self-check: fixture=<PASS\|FAIL> population=<PASS\|FAIL> falsification=<PASS\|FAIL>` | the three self-check families |
+| `GATE RED: <row> <n> > MAX=<n> — a <thing> was ADDED.` | printed once per rising row, before exit 1 |
+| `RATCHET SLACK: <row> <n> < MAX=<n> ...` | printed once per fallen row; does not change the exit status |
+| `GATE GREEN: ...` | printed only when no row rose |
+| `NOTE: GATE GREEN does not mean the ratchet is current. ...` | printed on every green run |
+
+**Internal functions** (names and arguments fixed so the auditor can address
+them; bodies are the commit owner's):
+
+| function | arguments | returns / emits |
+|---|---|---|
+| `discover_packages` | `tree_root` | one `name<TAB>cabal_path` line per `lib/*` package found |
+| `extract_edges` | `cabal_path`, `package_name` | one `package<TAB>stanza_kind<TAB>field<TAB>dep` line per dependency, with `COMMON` imports already attributed to the importing stanza's kind |
+| `closure_rows` | edge stream on stdin, `target_package` | `closure-lib` and `closure-any` counts and their member lists |
+| `count_suppressions` | `tree_root` | occurrence count and one `path:line` per occurrence |
+| `build_fixture` | `dir` | a self-contained package tree exercising: a library edge to the target; a non-library-only edge to the target; a package depended on by both that reaches the target by no path; a `common` stanza whose `build-depends` names the target, imported by a library; a name sharing the target's prefix; a 2-cycle; and a self-edge |
+| `self_check` | `dir` | `PASS`/`FAIL` per self-check family; any `FAIL` exits 2 |
+
+`build_fixture`'s tree is the permanent form of the exclusion, grammar and
+termination demonstrations (INV-10..INV-13). `self_check` must be shown able to
+return `FAIL`.
+
+## M-2 `scripts/ci/cardano-api-closure-negative-control.sh`
+
+**Invocation:** `cardano-api-closure-negative-control.sh [tree-root]`.
+
+**Exit:** `0` only when the pristine run exited 0 **and** all three seeded runs
+produced their expected measured per-row deltas **and** each seeded run exited
+1 · `1` anything else, including a delta that is not the expected one — that is
+this control failing, not the gate.
+
+**Required stdout, one key per line, per seeded row `<r>`:**
+
+| line | meaning |
+|---|---|
+| `pristine closure-lib=<n> closure-any=<n> suppressions=<n> exit=<n>` | the untouched tree, read from M-1's stdout |
+| `seed <r> path=<path relative to tree-root>` | what it created |
+| `seeded <r> closure-lib=<n> closure-any=<n> suppressions=<n> exit=<n>` | with the seed present |
+| `delta <r> closure-lib=<n> closure-any=<n> suppressions=<n>` | seeded minus pristine |
+| `verdict <r> = PASS\|FAIL <reason>` | bound to the measured deltas, not to the exit alone |
+
+**Expected deltas, which the control asserts rather than assumes:**
+
+| seed | `closure-lib` | `closure-any` | `suppressions` |
+|---|---:|---:|---:|
+| a new package whose **library** depends on the target | +1 | +1 | 0 |
+| a new package whose **benchmark only** depends on the target | 0 | +1 | 0 |
+| a new `*.hs` file carrying the pragma at line start | 0 | 0 | +1 |
+
+The second row is what proves the closure rows are two computations rather than
+one number printed twice (INV-3); a `closure-lib` delta of anything but 0 there
+is a control failure.
+
+**Seed ownership:** each seed path is refused if it already exists, created
+without clobbering, owned only after a successful create, and removed on every
+exit path including signals. No seed is placed under `lib/integration/`.

--- a/specs/5423-closure-ratchet/modules-model.md
+++ b/specs/5423-closure-ratchet/modules-model.md
@@ -1,0 +1,31 @@
+# 5423 — Modules model
+
+Three new files. No existing file is modified.
+
+| M-ID | Path | Responsibility | Depends on |
+|---|---|---|---|
+| M-1 | `scripts/ci/cardano-api-closure-gate.sh` | Compute the three counters over a tree root, print each with its licence, compare each against its ratchet, exit 1 on any rise. Owns its own positive/negative self-checks and the fixture that carries the grammar-shape and exclusion demonstrations. | nothing in-repo |
+| M-2 | `scripts/ci/cardano-api-closure-negative-control.sh` | Falsify M-1 once per row: seed one violation, read M-1's own reported per-row counts before and after, require the measured delta on that row and exit 1 from M-1, then restore. Contains no ratchet value and no count. | M-1, by path, as an external process |
+| M-3 | `.github/workflows/cardano-api-closure.yml` | Run M-2 then M-1 on every pull request, every push to `master`, and on demand. Own concurrency group, no `needs:`, no secrets reference. | M-1, M-2 |
+
+## Dependency direction
+
+`M-3 → M-2 → M-1`. M-1 knows nothing of M-2 or M-3: it reads a tree root and
+reports. That direction is what lets M-2 bind its verdict to M-1's own stdout
+rather than to a reimplementation of the count, and what lets a later
+consolidation ticket replace M-3 without touching M-1.
+
+## Promotion
+
+None. The counting logic is not promoted to a shared library with #5407's
+scripts in this ticket; that is a named later consolidation, and coupling this
+work to another branch is a cost with no acceptance benefit here.
+
+## Boundary the modules model owns
+
+M-1 is one process producing one report. It does not read the ratchet from a
+file another lane edits, does not call `cabal`, does not touch the network, and
+writes nothing outside a private temporary directory it creates and removes.
+M-2 is the only component permitted to write inside the tree, and only the seed
+paths it owns, only after proving each is absent, and it removes them on every
+exit path.

--- a/specs/5423-closure-ratchet/plan.md
+++ b/specs/5423-closure-ratchet/plan.md
@@ -1,0 +1,112 @@
+# 5423 — Plan
+
+## Strategy
+
+Copy the shape of the sibling instrument merged in #5407
+(`scripts/ci/dijkstra-stub-gate.sh`, `scripts/ci/dijkstra-census-negative-control.sh`,
+`.github/workflows/dijkstra-census.yml`). Do not edit those files; duplicating
+two short shell scripts is cheap, and coupling this work to a consolidation
+branch is not. Sharing them is a later ticket.
+
+The instrument is plain POSIX-ish `bash` with `awk`, `grep`, `find` and `sort`
+over the checked-out tree. It invokes no `cabal`, needs no network, and does not
+build. The full stanza-aware transitive computation over all `lib/*` packages
+was measured at ~0.31s during planning.
+
+## Decision: standalone workflow, not a job in `ci.yml`
+
+Taken on the sibling's three reasons, each verified against this repository at
+`6b42c36b58` rather than assumed:
+
+1. **Concurrency.** `ci.yml:9-11` declares `group: ci-${{ github.ref }}` with
+   `cancel-in-progress: true`. A job folded into `ci.yml` can be cancelled by a
+   later push; a separate workflow carries its own group and cannot be.
+2. **`needs:`.** Every candidate host job in `ci.yml` carries one — the shell
+   lint matrix that would be the natural home is `quality-checks` at
+   `ci.yml:686-688`, `needs: build-gate-quality`. An unrelated build failure
+   would skip this check.
+3. **A skipped check looks green.** Combined with (2), that is the exact failure
+   this ticket exists to make impossible.
+
+All three transfer without qualification, so the gate ships as
+`.github/workflows/cardano-api-closure.yml`. This is additive, which also keeps
+the additive-only fence (INV-16) true by construction; that consequence did not
+drive the decision.
+
+## Live boundary
+
+The instrument's real boundary is **CI**, not a laptop. A control that only ever
+ran locally is a claim (INV-8), so the negative control is a workflow step
+beside the gate, unconditional on any other job, and ordered **before** it — a
+gate that has stopped being able to fail must be caught before any of its green
+is believed.
+
+The instrument's other boundary is the **`.cabal` grammar**. The real tree
+cannot exercise every shape the grammar permits, so the shapes it cannot reach
+(INV-13 `import:` inheritance into a library, INV-11 cycles, INV-12 name
+prefixes) are exercised on a fixture tree the instrument constructs and then
+discards. A fixture-based control is permanent; a control pinned to today's
+package names retires itself the moment the migration succeeds.
+
+## Why the exclusion demonstrations are fixture-based
+
+Acceptance requires each row to demonstrate a case it correctly excludes. Two of
+the three named witnesses are real packages: `cardano-wallet-read` (in neither
+row, while in-closure packages depend on it) and
+`cardano-wallet-blackbox-benchmarks` (in `closure-any`, out of `closure-lib` —
+the only package where the rows disagree, and therefore the only real case that
+proves they are two computations).
+
+Pinning a hard assertion to either name makes the instrument fail when the
+migration succeeds: when `closure-any` reaches 0, `blackbox-benchmarks` leaves
+it. So the **falsifiable** demonstrations live on the fixture, where they cannot
+rot, and the real-tree witnesses are **measured and reported** on every run —
+the count of closure members depending on `cardano-wallet-read`, and the
+computed membership of both witnesses. A reported witness that has retired is
+information; a hard-coded one is a future red build for a branch that did
+nothing wrong.
+
+## Ratchet transport
+
+Three maxima, one per row, each overridable by environment variable for the
+controls and for a future tightening ticket. The negative control contains no
+ratchet value and no count, so lowering a `MAX` later cannot invalidate it.
+
+## Slices
+
+One slice. The gate script, its controls and the workflow are one instrument:
+landing the script without the workflow ships a check nothing runs, which is the
+defect class this ticket exists to close. Splitting them is not bisect-safe in
+the sense that matters here — it is bisect-safe and *useless* at the midpoint.
+
+- **S-1** `cardano-api` closure and suppression ratchet: gate script, negative
+  control, workflow, and the land-time measurement recorded in the PR body.
+
+## Verification
+
+No Haskell, Cabal, `cabal.project` or Nix input changes, so no build is
+required — and that is asserted mechanically (INV-17) rather than claimed. The
+ticket gate runs:
+
+- `./scripts/shellcheck.sh` over the two new scripts (CI runs the same script
+  over all of `scripts/**/*.sh`, measured at ~5s locally through its `nix-shell`
+  shebang);
+- the gate on the pristine tree, requiring exit 0 and the three measured rows;
+- the negative control, requiring exit 0 (it exits 0 only when all three seeded
+  rows went red for the measured reason);
+- the advisory direction per row: `MAX` set one above the measured value,
+  requiring the slack message and exit **0**;
+- a YAML parse of the new workflow and a check that the paths it names exist and
+  are executable;
+- the fence: no `lib/integration/**` path and none of #5407's three files in the
+  diff.
+
+Every exit status is read immediately, never after a pipe, and every probe
+prints both the classification and the status so a probe that lies can be caught
+contradicting itself.
+
+## Out of scope
+
+- Lowering any `MAX` below its land-time measurement.
+- Consolidating with #5407's scripts.
+- Any change under `lib/integration/**` (#5412's fence) or to `specs/5419-*`.

--- a/specs/5423-closure-ratchet/spec.md
+++ b/specs/5423-closure-ratchet/spec.md
@@ -1,0 +1,90 @@
+# 5423 — CI ratchet over the `cardano-api` closure and its deprecation suppressions
+
+Issue: cardano-foundation/cardano-wallet#5423 (parent #5237, milestone #113).
+Base: `master` at `6b42c36b58`.
+
+## Problem
+
+Nothing observes the size of the `cardano-api` surface. A tenth `lib/*` package
+can take a `cardano-api` dependency and land green, and so can a tenth
+deprecation suppression. The removal effort has no instrument that can go red
+when its own subject grows.
+
+## Observable outcome
+
+One CI check, running on every pull request and every push to `master`,
+computes three counters over the checked-out tree and exits non-zero when any
+of them rises above a ratcheted maximum.
+
+| row | counts | what a **zero** licenses |
+|---|---|---|
+| `closure-lib` | `lib/*` packages whose **library** transitively depends on `cardano-api` | no production library depends on `cardano-api` |
+| `closure-any` | `lib/*` packages reaching `cardano-api` through **any** stanza | the `cardano-api` pin can be deleted from `cabal.project` |
+| `suppressions` | deprecation-suppression pragmas and `ghc-options:`, both spellings | no new suppression has landed unobserved |
+
+Neither closure row is the other's restatement. `closure-lib` reaching 0 while
+`cardano-wallet-benchmarks` still names `cardano-api` in `benchmark db` and
+`benchmark api` would report the removal done while the dependency is still
+built; `closure-any` reaching 0 would block acceptance of the `cardano-api`
+removal on benchmark work that is not part of it. Two rows, each labelled with
+what it licenses, say the true thing in both directions.
+
+## Requirements
+
+- **REQ-1** One CI check computes all three counters and exits 1 if any rises.
+- **REQ-2** Each row prints, at runtime, what a zero on that row licenses.
+- **REQ-3** Each `MAX` equals the value measured at land time, with that
+  measurement shown in the PR. No row lands with slack.
+- **REQ-4** A negative control seeds one violation **per row — all three** and
+  requires exit 1 for each. It runs in CI beside the gate.
+- **REQ-5** A positive control shows each counter counts what it claims,
+  including both suppression spellings.
+- **REQ-6** Each row demonstrates a case it correctly excludes (INV-10).
+- **REQ-7** The computation terminates on cycles and self-edges.
+- **REQ-8** Additive only. No file under `lib/integration/**`, and no edit to
+  `#5407`'s three files.
+
+## Rejection behaviour
+
+- A row above its `MAX` → the run prints `GATE RED`, names the row and both
+  numbers, and exits **1**.
+- A row below its `MAX` with `MAX` unchanged → the run prints a per-row slack
+  message naming the value to lower `MAX` to, and exits **0**.
+
+That asymmetry is deliberate. A hard failure on slack turns a retirement made
+on another branch into a red build for a branch that did nothing wrong, and
+this repository has already produced that case. It is stated rather than
+inferred: the run's own output must say that `GATE GREEN` means nothing was
+added, not that the ratchet is current, and that tightening a fallen row is an
+obligation of whoever lands the change, checked at review.
+
+## Invariants
+
+| ID | Statement | Fails when |
+|---|---|---|
+| INV-1 | `closure-lib` = `lib/*` packages with a **library-only** build-depends path to `cardano-api` | a direct-edge count is used; four packages are transitive-only today and reach 0 while the closure is non-empty |
+| INV-2 | `closure-any` = `closure-lib` ∪ `lib/*` packages any of whose stanzas build-depends on a member of `closure-lib ∪ {cardano-api}` | a stanza-blind or fully-transitive-through-any-stanza reading is used |
+| INV-3 | The two closure rows are two computations | a perturbation that moves `closure-any` alone also moves `closure-lib`, or vice versa |
+| INV-4 | Suppressions are counted **by form**: `^{-# OPTIONS_GHC` in `*.hs`, anchored `ghc-options:` in `*.cabal` and `cabal.project*`, both spellings | one spelling is missed (three sites), or prose is excluded by discarding a file population instead of by form |
+| INV-5 | A rise exits 1; a fall with `MAX` unchanged prints slack and exits 0 | either direction is inverted or collapsed |
+| INV-6 | Each `MAX` equals the land-time measurement | a seeded violation passes because the row had slack |
+| INV-7 | Every row prints its licence, and the run states that green ≠ current | a number is read as the criterion printed next to it |
+| INV-8 | The negative control seeds each row independently, binds the measured per-row delta, requires exit 1, and runs in CI unconditional on any other job | a red unrelated to the seeded delta is accepted; or the control only ever ran on a laptop |
+| INV-9 | Positive control: each counter counts what it claims, both spellings included | a counter that always returns its ratchet passes |
+| INV-10 | Exclusions are demonstrated on a fixture the instrument builds: a package depended on by closure members but reaching `cardano-api` by no path is in neither row; a package reaching it only through a non-library stanza is in `closure-any` and not `closure-lib`; prose is not counted | proximity or co-occurrence is used instead of a directed-edge computation |
+| INV-11 | The computation terminates on self-edges and cycles, proven on a fixture containing both | a naive recursive walk hangs or double-counts (`cardano-wallet-read` depends on itself) |
+| INV-12 | Dependency names are compared as whole package names | `cardano-api-extra` is counted as `cardano-api` |
+| INV-13 | `build-depends` carried by a `common` stanza is attributed to each stanza that imports it, with the importing stanza's kind | a library that inherits a `cardano-api` edge through `import:` is missed; two such `common` stanzas already exist and today feed only non-library stanzas, so the real tree cannot exercise this |
+| INV-14 | The package population is read out of the tree; the computation refuses to report success over an empty or truncated population, and that refusal is itself falsified | a gate that must be edited to keep covering its subject silently stops covering it |
+| INV-15 | Every control is demonstrated red before its green is believed | a control that has stopped being able to fail |
+| INV-16 | Additive fence holds (REQ-8) | a sibling lane's file is touched |
+| INV-17 | The change set contains no Haskell, Cabal, `cabal.project` or Nix input, asserted mechanically | the "no build needed" claim is asserted rather than measured |
+
+## Land-time measurement (planning-time value, to be re-measured)
+
+Measured independently at `6b42c36b58`, reproducing the issue's populations
+exactly: `closure-lib = 12`, `closure-any = 13`, `suppressions = 9`;
+`cardano-wallet-blackbox-benchmarks` is the sole member of
+`closure-any \ closure-lib`; `cardano-wallet-read` is in neither row while
+in-closure packages depend on it. **These are not the values to ship.** The
+commit owner re-measures at land time and shows that measurement.

--- a/specs/5423-closure-ratchet/tasks.md
+++ b/specs/5423-closure-ratchet/tasks.md
@@ -1,0 +1,22 @@
+# 5423 — Tasks
+
+## S-1 — `cardano-api` closure and suppression ratchet
+
+- [ ] **T-1** RED: a proof that the three rows can each be made to go red, and
+      that the instrument's self-checks can return FAIL, executed and captured
+      before any of M-1 exists in a form that could pass it.
+- [ ] **T-2** `scripts/ci/cardano-api-closure-gate.sh` (M-1): population
+      discovery, stanza-aware edge extraction with `common`/`import:`
+      attribution, the two closure rows, the suppression row, per-row licences,
+      the fixture self-check, and the ratchet with its one-directional exit.
+- [ ] **T-3** `scripts/ci/cardano-api-closure-negative-control.sh` (M-2): three
+      independent seedings, per-row measured deltas, exit bound to those deltas.
+- [ ] **T-4** `.github/workflows/cardano-api-closure.yml` (M-3): own concurrency
+      group, no `needs:`, control before gate, no secrets reference.
+- [ ] **T-5** Land-time measurement of all three rows, mechanically captured,
+      each `MAX` set to its measured value with no slack, and the measurement
+      recorded for the PR body.
+- [ ] **T-6** Evidence bundle: pristine green, three seeded reds, three slack
+      runs green, self-check forced to FAIL, shellcheck, YAML parse, fence
+      check, and the INV-17 no-build assertion — each with its own exit status
+      read immediately.


### PR DESCRIPTION
> **Superseded by #5426**, which tracks issue #5425. This branch names a ticket that is now closed; its pushed tree is six spec files and the content carries forward unchanged.

Closes #5423.

One CI check ratchets three counters over the `cardano-api` surface. Each may
fall and may not rise; a rise fails the build.

| row | counts | what a zero licenses |
|---|---|---|
| `closure-lib` | `lib/*` packages whose **library** transitively depends on `cardano-api` | no production library depends on `cardano-api` |
| `closure-any` | `lib/*` packages reaching `cardano-api` through **any** stanza | the `cardano-api` pin can be deleted from `cabal.project` |
| `suppressions` | deprecation-suppression pragmas and `ghc-options:`, both spellings | no new suppression has landed unobserved |

Work in progress. The mandate is in `specs/5423-closure-ratchet/`; the
measurement that sets each `MAX`, and the evidence that each row can be made to
go red, land with the instrument.

