### PR TITLE
test(5288,5427): restore a falsifiable script-witness parity oracle

### DIFF
--- a/specs/5288-parity-oracle/data-model.md
+++ b/specs/5288-parity-oracle/data-model.md
@@ -1,0 +1,10 @@
+# data-model — #5288 / #5427
+
+| ID | Datum | Shape | Invariant |
+|---|---|---|---|
+| D1 | parity scenario set | the enumerated script-witness cases the oracle covers | non-empty; if the implementation quantifies over it rather than writing one `it` per case, the quantifier carries a guard that fails on an empty or truncated set, and that guard is itself demonstrated red |
+| D2 | `reviewInputScript0/1`, `reviewPreservedScript`, `reviewAddedInputScript` | `Script KeyHash` fixtures, currently `mkScript 91/92/94/93` | `reviewAddedInputScript`'s hash is **absent** from the declared witness set built from the other three, and present in the balanced set |
+| D3 | comparison surface | `serialize (eraProtVerLow @Conway) (tx ^. bodyTxL)` and `tx ^. witsTxL . scriptTxWitsL` | unchanged by this ticket; both sides are compared for every scenario |
+
+D2 is the whole of #5427: the current assertion constrains only the second half
+of that invariant, which is why the `93 -> 91` collision passes.

--- a/specs/5288-parity-oracle/functions-model.md
+++ b/specs/5288-parity-oracle/functions-model.md
@@ -1,0 +1,17 @@
+# functions-model — #5288 / #5427
+
+New and changed signatures only.
+
+| ID | Signature | Constraint |
+|---|---|---|
+| F1 | `buildCardanoApiParityTx :: RecentEra Write.Conway -> SelectionOf TxOut -> ScriptWitnesses -> ScriptParityCtx -> Write.Tx Write.Conway` | Reaches its result through `Cardano.Api.Experimental.makeUnsignedTx`. Its call graph must not reach `buildLedgerTx`, `buildLedgerTxRaw`, `mkLedgerTx` or `mkUnsignedTx`. Replaces `buildLegacyParityTx`. |
+| F2 | `buildNewParityTx` — unchanged signature | Remains the wallet-ledger arm. |
+| F3 | `reviewResponseTx :: Coin -> Write.Tx Write.Conway` — unchanged signature | Changed body: builds via F2, not via the cardano-api arm. |
+| F4 | `shouldHaveBodyParity`, `propParity` — unchanged signatures | Changed bodies: the first argument arm becomes F1. Comparison operators unchanged. |
+
+`ScriptParityCtx`, `parityTtl`, `parityFee`, `parityBodyCbor`,
+`parityScriptWits` keep their current signatures.
+
+Deleted with F1's arrival: `buildLegacyParityTx` and `mintBurnFromMintingSources`
+if it loses its last caller. A caller sweep is part of the slice, not a
+follow-up.

--- a/specs/5288-parity-oracle/modules-model.md
+++ b/specs/5288-parity-oracle/modules-model.md
@@ -1,0 +1,16 @@
+# modules-model — #5288 / #5427
+
+All changed responsibility is inside one test module. No production module
+changes, so no dependency direction moves and no abstraction is promoted.
+
+| ID | Module | Responsibility after this ticket | Direction |
+|---|---|---|---|
+| M1 | `lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs` | Owns both parity arms, the comparison harness, the `5413 review response` examples and their fixtures | depends on `cardano-api` (already declared) and `cardano-wallet`; nothing depends on it |
+
+- M1 gains a `cardano-api` **construction** responsibility it does not have
+  today; it already imports `Cardano.Api` for conversion helpers.
+- The cardano-api arm is a **migration-window oracle**. It carries, in its
+  haddock, the condition under which it is deleted, in the manner of
+  `roundTripThroughCardanoApi` (`TransactionLedgerSpec.hs:1635-1641`).
+- Forbidden: moving either arm into `lib/wallet` or `lib/primitive`. A test
+  oracle in production code re-adds the surface M1 is retiring.

--- a/specs/5288-parity-oracle/plan.md
+++ b/specs/5288-parity-oracle/plan.md
@@ -1,0 +1,61 @@
+# plan — #5288 / #5427
+
+## Constraint that selects the approach
+
+`scripts/ci/cardano-api-closure-gate.sh` at base reports
+`closure-lib=12 (MAX=12)`, `closure-any=13 (MAX=13)`, `suppressions=9 (MAX=9)`:
+zero slack on every row. `suppressions` counts *occurrences* of
+`-Wno-deprecations` / `-fno-warn-deprecations` in `.hs`, `.cabal` and
+`cabal.project*`, so one new pragma is `10 > 9`, GATE RED.
+
+`Cardano.createTransactionBody`, `TxBodyContent`, `TxBody` and `ShelleyTxBody`
+are `{-# DEPRECATED #-}` in cardano-api 11.5.0.0
+(`src/Cardano/Api/Tx/Internal/Body.hs:864,1258,1441`,
+`Tx/Internal/Sign.hs:302,304`). Restoring the pre-#5285 builder verbatim
+therefore needs a suppression and is unavailable.
+
+`Cardano.Api.Experimental.makeUnsignedTx` is not deprecated:
+
+    makeUnsignedTx :: Era era -> TxBodyContent (LedgerEra era)
+                   -> Either MakeUnsignedTxError (UnsignedTx (LedgerEra era))
+
+It builds `bodyTxL` from `L.mkBasicTxBody` and the witness set from
+`L.mkBasicTxWits & L.scriptTxWitsL .~ ...` itself
+(`Experimental/Tx/Internal/BodyContent/New.hs:185-256`), independently of the
+wallet's `mkLedgerTx`. `UnsignedTx era = UnsignedTx (Ledger.Tx TopTx era)`, so
+the result is directly comparable with `Write.Tx Write.Conway`.
+`lib/unit` already `build-depends: cardano-api` in both stanzas, so the arm adds
+no closure member.
+
+**Decision: the cardano-api arm is built on `Cardano.Api.Experimental`.**
+Rejected alternative, and it stays rejected: restoring the deprecated
+`createTransactionBody` path, because it costs a suppression the ratchet has no
+room for.
+
+## Live boundary
+
+None. Both builders are pure; there is no node, socket or database on this path.
+
+## Ordered, bisect-safe slices
+
+- **S1 — #5427 fixture distinctness.** Independent of S2, smaller, and its red
+  is cheap to demonstrate. Land it first so a bisect between S1 and S2 has a
+  meaningful tree.
+- **S2 — the cardano-api parity arm.** Replaces `buildLegacyParityTx` with a
+  `Cardano.Api.Experimental` builder, repoints `reviewResponseTx` at the wallet
+  builder, and demonstrates R2's red.
+
+## Why S2 repoints `reviewResponseTx`
+
+The `5413 review response` examples are about `balanceTx`'s treatment of a tx
+built by the **wallet** builder; cardano-api is not their subject. Today
+`buildLegacyParityTx` and `buildNewParityTx` bottom out in the same
+`buildLedgerTxRaw` call with equal arguments, so repointing `reviewResponseTx`
+at the wallet arm is behaviour-preserving at this base. S2 demonstrates that
+equivalence before removing the legacy arm rather than asserting it.
+
+## Risk the ticket owner accepts
+
+The two builders may genuinely disagree on a scenario — that is the information
+the oracle exists to produce. Report it; do not weaken the comparison. See
+spec.md, "Rejection behaviour".

--- a/specs/5288-parity-oracle/spec.md
+++ b/specs/5288-parity-oracle/spec.md
@@ -1,0 +1,58 @@
+# spec — #5288 script-witness parity oracle, #5427 fixture distinctness
+
+Issues: cardano-foundation/cardano-wallet#5288, #5427. Base `bd187ae44d`.
+
+## Why one ticket
+
+`reviewResponseTx` (`TransactionLedgerSpec.hs:1646`) calls `buildLegacyParityTx`
+(`:1473`). #5427's fixture is built by the exact function #5288 must replace, so
+two lanes in that file conflict by construction. Premise checked, not assumed.
+
+## Problem, stated as observed fact
+
+`buildLegacyParityTx` calls `mkUnsignedTx` (`Shelley/Transaction.hs:794`), whose
+body is `buildLedgerTxRaw`. `buildNewParityTx` calls `buildLedgerTx`
+(`Shelley/Transaction/Unsigned.hs:280`), whose body is `buildLedgerTxRaw`. The
+two arms are the same function applied to equal arguments. The comparison
+`parityBodyCbor legacy == parityBodyCbor new` holds by construction and is
+green whatever either builder does.
+
+The oracle did not decay. It was killed by `16e3089986` (`feat(5285)`), the
+migration it existed to guard: before that commit `mkUnsignedTx` built through
+`Cardano.createTransactionBody`. `#5411` later changed only the return type.
+
+#5288 acceptance criterion 3 — "compare ledger-builder output against the
+existing cardano-api builder" — is therefore unmet, and that is why #5288 is open.
+
+#5427: the added-script test asserts `Set.member reviewAddedInputScriptHash`
+in the balanced witness map. `reviewAddedInputScript = mkScript 93`; the
+declared set already holds 91, 92, 94. Rewriting 93 to 91 leaves the test
+green, so it cannot distinguish "a distinct script was added" from "an existing
+one was reused". The reporter is explicit that this is a test-quality finding,
+not a production defect.
+
+## Requirements
+
+- **R1** The parity oracle's two arms are built by independent builders. One
+  arm constructs the transaction through `cardano-api`; the other through the
+  wallet ledger builder. Neither arm's call graph reaches the other's builder.
+- **R2** The parity comparison can fail. A seeded perturbation of the wallet
+  ledger builder turns at least one enumerated scenario and the property red;
+  the unperturbed tree is green.
+- **R3** The added-script test fails under the `93 -> 91` collision the #5427
+  report names, and passes with the original fixture.
+- **R4** #5288 criteria 1, 2, 4, 5, 6 remain satisfied, each with a named check.
+- **R5** No new deprecation suppression and no new cardano-api closure member.
+- **R6** No file under `lib/integration/**`.
+
+## Observable success
+
+Green under a sanctioned build path with mechanically captured exit codes, plus
+a demonstrated red for R2 and R3 from the perturbations those requirements name.
+
+## Rejection behaviour
+
+If a scenario cannot be made to agree across the two independent builders, the
+divergence is **reported as a finding with evidence**. The comparison is never
+weakened, narrowed, or made tolerant to restore green. A green obtained by
+softening the oracle fails this spec outright.

--- a/specs/5288-parity-oracle/tasks.md
+++ b/specs/5288-parity-oracle/tasks.md
@@ -1,0 +1,31 @@
+# tasks — #5288 / #5427
+
+## S1 — fixture distinctness (#5427)
+
+- [ ] T1 RED: with `reviewAddedInputScript = mkScript 91`, the added-script
+      example fails; capture the failing run.
+- [ ] T2 Assert `reviewAddedInputScriptHash` is absent from the declared
+      witness set and present in the balanced set.
+- [ ] T3 GREEN with the original `mkScript 93` fixture; re-run the `93 -> 91`
+      mutation and capture the red.
+
+## S2 — cardano-api parity arm (#5288 AC3)
+
+- [ ] T4 RED: seed a perturbation in the wallet ledger builder
+      (`Shelley/Transaction/Unsigned.hs`) and show the current oracle stays
+      green — the vacuity, demonstrated rather than argued.
+- [ ] T5 Add `buildCardanoApiParityTx` (F1) over
+      `Cardano.Api.Experimental.makeUnsignedTx`.
+- [ ] T6 Show `buildLegacyParityTx` and `buildNewParityTx` agree at this base,
+      then repoint `reviewResponseTx` at F2 and delete the legacy arm and any
+      helper it orphans.
+- [ ] T7 Point `shouldHaveBodyParity` and `propParity` at F1.
+- [ ] T8 GREEN: all enumerated scenarios and the property pass. Any scenario
+      that cannot agree is reported, not softened.
+- [ ] T9 Re-run T4's perturbation and capture the red.
+
+## Ticket-wide
+
+- [ ] T10 Closure gate green; record all three rows; lower any `MAX` that falls.
+- [ ] T11 `git diff --name-only` shows no `lib/integration/**` path.
+- [ ] T12 #5288 criteria 1, 2, 4, 5, 6 each checked, with the command per row.


### PR DESCRIPTION
Closes #5288. Closes #5427.

## What is wrong

`buildLegacyParityTx` (`lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionLedgerSpec.hs:1473`)
calls `mkUnsignedTx`, whose body is `buildLedgerTxRaw`. `buildNewParityTx`
calls `buildLedgerTx`, whose body is `buildLedgerTxRaw`. The two arms of the
script-witness parity oracle are the same function applied to equal arguments,
so the comparison holds by construction and stays green whatever either builder
does. #5288's third acceptance criterion — compare the ledger builder against
the cardano-api builder — is unmet, and that is why #5288 is open.

The oracle did not decay over time. It went vacuous at `16e3089986`
(`feat(5285)`), the migration it was written to guard; before that commit
`mkUnsignedTx` built through `Cardano.createTransactionBody`.

#5427 reports the neighbouring case: the added-script example asserts
`Set.member reviewAddedInputScriptHash` in the balanced witness map, and
rewriting the fixture from `mkScript 93` to `mkScript 91` leaves it green, so it
cannot distinguish a distinct added script from a reused one.

## What this changes

- Restores an arm that genuinely traverses `cardano-api`, built on
  `Cardano.Api.Experimental.makeUnsignedTx`. `createTransactionBody`,
  `TxBodyContent` and `TxBody` are deprecated in cardano-api 11.5.0.0 and the
  deprecation-suppression ratchet is at `MAX=9` with no slack, so the
  experimental surface is the one available route.
- Adds the fixture-distinctness assertion #5427 asks for.

Both live in one file with interlocking helpers — `reviewResponseTx` calls
`buildLegacyParityTx` — so they are one change.

## Evidence

The parity comparison is demonstrated red by perturbing the wallet ledger
builder, then green. The added-script example is demonstrated red under the
`93 -> 91` collision, then green. Receipts are attached to the ticket record.

Mandate: `specs/5288-parity-oracle/`.
