### PR TITLE
Dijkstra: one native script conversion for both read sites

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -240,17 +240,22 @@ test-suite test
     , cardano-addresses
     , cardano-api
     , cardano-crypto-class
+    , cardano-ledger-allegra
     , cardano-ledger-allegra:testlib
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-core:testlib
+    , cardano-ledger-dijkstra
     , cardano-ledger-mary
     , cardano-ledger-shelley
     , cardano-numeric
     , cardano-protocol
     , cardano-protocol-tpraos
     , cardano-slotting
+    , cardano-strict-containers
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , cardano-wallet-tracing

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -482,11 +482,9 @@ toWalletUTxOConway (Ledger.UTxO m) =
 
 toWalletScript
     :: forall era
-     . ( Scripts.AllegraEraScript era
-       , Ledger.NativeScript era ~ Scripts.Timelock era
-       )
+     . Scripts.AllegraEraScript era
     => (Hash "VerificationKey" -> KeyRole)
-    -> Scripts.Timelock era
+    -> Ledger.NativeScript era
     -> Script KeyHash
 toWalletScript tokeyrole = \case
     Scripts.RequireSignature (Ledger.KeyHash h) ->
@@ -503,7 +501,9 @@ toWalletScript tokeyrole = \case
         ActiveUntilSlot $ fromIntegral slot
     Scripts.RequireTimeStart (SlotNo slot) ->
         ActiveFromSlot $ fromIntegral slot
-    _ -> error "toWalletScript: impossible"
+    _ ->
+        error
+            "toWalletScript: a Dijkstra native script shape has no wallet representation"
 
 toWalletScriptFromShelley
     :: forall era

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -332,12 +332,8 @@ fromLedgerScriptToAnyScriptDijkstra
     :: Core.Script DijkstraEra -> AnyScript
 fromLedgerScriptToAnyScriptDijkstra = toAnyScript
   where
-    -- TODO: Dijkstra era uses DijkstraNativeScript, not Timelock.
-    -- toWalletScript needs adaptation for the new NativeScript type.
-    toAnyScript (Alonzo.NativeScript _script) =
-        NativeScript
-            (error "TODO: DijkstraNativeScript conversion")
-            ViaSpending
+    toAnyScript (Alonzo.NativeScript script) =
+        NativeScript (toWalletScript (const Policy) script) ViaSpending
     toAnyScript s@(Alonzo.PlutusScript script) =
         PlutusScript
             ( PlutusScriptInfo

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs
@@ -127,14 +127,13 @@ dijkstraAnyExplicitScript
        , AlonzoScript DijkstraEra
        )
     -> (TokenPolicyId, AnyExplicitScript)
-dijkstraAnyExplicitScript _witCtx (scriptRef, scriptH, script) =
+dijkstraAnyExplicitScript witCtx (scriptRef, scriptH, script) =
     (toWalletTokenPolicyId (PolicyID scriptH), toAnyScript script)
   where
     toAnyScript = \case
-        -- TODO: Dijkstra era uses DijkstraNativeScript, not Timelock
-        Alonzo.NativeScript _timelockScript ->
+        Alonzo.NativeScript timelockScript ->
             NativeExplicitScript
-                (error "TODO: DijkstraNativeScript conversion")
+                (toWalletScript (toKeyRole witCtx) timelockScript)
                 scriptRef
         Alonzo.PlutusScript s ->
             PlutusExplicitScript

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -14,12 +16,24 @@ import Cardano.Address.KeyHash
 import Cardano.Address.Script
     ( Script (..)
     )
+import Cardano.Ledger.Allegra.Scripts
+    ( Timelock
+    )
 import Cardano.Ledger.Api
     ( ConwayEra
     , DijkstraEra
     )
 import Cardano.Ledger.Babbage
     ( BabbageEra
+    )
+import Cardano.Ledger.Credential
+    ( Credential (KeyHashObj, ScriptHashObj)
+    )
+import Cardano.Ledger.Dijkstra.Scripts
+    ( pattern RequireGuard
+    )
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( Convert (..)
@@ -34,6 +48,10 @@ import Cardano.Wallet.Primitive.Ledger.Convert
     , toWalletAssetName
     , toWalletScript
     , toWalletTokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Scripts
+    ( conwayAnyExplicitScript
+    , dijkstraAnyExplicitScript
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -65,6 +83,9 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMapSmallRange
     , shrinkTokenMap
     )
+import Cardano.Wallet.Primitive.Types.TokenMapWithScripts
+    ( ScriptReference (ViaSpending)
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
@@ -95,8 +116,22 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     )
+import Cardano.Wallet.Primitive.Types.WitnessCount
+    ( WitnessCountCtx (..)
+    )
+import Control.Exception
+    ( ErrorCall (..)
+    , evaluate
+    , try
+    )
 import Control.Monad
     ( replicateM
+    )
+import Data.Char
+    ( toLower
+    )
+import Data.List
+    ( isInfixOf
     )
 import Data.Proxy
     ( Proxy (..)
@@ -111,10 +146,16 @@ import Data.Typeable
 import Test.Cardano.Ledger.Allegra.Arbitrary
     (
     )
+import Test.Cardano.Ledger.Core.Arbitrary
+    (
+    )
 import Test.Hspec
     ( Spec
     , describe
     , it
+    , shouldBe
+    , shouldContain
+    , shouldNotContain
     )
 import Test.Hspec.Core.QuickCheck
     ( modifyMaxSuccess
@@ -127,14 +168,19 @@ import Test.QuickCheck
     , arbitrarySizedNatural
     , checkCoverage
     , choose
+    , classify
     , conjoin
     , counterexample
     , cover
     , elements
     , forAll
     , frequency
+    , generate
+    , ioProperty
+    , listOf1
     , oneof
     , property
+    , resize
     , scale
     , sized
     , tabulate
@@ -147,14 +193,27 @@ import Prelude
 import qualified Cardano.Ledger.Address as Ledger
     ( Addr
     )
+import qualified Cardano.Ledger.Allegra.Scripts as LedgerScripts
+    ( pattern RequireTimeExpire
+    , pattern RequireTimeStart
+    )
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Api as LedgerApi
 import qualified Cardano.Ledger.Api.UTxO as Ledger
     ( UTxO (..)
     )
 import qualified Cardano.Ledger.Babbage.TxOut as Babbage
 import qualified Cardano.Ledger.Mary.Value as Ledger
+import qualified Cardano.Ledger.Shelley.Scripts as LedgerScripts
+    ( pattern RequireAllOf
+    , pattern RequireAnyOf
+    , pattern RequireMOf
+    , pattern RequireSignature
+    )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 
 spec :: Spec
@@ -216,6 +275,45 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
                 it "ledger . wallet == id" $ property $ \s -> do
                     ledger (wallet s) === s
 
+        describe "dijkstraAnyExplicitScript (Dijkstra call site, end to end)" $ do
+            let ctx = AnyWitnessCountCtx
+
+            it "shared shapes decode to the same explicit script as the Conway decoding"
+                $ property
+                $ forAll genDijkstraSharedNativeScript $ \d ->
+                    forAll arbitrary $ \(h :: LedgerApi.ScriptHash) ->
+                        dijkstraAnyExplicitScript ctx (ViaSpending, h, Alonzo.NativeScript d)
+                            === conwayAnyExplicitScript
+                                ctx
+                                (ViaSpending, h, Alonzo.NativeScript (toConwayCounterpart d))
+
+            it "a guard script fails naming the era, without claiming the shape"
+                $ property
+                $ forAll genDijkstraGuardNativeScript $ \g ->
+                    forAll arbitrary $ \(h :: LedgerApi.ScriptHash) ->
+                        classify (guardCredentialForm g == "KeyHashObj") "KeyHashObj guard"
+                            $ classify
+                                (guardCredentialForm g == "ScriptHashObj")
+                                "ScriptHashObj guard"
+                            $ ioProperty
+                                ( assertDijkstraConversionFails
+                                    ( snd
+                                        ( dijkstraAnyExplicitScript
+                                            ctx
+                                            (ViaSpending, h, Alonzo.NativeScript g)
+                                        )
+                                    )
+                                )
+
+            it "the generated shared-shape population contains every shared shape, nested"
+                $ do
+                    samples <-
+                        generate
+                            (replicateM 2000 (resize 25 genDijkstraSharedNativeScript))
+                    Set.unions (map allSharedShapes samples)
+                        `shouldBe` Set.fromList [minBound .. maxBound]
+                    any hasNestedCompound samples `shouldBe` True
+
         describe "toLedgerMintValue" $ do
             it "is total for generated mint and burn maps"
                 $ property
@@ -247,6 +345,128 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
             it "roundtrips disjoint mints and burns"
                 $ property
                     prop_mintValue_roundtripDisjoint
+
+--------------------------------------------------------------------------------
+-- Dijkstra native script conversion
+--------------------------------------------------------------------------------
+
+-- Standalone generators (no Arbitrary instances are defined in this
+-- repository's tests). Leaves come from the ledger testlib's Arbitrary
+-- instances for hashes.
+
+-- | The six native script shapes Dijkstra shares with 'Timelock', including
+-- nested compounds.
+genDijkstraSharedNativeScript :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraSharedNativeScript = sized $ \(n :: Int) ->
+    if n <= 1
+        then genSharedLeaf
+        else oneof [genSharedLeaf, genSharedNode]
+  where
+    genSharedLeaf = oneof
+        [ LedgerScripts.RequireSignature <$> arbitrary
+        , LedgerScripts.RequireTimeStart <$> genSlotNo
+        , LedgerScripts.RequireTimeExpire <$> genSlotNo
+        ]
+    genSharedNode = oneof
+        [ compound LedgerScripts.RequireAllOf
+        , compound LedgerScripts.RequireAnyOf
+        , do
+            subs <- listOf1 sub
+            Positive k <- arbitrary
+            pure
+                $ LedgerScripts.RequireMOf
+                    (1 + (k - 1) `mod` length subs)
+                    (StrictSeq.fromList subs)
+        ]
+    compound mk = mk . StrictSeq.fromList <$> listOf1 sub
+    sub = scale (`div` 2) genDijkstraSharedNativeScript
+    genSlotNo = SlotNo <$> choose (0, 2 ^ (40 :: Int))
+
+-- | A guard script over a key-hash credential.
+genDijkstraKeyHashGuard :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraKeyHashGuard = RequireGuard . KeyHashObj <$> arbitrary
+
+-- | A guard script over a script-hash credential.
+genDijkstraScriptHashGuard :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraScriptHashGuard = RequireGuard . ScriptHashObj <$> arbitrary
+
+-- | Guard scripts over both credential forms.
+genDijkstraGuardNativeScript :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraGuardNativeScript =
+    oneof [genDijkstraKeyHashGuard, genDijkstraScriptHashGuard]
+
+-- | The Conway counterpart of a shared-shape Dijkstra native script: the
+-- identical structure over 'Timelock ConwayEra'. Shape-for-shape this mirrors
+-- the ledger's own 'upgradeTimelock' mapping.
+toConwayCounterpart :: LedgerApi.NativeScript DijkstraEra -> Timelock ConwayEra
+toConwayCounterpart = \case
+    LedgerScripts.RequireSignature kh -> LedgerScripts.RequireSignature kh
+    LedgerScripts.RequireAllOf xs ->
+        LedgerScripts.RequireAllOf (fmap toConwayCounterpart xs)
+    LedgerScripts.RequireAnyOf xs ->
+        LedgerScripts.RequireAnyOf (fmap toConwayCounterpart xs)
+    LedgerScripts.RequireMOf n xs ->
+        LedgerScripts.RequireMOf n (fmap toConwayCounterpart xs)
+    LedgerScripts.RequireTimeStart s -> LedgerScripts.RequireTimeStart s
+    LedgerScripts.RequireTimeExpire s -> LedgerScripts.RequireTimeExpire s
+    s -> error ("no Conway counterpart: " <> show s)
+
+data SharedShape
+    = ShapeRequireSignature
+    | ShapeRequireAllOf
+    | ShapeRequireAnyOf
+    | ShapeRequireMOf
+    | ShapeRequireTimeStart
+    | ShapeRequireTimeExpire
+    deriving (Bounded, Enum, Eq, Ord, Show)
+
+-- | Every shared shape occurring anywhere in the script, nested or not.
+allSharedShapes :: LedgerApi.NativeScript DijkstraEra -> Set SharedShape
+allSharedShapes = \case
+    LedgerScripts.RequireSignature _ -> Set.singleton ShapeRequireSignature
+    LedgerScripts.RequireAllOf xs ->
+        Set.insert ShapeRequireAllOf (foldMap allSharedShapes xs)
+    LedgerScripts.RequireAnyOf xs ->
+        Set.insert ShapeRequireAnyOf (foldMap allSharedShapes xs)
+    LedgerScripts.RequireMOf _ xs ->
+        Set.insert ShapeRequireMOf (foldMap allSharedShapes xs)
+    LedgerScripts.RequireTimeStart _ -> Set.singleton ShapeRequireTimeStart
+    LedgerScripts.RequireTimeExpire _ -> Set.singleton ShapeRequireTimeExpire
+    RequireGuard _ -> Set.empty
+    s -> error ("unexpected script in shape census: " <> show s)
+
+-- | True when some compound node contains another compound node below it.
+hasNestedCompound :: LedgerApi.NativeScript DijkstraEra -> Bool
+hasNestedCompound = go False
+  where
+    go belowCompound = \case
+        LedgerScripts.RequireSignature _ -> False
+        LedgerScripts.RequireAllOf xs -> belowCompound || any (go True) xs
+        LedgerScripts.RequireAnyOf xs -> belowCompound || any (go True) xs
+        LedgerScripts.RequireMOf _ xs -> belowCompound || any (go True) xs
+        LedgerScripts.RequireTimeStart _ -> False
+        LedgerScripts.RequireTimeExpire _ -> False
+        RequireGuard _ -> False
+        _ -> False
+
+guardCredentialForm :: LedgerApi.NativeScript DijkstraEra -> String
+guardCredentialForm = \case
+    RequireGuard (KeyHashObj _) -> "KeyHashObj"
+    RequireGuard (ScriptHashObj _) -> "ScriptHashObj"
+    _ -> error "not a guard script"
+
+-- | Requires the conversion of the given script to fail with an error message
+-- that names the Dijkstra era, states that the script has no wallet
+-- representation, and does not claim to identify which shape it caught.
+assertDijkstraConversionFails :: Show a => a -> IO ()
+assertDijkstraConversionFails result = do
+    r <- try (evaluate (show result))
+    case r of
+        Left (ErrorCall msg) -> do
+            msg `shouldContain` "Dijkstra"
+            msg `shouldContain` "no wallet representation"
+            map toLower msg `shouldNotContain` "guard"
+        Right shown -> fail ("expected the conversion to fail, got: " <> shown)
 
 --------------------------------------------------------------------------------
 -- Utilities

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -130,9 +130,6 @@ import Control.Monad
 import Data.Char
     ( toLower
     )
-import Data.List
-    ( isInfixOf
-    )
 import Data.Proxy
     ( Proxy (..)
     )
@@ -275,12 +272,45 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
                 it "ledger . wallet == id" $ property $ \s -> do
                     ledger (wallet s) === s
 
+        describe
+            "Dijkstra native scripts (toWalletScript, shared conversion)"
+            $ do
+                it
+                    "shared shapes convert to the same wallet script as their Conway counterparts"
+                    $ property
+                    $ forAll genDijkstraSharedNativeScript
+                    $ \d ->
+                        toWalletScript (const Unknown) d
+                            === toWalletScript
+                                (const Unknown)
+                                (toConwayCounterpart d)
+
+                it "a guard over a KeyHashObj credential reaches the named failure"
+                    $ property
+                    $ forAll genDijkstraKeyHashGuard
+                    $ \g ->
+                        ioProperty
+                            ( assertDijkstraConversionFails
+                                (toWalletScript (const Unknown) g)
+                            )
+
+                it "a guard over a ScriptHashObj credential reaches the named failure"
+                    $ property
+                    $ forAll genDijkstraScriptHashGuard
+                    $ \g ->
+                        ioProperty
+                            ( assertDijkstraConversionFails
+                                (toWalletScript (const Unknown) g)
+                            )
+
         describe "dijkstraAnyExplicitScript (Dijkstra call site, end to end)" $ do
             let ctx = AnyWitnessCountCtx
 
-            it "shared shapes decode to the same explicit script as the Conway decoding"
+            it
+                "shared shapes decode to the same explicit script as the Conway decoding"
                 $ property
-                $ forAll genDijkstraSharedNativeScript $ \d ->
+                $ forAll genDijkstraSharedNativeScript
+                $ \d ->
                     forAll arbitrary $ \(h :: LedgerApi.ScriptHash) ->
                         dijkstraAnyExplicitScript ctx (ViaSpending, h, Alonzo.NativeScript d)
                             === conwayAnyExplicitScript
@@ -289,7 +319,8 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
 
             it "a guard script fails naming the era, without claiming the shape"
                 $ property
-                $ forAll genDijkstraGuardNativeScript $ \g ->
+                $ forAll genDijkstraGuardNativeScript
+                $ \g ->
                     forAll arbitrary $ \(h :: LedgerApi.ScriptHash) ->
                         classify (guardCredentialForm g == "KeyHashObj") "KeyHashObj guard"
                             $ classify
@@ -305,7 +336,8 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
                                     )
                                 )
 
-            it "the generated shared-shape population contains every shared shape, nested"
+            it
+                "the generated shared-shape population contains every shared shape, nested"
                 $ do
                     samples <-
                         generate
@@ -356,28 +388,31 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec"
 
 -- | The six native script shapes Dijkstra shares with 'Timelock', including
 -- nested compounds.
-genDijkstraSharedNativeScript :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraSharedNativeScript
+    :: Gen (LedgerApi.NativeScript DijkstraEra)
 genDijkstraSharedNativeScript = sized $ \(n :: Int) ->
     if n <= 1
         then genSharedLeaf
         else oneof [genSharedLeaf, genSharedNode]
   where
-    genSharedLeaf = oneof
-        [ LedgerScripts.RequireSignature <$> arbitrary
-        , LedgerScripts.RequireTimeStart <$> genSlotNo
-        , LedgerScripts.RequireTimeExpire <$> genSlotNo
-        ]
-    genSharedNode = oneof
-        [ compound LedgerScripts.RequireAllOf
-        , compound LedgerScripts.RequireAnyOf
-        , do
-            subs <- listOf1 sub
-            Positive k <- arbitrary
-            pure
-                $ LedgerScripts.RequireMOf
-                    (1 + (k - 1) `mod` length subs)
-                    (StrictSeq.fromList subs)
-        ]
+    genSharedLeaf =
+        oneof
+            [ LedgerScripts.RequireSignature <$> arbitrary
+            , LedgerScripts.RequireTimeStart <$> genSlotNo
+            , LedgerScripts.RequireTimeExpire <$> genSlotNo
+            ]
+    genSharedNode =
+        oneof
+            [ compound LedgerScripts.RequireAllOf
+            , compound LedgerScripts.RequireAnyOf
+            , do
+                subs <- listOf1 sub
+                Positive k <- arbitrary
+                pure
+                    $ LedgerScripts.RequireMOf
+                        (1 + (k - 1) `mod` length subs)
+                        (StrictSeq.fromList subs)
+            ]
     compound mk = mk . StrictSeq.fromList <$> listOf1 sub
     sub = scale (`div` 2) genDijkstraSharedNativeScript
     genSlotNo = SlotNo <$> choose (0, 2 ^ (40 :: Int))
@@ -391,14 +426,16 @@ genDijkstraScriptHashGuard :: Gen (LedgerApi.NativeScript DijkstraEra)
 genDijkstraScriptHashGuard = RequireGuard . ScriptHashObj <$> arbitrary
 
 -- | Guard scripts over both credential forms.
-genDijkstraGuardNativeScript :: Gen (LedgerApi.NativeScript DijkstraEra)
+genDijkstraGuardNativeScript
+    :: Gen (LedgerApi.NativeScript DijkstraEra)
 genDijkstraGuardNativeScript =
     oneof [genDijkstraKeyHashGuard, genDijkstraScriptHashGuard]
 
 -- | The Conway counterpart of a shared-shape Dijkstra native script: the
 -- identical structure over 'Timelock ConwayEra'. Shape-for-shape this mirrors
 -- the ledger's own 'upgradeTimelock' mapping.
-toConwayCounterpart :: LedgerApi.NativeScript DijkstraEra -> Timelock ConwayEra
+toConwayCounterpart
+    :: LedgerApi.NativeScript DijkstraEra -> Timelock ConwayEra
 toConwayCounterpart = \case
     LedgerScripts.RequireSignature kh -> LedgerScripts.RequireSignature kh
     LedgerScripts.RequireAllOf xs ->
@@ -421,7 +458,8 @@ data SharedShape
     deriving (Bounded, Enum, Eq, Ord, Show)
 
 -- | Every shared shape occurring anywhere in the script, nested or not.
-allSharedShapes :: LedgerApi.NativeScript DijkstraEra -> Set SharedShape
+allSharedShapes
+    :: LedgerApi.NativeScript DijkstraEra -> Set SharedShape
 allSharedShapes = \case
     LedgerScripts.RequireSignature _ -> Set.singleton ShapeRequireSignature
     LedgerScripts.RequireAllOf xs ->

--- a/scripts/ci/dijkstra-stub-gate.sh
+++ b/scripts/ci/dijkstra-stub-gate.sh
@@ -51,7 +51,7 @@ total=$((tot_e+tot_p))
 # MAX is the number of Dijkstra stubs currently tolerated. It only ever goes
 # DOWN. Each child that retires stubs lowers it in the same PR; its terminal
 # value is 0, which is issue #5209's acceptance criterion.
-MAX=${DIJKSTRA_STUB_MAX:-33}
+MAX=${DIJKSTRA_STUB_MAX:-32}
 
 echo "total = $total across $files files   (ratchet MAX=$MAX)"
 

--- a/specs/5431-dijkstra-native-script-conversion/data-model.md
+++ b/specs/5431-dijkstra-native-script-conversion/data-model.md
@@ -12,12 +12,13 @@ carrying a credential that may be either a key hash or a script hash.
 `Script KeyHash` from `cardano-addresses`, whose constructors are
 `RequireSignatureOf`, `RequireAllOf`, `RequireAnyOf`, `RequireSomeOf`,
 `ActiveFromSlot`, `ActiveUntilSlot`. None of them can carry a guard credential,
-and the available key roles contain no guard role.
+and the available key roles contain no guard role. The type is not changed by
+this ticket and no field is added to `AnyScript` or `AnyExplicitScript`.
 
 ## State invariants
 
-- The six shared shapes round-trip to the same wallet script regardless of which
-  era's native script they came from.
-- A guard script has exactly one outcome, and it is total. Which outcome is the
-  open decision recorded in `spec.md`; the fields it may add to `AnyScript` and
-  `AnyExplicitScript` are specified once that is settled, not before.
+- The six shared shapes convert to the same wallet script regardless of which
+  era's native script they came from. Nesting is part of this: a shape holding
+  sub-scripts converts its children by the same rule.
+- A guard script has exactly one outcome, a named failure, and it occurs in one
+  place.

--- a/specs/5431-dijkstra-native-script-conversion/data-model.md
+++ b/specs/5431-dijkstra-native-script-conversion/data-model.md
@@ -1,0 +1,23 @@
+# Data model
+
+## Consumed
+
+`NativeScript era` for an era with an `AllegraEraScript` instance. For eras up
+to Conway this is `Timelock era` with six shapes. For Dijkstra it is
+`DijkstraNativeScript era`, which has those six and one more, `RequireGuard`,
+carrying a credential that may be either a key hash or a script hash.
+
+## Produced
+
+`Script KeyHash` from `cardano-addresses`, whose constructors are
+`RequireSignatureOf`, `RequireAllOf`, `RequireAnyOf`, `RequireSomeOf`,
+`ActiveFromSlot`, `ActiveUntilSlot`. None of them can carry a guard credential,
+and the available key roles contain no guard role.
+
+## State invariants
+
+- The six shared shapes round-trip to the same wallet script regardless of which
+  era's native script they came from.
+- A guard script has exactly one outcome, and it is total. Which outcome is the
+  open decision recorded in `spec.md`; the fields it may add to `AnyScript` and
+  `AnyExplicitScript` are specified once that is settled, not before.

--- a/specs/5431-dijkstra-native-script-conversion/functions-model.md
+++ b/specs/5431-dijkstra-native-script-conversion/functions-model.md
@@ -1,6 +1,6 @@
 # Functions model
 
-Changed signature:
+## Changed
 
 ```
 toWalletScript
@@ -11,10 +11,26 @@ toWalletScript
 ```
 
 The `NativeScript era ~ Timelock era` equality is removed and the argument
-becomes `NativeScript era`. Callers whose era predates Dijkstra are unchanged,
-because `NativeScript era` is already `Timelock era` for them.
+becomes `NativeScript era`. The result type is unchanged. Callers whose era
+predates Dijkstra are unchanged, because `NativeScript era` is already
+`Timelock era` for them.
 
-The result type is provisional: the open guard decision may replace
-`Script KeyHash` with a type that can also express an unconvertible script. No
-other signature in this ticket is settled until then, and none is recorded here
-on speculation.
+Its unmatched branch is reachable for Dijkstra and raises an error naming the
+era. There is exactly one such branch in the codebase after this change.
+
+## Unchanged signatures whose bodies change
+
+`fromLedgerScriptToAnyScriptDijkstra` and `dijkstraAnyExplicitScript` keep
+their types and call the conversion. `dijkstraAnyExplicitScript` uses the
+witness-count context argument it currently ignores.
+
+## New, in the test suite only
+
+```
+genDijkstraSharedNativeScript :: Gen (NativeScript DijkstraEra)
+genDijkstraGuardNativeScript  :: Gen (NativeScript DijkstraEra)
+```
+
+Standalone generators, not `Arbitrary` instances. The first produces only the
+six shapes shared with `Timelock`, including nested ones. The second produces
+guard scripts over both credential forms.

--- a/specs/5431-dijkstra-native-script-conversion/functions-model.md
+++ b/specs/5431-dijkstra-native-script-conversion/functions-model.md
@@ -1,0 +1,20 @@
+# Functions model
+
+Changed signature:
+
+```
+toWalletScript
+    :: AllegraEraScript era
+    => (Hash "VerificationKey" -> KeyRole)   -- tokeyrole
+    -> NativeScript era                      -- script
+    -> Script KeyHash
+```
+
+The `NativeScript era ~ Timelock era` equality is removed and the argument
+becomes `NativeScript era`. Callers whose era predates Dijkstra are unchanged,
+because `NativeScript era` is already `Timelock era` for them.
+
+The result type is provisional: the open guard decision may replace
+`Script KeyHash` with a type that can also express an unconvertible script. No
+other signature in this ticket is settled until then, and none is recorded here
+on speculation.

--- a/specs/5431-dijkstra-native-script-conversion/modules-model.md
+++ b/specs/5431-dijkstra-native-script-conversion/modules-model.md
@@ -1,0 +1,16 @@
+# Modules model
+
+| module | responsibility | change |
+|---|---|---|
+| `Cardano/Wallet/Primitive/Ledger/Convert` | ledger to wallet conversions | owns the single native script conversion; its era constraint is widened |
+| `.../Read/Tx/Features/Mint` | decode the mint/burn script map of an observed transaction | Dijkstra arm calls the conversion instead of failing |
+| `.../Read/Tx/Features/Scripts` | decode explicit scripts for witness counting | same |
+| `Cardano/Wallet/Primitive/Types/TokenMapWithScripts` | `AnyScript` | changed only if the open decision requires a case for unrepresentable native scripts |
+| `Cardano/Wallet/Primitive/Types/AnyExplicitScripts` | `AnyExplicitScript` | same |
+
+Dependency direction is unchanged: the two readers depend on `Convert`, never
+the reverse, and no module gains a dependency on `cardano-ledger-dijkstra` that
+does not already have one.
+
+No abstraction is promoted. The conversion already lives in the module both
+readers import; the change removes a constraint rather than introducing a layer.

--- a/specs/5431-dijkstra-native-script-conversion/plan.md
+++ b/specs/5431-dijkstra-native-script-conversion/plan.md
@@ -10,45 +10,43 @@ Measured with `scripts/ci/dijkstra-stub-gate.sh` on the tree at the merge base
 `d75c8365aa`, twice — once on this worktree and once in a separate detached
 checkout of that commit: total **39**, declared ratchet **39**, with this
 ticket's two sites contributing **one each** as read from the per-file
-breakdown. The target is therefore **37** with the ratchet at 37 in the same
-tree.
+breakdown. `Convert.hs` is not in that breakdown today.
 
-Every commit below this branch is docs-only, so the stack has not moved the
-count yet. The planned end state of the slices below is lower than 39; this
-plan records what the tree says rather than that projection, and re-measures
-if the base moves again.
+The target is **38** with the ratchet at 38: two counted stubs are deleted and
+one is created in the shared conversion. Every commit below this branch is
+docs-only, so the stack has not moved the count yet; re-measure if the base
+moves again.
 
 ## Constraints
 
 - `cardano-ledger-dijkstra` is pinned at `0.3.0.0` by `cabal.project`. Every
   claim about the Dijkstra script type is read from that version.
 - `Script` and `KeyRole` belong to `cardano-addresses` and are not changed here.
-- `AnyScript` and `AnyExplicitScript` are serialized into the public REST API.
-  Any change to them carries the swagger regeneration step.
+- `AnyScript` and `AnyExplicitScript` are not changed here. They are serialized
+  into the public REST API and the decision to widen them is taken elsewhere.
 - The census script is not edited except for its ratchet declaration.
+- No file claimed by the slice below is touched. That slice covers
+  `Cardano/Wallet.hs`, `Shelley/Transaction.hs`, `Shelley/Transaction/Unsigned.hs`,
+  `Pools.hs` and a local-cluster spec; this one covers `lib/primitive` only.
 
 ## Ordered slices
 
-Each is bisect-safe on its own.
+Both are bisect-safe.
 
 1. **Widen the conversion.** `toWalletScript` loses its `Timelock` equality
-   constraint and takes `NativeScript era`. Existing callers are unaffected
-   because their `NativeScript era` is already `Timelock era`. No behaviour
-   changes in any era that exists today. This slice does not touch the two
-   Dijkstra sites and does not move the census.
+   constraint and takes `NativeScript era`. Its unmatched branch becomes
+   reachable for Dijkstra and names the era. Existing callers are unaffected
+   because their `NativeScript era` is already `Timelock era`. This slice adds
+   one to the census and removes none, so it is not landed alone.
 
-2. **Resolve the guard case.** Blocked on the open decision in `spec.md`. Gives
-   `RequireGuard` its total outcome and, if the decision requires it, adds the
-   corresponding case to `AnyScript` and `AnyExplicitScript` with the swagger
-   regeneration that follows.
+2. **Route both readers through it.** Both Dijkstra arms call the shared
+   conversion and their `error`s are deleted. The census falls by two here, for
+   a net one across the pair, and the ratchet declaration moves with it in the
+   same tree.
 
-3. **Delete both stubs.** Both Dijkstra arms call the widened conversion. The
-   census falls by two and the ratchet declaration moves with it in the same
-   tree.
-
-Slice 1 is available now. Slices 2 and 3 are not started before the decision,
-because it determines the conversion's result type and therefore slice 1's
-signature is the only part that is settled.
+The two slices land together in one pull request. Slice 1 alone would raise the
+count, which the census hard-fails, so splitting them across pull requests is
+not available.
 
 ## Verification
 
@@ -69,8 +67,15 @@ era, so a repair that merely stops naming Dijkstra lowers the count and leaves
 the crash. Nothing mechanical catches that, which is why R1 says "by deletion"
 and why it is checked by reading the diff.
 
+Tests live in `lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs`,
+which already holds the `Timelock` roundtrip properties for `BabbageEra` and is
+the Conway-side control for R3. That suite does **not** currently depend on
+`cardano-ledger-dijkstra`; the dependency is added so a real Dijkstra native
+script can be constructed rather than simulated.
+
 ## Live boundary
 
 None. Both functions are pure decoders over a transaction already in memory.
-The boundary that matters is the ledger type, and it is exercised by
-constructing real Dijkstra native scripts rather than by mocking them.
+The boundary that matters is the ledger type, and it is crossed by constructing
+real `DijkstraNativeScript` values through the ledger's own class methods rather
+than by mocking them.

--- a/specs/5431-dijkstra-native-script-conversion/plan.md
+++ b/specs/5431-dijkstra-native-script-conversion/plan.md
@@ -1,0 +1,76 @@
+# Dijkstra native script conversion — plan
+
+## Base
+
+Branches from `feat/5429-dijkstra-converter-mirrors`, which sits on
+`refactor/5422-delete-era-split`, which sits on `master`. Targets the branch
+directly below it, never `master`.
+
+Measured with `scripts/ci/dijkstra-stub-gate.sh` on the tree at the merge base
+`d75c8365aa`, twice — once on this worktree and once in a separate detached
+checkout of that commit: total **39**, declared ratchet **39**, with this
+ticket's two sites contributing **one each** as read from the per-file
+breakdown. The target is therefore **37** with the ratchet at 37 in the same
+tree.
+
+Every commit below this branch is docs-only, so the stack has not moved the
+count yet. The planned end state of the slices below is lower than 39; this
+plan records what the tree says rather than that projection, and re-measures
+if the base moves again.
+
+## Constraints
+
+- `cardano-ledger-dijkstra` is pinned at `0.3.0.0` by `cabal.project`. Every
+  claim about the Dijkstra script type is read from that version.
+- `Script` and `KeyRole` belong to `cardano-addresses` and are not changed here.
+- `AnyScript` and `AnyExplicitScript` are serialized into the public REST API.
+  Any change to them carries the swagger regeneration step.
+- The census script is not edited except for its ratchet declaration.
+
+## Ordered slices
+
+Each is bisect-safe on its own.
+
+1. **Widen the conversion.** `toWalletScript` loses its `Timelock` equality
+   constraint and takes `NativeScript era`. Existing callers are unaffected
+   because their `NativeScript era` is already `Timelock era`. No behaviour
+   changes in any era that exists today. This slice does not touch the two
+   Dijkstra sites and does not move the census.
+
+2. **Resolve the guard case.** Blocked on the open decision in `spec.md`. Gives
+   `RequireGuard` its total outcome and, if the decision requires it, adds the
+   corresponding case to `AnyScript` and `AnyExplicitScript` with the swagger
+   regeneration that follows.
+
+3. **Delete both stubs.** Both Dijkstra arms call the widened conversion. The
+   census falls by two and the ratchet declaration moves with it in the same
+   tree.
+
+Slice 1 is available now. Slices 2 and 3 are not started before the decision,
+because it determines the conversion's result type and therefore slice 1's
+signature is the only part that is settled.
+
+## Verification
+
+The ticket gate carries one leg per failure class CI enforces — whitespace,
+compile, format, hlint, the `cardano-wallet-primitive` suite, the census and
+its negative control — read from `.github/workflows/`. It adds the class CI
+does not enforce: the census total and the declared ratchet must be **equal**,
+not merely ordered. CI hard-fails an added stub but exits 0 with a warning when
+a stub is retired and the ratchet is left behind, so that half is otherwise
+unchecked.
+
+That leg was falsified in both directions before use: a retired stub with the
+ratchet left at its old value exits 0 under the census alone and non-zero under
+the gate.
+
+**The census cannot see a rename.** It counts error literals that mention the
+era, so a repair that merely stops naming Dijkstra lowers the count and leaves
+the crash. Nothing mechanical catches that, which is why R1 says "by deletion"
+and why it is checked by reading the diff.
+
+## Live boundary
+
+None. Both functions are pure decoders over a transaction already in memory.
+The boundary that matters is the ledger type, and it is exercised by
+constructing real Dijkstra native scripts rather than by mocking them.

--- a/specs/5431-dijkstra-native-script-conversion/spec.md
+++ b/specs/5431-dijkstra-native-script-conversion/spec.md
@@ -13,13 +13,18 @@ transaction. Their Dijkstra arms are `error` stubs sharing one literal,
 | `Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs` | `fromLedgerScriptToAnyScriptDijkstra` |
 | `Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs` | `dijkstraAnyExplicitScript` |
 
-Any Dijkstra transaction carrying a native script therefore crashes the reader.
+Any Dijkstra transaction carrying a native script therefore crashes the reader,
+including the six script shapes the wallet has always been able to represent.
 
 ## User-visible outcome
 
-A wallet observing a Dijkstra transaction that carries a native script reports
-that script over the API — as the policy script of a mint or burn, and in the
-witness count — instead of crashing.
+A wallet observing a Dijkstra transaction whose native scripts use the shapes
+shared with earlier eras reports those scripts over the API — as the policy
+script of a mint or burn, and in the witness count — instead of crashing.
+
+A Dijkstra *guard* script still fails, loudly and by name. That is a smaller
+outcome than "Dijkstra native scripts work", and it is the honest one: see
+"Guard scripts" below.
 
 ## Why one function and not two era arms
 
@@ -32,55 +37,59 @@ matches only pattern synonyms that are era-polymorphic over `NativeScript era`
 `NativeScript era ~ Timelock era` equality excludes Dijkstra.
 
 The change is therefore a widening of one existing function, not a new era arm,
-and the eras whose `NativeScript` already *is* `Timelock` keep compiling
-unchanged.
+and the eras whose `NativeScript` already *is* `Timelock` keep compiling and
+behaving unchanged.
 
-## The case that makes this more than a widening
+## Guard scripts
 
 `Timelock` has six shapes and `toWalletScript` ends in a catch-all that is
-genuinely unreachable for it. Dijkstra's native script has a seventh:
+genuinely unreachable for it. Dijkstra's native script has a seventh,
 `RequireGuard`, carrying a guard credential, with its own CBOR tag and its own
 evaluation rule — a guard is satisfied by membership in the transaction's guard
 set, not by a witness.
 
-Widening the signature without deciding `RequireGuard` would move an
-unreachable branch into a live crash path while removing the two counted stubs.
-
 `Script` from `cardano-addresses` has no constructor that can hold it, and no
 lossy mapping is available: a guard credential may be a script hash rather than
 a key hash, and there is no guard key role to label the key-hash form with.
-Making the conversion total therefore requires a case on `AnyScript` and
-`AnyExplicitScript`, both of which are serialized into the public REST API.
+Mapping a guard to `RequireSignatureOf` would misreport the script to API
+consumers and to the witness counter, which is worse than crashing because it
+is silent.
 
-**That decision is open, and it determines the conversion's result type.**
-Implementation does not start before it is settled.
+**So the guard case remains an explicit failure naming the era.** Making the
+conversion total would need a case on `AnyScript` and `AnyExplicitScript`, both
+of which are serialized into the public REST API; that is a separate decision
+about a published interface and is not taken here.
 
 ## Requirements
 
-- R1 — Both `error` stubs are gone, by deletion. A widened catch-all, a message
-  that stops naming the era, or a test made pending in another form does not
-  satisfy this.
+- R1 — Both `error` stubs at the two call sites are gone, by deletion. A
+  widened catch-all, a message that stops naming the era, or a test made
+  pending in another form does not satisfy this.
 - R2 — One conversion serves both call sites; neither carries its own copy.
-- R3 — A Dijkstra native script built from the shapes shared with Timelock
+- R3 — A Dijkstra native script built from the six shapes shared with `Timelock`
   converts to the same wallet script its Conway counterpart converts to.
-- R4 — A Dijkstra guard script has an explicit, total outcome. An `error`
-  reachable from an observed transaction is not one.
+- R4 — A Dijkstra guard script fails, and the failure names the era so the
+  census counts it. It is one failure, in the shared conversion, not one per
+  call site.
 - R5 — The eras already served by the conversion keep their present behaviour.
 - R6 — The count reported by `scripts/ci/dijkstra-stub-gate.sh` on the tree
-  falls by two from the base, and the declared ratchet moves with it in the same
-  tree.
+  falls by **one** from the merge base, and the declared ratchet moves by one
+  in the same tree.
 
 ## Rejection behaviour
 
-R4's outcome is whatever the open decision settles. Until then this section is
-deliberately unwritten rather than guessed.
+A guard script reaching the conversion raises an error whose message names the
+Dijkstra era and says that the script has no wallet representation. It does not
+claim to know which future shape it caught: the conversion is polymorphic over
+eras, so its unmatched branch is not evidence that the value was a guard.
 
 ## Observable success
 
-- The census script on the tree reports a total two lower than the base's, and
-  a ratchet equal to it.
-- The Dijkstra conversion is exercised by a test whose input is a real Dijkstra
-  native script. A test that only shows Conway still works has not exercised it.
-- Where the exercise is a property, its generated population is shown to contain
-  a Dijkstra native script, including a guard script. A generator that cannot
-  produce the feature is blind to it at any sample size.
+- The census script on the tree reports a total one lower than the merge base's,
+  and a declared ratchet equal to it.
+- The conversion is exercised by a test whose input is a real Dijkstra native
+  script. A test that only shows Conway still works has not exercised it.
+- The property over the shared shapes is shown to generate Dijkstra native
+  scripts, including nested ones, rather than being satisfiable by a population
+  that never contains the feature.
+- A Dijkstra guard script is shown to be constructible and to reach the failure.

--- a/specs/5431-dijkstra-native-script-conversion/spec.md
+++ b/specs/5431-dijkstra-native-script-conversion/spec.md
@@ -1,0 +1,86 @@
+# Dijkstra native script conversion — spec
+
+Child of #5209 (items 20 and 21 of the partition). Issue #5431.
+
+## Problem
+
+Two readers in `lib/primitive` decode the scripts carried by an observed
+transaction. Their Dijkstra arms are `error` stubs sharing one literal,
+`error "TODO: DijkstraNativeScript conversion"`:
+
+| module | function |
+|---|---|
+| `Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs` | `fromLedgerScriptToAnyScriptDijkstra` |
+| `Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Scripts.hs` | `dijkstraAnyExplicitScript` |
+
+Any Dijkstra transaction carrying a native script therefore crashes the reader.
+
+## User-visible outcome
+
+A wallet observing a Dijkstra transaction that carries a native script reports
+that script over the API — as the policy script of a mint or burn, and in the
+witness count — instead of crashing.
+
+## Why one function and not two era arms
+
+Both sites hand their result to a field of type `Script KeyHash`, so both need
+the same conversion. `Convert.toWalletScript` already contains it. Its body
+matches only pattern synonyms that are era-polymorphic over `NativeScript era`
+(`RequireSignature`, `RequireAllOf`, `RequireAnyOf`, `RequireMOf` from
+`ShelleyEraScript`; `RequireTimeStart`, `RequireTimeExpire` from
+`AllegraEraScript`), and `DijkstraEra` has both instances. Only the signature's
+`NativeScript era ~ Timelock era` equality excludes Dijkstra.
+
+The change is therefore a widening of one existing function, not a new era arm,
+and the eras whose `NativeScript` already *is* `Timelock` keep compiling
+unchanged.
+
+## The case that makes this more than a widening
+
+`Timelock` has six shapes and `toWalletScript` ends in a catch-all that is
+genuinely unreachable for it. Dijkstra's native script has a seventh:
+`RequireGuard`, carrying a guard credential, with its own CBOR tag and its own
+evaluation rule — a guard is satisfied by membership in the transaction's guard
+set, not by a witness.
+
+Widening the signature without deciding `RequireGuard` would move an
+unreachable branch into a live crash path while removing the two counted stubs.
+
+`Script` from `cardano-addresses` has no constructor that can hold it, and no
+lossy mapping is available: a guard credential may be a script hash rather than
+a key hash, and there is no guard key role to label the key-hash form with.
+Making the conversion total therefore requires a case on `AnyScript` and
+`AnyExplicitScript`, both of which are serialized into the public REST API.
+
+**That decision is open, and it determines the conversion's result type.**
+Implementation does not start before it is settled.
+
+## Requirements
+
+- R1 — Both `error` stubs are gone, by deletion. A widened catch-all, a message
+  that stops naming the era, or a test made pending in another form does not
+  satisfy this.
+- R2 — One conversion serves both call sites; neither carries its own copy.
+- R3 — A Dijkstra native script built from the shapes shared with Timelock
+  converts to the same wallet script its Conway counterpart converts to.
+- R4 — A Dijkstra guard script has an explicit, total outcome. An `error`
+  reachable from an observed transaction is not one.
+- R5 — The eras already served by the conversion keep their present behaviour.
+- R6 — The count reported by `scripts/ci/dijkstra-stub-gate.sh` on the tree
+  falls by two from the base, and the declared ratchet moves with it in the same
+  tree.
+
+## Rejection behaviour
+
+R4's outcome is whatever the open decision settles. Until then this section is
+deliberately unwritten rather than guessed.
+
+## Observable success
+
+- The census script on the tree reports a total two lower than the base's, and
+  a ratchet equal to it.
+- The Dijkstra conversion is exercised by a test whose input is a real Dijkstra
+  native script. A test that only shows Conway still works has not exercised it.
+- Where the exercise is a property, its generated population is shown to contain
+  a Dijkstra native script, including a guard script. A generator that cannot
+  produce the feature is blind to it at any sample size.

--- a/specs/5431-dijkstra-native-script-conversion/tasks.md
+++ b/specs/5431-dijkstra-native-script-conversion/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Slice 1 — widen the conversion
+
+- [ ] T001 `toWalletScript` accepts `NativeScript era` under `AllegraEraScript era`, with the `Timelock` equality constraint removed.
+- [ ] T002 Existing callers compile unchanged and the eras already served keep their behaviour.
+
+## Slice 2 — the guard case (blocked on the open decision in spec.md)
+
+- [ ] T003 A Dijkstra guard script has an explicit total outcome; no reachable `error` remains on the path.
+- [ ] T004 If the outcome requires it, `AnyScript` and `AnyExplicitScript` carry it and the swagger is regenerated.
+
+## Slice 3 — delete both stubs
+
+- [ ] T005 The Dijkstra arm of the mint/burn script map decoder calls the shared conversion; its `error` is deleted.
+- [ ] T006 The Dijkstra arm of the explicit script decoder does the same; its `error` is deleted.
+- [ ] T007 A Dijkstra native script built from the shapes shared with Timelock converts to the same wallet script its Conway counterpart does.
+- [ ] T008 The exercise covers a guard script, and where it is a property its generated population is shown to contain one.
+- [ ] T009 The census total on the tree is two below the base's and the declared ratchet equals it.

--- a/specs/5431-dijkstra-native-script-conversion/tasks.md
+++ b/specs/5431-dijkstra-native-script-conversion/tasks.md
@@ -2,18 +2,15 @@
 
 ## Slice 1 — widen the conversion
 
-- [ ] T001 `toWalletScript` accepts `NativeScript era` under `AllegraEraScript era`, with the `Timelock` equality constraint removed.
-- [ ] T002 Existing callers compile unchanged and the eras already served keep their behaviour.
+- [ ] T001 `toWalletScript` accepts `NativeScript era` under `AllegraEraScript era`, with the `Timelock` equality constraint removed and the result type unchanged.
+- [ ] T002 Its unmatched branch names the Dijkstra era and states that the script has no wallet representation, without claiming to identify which shape it caught.
+- [ ] T003 Existing callers compile unchanged and the eras already served keep their behaviour.
 
-## Slice 2 — the guard case (blocked on the open decision in spec.md)
+## Slice 2 — route both readers through it
 
-- [ ] T003 A Dijkstra guard script has an explicit total outcome; no reachable `error` remains on the path.
-- [ ] T004 If the outcome requires it, `AnyScript` and `AnyExplicitScript` carry it and the swagger is regenerated.
-
-## Slice 3 — delete both stubs
-
-- [ ] T005 The Dijkstra arm of the mint/burn script map decoder calls the shared conversion; its `error` is deleted.
-- [ ] T006 The Dijkstra arm of the explicit script decoder does the same; its `error` is deleted.
-- [ ] T007 A Dijkstra native script built from the shapes shared with Timelock converts to the same wallet script its Conway counterpart does.
-- [ ] T008 The exercise covers a guard script, and where it is a property its generated population is shown to contain one.
-- [ ] T009 The census total on the tree is two below the base's and the declared ratchet equals it.
+- [ ] T004 The Dijkstra arm of the mint/burn script map decoder calls the shared conversion; its `error` is deleted.
+- [ ] T005 The Dijkstra arm of the explicit script decoder calls the shared conversion with the witness-count context it currently ignores; its `error` is deleted.
+- [ ] T006 A Dijkstra native script built from the six shapes shared with `Timelock`, including nested shapes, converts to the same wallet script its Conway counterpart converts to.
+- [ ] T007 The generated population for T006 is shown to contain Dijkstra native scripts of each shared shape, and to contain nested ones.
+- [ ] T008 A Dijkstra guard script is shown to be constructible over both credential forms and to reach the named failure.
+- [ ] T009 The census total on the tree is one below the merge base's and the declared ratchet equals it.


### PR DESCRIPTION
Closes #5431. Child of epic #5209.

## What breaks today

`lib/primitive` has two readers that decode the scripts carried by an observed
transaction. Both abort on Dijkstra:

- `…/Read/Tx/Features/Mint.hs` — `fromLedgerScriptToAnyScriptDijkstra`
- `…/Read/Tx/Features/Scripts.hs` — `dijkstraAnyExplicitScript`

**Any Dijkstra transaction carrying a native script crashes the reader.** These
sites consume arbitrary on-chain transactions, so the path is reachable by
anything the chain presents.

## Why this is one function, not two era arms

Both sites hand their result to a field of type `Script KeyHash`, and
`Convert.toWalletScript` already contains the conversion. Its body matches only
pattern synonyms that are **era-polymorphic** over `NativeScript era` —
`RequireSignature`, `RequireAllOf`, `RequireAnyOf`, `RequireMOf` from
`ShelleyEraScript`, and `RequireTimeStart`, `RequireTimeExpire` from
`AllegraEraScript`. `DijkstraEra` has both instances.

The only thing excluding Dijkstra was the signature's
`NativeScript era ~ Timelock era` equality constraint.

So this widens one existing function rather than adding an era arm. Eras whose
`NativeScript` already is `Timelock` keep compiling and behaving exactly as
before.

## The case that cannot be represented, and why it still fails loudly

`Timelock` has six shapes, and `toWalletScript`'s trailing catch-all is
genuinely unreachable for it. **Dijkstra's native script has a seventh:
`RequireGuard`**, carrying a guard credential. It has its own CBOR tag in both
encoder and decoder and its own evaluation rule — a guard is satisfied by
membership in the transaction's guard set, not by a witness.

**It has no honest target in the wallet's script type.** That type is
`Cardano.Address.Script.Script` from `cardano-addresses`, whose six constructors
include nothing guard-shaped, and:

- a guard credential can be a **script hash**, while `RequireSignatureOf` takes
  a key hash — that half has no shape at all;
- `cardano-addresses` has no guard key role to label the other half with.

Mapping it to `RequireSignatureOf` would misreport the script to every API
consumer **and** to the witness counter — quietly wrong, which is worse than a
crash.

So the guard case **stays an explicit, loud failure naming Dijkstra** rather
than becoming a silently incorrect conversion. Making it total requires a new
case on the public `AnyScript` / `AnyExplicitScript` response types, which
changes the REST schema and belongs to its own change, not to a
transaction-layer one.

## How it is proved

The conversion is exercised with **real Dijkstra native scripts**, built through
the ledger's own constructors, not with Conway values relabelled:

- a Dijkstra native script built from the six shapes shared with `Timelock`,
  **including nested ones**, converts to the same wallet script its Conway
  counterpart converts to;
- the generated population is shown to **actually contain** Dijkstra scripts of
  each shared shape. A property whose generator never produces the feature would
  pass at any sample size while establishing nothing about it, so that is
  checked rather than assumed;
- a guard script is shown to be constructible over **both** credential forms —
  key hash and script hash — and to reach the loud failure described above, so
  that path is known to be live rather than asserted;
- the eras already served keep their behaviour, not merely their ability to
  compile.

## Scope

The two script-reader sites, and only those. The guard representation is
deliberately left open and is not silently resolved here.

