### PR TITLE
Dijkstra: delete the spurious era split in mkLedgerTx, and sweep the other suspected sites

### DIFF
--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -71,7 +71,9 @@ import Cardano.Balance.Tx.Balance
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
+    , IsRecentEra
     , RecentEra (..)
+    , allRecentEras
     )
 import Cardano.Balance.Tx.Gen
     ( mockPParams
@@ -109,12 +111,25 @@ import Cardano.Ledger.Api
     , scriptTxWitsL
     , witsTxL
     )
+import Cardano.Ledger.Api.Tx
+    ( auxDataTxL
+    )
 import Cardano.Ledger.Api.Tx.Body
-    ( collateralInputsTxBodyL
+    ( certsTxBodyL
+    , collateralInputsTxBodyL
+    , feeTxBodyL
     , inputsTxBodyL
     , mintTxBodyL
     , outputsTxBodyL
+    , vldtTxBodyL
     , withdrawalsTxBodyL
+    )
+import Cardano.Ledger.Core
+    ( TxAuxData
+    , auxDataHashTxBodyL
+    , hashTxAuxData
+    , metadataTxAuxDataL
+    , mkBasicTxAuxData
     )
 import Cardano.Ledger.BaseTypes
     ( StrictMaybe (..)
@@ -421,7 +436,8 @@ import Ouroboros.Network.Block
     ( SlotNo (..)
     )
 import Test.Hspec
-    ( Spec
+    ( Expectation
+    , Spec
     , describe
     , it
     , pendingWith
@@ -522,6 +538,7 @@ spec = describe "TransactionSpec" $ do
     forAllRecentEras ledgerScriptWitnessParitySpec
     reviewResponse5413Spec
     transactionConstraintsSpec
+    mkLedgerTxEraPolymorphismSpec
     describe "four-field differential (INV-3)" $ do
         prop
             "ledger reads equal the generated fields, per field"
@@ -2436,6 +2453,93 @@ transactionConstraintsSpec = describe "Transaction constraints" $ do
     it "size of empty transaction" prop_txConstraints_txBaseSize
     it "size of non-empty transaction"
         $ property prop_txConstraints_txSize
+
+--------------------------------------------------------------------------------
+-- mkLedgerTx is era-polymorphic (issue #5422)
+--------------------------------------------------------------------------------
+
+mkLedgerTxEraPolymorphismSpec :: Spec
+mkLedgerTxEraPolymorphismSpec = describe "mkLedgerTx" $ do
+    it
+        "returns the components it was handed, in every recent era"
+        (property prop_mkLedgerTxReturnsComponents)
+    it
+        "extent guard: allRecentEras is non-empty and contains Dijkstra"
+        prop_mkLedgerTxExtentContainsDijkstra
+
+-- | The components handed to 'mkLedgerTx' come back out of the built
+-- transaction, for every era in the extent discovered from 'allRecentEras'.
+-- The extent is read out of the library rather than listed by hand, so a
+-- future era is covered without editing this test.
+prop_mkLedgerTxReturnsComponents :: Property
+prop_mkLedgerTxReturnsComponents =
+    forAll genTxIn $ \txIn ->
+        conjoin
+            [ returnsComponents txIn anyEra
+            | anyEra <- Set.toAscList allRecentEras
+            ]
+  where
+    returnsComponents :: TxIn -> AnyRecentEra -> Property
+    returnsComponents txIn (AnyRecentEra era) = case era of
+        RecentEraConway -> go RecentEraConway
+        RecentEraDijkstra -> go RecentEraDijkstra
+      where
+        go
+            :: forall era
+             . IsRecentEra era
+            => RecentEra era
+            -> Property
+        go e =
+            let metadata =
+                    toShelleyMetadata (Map.singleton 7 (TxMetaNumber 42))
+                auxData :: TxAuxData era
+                auxData =
+                    mkBasicTxAuxData
+                        & metadataTxAuxDataL .~ metadata
+                validity =
+                    ValidityInterval (SJust (SlotNo 24)) (SJust (SlotNo 2_424))
+                tx =
+                    mkLedgerTx
+                        e
+                        (Set.singleton (toLedger txIn))
+                        (fromList [])
+                        (toLedgerCoin (Coin.Coin 1_000_000))
+                        validity
+                        (Withdrawals Map.empty)
+                        mempty
+                        mempty
+                        metadata
+                body = tx ^. bodyTxL
+            in  conjoin
+                    [ counterexample "inputs"
+                        (view inputsTxBodyL body ==== Set.singleton (toLedger txIn))
+                    , counterexample "outputs"
+                        (view outputsTxBodyL body ==== fromList [])
+                    , counterexample "fee"
+                        (view feeTxBodyL body ==== toLedgerCoin (Coin.Coin 1_000_000))
+                    , counterexample "validity interval"
+                        (view vldtTxBodyL body ==== validity)
+                    , counterexample "withdrawals"
+                        (view withdrawalsTxBodyL body ==== Withdrawals Map.empty)
+                    , counterexample "certificates"
+                        (view certsTxBodyL body ==== mempty)
+                    , counterexample "mint"
+                        (view mintTxBodyL body ==== toLedgerMintValue mempty mempty)
+                    , counterexample "auxiliary data hash"
+                        (view auxDataHashTxBodyL body ==== SJust (hashTxAuxData auxData))
+                    , counterexample "metadata"
+                        (fmap (view metadataTxAuxDataL) (view auxDataTxL tx) ==== SJust metadata)
+                    ]
+
+-- | Population guard for 'prop_mkLedgerTxReturnsComponents': the property
+-- ranges over the extent read from 'allRecentEras', so an empty or truncated
+-- extent would make it report success having tested nothing. This guard
+-- asserts the extent is non-empty and contains the era this ticket is about.
+prop_mkLedgerTxExtentContainsDijkstra :: Expectation
+prop_mkLedgerTxExtentContainsDijkstra = do
+    let extent = Set.toList allRecentEras
+    extent `shouldSatisfy` not . null
+    extent `shouldSatisfy` elem (AnyRecentEra RecentEraDijkstra)
 
 --------------------------------------------------------------------------------
 -- Roundtrip tests for SealedTx

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs
@@ -124,18 +124,18 @@ import Cardano.Ledger.Api.Tx.Body
     , vldtTxBodyL
     , withdrawalsTxBodyL
     )
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (..)
+    )
+import Cardano.Ledger.Binary
+    ( serialize
+    )
 import Cardano.Ledger.Core
     ( TxAuxData
     , auxDataHashTxBodyL
     , hashTxAuxData
     , metadataTxAuxDataL
     , mkBasicTxAuxData
-    )
-import Cardano.Ledger.BaseTypes
-    ( StrictMaybe (..)
-    )
-import Cardano.Ledger.Binary
-    ( serialize
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic)
@@ -2511,24 +2511,35 @@ prop_mkLedgerTxReturnsComponents =
                         metadata
                 body = tx ^. bodyTxL
             in  conjoin
-                    [ counterexample "inputs"
+                    [ counterexample
+                        "inputs"
                         (view inputsTxBodyL body ==== Set.singleton (toLedger txIn))
-                    , counterexample "outputs"
+                    , counterexample
+                        "outputs"
                         (view outputsTxBodyL body ==== fromList [])
-                    , counterexample "fee"
+                    , counterexample
+                        "fee"
                         (view feeTxBodyL body ==== toLedgerCoin (Coin.Coin 1_000_000))
-                    , counterexample "validity interval"
+                    , counterexample
+                        "validity interval"
                         (view vldtTxBodyL body ==== validity)
-                    , counterexample "withdrawals"
+                    , counterexample
+                        "withdrawals"
                         (view withdrawalsTxBodyL body ==== Withdrawals Map.empty)
-                    , counterexample "certificates"
+                    , counterexample
+                        "certificates"
                         (view certsTxBodyL body ==== mempty)
-                    , counterexample "mint"
+                    , counterexample
+                        "mint"
                         (view mintTxBodyL body ==== toLedgerMintValue mempty mempty)
-                    , counterexample "auxiliary data hash"
+                    , counterexample
+                        "auxiliary data hash"
                         (view auxDataHashTxBodyL body ==== SJust (hashTxAuxData auxData))
-                    , counterexample "metadata"
-                        (fmap (view metadataTxAuxDataL) (view auxDataTxL tx) ==== SJust metadata)
+                    , counterexample
+                        "metadata"
+                        ( fmap (view metadataTxAuxDataL) (view auxDataTxL tx)
+                            ==== SJust metadata
+                        )
                     ]
 
 -- | Population guard for 'prop_mkLedgerTxReturnsComponents': the property

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -97,6 +97,9 @@ data VoteRequest
 {-----------------------------------------------------------------------------
     Join stake pool
 ------------------------------------------------------------------------------}
+-- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+-- the vote coupling decided here rests on Conway registration certificates, which
+-- Dijkstra reshapes (deposit-free registration expunged).
 joinStakePoolDelegationAction
     :: Write.IsRecentEra era
     => Write.RecentEra era
@@ -158,6 +161,9 @@ joinStakePoolDelegationAction
                 . view #retirementEpoch
                 <$> W.getPoolRetirementCertificate poolStatus
 
+-- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+-- the duplicate-vote policy was decided against Conway's certificate space, not
+-- Dijkstra's.
 guardJoin
     :: Write.IsRecentEra era
     => Write.RecentEra era
@@ -288,6 +294,9 @@ joinDRepVotingAction era targetDRep dlg stakeKeyIsRegistered = do
         $ ErrAlreadyVoted targetDRep
     second (const votingAction) $ guardEraIsConway era
   where
+    -- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+    -- era-blind acceptance would silence a rejection the Dijkstra certificate space
+    -- has not earned.
     guardEraIsConway
         :: Write.IsRecentEra era
         => Write.RecentEra era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Build.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
@@ -15,7 +14,7 @@ module Cardano.Wallet.Shelley.Transaction.Build
 
 import Cardano.Balance.Tx.Eras
     ( IsRecentEra
-    , RecentEra (..)
+    , RecentEra
     )
 import Cardano.Balance.Tx.Tx
     ( Tx
@@ -106,31 +105,25 @@ mkLedgerTx
     -> Map Word64 Metadatum
     -- ^ Metadata
     -> Tx era
-mkLedgerTx era ins outs fee validity wdrls certs mint metadata =
-    case era of
-        RecentEraConway -> go
-        RecentEraDijkstra ->
-            error "mkLedgerTx: Dijkstra era not yet supported"
-  where
-    go =
-        let
-            auxData
-                | Map.null metadata = SNothing
-                | otherwise =
-                    SJust
-                        $ mkBasicTxAuxData
-                        & metadataTxAuxDataL .~ metadata
-            body =
-                mkBasicTxBody
-                    & inputsTxBodyL .~ ins
-                    & outputsTxBodyL .~ outs
-                    & feeTxBodyL .~ fee
-                    & vldtTxBodyL .~ validity
-                    & withdrawalsTxBodyL .~ wdrls
-                    & certsTxBodyL .~ certs
-                    & mintTxBodyL .~ mint
-                    & auxDataHashTxBodyL
-                        .~ fmap hashTxAuxData auxData
-        in
-            mkBasicTx body
-                & auxDataTxL .~ auxData
+mkLedgerTx _era ins outs fee validity wdrls certs mint metadata =
+    let
+        auxData
+            | Map.null metadata = SNothing
+            | otherwise =
+                SJust
+                    $ mkBasicTxAuxData
+                    & metadataTxAuxDataL .~ metadata
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ ins
+                & outputsTxBodyL .~ outs
+                & feeTxBodyL .~ fee
+                & vldtTxBodyL .~ validity
+                & withdrawalsTxBodyL .~ wdrls
+                & certsTxBodyL .~ certs
+                & mintTxBodyL .~ mint
+                & auxDataHashTxBodyL
+                    .~ fmap hashTxAuxData auxData
+    in
+        mkBasicTx body
+            & auxDataTxL .~ auxData

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs
@@ -360,6 +360,9 @@ buildLedgerTxRaw
             Just m -> toShelleyMetadata (unTxMetadata m)
 
 -- | Install script-witness extras on a freshly-built ledger 'Tx'.
+-- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+-- script witnesses are era-indexed values and the Conway helper below is
+-- Conway-typed; the compiler rejects the deletion.
 installScriptWitnesses
     :: RecentEra era
     -> ScriptWitnesses
@@ -537,6 +540,9 @@ extractValidatedOutputs sel =
                                     txOutMaxTokenQuantity
                                 }
 
+-- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+-- Dijkstra expunges deposit-free registration, so the Conway decision below does
+-- not describe Dijkstra behavior.
 certificateFromDelegationActionLedger
     :: RecentEra era
     -> Either XPub (Script KeyHash)
@@ -594,6 +600,9 @@ certificateFromDelegationActionLedger
             "certificateFromDelegationAction\
             \Ledger: Dijkstra not yet supported"
 
+-- Deleting this split is recorded unsafe in specs/5422-delete-era-split/sweep.md:
+-- the vote half survives in Dijkstra but the coupled registration half does not
+-- (deposit-free registration expunged).
 certificateFromVotingActionLedger
     :: RecentEra era
     -> Either XPub (Script KeyHash)

--- a/scripts/ci/dijkstra-stub-gate.sh
+++ b/scripts/ci/dijkstra-stub-gate.sh
@@ -51,7 +51,7 @@ total=$((tot_e+tot_p))
 # MAX is the number of Dijkstra stubs currently tolerated. It only ever goes
 # DOWN. Each child that retires stubs lowers it in the same PR; its terminal
 # value is 0, which is issue #5209's acceptance criterion.
-MAX=${DIJKSTRA_STUB_MAX:-39}
+MAX=${DIJKSTRA_STUB_MAX:-38}
 
 echo "total = $total across $files files   (ratchet MAX=$MAX)"
 

--- a/specs/5422-delete-era-split/data-model.md
+++ b/specs/5422-delete-era-split/data-model.md
@@ -1,0 +1,20 @@
+# Data model — 5422
+
+No data type is added, removed, or changed. No field, relationship, validation
+rule or persisted representation moves.
+
+The slice's whole subject is a **term-level** branch on the `RecentEra era`
+GADT. The GADT itself, its two constructors, and every type reachable from
+`mkLedgerTx`'s signature are untouched.
+
+## State invariants relied upon (not introduced)
+
+| Invariant | Where it lives | Why this slice depends on it |
+|---|---|---|
+| `RecentEra era` has exactly the constructors `RecentEraConway` and `RecentEraDijkstra` | `Cardano.Balance.Tx.Eras` | the extent guard in the new test quantifies over `allRecentEras` rather than over a literal list, so this invariant is *observed*, not assumed |
+| `IsRecentEra era` entails `RecentEraConstraints era` | `Cardano.Balance.Tx.Eras` | this is what makes the deletion type-check at all; leg A at site 12 is the check |
+| Dijkstra expunges `RegTxCert` / `UnRegTxCert`, retaining only the deposit-carrying forms | `Cardano.Ledger.Dijkstra.TxCert` | leg B evidence at the certificate-building sites, and the standing hazard for any path that builds a certificate in a lower era and **upgrades** it |
+
+The third row is a fact about a dependency, and it is version-bound. The
+resolved `cardano-ledger-dijkstra` version must be read from this worktree's own
+build plan and recorded with the citation.

--- a/specs/5422-delete-era-split/functions-model.md
+++ b/specs/5422-delete-era-split/functions-model.md
@@ -1,0 +1,39 @@
+# Functions model — 5422
+
+## Changed signatures
+
+**None.** `mkLedgerTx` keeps its exported signature exactly:
+
+```
+mkLedgerTx
+    :: forall era
+     . IsRecentEra era
+    => RecentEra era
+    -> Set TxIn -> StrictSeq (TxOut era) -> Coin -> ValidityInterval
+    -> Withdrawals -> StrictSeq (TxCert era) -> MultiAsset
+    -> Map Word64 Metadatum
+    -> Tx era
+```
+
+Per decision D-1 the first argument is retained and becomes an unused binder.
+No constraint is added. **Adding a constraint to make a site compile is an era
+arm by another name and is forbidden by X-2** — at site 12 it would mean the
+deletion failed and X-1's finding applies.
+
+## New functions
+
+| Name | Arguments | Result | Constraints / effects |
+|---|---|---|---|
+| the Dijkstra-exercising property | one `RecentEra era` drawn from the quantified extent, plus the transaction components | `Property` | pure; asserts the components handed to `mkLedgerTx` are recoverable from the resulting `Tx era` |
+| the extent guard | none | `Expectation` | pure; asserts `allRecentEras` is non-empty and contains `RecentEraDijkstra` |
+
+Names, module placement within the existing spec module, helper decomposition,
+and the exact assertion set are the implementer's, inside these constraints.
+
+## Functions inspected but NOT changed
+
+`joinStakePoolDelegationAction`, `guardJoin`, `guardEraIsConway`,
+`installScriptWitnesses`, `certificateFromDelegationActionLedger`,
+`certificateFromVotingActionLedger`. Leg A's compile experiment is performed
+against each and then **reverted**. None of their signatures or bodies is
+changed by this slice.

--- a/specs/5422-delete-era-split/functions-model.md
+++ b/specs/5422-delete-era-split/functions-model.md
@@ -15,10 +15,11 @@ mkLedgerTx
     -> Tx era
 ```
 
-Per decision D-1 the first argument is retained and becomes an unused binder.
-No constraint is added. **Adding a constraint to make a site compile is an era
-arm by another name and is forbidden by X-2** — at site 12 it would mean the
-deletion failed and X-1's finding applies.
+The first argument is retained and becomes an unused binder, so no call site
+changes. No constraint is added. **Adding a constraint to make a site compile is
+an era arm by another name and is forbidden** — at the deletion site it would
+mean the deletion failed, which is a finding that changes the ticket rather than
+something absorbed into it.
 
 ## New functions
 

--- a/specs/5422-delete-era-split/modules-model.md
+++ b/specs/5422-delete-era-split/modules-model.md
@@ -1,0 +1,30 @@
+# Modules model — 5422
+
+No module is created, moved, renamed or deleted. No dependency edge changes.
+The slice removes a branch inside one existing module and adds a test to one
+existing spec module.
+
+| Module | Change | Responsibility after |
+|---|---|---|
+| `Cardano.Wallet.Shelley.Transaction.Build` | the era match inside `mkLedgerTx` is removed; imports that the removal orphans are trimmed | unchanged: build a ledger `Tx` from its components using `mkBasicTxBody` and ledger lenses, for **every** recent era rather than for Conway only |
+| `Cardano.Wallet.Shelley.TransactionLedgerSpec` (test) | gains one property plus its extent guard | unchanged: unit coverage for the ledger transaction-construction path |
+| `Cardano.Wallet.Delegation` | comment only, at sites 22, 23, 24 | unchanged |
+| `Cardano.Wallet.Shelley.Transaction.Unsigned` | comment only, at sites 27, 28, 29 | unchanged |
+
+Dependency direction is untouched: `Build` continues to depend on
+`Cardano.Balance.Tx.Eras` and the `cardano-ledger-*` API, and nothing new
+depends on `Build`.
+
+## Promotion
+
+None. Nothing here belongs further upstream. In particular the era-polymorphism
+this slice reveals is already owned upstream by `IsRecentEra` /
+`RecentEraConstraints` in `cardano-balance-transaction`; the slice stops
+shadowing it, it does not re-implement it.
+
+## Non-module artifacts changed
+
+| Path | Owner | Change |
+|---|---|---|
+| `scripts/ci/dijkstra-stub-gate.sh` | #5209's census gate | the ratchet default `MAX` moves 39 → 38. Nothing else in the script changes: not the counter, not the controls, not the exit contract. |
+| `specs/5422-delete-era-split/sweep.md` | this ticket | new: the six evidenced verdicts |

--- a/specs/5422-delete-era-split/plan.md
+++ b/specs/5422-delete-era-split/plan.md
@@ -115,10 +115,19 @@ code read directly.
 `scripts/ci/dijkstra-stub-gate.sh` carries `MAX=${DIJKSTRA_STUB_MAX:-39}`. The
 default moves to 38. Measured on the merged script with exit codes read
 directly and not through a pipe: adding a stub exits **1**; retiring one and
-leaving the maximum alone prints `RATCHET SLACK` and exits **0**. So CI enforces
-the census falling and does **not** enforce the ratchet moving. The ticket gate
-closes that hole locally by running the same script with
-`DIJKSTRA_STUB_STRICT=1`, under which slack is a hard failure.
+leaving the maximum alone prints `RATCHET SLACK` and exits **0**.
+
+That is a fact about the **script**, and it does not settle what **CI** does —
+the workflow runs more than the script. Measured on the workflow: the census
+negative control is a separate step that seeds one stub and requires the gate to
+exit 1. With the census at 38 and the maximum at 39, the seeded total is 39,
+which is *at* the ratchet, so the gate exits 0 and the control cannot fire:
+`negative-control: FAIL — gate-exit-0-not-1`. **CI does catch a ratchet left
+carrying slack**, by way of the control rather than the census. Lowering the
+maximum to 38 restores `gate_exit=1` and the control passes.
+
+The ticket gate also closes it locally by running the same script under
+`DIJKSTRA_STUB_STRICT=1`, where slack is a hard failure directly.
 
 ## Slices
 

--- a/specs/5422-delete-era-split/plan.md
+++ b/specs/5422-delete-era-split/plan.md
@@ -1,0 +1,147 @@
+# Plan — 5422
+
+Base: `master` = `6b42c36b586c495a294eb11331984f90a3609470`
+Branch: `refactor/5422-delete-era-split` · worktree `/code/cardano-wallet-5422`
+
+## Invariants
+
+| ID | Statement | Fails when | Succeeds when |
+|---|---|---|---|
+| INV-1 | The census reads 38 and the ratchet `MAX` reads 38, in this PR. | the gate prints any `total` other than 38, or prints `RATCHET SLACK`, or exits non-zero under `DIJKSTRA_STUB_STRICT=1` | the gate's own stdout shows `total = 38 across <n> files   (ratchet MAX=38)` and exit 0 under strict |
+| INV-2 | No stub is closed by suppression. | a stub disappears from the census while its failure still exists in some form — a widened catch-all, a renamed message, a loud failure made silent, or a rename that hides it from the counter | every retired stub is retired because the code that threw it is **gone**, and the census delta equals the number of deleted `error` literals |
+| INV-3 | The Dijkstra path is exercised. | restoring the deleted `error` leaves the suite green | restoring the deleted `error` makes a named test fail, with that failure captured |
+| INV-4 | The population contains the case. | the property's generated/enumerated population does not actually contain the Dijkstra case, or the extent it quantifies over can be empty or truncated without the check noticing | the extent is read out of `allRecentEras` rather than listed, an assertion proves that extent non-empty and containing `RecentEraDijkstra`, and **that assertion is itself shown able to fail** |
+| INV-5 | Six sites, six verdicts, each with evidence. Silence is not a pass. | any of sites 22, 23, 24, 27, 28, 29 lacks a verdict, or carries a verdict without both evidence legs | `sweep.md` has six entries, each with leg A and leg B below |
+
+INV-1, INV-2, INV-3 are **blocking**.
+
+## The sweep method — two legs, and a site is deletable only if both pass
+
+This is the whole intellectual content of the ticket, and it exists because the
+obvious instrument gives the wrong answer at three of the six sites.
+
+**Leg A — type.** Delete the era match at the site, compile, record GHC's
+verbatim answer (or verbatim success). Then revert. This is an *experiment*, not
+a change: the tree returns to its prior state and `git status --porcelain` is
+empty afterwards.
+
+**Leg B — semantics.** State in one sentence what the Conway arm *decides*, then
+cite the ledger or protocol fact that settles whether Dijkstra decides it the
+same way. The citation names a file, a line and the **resolved package version**,
+taken from the build this worktree actually produces — never from
+`dist-newstyle/cache/plan.json` in another checkout, which is stale.
+
+A site is **same shape (deletable)** only when leg A compiles **and** leg B shows
+Dijkstra decides identically. Anything else is **not same shape**, and the
+verdict records which leg failed.
+
+### Why both legs are mandatory
+
+Leg A alone is the trap the ticket was written around. At sites 22, 23 and 24
+the arms produce era-free types — `Maybe Tx.VotingAction`, `Either
+ErrCannotJoin ()`, `Either ErrCannotVote ()` — so deleting the era match
+**compiles**, the suite stays green, and the change is wrong. A sweep whose only
+instrument is "does it still build?" returns *deletable* three times.
+
+Leg B alone cannot see a missing class constraint. `RecentEraConstraints` in
+`Cardano.Balance.Tx.Eras` supplies `Core.EraTx`, `Core.EraTxCert`,
+`Alonzo.AlonzoEraTxBody`, `Babbage.BabbageEraTxBody` and more, but it does not
+supply everything a Conway-only arm may be using. Only the compiler knows.
+
+Site 24 has a third character worth naming: `guardEraIsConway` exists **in order
+to reject** non-Conway. Deleting its split does not generalize it, it makes it
+return `Right ()` unconditionally — that is INV-2 suppression wearing a deletion's
+clothes.
+
+## Strategy for R-1
+
+`mkLedgerTx`'s body uses `mkBasicTxBody`, `inputsTxBodyL`, `outputsTxBodyL`,
+`feeTxBodyL`, `vldtTxBodyL`, `withdrawalsTxBodyL`, `certsTxBodyL`,
+`mintTxBodyL`, `auxDataHashTxBodyL`, `mkBasicTxAuxData`, `metadataTxAuxDataL`,
+`hashTxAuxData`, `mkBasicTx`, `auxDataTxL`. The hypothesis is that every one of
+them is available from `RecentEraConstraints`; leg A at site 12 is what settles
+it. If it does not compile, that is X-1's finding and the ticket stops.
+
+### Decision D-1 — the `RecentEra era` parameter stays
+
+After the deletion the `era` argument has no use in the body. Two options:
+
+- **chosen:** keep the parameter and bind it `_era`. Minimal diff, no call-site
+  churn, and `Cardano.Balance.Tx.Eras`' own convention keeps a `RecentEra era`
+  argument for disambiguation.
+- rejected: drop the parameter and update every call site. It changes an
+  exported signature and touches four call sites in
+  `TransactionLedgerSpec.hs` and `Unsigned.hs` for no behavioural gain — scope
+  this ticket was explicitly cut to avoid.
+
+### Decision D-2 — deletion orphans things, and `-Werror` will say so
+
+Deleting the `case era of` removes the only uses of the `RecentEraConway` and
+`RecentEraDijkstra` **constructors** in `Build.hs`, while the `RecentEra`
+**type** is still used in the signature. `-Wall -Werror` reports unused import
+items, so `RecentEra (..)` and possibly the `GADTs` pragma become live warnings.
+Cleaning up exactly what the deletion orphaned is part of the deletion (swap
+rule); it is not adjacent cleanup, and it is not licence to touch anything the
+deletion did not orphan.
+
+This class — a lint regression created by removing code — is the one that got
+past a ticket gate on #5419 and was caught by CI after push. The gate below runs
+`hlint` and the format check, and the base is measured as a control so a
+pre-existing hint is not attributed to this slice.
+
+## Strategy for R-2 / INV-3 / INV-4
+
+One property in `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`,
+which already imports `mkLedgerTx`.
+
+- Quantify over the **discovered extent**: `allRecentEras :: Set AnyRecentEra`
+  from `Cardano.Balance.Tx.Eras`, not a hand-written two-element list. A future
+  era is then covered without editing the test.
+- Assert separately that this extent is non-empty **and** contains
+  `RecentEraDijkstra`. Without that guard the property can range over an empty
+  or truncated set and report success having tested nothing.
+- Show that guard can fail. An extent guard that has never been red is a
+  hypothesis.
+- The property's own assertion must be about the built transaction — the fields
+  handed in come back out — so it is not satisfied by the mere absence of an
+  exception.
+
+RED is not "the test does not exist yet". RED is: with the `error` present, the
+named test **executes and fails**, and that failure is captured with its exit
+code read directly.
+
+## Strategy for R-4
+
+`scripts/ci/dijkstra-stub-gate.sh` carries `MAX=${DIJKSTRA_STUB_MAX:-39}`. The
+default moves to 38. Measured on the merged script with exit codes read
+directly and not through a pipe: adding a stub exits **1**; retiring one and
+leaving `MAX` alone prints `RATCHET SLACK` and exits **0**. So CI enforces the
+census falling and does **not** enforce the ratchet moving. The ticket gate
+closes that hole locally by running the same script with
+`DIJKSTRA_STUB_STRICT=1`, under which slack is a hard failure.
+
+## Slices
+
+One bisect-safe slice, `S1`. The deletion, its test, the ratchet move and the
+sweep record travel together: a commit with the deletion but not the ratchet
+leaves the gate carrying slack, and a commit with the ratchet but not the
+deletion is red.
+
+## Live boundaries
+
+None. Everything here is pure transaction construction and a shell census over
+the source tree. No node, no database, no network.
+
+## Rejected alternative — recording the verdicts only in source comments
+
+Considered, because the next engineer opens `Delegation.hs`, not `specs/`.
+Rejected as the *primary* record: a comment cannot carry the compiler transcript
+that is leg A's evidence. Adopted as a *pointer*: one comment per non-deletable
+site naming the operative reason in one line and pointing at `sweep.md`, so both
+audiences are served.
+
+**Mechanical constraint on those comments, and it is not optional:** the census
+counts `error` followed by a string literal mentioning Dijkstra, over raw file
+bytes, with no comment stripping. A comment containing the word `error` next to
+a Dijkstra string would be counted as a new stub and turn CI red. The comments
+must not contain the token `error` at all.

--- a/specs/5422-delete-era-split/plan.md
+++ b/specs/5422-delete-era-split/plan.md
@@ -3,17 +3,15 @@
 Base: `master` = `6b42c36b586c495a294eb11331984f90a3609470`
 Branch: `refactor/5422-delete-era-split` · worktree `/code/cardano-wallet-5422`
 
-## Invariants
+## What must hold
 
-| ID | Statement | Fails when | Succeeds when |
-|---|---|---|---|
-| INV-1 | The census reads 38 and the ratchet `MAX` reads 38, in this PR. | the gate prints any `total` other than 38, or prints `RATCHET SLACK`, or exits non-zero under `DIJKSTRA_STUB_STRICT=1` | the gate's own stdout shows `total = 38 across <n> files   (ratchet MAX=38)` and exit 0 under strict |
-| INV-2 | No stub is closed by suppression. | a stub disappears from the census while its failure still exists in some form — a widened catch-all, a renamed message, a loud failure made silent, or a rename that hides it from the counter | every retired stub is retired because the code that threw it is **gone**, and the census delta equals the number of deleted `error` literals |
-| INV-3 | The Dijkstra path is exercised. | restoring the deleted `error` leaves the suite green | restoring the deleted `error` makes a named test fail, with that failure captured |
-| INV-4 | The population contains the case. | the property's generated/enumerated population does not actually contain the Dijkstra case, or the extent it quantifies over can be empty or truncated without the check noticing | the extent is read out of `allRecentEras` rather than listed, an assertion proves that extent non-empty and containing `RecentEraDijkstra`, and **that assertion is itself shown able to fail** |
-| INV-5 | Six sites, six verdicts, each with evidence. Silence is not a pass. | any of sites 22, 23, 24, 27, 28, 29 lacks a verdict, or carries a verdict without both evidence legs | `sweep.md` has six entries, each with leg A and leg B below |
-
-INV-1, INV-2, INV-3 are **blocking**.
+| Property | Fails when | Succeeds when |
+|---|---|---|
+| **The census falls to 38 and the ratchet moves with it, in this PR.** *(blocking)* | the gate prints any `total` other than 38, or prints `RATCHET SLACK`, or exits non-zero under `DIJKSTRA_STUB_STRICT=1` | the gate's own stdout shows `total = 38 across <n> files   (ratchet MAX=38)` and exit 0 under strict |
+| **No stub is closed by suppression.** *(blocking)* | a stub disappears from the census while its failure still exists in some form — a widened catch-all, a renamed message, a loud failure made silent, or a rename that hides it from the counter | every retired stub is retired because the code that threw it is **gone**, and the census delta equals the number of deleted failure literals |
+| **The Dijkstra path is exercised.** *(blocking)* | restoring the deleted failure leaves the suite green | restoring the deleted failure makes a named test fail, with that failure captured |
+| **The generated population actually contains the Dijkstra case.** | the property's generated/enumerated population does not actually contain the Dijkstra case, or the extent it quantifies over can be empty or truncated without the check noticing | the extent is read out of `allRecentEras` rather than listed, an assertion proves that extent non-empty and containing `RecentEraDijkstra`, and **that assertion is itself shown able to fail** |
+| **Six sites, six verdicts, each with evidence. Silence is not a pass.** | any of the six sites lacks a verdict, or carries a verdict without both evidence legs | `sweep.md` has six entries, each with leg A and leg B below |
 
 ## The sweep method — two legs, and a site is deletable only if both pass
 
@@ -37,32 +35,34 @@ verdict records which leg failed.
 
 ### Why both legs are mandatory
 
-Leg A alone is the trap the ticket was written around. At sites 22, 23 and 24
-the arms produce era-free types — `Maybe Tx.VotingAction`, `Either
-ErrCannotJoin ()`, `Either ErrCannotVote ()` — so deleting the era match
-**compiles**, the suite stays green, and the change is wrong. A sweep whose only
-instrument is "does it still build?" returns *deletable* three times.
+Leg A alone is the trap the ticket was written around. At
+`joinStakePoolDelegationAction`, `guardJoin` and `guardEraIsConway` the arms
+produce era-free types — `Maybe Tx.VotingAction`, `Either ErrCannotJoin ()`,
+`Either ErrCannotVote ()` — so deleting the era match **compiles**, the suite
+stays green, and the change is wrong. A sweep whose only instrument is "does it
+still build?" returns *deletable* three times.
 
 Leg B alone cannot see a missing class constraint. `RecentEraConstraints` in
 `Cardano.Balance.Tx.Eras` supplies `Core.EraTx`, `Core.EraTxCert`,
 `Alonzo.AlonzoEraTxBody`, `Babbage.BabbageEraTxBody` and more, but it does not
 supply everything a Conway-only arm may be using. Only the compiler knows.
 
-Site 24 has a third character worth naming: `guardEraIsConway` exists **in order
-to reject** non-Conway. Deleting its split does not generalize it, it makes it
-return `Right ()` unconditionally — that is INV-2 suppression wearing a deletion's
+`guardEraIsConway` has a third character worth naming: it exists **in order to
+reject** non-Conway. Deleting its split does not generalize it, it makes it
+return `Right ()` unconditionally — that is suppression wearing a deletion's
 clothes.
 
-## Strategy for R-1
+## Strategy for the deletion
 
 `mkLedgerTx`'s body uses `mkBasicTxBody`, `inputsTxBodyL`, `outputsTxBodyL`,
 `feeTxBodyL`, `vldtTxBodyL`, `withdrawalsTxBodyL`, `certsTxBodyL`,
 `mintTxBodyL`, `auxDataHashTxBodyL`, `mkBasicTxAuxData`, `metadataTxAuxDataL`,
 `hashTxAuxData`, `mkBasicTx`, `auxDataTxL`. The hypothesis is that every one of
-them is available from `RecentEraConstraints`; leg A at site 12 is what settles
-it. If it does not compile, that is X-1's finding and the ticket stops.
+them is available from `RecentEraConstraints`; leg A at the deletion site is
+what settles it. If it does not compile, the deletion needed an era arm after
+all — that is the finding, and the ticket stops.
 
-### Decision D-1 — the `RecentEra era` parameter stays
+### The era parameter stays
 
 After the deletion the `era` argument has no use in the body. Two options:
 
@@ -74,7 +74,7 @@ After the deletion the `era` argument has no use in the body. Two options:
   `TransactionLedgerSpec.hs` and `Unsigned.hs` for no behavioural gain — scope
   this ticket was explicitly cut to avoid.
 
-### Decision D-2 — deletion orphans things, and `-Werror` will say so
+### Deletion orphans things, and `-Werror` will say so
 
 Deleting the `case era of` removes the only uses of the `RecentEraConway` and
 `RecentEraDijkstra` **constructors** in `Build.hs`, while the `RecentEra`
@@ -89,7 +89,7 @@ past a ticket gate on #5419 and was caught by CI after push. The gate below runs
 `hlint` and the format check, and the base is measured as a control so a
 pre-existing hint is not attributed to this slice.
 
-## Strategy for R-2 / INV-3 / INV-4
+## Strategy for exercising the Dijkstra path
 
 One property in `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs`,
 which already imports `mkLedgerTx`.
@@ -106,26 +106,26 @@ which already imports `mkLedgerTx`.
   handed in come back out — so it is not satisfied by the mere absence of an
   exception.
 
-RED is not "the test does not exist yet". RED is: with the `error` present, the
+RED is not "the test does not exist yet". RED is: with the failure present, the
 named test **executes and fails**, and that failure is captured with its exit
 code read directly.
 
-## Strategy for R-4
+## Strategy for the ratchet
 
 `scripts/ci/dijkstra-stub-gate.sh` carries `MAX=${DIJKSTRA_STUB_MAX:-39}`. The
 default moves to 38. Measured on the merged script with exit codes read
 directly and not through a pipe: adding a stub exits **1**; retiring one and
-leaving `MAX` alone prints `RATCHET SLACK` and exits **0**. So CI enforces the
-census falling and does **not** enforce the ratchet moving. The ticket gate
+leaving the maximum alone prints `RATCHET SLACK` and exits **0**. So CI enforces
+the census falling and does **not** enforce the ratchet moving. The ticket gate
 closes that hole locally by running the same script with
 `DIJKSTRA_STUB_STRICT=1`, under which slack is a hard failure.
 
 ## Slices
 
-One bisect-safe slice, `S1`. The deletion, its test, the ratchet move and the
-sweep record travel together: a commit with the deletion but not the ratchet
-leaves the gate carrying slack, and a commit with the ratchet but not the
-deletion is red.
+One bisect-safe slice. The deletion, its test, the ratchet move and the sweep
+record travel together: a commit with the deletion but not the ratchet leaves
+the gate carrying slack, and a commit with the ratchet but not the deletion is
+red.
 
 ## Live boundaries
 
@@ -141,7 +141,7 @@ site naming the operative reason in one line and pointing at `sweep.md`, so both
 audiences are served.
 
 **Mechanical constraint on those comments, and it is not optional:** the census
-counts `error` followed by a string literal mentioning Dijkstra, over raw file
-bytes, with no comment stripping. A comment containing the word `error` next to
-a Dijkstra string would be counted as a new stub and turn CI red. The comments
-must not contain the token `error` at all.
+counts a failure call followed by a string literal mentioning Dijkstra, over raw
+file bytes, with no comment stripping. A comment containing the word that names
+that call, next to a Dijkstra string, would be counted as a new stub and turn CI
+red. The comments must not contain that token at all.

--- a/specs/5422-delete-era-split/spec.md
+++ b/specs/5422-delete-era-split/spec.md
@@ -22,42 +22,67 @@ That makes this the highest-value shape in #5209's census, and it is worth one
 ticket on its own precisely because the *next* five sites look identical from a
 distance and are not.
 
-## User stories
+## Who this is for
 
-**US-1 — a wallet operator building a transaction in the Dijkstra era.**
+**A wallet operator building a transaction in the Dijkstra era.**
 `mkLedgerTx` returns a transaction instead of throwing. Today the call is a
 crash; after this ticket the Dijkstra path is exercised by a test that would
 fail if the crash returned.
 
-**US-2 — the next engineer who opens `Delegation.hs` or `Unsigned.hs` intending
-to "do the same thing here".** They find a recorded, evidenced verdict for each
-of the six suspected sites, and do not have to re-derive why five of them are
+**The next engineer who opens `Delegation.hs` or `Unsigned.hs` intending to "do
+the same thing here".** They find a recorded, evidenced verdict for each of the
+six suspected sites, and do not have to re-derive why five of them are
 different — or, worse, fail to derive it and ship a change that compiles, passes
 every currently-green test, and is wrong.
 
-**US-3 — #5209's owner.** The census falls by exactly the number of stubs this
-ticket retires and the ratchet moves with it in the same PR, so the gate keeps
-no slack it could later hide a regression behind.
+**#5209's owner.** The census falls by exactly the number of stubs this ticket
+retires and the ratchet moves with it in the same PR, so the gate keeps no slack
+it could later hide a regression behind.
 
 ## Requirements
 
-| ID | Requirement |
-|---|---|
-| R-1 | The `case era of` in `Cardano.Wallet.Shelley.Transaction.Build.mkLedgerTx` is deleted and the body returned directly. The function stays era-polymorphic under its existing `IsRecentEra era` constraint. |
-| R-2 | `mkLedgerTx` is exercised **for Dijkstra** by an executable test that fails when the deleted `error` is restored. |
-| R-3 | Six sites — 22, 23, 24 (`Delegation.hs`), 27, 28, 29 (`Unsigned.hs`) — each carry a recorded verdict, *same shape* or *not same shape*, each with the evidence that decides it. |
-| R-4 | The Dijkstra stub census falls to **38** and the ratchet `MAX` in `scripts/ci/dijkstra-stub-gate.sh` moves to **38** in this same PR. |
-| R-5 | No stub is closed by suppression: no widened catch-all, no renamed message, no loud failure turned silent, no rename that merely hides a stub from the census. |
+**The deletion.** The `case era of` in
+`Cardano.Wallet.Shelley.Transaction.Build.mkLedgerTx` is deleted and the body
+returned directly. The function stays era-polymorphic under its existing
+`IsRecentEra era` constraint.
 
-## Rejection behaviour — what this ticket must NOT do
+**The path is exercised.** `mkLedgerTx` is exercised **for Dijkstra** by an
+executable test that fails when the deleted failure is restored.
 
-| ID | Forbidden | Why |
-|---|---|---|
-| X-1 | Write a Dijkstra **era arm** at `Build.hs`. | R-1 is a deletion. If an arm turns out to be required, that is a **finding** that changes the ticket, escalated, not absorbed. |
-| X-2 | "Generalize the Conway arm" at any swept site. | Sites 22–24 and 28–29 are semantic or constraint-bearing splits. Deleting three of them **compiles**. |
-| X-3 | Implement any swept site. | Item 2 is a sweep. A verdict is a recorded decision, not a change. A site found deletable is a finding, and it belongs to a follow-up ticket. |
-| X-4 | Touch #5421, the genesis-checkpoint path, #5413, #5420, #5423, #5424, or `Cardano/Api/Extra.hs`. | Other desks' scope, and `Api/Extra.hs`'s five stubs die with #5290. |
-| X-5 | Raise `MAX`, or leave it at 39. | The ratchet only ever goes down, and CI *cannot* catch a missing `MAX` change — it prints the remedy and exits 0. |
+**Six verdicts.** Six sites — `joinStakePoolDelegationAction`, `guardJoin` and
+`guardEraIsConway` in `Delegation.hs`; `installScriptWitnesses`,
+`certificateFromDelegationActionLedger` and `certificateFromVotingActionLedger`
+in `Unsigned.hs` — each carry a recorded verdict, *same shape* or *not same
+shape*, each with the evidence that decides it.
+
+**The census and the ratchet move together.** The Dijkstra stub census falls to
+**38** and the ratchet maximum in `scripts/ci/dijkstra-stub-gate.sh` moves to
+**38** in this same PR.
+
+**Nothing is closed by suppression.** No widened catch-all, no renamed message,
+no loud failure turned silent, no rename that merely hides a stub from the
+census.
+
+## What this ticket must NOT do
+
+**No Dijkstra era arm at `Build.hs`.** The change is a deletion. If an arm turns
+out to be required, that is a **finding** that changes the ticket, escalated,
+not absorbed.
+
+**No "generalizing the Conway arm"** at any swept site. Five of the six are
+semantic or constraint-bearing splits, and deleting three of them **compiles**.
+
+**No implementing a swept site.** The second half of this ticket is a sweep. A
+verdict is a recorded decision, not a change. A site found deletable is a
+finding, and it belongs to a follow-up ticket.
+
+**No touching** #5421, the genesis-checkpoint path, #5413, #5420, #5423, #5424,
+or `Cardano/Api/Extra.hs` — other desks' scope, and `Api/Extra.hs`'s five stubs
+die with #5290.
+
+**The ratchet is never raised and never left where it was.** It only ever goes
+down, and CI *cannot* catch a ratchet left carrying slack — it prints the remedy
+and exits 0.
 
 ## Observable success
 
@@ -67,7 +92,7 @@ no slack it could later hide a regression behind.
 2. `scripts/ci/dijkstra-census-negative-control.sh .` exits 0 with `delta=1`
    and `gate_exit=1` — the census can still go red.
 3. A unit test reaches `mkLedgerTx` at `RecentEraDijkstra` and asserts a
-   property of its result; restoring the deleted `error` makes it fail.
+   property of its result; restoring the deleted failure makes it fail.
 4. `specs/5422-delete-era-split/sweep.md` carries six verdicts, each with both
    evidence legs required by `plan.md`.
 5. The repository builds with `-Werror` and passes `hlint` and the format check

--- a/specs/5422-delete-era-split/spec.md
+++ b/specs/5422-delete-era-split/spec.md
@@ -81,8 +81,10 @@ or `Cardano/Api/Extra.hs` — other desks' scope, and `Api/Extra.hs`'s five stub
 die with #5290.
 
 **The ratchet is never raised and never left where it was.** It only ever goes
-down, and CI *cannot* catch a ratchet left carrying slack — it prints the remedy
-and exits 0.
+down. The gate script itself exits 0 on slack — it prints the remedy and passes —
+but the workflow runs the census negative control as its own step, and slack
+makes that control unfalsifiable, so the job does go red. A ratchet carrying
+slack is a gate that cannot fail, and the control is what notices.
 
 ## Observable success
 

--- a/specs/5422-delete-era-split/spec.md
+++ b/specs/5422-delete-era-split/spec.md
@@ -1,0 +1,80 @@
+# 5422 — Delete the spurious era split in `mkLedgerTx`, and sweep six sites
+
+Issue: cardano-foundation/cardano-wallet#5422 · child of #5209 · milestone M6 (#118)
+Base: `master` = `6b42c36b586c495a294eb11331984f90a3609470`
+
+## Why this ticket exists
+
+`mkLedgerTx` branches on the era and dies on Dijkstra:
+
+```haskell
+case era of
+    RecentEraConway -> go
+    RecentEraDijkstra -> error "mkLedgerTx: Dijkstra era not yet supported"
+```
+
+`go` is written entirely against era-polymorphic ledger lenses under an
+`IsRecentEra era` constraint. If nothing in it is Conway-specific, the branch is
+not an unimplemented era — it is a split that never had a reason to exist, and
+the stub is retired by **deleting code**, not by adding an era arm.
+
+That makes this the highest-value shape in #5209's census, and it is worth one
+ticket on its own precisely because the *next* five sites look identical from a
+distance and are not.
+
+## User stories
+
+**US-1 — a wallet operator building a transaction in the Dijkstra era.**
+`mkLedgerTx` returns a transaction instead of throwing. Today the call is a
+crash; after this ticket the Dijkstra path is exercised by a test that would
+fail if the crash returned.
+
+**US-2 — the next engineer who opens `Delegation.hs` or `Unsigned.hs` intending
+to "do the same thing here".** They find a recorded, evidenced verdict for each
+of the six suspected sites, and do not have to re-derive why five of them are
+different — or, worse, fail to derive it and ship a change that compiles, passes
+every currently-green test, and is wrong.
+
+**US-3 — #5209's owner.** The census falls by exactly the number of stubs this
+ticket retires and the ratchet moves with it in the same PR, so the gate keeps
+no slack it could later hide a regression behind.
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| R-1 | The `case era of` in `Cardano.Wallet.Shelley.Transaction.Build.mkLedgerTx` is deleted and the body returned directly. The function stays era-polymorphic under its existing `IsRecentEra era` constraint. |
+| R-2 | `mkLedgerTx` is exercised **for Dijkstra** by an executable test that fails when the deleted `error` is restored. |
+| R-3 | Six sites — 22, 23, 24 (`Delegation.hs`), 27, 28, 29 (`Unsigned.hs`) — each carry a recorded verdict, *same shape* or *not same shape*, each with the evidence that decides it. |
+| R-4 | The Dijkstra stub census falls to **38** and the ratchet `MAX` in `scripts/ci/dijkstra-stub-gate.sh` moves to **38** in this same PR. |
+| R-5 | No stub is closed by suppression: no widened catch-all, no renamed message, no loud failure turned silent, no rename that merely hides a stub from the census. |
+
+## Rejection behaviour — what this ticket must NOT do
+
+| ID | Forbidden | Why |
+|---|---|---|
+| X-1 | Write a Dijkstra **era arm** at `Build.hs`. | R-1 is a deletion. If an arm turns out to be required, that is a **finding** that changes the ticket, escalated, not absorbed. |
+| X-2 | "Generalize the Conway arm" at any swept site. | Sites 22–24 and 28–29 are semantic or constraint-bearing splits. Deleting three of them **compiles**. |
+| X-3 | Implement any swept site. | Item 2 is a sweep. A verdict is a recorded decision, not a change. A site found deletable is a finding, and it belongs to a follow-up ticket. |
+| X-4 | Touch #5421, the genesis-checkpoint path, #5413, #5420, #5423, #5424, or `Cardano/Api/Extra.hs`. | Other desks' scope, and `Api/Extra.hs`'s five stubs die with #5290. |
+| X-5 | Raise `MAX`, or leave it at 39. | The ratchet only ever goes down, and CI *cannot* catch a missing `MAX` change — it prints the remedy and exits 0. |
+
+## Observable success
+
+1. `scripts/ci/dijkstra-stub-gate.sh .` prints `total = 38` and `(ratchet MAX=38)`
+   and does not print `RATCHET SLACK`, and the same script under
+   `DIJKSTRA_STUB_STRICT=1` still exits 0.
+2. `scripts/ci/dijkstra-census-negative-control.sh .` exits 0 with `delta=1`
+   and `gate_exit=1` — the census can still go red.
+3. A unit test reaches `mkLedgerTx` at `RecentEraDijkstra` and asserts a
+   property of its result; restoring the deleted `error` makes it fail.
+4. `specs/5422-delete-era-split/sweep.md` carries six verdicts, each with both
+   evidence legs required by `plan.md`.
+5. The repository builds with `-Werror` and passes `hlint` and the format check
+   with no regression against the base.
+
+## Out of scope, but not out of the goal
+
+The five stubs in `lib/wallet/src/Cardano/Api/Extra.hs`. They belong to the shim
+module's deletion (#5290). #5209 still owes a *verification* that they died with
+their owner — an implementation here would be work that dies with its subject.

--- a/specs/5422-delete-era-split/sweep.md
+++ b/specs/5422-delete-era-split/sweep.md
@@ -1,0 +1,209 @@
+# Sweep — six suspected era splits, and whether deleting them is safe
+
+Ticket: delete the spurious era split in `mkLedgerTx` (cardano-wallet #5422).
+This file records, for each suspected site, the two evidence legs that decide
+whether deleting the era match is safe, and the verdict that follows.
+
+**The method.** A site is *same shape* — its era match can simply be deleted —
+only when both legs pass:
+
+- **Leg A — type.** Delete the era match at the site, compile the library with
+  the compiler set to treat every warning as fatal, record the compiler's
+  answer verbatim, then revert. The experiment leaves the tree untouched.
+- **Leg B — semantics.** State in one sentence what the surviving Conway arm
+  decides, then cite the ledger fact that settles whether the Dijkstra era
+  decides it the same way.
+
+Anything else is *not same shape*, and the verdict names which leg failed. A
+verdict is a recorded decision, not a change: no swept site is implemented
+here; a site found deletable belongs to a follow-up ticket.
+
+**Resolved dependency versions** used for every citation below, read from this
+tree's own build plan (`dist-newstyle/cache/plan.json`):
+
+- `cardano-ledger-conway-1.23.0.0`
+- `cardano-ledger-dijkstra-0.3.0.0`
+- `cardano-ledger-core-1.21.0.0`
+- `cardano-balance-transaction` at `d0360834df9d4d4730d5a0b96623d50aadf010d5`
+  (pinned in `cabal.project`)
+
+**The standing hazard.** In `cardano-ledger-conway-1.23.0.0`, registration
+without a deposit exists: `mkRegTxCert` /
+`mkUnRegTxCert` build `ConwayRegCert c SNothing`
+(`src/Cardano/Ledger/Conway/TxCert.hs:150-157`). In
+`cardano-ledger-dijkstra-0.3.0.0` it does not: every form of
+`DijkstraDelegCert` carries a `Coin` deposit
+(`src/Cardano/Ledger/Dijkstra/TxCert.hs:80-85`), the `DijkstraTxCert` data
+type has no deposit-free registration constructor
+(`src/Cardano/Ledger/Dijkstra/TxCert.hs:172-175`), and
+`upgradeTxCert` rejects the old forms outright —
+`RegTxCert {} -> Left RegTxCertExpunged` and
+`UnRegTxCert {} -> Left UnRegTxCertExpunged`
+(`src/Cardano/Ledger/Dijkstra/TxCert.hs:258-259`). A change that looks
+identical on both sides of that difference compiles, passes every
+currently-green test, and is wrong.
+
+--------------------------------------------------------------------------------
+
+## Site 22 — `joinStakePoolDelegationAction` (`lib/wallet/src/Cardano/Wallet/Delegation.hs`)
+
+What the Conway arm decides: whether a DRep voting action accompanies the
+stake-pool join — an unregistered stake key joins with an abstain vote
+attached, a registered one votes abstain unless the request explicitly
+declines.
+
+**Leg A — type.** Deleting the era match and letting the Conway body serve
+both eras compiles: the arm produces era-free values
+(`Maybe Tx.VotingAction`). Recorded compile of the library with warnings
+fatal: exit 0.
+
+**Leg B — semantics.** The decision couples a join to DRep-vote
+certificates whose registration half is exactly the Conway-only facility:
+Conway tolerates deposit-free registration (`Conway/TxCert.hs:150-157`),
+while Dijkstra expunges it (`Dijkstra/TxCert.hs:258-259`) and offers only
+deposit-carrying registration, including a combined
+register-and-delegate certificate (`mkRegDepositDelegTxCert`,
+`Dijkstra/TxCert.hs:336`) whose decomposition differs from what the Conway
+path emits. The Conway decision does not describe Dijkstra behavior, so it
+cannot simply serve both eras.
+
+**Verdict:** not same shape (leg A compiles; leg B fails on the registration
+asymmetry).
+
+## Site 23 — `guardJoin` (`lib/wallet/src/Cardano/Wallet/Delegation.hs`)
+
+What the Conway arm decides: the duplicate-vote policy for re-joining while
+already delegating — which vote requests are accepted and which are refused
+as already-delegating/already-voting.
+
+**Leg A — type.** Deleting the era match compiles: the arm produces
+era-free `Either ErrCannotJoin ()` values. Recorded compile with warnings
+fatal: exit 0.
+
+**Leg B — semantics.** The policy's consequences are vote-coupled
+delegation certificates, and the certificate space it was decided against
+moved: Dijkstra keeps DRep vote delegation itself (the `Delegatee` type is
+shared — `Dijkstra/TxCert.hs:26`, defined at `Conway/TxCert.hs:379-382`),
+but reshapes every registration around a mandatory deposit
+(`Dijkstra/TxCert.hs:80-85`, expunging at `:258-259`). The refusals the
+Conway arm hands out for Conway requests are not thereby settled for
+Dijkstra requests.
+
+**Verdict:** not same shape (leg A compiles; leg B fails).
+
+## Site 24 — `guardEraIsConway` (`lib/wallet/src/Cardano/Wallet/Delegation.hs`, local binding inside `joinDRepVotingAction`)
+
+What the Conway arm decides: nothing about content — the function exists in
+order to reject every non-Conway era loudly.
+
+**Leg A — type.** Deleting the era match (an era-blind `Right ()`)
+compiles: exit 0. This is the trap the two-leg method exists for: the
+compile succeeds precisely because the deletion removes a rejection, not
+because the eras agree.
+
+**Leg B — semantics.** Generalizing the guard would convert a loud refusal
+into unconditional acceptance for Dijkstra, whose registration-certificate
+space the guarded vote construction has not been checked against
+(expunging at `Dijkstra/TxCert.hs:258-259`); a failure made quiet is not a
+behavior shared by the two eras, it is a behavior lost.
+
+**Verdict:** not same shape (leg A compiles; leg B fails — the deletion is
+suppression wearing a deletion's clothes).
+
+## Site 27 — `installScriptWitnesses` (`lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs`)
+
+What the Conway arm decides: that a freshly built transaction receives
+reference inputs, reference scripts on outputs, and native-script witnesses
+before it is returned.
+
+**Leg A — type.** Deleting the era match does not compile. Verbatim:
+
+```
+src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs:368:38: error: [GHC-25897]
+    • Couldn't match type ‘era’ with ‘Write.Conway’
+      Expected: Write.Tx era
+        Actual: Write.Tx Write.Conway
+```
+
+The surviving helper is Conway-typed
+(`installScriptWitnessesConway :: ScriptWitnesses -> Write.Tx Write.Conway ->
+Write.Tx Write.Conway`, `Unsigned.hs:374-377`), so the body cannot serve a
+rigid era.
+
+**Leg B — semantics.** The things the arm installs are era-indexed values:
+script witnesses have type `AlonzoScript era` (`Core.Script era ~
+AlonzoScript era`, `Cardano.Balance.Tx.Eras.hs:184` in
+`cardano-balance-transaction`), so what Conway decides to install is not a
+value a Dijkstra transaction carries; the ledger does not decide the same
+attachment for both eras.
+
+**Verdict:** not same shape (leg A fails).
+
+## Site 28 — `certificateFromDelegationActionLedger` (`lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs`)
+
+What the Conway arm decides: how a delegation action becomes certificates —
+a plain join becomes one delegation certificate; join-with-registration and
+quit become deposit-carrying certificates; a missing deposit is a refused,
+loud degraded case.
+
+**Leg A — type.** Deleting the Dijkstra equation leaves the function
+non-exhaustive and does not compile. Verbatim:
+
+```
+src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs:546:1: error: [GHC-62161]
+[-Wincomplete-patterns, Werror=incomplete-patterns]
+    Pattern match(es) are non-exhaustive
+    In an equation for ‘certificateFromDelegationActionLedger’:
+        Patterns of type ‘RecentEra era’, ‘Either XPub (Script KeyHash)’,
+                         ‘Maybe Coin’, ‘DelegationAction’ not matched:
+            RecentEraDijkstra _ _ _
+```
+
+**Leg B — semantics.** Dijkstra decides registration differently at the
+ledger level: deposit-free registration is expunged
+(`Dijkstra/TxCert.hs:258-259`) and every registration carries its deposit
+(`:80-85`), so the Conway-era meaning of the missing-deposit case — a
+tolerated degraded path refused by the wallet — has no Dijkstra counterpart
+to reuse; the same body would be deciding something Dijkstra's certificate
+language cannot express.
+
+**Verdict:** not same shape (leg A fails; leg B fails independently).
+
+## Site 29 — `certificateFromVotingActionLedger` (`lib/wallet/src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs`)
+
+What the Conway arm decides: how a voting action becomes certificates — a
+plain vote becomes one DRep delegation certificate; vote-with-registration
+becomes a deposit certificate plus a delegation certificate; a missing
+deposit is refused.
+
+**Leg A — type.** Deleting the Dijkstra equation leaves the function
+non-exhaustive and does not compile. Verbatim:
+
+```
+src/Cardano/Wallet/Shelley/Transaction/Unsigned.hs:603:1: error: [GHC-62161]
+[-Wincomplete-patterns, Werror=incomplete-patterns]
+    Pattern match(es) are non-exhaustive
+    In an equation for ‘certificateFromVotingActionLedger’:
+        Patterns of type ‘RecentEra era’, ‘Either XPub (Script KeyHash)’,
+                         ‘Maybe Coin’, ‘VotingAction’ not matched:
+            RecentEraDijkstra _ _ _
+```
+
+**Leg B — semantics.** Dijkstra retains the vote half (shared `Delegatee`,
+`mkDelegTxCert` at `Dijkstra/TxCert.hs:331`) but not the registration half
+the coupled case depends on (expunging at `:258-259`), so the Conway arm's
+decision — in particular its treatment of a missing deposit — does not
+describe Dijkstra behavior.
+
+**Verdict:** not same shape (leg A fails; leg B fails independently).
+
+--------------------------------------------------------------------------------
+
+## Outcome
+
+Six suspected sites, six verdicts, all *not same shape*: sites 22, 23 and 24
+compile after deletion and are refuted by leg B (the compiler alone returns
+the wrong answer at exactly these three); sites 27, 28 and 29 fail leg A
+directly, with leg B concurring at 28 and 29 and the ledger citations
+recording why. None of the six is implemented here. Each carries a one-line
+pointer comment at its site naming the operative reason and this file.

--- a/specs/5422-delete-era-split/tasks.md
+++ b/specs/5422-delete-era-split/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — 5422
+
+Slice **S1** (one bisect-safe commit).
+
+- [ ] **T5422-01** — RED: a test reaching `mkLedgerTx` at `RecentEraDijkstra`
+      executes and fails against the unmodified base, with the failure and its
+      exit code captured. (R-2, INV-3)
+- [ ] **T5422-02** — RED: the extent guard over `allRecentEras` is shown able to
+      fail. (INV-4)
+- [ ] **T5422-03** — Delete the `case era of` in `mkLedgerTx` and return the
+      body directly; trim exactly what the deletion orphans. (R-1, D-1, D-2)
+- [ ] **T5422-04** — GREEN: the T5422-01 test passes and the T5422-02 guard
+      passes. (R-2)
+- [ ] **T5422-05** — Lower the ratchet default in
+      `scripts/ci/dijkstra-stub-gate.sh` from 39 to 38, and show the census
+      reporting `total = 38`, `MAX=38`, no `RATCHET SLACK`, exit 0 under
+      `DIJKSTRA_STUB_STRICT=1`. (R-4, INV-1)
+- [ ] **T5422-06** — Show the census can still go red: the negative control
+      reports `delta=1`, `gate_exit=1`, exit 0. (INV-2 instrument)
+- [ ] **T5422-07** — Sweep site 22 `joinStakePoolDelegationAction`: legs A and B,
+      verdict recorded. (R-3, INV-5)
+- [ ] **T5422-08** — Sweep site 23 `guardJoin`: legs A and B, verdict recorded.
+- [ ] **T5422-09** — Sweep site 24 `guardEraIsConway`: legs A and B, verdict
+      recorded.
+- [ ] **T5422-10** — Sweep site 27 `installScriptWitnesses`: legs A and B,
+      verdict recorded.
+- [ ] **T5422-11** — Sweep site 28 `certificateFromDelegationActionLedger`:
+      legs A and B, verdict recorded.
+- [ ] **T5422-12** — Sweep site 29 `certificateFromVotingActionLedger`:
+      legs A and B, verdict recorded.
+- [ ] **T5422-13** — One pointer comment per non-deletable site, containing no
+      occurrence of the token `error`. (US-2, plan.md's census constraint)
+- [ ] **T5422-14** — The `-Werror` build, `hlint` and format-check legs are
+      green on the candidate, and `hlint` is measured on the **base** as a
+      control so a pre-existing hint is not attributed to this slice. (D-2)

--- a/specs/5422-delete-era-split/tasks.md
+++ b/specs/5422-delete-era-split/tasks.md
@@ -1,35 +1,35 @@
 # Tasks — 5422
 
-Slice **S1** (one bisect-safe commit).
+One bisect-safe slice.
 
-- [ ] **T5422-01** — RED: a test reaching `mkLedgerTx` at `RecentEraDijkstra`
-      executes and fails against the unmodified base, with the failure and its
-      exit code captured. (R-2, INV-3)
-- [ ] **T5422-02** — RED: the extent guard over `allRecentEras` is shown able to
-      fail. (INV-4)
-- [ ] **T5422-03** — Delete the `case era of` in `mkLedgerTx` and return the
-      body directly; trim exactly what the deletion orphans. (R-1, D-1, D-2)
-- [ ] **T5422-04** — GREEN: the T5422-01 test passes and the T5422-02 guard
-      passes. (R-2)
-- [ ] **T5422-05** — Lower the ratchet default in
+- [ ] **RED: the Dijkstra path fails first.** A test reaching `mkLedgerTx` at
+      `RecentEraDijkstra` executes and fails against the unmodified base, with
+      the failure and its exit code captured.
+- [ ] **RED: the extent guard can fail.** The guard over `allRecentEras` is
+      shown able to go red without being edited.
+- [ ] **Delete the era match** in `mkLedgerTx` and return the body directly;
+      trim exactly what the deletion orphans.
+- [ ] **GREEN.** The Dijkstra test passes and the extent guard passes.
+- [ ] **Move the ratchet.** Lower the default in
       `scripts/ci/dijkstra-stub-gate.sh` from 39 to 38, and show the census
       reporting `total = 38`, `MAX=38`, no `RATCHET SLACK`, exit 0 under
-      `DIJKSTRA_STUB_STRICT=1`. (R-4, INV-1)
-- [ ] **T5422-06** — Show the census can still go red: the negative control
-      reports `delta=1`, `gate_exit=1`, exit 0. (INV-2 instrument)
-- [ ] **T5422-07** — Sweep site 22 `joinStakePoolDelegationAction`: legs A and B,
-      verdict recorded. (R-3, INV-5)
-- [ ] **T5422-08** — Sweep site 23 `guardJoin`: legs A and B, verdict recorded.
-- [ ] **T5422-09** — Sweep site 24 `guardEraIsConway`: legs A and B, verdict
-      recorded.
-- [ ] **T5422-10** — Sweep site 27 `installScriptWitnesses`: legs A and B,
+      `DIJKSTRA_STUB_STRICT=1`.
+- [ ] **Show the census can still go red.** The negative control reports
+      `delta=1`, `gate_exit=1`, exit 0.
+- [ ] **Sweep `joinStakePoolDelegationAction`** (`Delegation.hs`): legs A and B,
       verdict recorded.
-- [ ] **T5422-11** — Sweep site 28 `certificateFromDelegationActionLedger`:
-      legs A and B, verdict recorded.
-- [ ] **T5422-12** — Sweep site 29 `certificateFromVotingActionLedger`:
-      legs A and B, verdict recorded.
-- [ ] **T5422-13** — One pointer comment per non-deletable site, containing no
-      occurrence of the token `error`. (US-2, plan.md's census constraint)
-- [ ] **T5422-14** — The `-Werror` build, `hlint` and format-check legs are
-      green on the candidate, and `hlint` is measured on the **base** as a
-      control so a pre-existing hint is not attributed to this slice. (D-2)
+- [ ] **Sweep `guardJoin`** (`Delegation.hs`): legs A and B, verdict recorded.
+- [ ] **Sweep `guardEraIsConway`** (`Delegation.hs`): legs A and B, verdict
+      recorded.
+- [ ] **Sweep `installScriptWitnesses`** (`Unsigned.hs`): legs A and B, verdict
+      recorded.
+- [ ] **Sweep `certificateFromDelegationActionLedger`** (`Unsigned.hs`): legs A
+      and B, verdict recorded.
+- [ ] **Sweep `certificateFromVotingActionLedger`** (`Unsigned.hs`): legs A and
+      B, verdict recorded.
+- [ ] **One pointer comment per non-deletable site**, containing no occurrence
+      of the token the census counts.
+- [ ] **Lint and format are green, with a base control.** The `-Werror` build,
+      `hlint` and format-check legs pass on the candidate, and `hlint` is
+      measured on the **base** as a control so a pre-existing hint is not
+      attributed to this slice.

--- a/specs/5422-delete-era-split/tasks.md
+++ b/specs/5422-delete-era-split/tasks.md
@@ -2,34 +2,34 @@
 
 One bisect-safe slice.
 
-- [ ] **RED: the Dijkstra path fails first.** A test reaching `mkLedgerTx` at
+- [x] **RED: the Dijkstra path fails first.** A test reaching `mkLedgerTx` at
       `RecentEraDijkstra` executes and fails against the unmodified base, with
       the failure and its exit code captured.
-- [ ] **RED: the extent guard can fail.** The guard over `allRecentEras` is
+- [x] **RED: the extent guard can fail.** The guard over `allRecentEras` is
       shown able to go red without being edited.
-- [ ] **Delete the era match** in `mkLedgerTx` and return the body directly;
+- [x] **Delete the era match** in `mkLedgerTx` and return the body directly;
       trim exactly what the deletion orphans.
-- [ ] **GREEN.** The Dijkstra test passes and the extent guard passes.
-- [ ] **Move the ratchet.** Lower the default in
+- [x] **GREEN.** The Dijkstra test passes and the extent guard passes.
+- [x] **Move the ratchet.** Lower the default in
       `scripts/ci/dijkstra-stub-gate.sh` from 39 to 38, and show the census
       reporting `total = 38`, `MAX=38`, no `RATCHET SLACK`, exit 0 under
       `DIJKSTRA_STUB_STRICT=1`.
-- [ ] **Show the census can still go red.** The negative control reports
+- [x] **Show the census can still go red.** The negative control reports
       `delta=1`, `gate_exit=1`, exit 0.
-- [ ] **Sweep `joinStakePoolDelegationAction`** (`Delegation.hs`): legs A and B,
+- [x] **Sweep `joinStakePoolDelegationAction`** (`Delegation.hs`): legs A and B,
       verdict recorded.
-- [ ] **Sweep `guardJoin`** (`Delegation.hs`): legs A and B, verdict recorded.
-- [ ] **Sweep `guardEraIsConway`** (`Delegation.hs`): legs A and B, verdict
+- [x] **Sweep `guardJoin`** (`Delegation.hs`): legs A and B, verdict recorded.
+- [x] **Sweep `guardEraIsConway`** (`Delegation.hs`): legs A and B, verdict
       recorded.
-- [ ] **Sweep `installScriptWitnesses`** (`Unsigned.hs`): legs A and B, verdict
+- [x] **Sweep `installScriptWitnesses`** (`Unsigned.hs`): legs A and B, verdict
       recorded.
-- [ ] **Sweep `certificateFromDelegationActionLedger`** (`Unsigned.hs`): legs A
+- [x] **Sweep `certificateFromDelegationActionLedger`** (`Unsigned.hs`): legs A
       and B, verdict recorded.
-- [ ] **Sweep `certificateFromVotingActionLedger`** (`Unsigned.hs`): legs A and
+- [x] **Sweep `certificateFromVotingActionLedger`** (`Unsigned.hs`): legs A and
       B, verdict recorded.
-- [ ] **One pointer comment per non-deletable site**, containing no occurrence
+- [x] **One pointer comment per non-deletable site**, containing no occurrence
       of the token the census counts.
-- [ ] **Lint and format are green, with a base control.** The `-Werror` build,
+- [x] **Lint and format are green, with a base control.** The `-Werror` build,
       `hlint` and format-check legs pass on the candidate, and `hlint` is
       measured on the **base** as a control so a pre-existing hint is not
       attributed to this slice.


### PR DESCRIPTION
Resolves #5422.

## What breaks today

Building a transaction in the Dijkstra era crashes. `mkLedgerTx` branches on the
era and throws on anything that is not Conway:

```haskell
case era of
    RecentEraConway -> go
    RecentEraDijkstra -> error "mkLedgerTx: Dijkstra era not yet supported"
```

Every path that constructs a ledger transaction — balancing, signing, the
delegation flows — reaches this function, so in Dijkstra none of them can
complete.

## What this changes

The era branch is deleted and the body returned directly.

Nothing else was needed, because the body was already era-polymorphic: it is
written entirely against `mkBasicTxBody` and the ledger's own lenses under an
`IsRecentEra era` constraint, none of which is Conway-specific. The era argument
is kept so no call site changes.

## Why a deletion rather than a Dijkstra arm

This was never an unimplemented era. It was a branch that had no reason to
exist — the Conway arm was the general implementation all along, sitting behind
a match that only ever narrowed it. Adding a Dijkstra arm would have duplicated
that body; adding a constraint to make the deletion typecheck would have been
the same arm under another name. Neither was necessary, and the change is
smaller than either.

## How it is proved

A test constructs a transaction at Dijkstra and asserts the components handed in
come back out of the result — so it is not satisfied by the mere absence of an
exception. Restoring the deleted failure makes that test fail.

The test quantifies over the set of recent eras read out of the codebase rather
than a hand-written list, so a future era is covered without editing it. Because
a set-driven test passes trivially when the set is empty or missing the case, a
guard asserts the set is non-empty and contains Dijkstra, and that guard has
itself been shown able to fail.

## Five nearby sites that look the same and are not

Five other era matches have the same shape at a glance, in `Delegation.hs` and
`Transaction/Unsigned.hs`. **None of them is safe to delete, and three of them
compile if you do.** Each carries a recorded verdict with its evidence in
`specs/5422-delete-era-split/sweep.md`.

The reason is in the ledger. Dijkstra expunges `RegTxCert` and `UnRegTxCert` —
`upgradeTxCert` returns `Left RegTxCertExpunged` / `Left UnRegTxCertExpunged`,
and only the deposit-carrying certificate forms survive. On Conway a missing
deposit is a tolerated degraded case; on Dijkstra it is unrepresentable, because
the constructor does not exist. So at `joinStakePoolDelegationAction`,
`guardJoin` and `guardEraIsConway` the arms produce era-free types, deleting the
match typechecks, the suite stays green — and the result is wrong.
`guardEraIsConway` is the sharpest: it exists in order to *reject* non-Conway,
so deleting its match does not generalise it, it makes it accept everything.

The remaining two, `certificateFromDelegationActionLedger` and
`certificateFromVotingActionLedger`, do not compile when the match is removed.
Neither does `installScriptWitnesses`, whose helper is typed to Conway.

## Out of scope

The five sites above are **recorded, not changed** — a verdict is a decision, and
any of them turning out to be deletable belongs in its own change. The remaining
Dijkstra failures in `Cardano/Api/Extra.hs` go with that module's own removal
(#5290).
